### PR TITLE
feat(config): persist EmbeddingConfig with keyring-backed api_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 ### Added
+- **`EmbeddingConfig` dataclass on `AMXConfig`**: `cfg.embedding` persists the user's chosen embedding provider (`kind` ∈ `minilm` / `openai_compatible` / `sentence_transformers`), `model`, `base_url`, and `api_key`. Round-trips through `~/.amx/config.yml`. The `api_key` is externalised to the OS keyring under `embedding/api_key` (same path as DB / LLM secrets) so it never lands on disk in plaintext. Legacy plaintext configs migrate on the next save.
+- **`EmbeddingConfig.is_configured()`**: returns `True` for the MiniLM default (which needs no setup) and requires a non-empty `model` for the other two kinds. The CLI uses this to route users to a future `/embeddings` setup command without failing silently.
+- **5 new `EmbeddingConfigPersistenceTests`** covering the default-MiniLM state, `openai_compatible` model-required validation, full save/load round-trip, keyring externalisation of the api_key, and legacy-plaintext migration.
 - **Pluggable search embeddings** (`amx/search/embeddings.py`): the AMX search index now accepts a swap-in `EmbeddingFunction` so users can pick how their catalog is vectorised:
   - `MiniLMEmbedding` (default) — explicit wrapper around Chroma's bundled `all-MiniLM-L6-v2`. Behaviour unchanged for existing users; the choice is now visible in the codebase rather than implicit.
   - `OpenAICompatibleEmbedding` — points at any OpenAI-compatible `/embeddings` endpoint via `base_url + api_key + model`. Plugs in OpenAI proper, Azure OpenAI, OpenRouter, Together, Mistral, or local servers like LM Studio / vLLM / llama.cpp.

--- a/amx/config.py
+++ b/amx/config.py
@@ -26,11 +26,14 @@ from amx.storage.secrets import (
 SUPPORTED_BACKENDS = ("postgresql", "snowflake", "databricks", "bigquery")
 DISABLED_PROFILE = "__none__"
 PROFILING_MODES = ("full", "sampled", "metadata")
+SUPPORTED_EMBEDDING_KINDS = ("minilm", "openai_compatible", "sentence_transformers")
+DEFAULT_EMBEDDING_KIND = "minilm"
 
 # Secret-bearing fields per scope. These are externalised to the OS keyring
 # on save and resolved back to plaintext on load via amx.storage.secrets.
 _DB_SECRET_FIELDS = ("password", "access_token")
 _LLM_SECRET_FIELDS = ("api_key",)
+_EMBEDDING_SECRET_FIELDS = ("api_key",)
 
 
 def _externalise_secret(
@@ -102,6 +105,11 @@ def _externalise_secrets_in_data(
             _externalise_secret(
                 llm_top, fld, f"llm_profiles/{active_llm_profile}/{fld}", store
             )
+
+    embedding = data.get("embedding")
+    if isinstance(embedding, dict):
+        for fld in _EMBEDDING_SECRET_FIELDS:
+            _externalise_secret(embedding, fld, f"embedding/{fld}", store)
     return data
 
 
@@ -148,6 +156,11 @@ def _resolve_secrets_in_data(data: dict[str, Any], store: SecretStore) -> dict[s
     if isinstance(llm_top, dict):
         for fld in _LLM_SECRET_FIELDS:
             _resolve_secret_field(llm_top, fld, store)
+
+    embedding = data.get("embedding")
+    if isinstance(embedding, dict):
+        for fld in _EMBEDDING_SECRET_FIELDS:
+            _resolve_secret_field(embedding, fld, store)
     return data
 
 _OPENROUTER_MODEL_NAMESPACES = (
@@ -608,9 +621,52 @@ def _llm_to_mapping(llm: LLMConfig) -> dict[str, Any]:
 
 
 @dataclass
+class EmbeddingConfig(_ObservableConfig):
+    """Search-index embedding provider settings.
+
+    Maps onto :mod:`amx.search.embeddings` providers; ``kind="minilm"``
+    keeps the historical Chroma default. ``api_key`` is treated as a
+    secret and stored in the OS keyring just like DB passwords.
+    """
+
+    kind: str = DEFAULT_EMBEDDING_KIND  # minilm | openai_compatible | sentence_transformers
+    model: str = ""        # provider-specific (e.g. text-embedding-3-small, BAAI/bge-large-en-v1.5)
+    api_key: str = ""      # only used by openai_compatible; secret-managed
+    base_url: str = ""     # only used by openai_compatible; defaults to OpenAI proper
+
+    def is_configured(self) -> bool:
+        """True when the configured provider has the minimum fields to operate.
+
+        MiniLM needs no setup; the other two need at least a model id."""
+        normalised = (self.kind or "").lower().strip()
+        if normalised in {"", "minilm", "default"}:
+            return True
+        return bool(self.model)
+
+
+def _embedding_from_mapping(m: dict[str, Any]) -> EmbeddingConfig:
+    return EmbeddingConfig(
+        kind=str(m.get("kind", DEFAULT_EMBEDDING_KIND) or DEFAULT_EMBEDDING_KIND),
+        model=str(m.get("model", "") or ""),
+        api_key=str(m.get("api_key", "") or ""),
+        base_url=str(m.get("base_url", "") or ""),
+    )
+
+
+def _embedding_to_mapping(emb: EmbeddingConfig) -> dict[str, Any]:
+    return {
+        "kind": emb.kind or DEFAULT_EMBEDDING_KIND,
+        "model": emb.model,
+        "api_key": emb.api_key,
+        "base_url": emb.base_url,
+    }
+
+
+@dataclass
 class AMXConfig:
     db: DBConfig = field(default_factory=DBConfig)
     llm: LLMConfig = field(default_factory=LLMConfig)
+    embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
     doc_paths: list[str] = field(default_factory=list)
     code_paths: list[str] = field(default_factory=list)
     selected_schemas: list[str] = field(default_factory=list)
@@ -639,6 +695,7 @@ class AMXConfig:
         {
             "db",
             "llm",
+            "embedding",
             "doc_paths",
             "code_paths",
             "selected_schemas",
@@ -661,7 +718,7 @@ class AMXConfig:
         object.__setattr__(self, name, value)
         if name.startswith("_") or name == "CONFIG_DIR":
             return
-        if name in {"db", "llm", "db_profiles", "llm_profiles"}:
+        if name in {"db", "llm", "embedding", "db_profiles", "llm_profiles"}:
             self._attach_children()
         if name in self._PERSISTED_FIELDS:
             if name == "write_through_config" and getattr(self, "_autosave_ready", False):
@@ -734,6 +791,10 @@ class AMXConfig:
 
             cfg.active_code_profile = str(data.get("active_code_profile") or "")
             cfg.write_through_config = bool(data.get("write_through_config", True))
+
+            embedding_raw = data.get("embedding")
+            if isinstance(embedding_raw, dict):
+                cfg.embedding = _embedding_from_mapping(embedding_raw)
 
         cfg.llm.api_key = cfg.llm.api_key or os.getenv("AMX_LLM_API_KEY", "")
 
@@ -823,6 +884,7 @@ class AMXConfig:
                 "selected_schemas": self.selected_schemas,
                 "selected_tables": self.selected_tables,
                 "write_through_config": self.write_through_config,
+                "embedding": _embedding_to_mapping(self.embedding),
             }
             # Move plaintext secrets to the OS keyring; the YAML now stores only
             # opaque "keyring:..." references. No-op when keyring is unavailable.
@@ -1028,6 +1090,10 @@ class AMXConfig:
             pass
         try:
             object.__setattr__(self.llm, "_amx_owner", self)
+        except Exception:
+            pass
+        try:
+            object.__setattr__(self.embedding, "_amx_owner", self)
         except Exception:
             pass
         for profile in getattr(self, "db_profiles", {}).values():

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2232,6 +2232,97 @@ class ConfigTransactionTests(unittest.TestCase):
             self.assertEqual(counter[0], 0)
 
 
+class EmbeddingConfigPersistenceTests(unittest.TestCase):
+    """The Week-3 EmbeddingConfig integrates with AMXConfig load/save and the
+    OS-keyring secret externalisation. These tests pin the round-trip and
+    confirm the api_key never lands in plaintext on disk."""
+
+    def setUp(self) -> None:
+        from amx.storage.secrets import InMemorySecretStore, set_default_store
+
+        self._store = InMemorySecretStore()
+        set_default_store(self._store)
+
+    def tearDown(self) -> None:
+        from amx.storage.secrets import set_default_store
+
+        set_default_store(None)
+
+    def test_default_embedding_is_minilm(self) -> None:
+        cfg = AMXConfig()
+        self.assertEqual(cfg.embedding.kind, "minilm")
+        self.assertEqual(cfg.embedding.model, "")
+        self.assertEqual(cfg.embedding.api_key, "")
+        self.assertTrue(cfg.embedding.is_configured())
+
+    def test_openai_compatible_requires_model_to_be_configured(self) -> None:
+        from amx.config import EmbeddingConfig
+
+        self.assertFalse(EmbeddingConfig(kind="openai_compatible", model="").is_configured())
+        self.assertTrue(
+            EmbeddingConfig(kind="openai_compatible", model="text-embedding-3-small").is_configured()
+        )
+
+    def test_save_and_load_round_trip_preserves_embedding_settings(self) -> None:
+        from amx.config import EmbeddingConfig
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = Path(td) / "config.yml"
+            cfg = AMXConfig()
+            cfg.embedding = EmbeddingConfig(
+                kind="openai_compatible",
+                model="text-embedding-3-large",
+                api_key="sk-embed-1234",
+                base_url="https://api.openai.com/v1",
+            )
+            cfg.save(str(cfg_path))
+
+            reloaded = AMXConfig.load(str(cfg_path))
+            self.assertEqual(reloaded.embedding.kind, "openai_compatible")
+            self.assertEqual(reloaded.embedding.model, "text-embedding-3-large")
+            self.assertEqual(reloaded.embedding.api_key, "sk-embed-1234")
+            self.assertEqual(reloaded.embedding.base_url, "https://api.openai.com/v1")
+
+    def test_embedding_api_key_externalised_to_keyring(self) -> None:
+        from amx.config import EmbeddingConfig
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = Path(td) / "config.yml"
+            cfg = AMXConfig()
+            cfg.embedding = EmbeddingConfig(
+                kind="openai_compatible",
+                model="text-embedding-3-small",
+                api_key="sk-must-not-leak",
+                base_url="https://api.openai.com/v1",
+            )
+            cfg.save(str(cfg_path))
+
+            yaml_text = cfg_path.read_text()
+            self.assertNotIn("sk-must-not-leak", yaml_text)
+            self.assertIn("keyring:embedding/api_key", yaml_text)
+            self.assertEqual(self._store.get("embedding/api_key"), "sk-must-not-leak")
+
+    def test_embedding_legacy_plaintext_loads_without_keyring(self) -> None:
+        """A YAML written before keyring integration (or by a user with
+        keyring unavailable) keeps working: api_key flows straight into the
+        in-memory dataclass, and the next save migrates it."""
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = Path(td) / "config.yml"
+            cfg_path.write_text(
+                "embedding:\n"
+                "  kind: openai_compatible\n"
+                "  model: text-embedding-3-small\n"
+                "  api_key: sk-plaintext-legacy\n"
+                "  base_url: https://api.openai.com/v1\n"
+            )
+            cfg = AMXConfig.load(str(cfg_path))
+            self.assertEqual(cfg.embedding.api_key, "sk-plaintext-legacy")
+
+            cfg.save(str(cfg_path))
+            self.assertEqual(self._store.get("embedding/api_key"), "sk-plaintext-legacy")
+            self.assertNotIn("sk-plaintext-legacy", cfg_path.read_text())
+
+
 class FirstRunConfigTests(unittest.TestCase):
     """Regression tests for the Week-2 first-run UX hardening."""
 


### PR DESCRIPTION
Adds cfg.embedding to AMXConfig so the pluggable embedding providers
shipped in the previous PR (MiniLM / OpenAI-compatible / Sentence-
Transformers) can be configured per-user and round-tripped through
~/.amx/config.yml.

What changed:
- amx/config.py: EmbeddingConfig dataclass with kind/model/api_key/
  base_url. Default kind is "minilm" (which needs no setup, so
  is_configured() returns True out of the box). Wired into
  AMXConfig: persisted field, save/load round-trip, _attach_children
  observability, and the keyring secret externalisation pipeline so
  api_key is stored under embedding/api_key and never lands in the
  YAML in plaintext. Legacy plaintext api_key still loads cleanly
  and migrates on next save.
- tests/test_regressions.py: 5 new EmbeddingConfigPersistenceTests
  covering the MiniLM default state, openai_compatible model
  requirement, full round-trip, keyring externalisation, and the
  legacy-plaintext migration path.

Next PR will wire cfg.embedding into the runtime SearchIndex via a
small singleton in amx/search/embeddings.py + a CLI startup hook,
plus add a /embeddings command for picking the provider
interactively.

All 163 tests pass (158 + 5 new).
