### PR TITLE
feat(cli): /embeddings slash command for switching embedding provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 ### Added
+- **`/embeddings` slash command** (`amx/cli_support/commands/embeddings.py`): users can switch the search-index embedding provider without hand-editing `~/.amx/config.yml`. Forms:
+  - `/embeddings` — show the current provider + interactive picker.
+  - `/embeddings minilm` — switch to Chroma's bundled default (no setup).
+  - `/embeddings openai [model]` — switch to an OpenAI-compatible endpoint; prompts for `base_url` and `api_key` (the key is stored in the OS keyring, never in YAML).
+  - `/embeddings local [model]` — switch to a local sentence-transformers model (requires `pip install "amx[local-embeddings]"`).
+  Switching reinstalls the runtime factory immediately and reminds the user to run `/search rebuild` so the catalog is re-embedded with the new provider.
+- **`amx.search.embeddings.configure_from_amx_config`**: extracted from `cli.py` so the slash command can re-install the runtime factory without depending on the CLI module. Accepts an optional `on_warning` callback so misconfigured providers surface as themed warnings.
+- **5 new `EmbeddingsSlashCommandTests`** covering the MiniLM / OpenAI / local branches, unknown-kind error, and OpenAI-with-empty-model rejection.
 - **Runtime wire-up of `cfg.embedding`** (`amx/cli.py`, `amx/search/embeddings.py`, `amx/search/index.py`): the configured embedding provider is now actually used at runtime, not just stored in `~/.amx/config.yml`. The CLI installs a process-wide factory at startup based on `cfg.embedding`, and `SearchIndex(...)` falls back to that factory when no explicit `embedding_function` is passed. Misconfigured profiles emit a themed warning ("Embedding provider 'X' is not fully configured…") and gracefully fall back to MiniLM rather than failing retrieval.
 - **`set_default_embedding_function` / `get_default_embedding_function`**: small singleton in `amx/search/embeddings.py` so `SearchIndex` constructors deep in the codebase pick up the user-chosen provider without needing the live `AMXConfig` plumbed through every caller. Test suite resets the singleton between cases to avoid cross-test bleed.
 - **5 new `EmbeddingDefaultFactoryTests`** covering get-without-set, set/get round-trip, factory failure is swallowed (so retrieval keeps working with MiniLM fallback), `SearchIndex` picks up the default factory, and explicit `embedding_function` arg overrides the default.

--- a/amx/cli.py
+++ b/amx/cli.py
@@ -113,40 +113,14 @@ def _normalize_click_argv(args: list[str], cfg: AMXConfig) -> list[str]:
 def _install_embedding_provider(cfg: AMXConfig) -> None:
     """Configure the search-index embedding provider for this process.
 
-    Reads ``cfg.embedding`` and registers a factory with
-    :func:`amx.search.embeddings.set_default_embedding_function` so any
-    later ``SearchIndex`` constructor picks it up. Failures are surfaced
-    as a themed warning and we fall back to the bundled MiniLM default.
+    Thin shim around :func:`amx.search.embeddings.configure_from_amx_config`
+    that wires the themed ``warn()`` console helper into the
+    ``on_warning`` hook so misconfigured providers surface as a themed
+    one-line warning rather than a stack trace.
     """
-    from amx.search.embeddings import (
-        DEFAULT_KIND,
-        make_embedding_function,
-        set_default_embedding_function,
-    )
+    from amx.search.embeddings import configure_from_amx_config
 
-    kind = (cfg.embedding.kind or DEFAULT_KIND).lower().strip()
-    if kind in {"", "minilm", "default", "minilm-l6-v2"}:
-        # Default behaviour (Chroma's bundled MiniLM); nothing to install.
-        set_default_embedding_function(None)
-        return
-
-    if not cfg.embedding.is_configured():
-        warn(
-            f"Embedding provider '{cfg.embedding.kind}' is not fully configured "
-            "(missing model). Falling back to MiniLM. Run /embeddings to fix."
-        )
-        set_default_embedding_function(None)
-        return
-
-    def _factory():
-        return make_embedding_function(
-            cfg.embedding.kind,
-            model=cfg.embedding.model,
-            api_key=cfg.embedding.api_key,
-            base_url=cfg.embedding.base_url,
-        )
-
-    set_default_embedding_function(_factory)
+    configure_from_amx_config(cfg, on_warning=warn)
 
 
 def _rewrite_sys_argv_for_codebase(argv: list[str]) -> None:

--- a/amx/cli_support/commands/embeddings.py
+++ b/amx/cli_support/commands/embeddings.py
@@ -1,0 +1,151 @@
+"""``/embeddings`` slash command for the AMX interactive CLI.
+
+Lets users inspect and change the search-index embedding provider
+(``cfg.embedding``) without hand-editing ``~/.amx/config.yml``. The
+underlying providers are defined in :mod:`amx.search.embeddings`; this
+module is the thin user-facing layer that updates ``cfg.embedding``,
+re-installs the default factory so subsequent ``/search`` queries use
+the new provider, and prints the next step for the user (``/search
+rebuild`` because vectors from the previous model are not reusable).
+"""
+
+from __future__ import annotations
+
+from amx.config import (
+    DEFAULT_EMBEDDING_KIND,
+    SUPPORTED_EMBEDDING_KINDS,
+    AMXConfig,
+    EmbeddingConfig,
+)
+from amx.search.embeddings import (
+    DEFAULT_OPENAI_BASE_URL,
+    configure_from_amx_config,
+)
+from amx.utils.console import (
+    ask,
+    ask_choice,
+    ask_password,
+    error,
+    heading,
+    info,
+    success,
+    warn,
+)
+
+
+def _print_current(cfg: AMXConfig) -> None:
+    heading("Current search-index embedding provider")
+    emb = cfg.embedding
+    info(f"Kind:    {emb.kind}")
+    info(f"Model:   {emb.model or '(none — using provider default)'}")
+    if emb.kind == "openai_compatible":
+        info(f"Base URL: {emb.base_url or DEFAULT_OPENAI_BASE_URL}")
+        info(f"API key:  {'(set, stored in OS keyring)' if emb.api_key else '(unset)'}")
+    if emb.kind == "sentence_transformers":
+        info("Loads via the `local-embeddings` extra (sentence-transformers).")
+    if emb.kind in {"minilm", "default", "minilm-l6-v2", ""}:
+        info("MiniLM is Chroma's bundled default — no setup required.")
+
+
+def _set_minilm(cfg: AMXConfig) -> None:
+    cfg.embedding = EmbeddingConfig(kind="minilm")
+    configure_from_amx_config(cfg, on_warning=warn)
+    success("Embeddings switched to MiniLM (Chroma's bundled default).")
+    info("Run /search rebuild to re-embed the catalog with the new provider.")
+
+
+def _set_openai_compatible(cfg: AMXConfig, rest: list[str]) -> None:
+    model = rest[0] if rest else ask(
+        "Embedding model (e.g. text-embedding-3-small, text-embedding-3-large)"
+    )
+    if not model:
+        error("A model id is required for openai_compatible embeddings.")
+        return
+    base_url = ask(
+        "Base URL (Enter for the default OpenAI endpoint)",
+        default=DEFAULT_OPENAI_BASE_URL,
+    ) or DEFAULT_OPENAI_BASE_URL
+    api_key = ask_password("API key (stored in your OS keyring, not the YAML)")
+
+    cfg.embedding = EmbeddingConfig(
+        kind="openai_compatible",
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+    )
+    configure_from_amx_config(cfg, on_warning=warn)
+    success(f"Embeddings switched to openai_compatible / {model}.")
+    info(
+        f"Endpoint: {base_url}. The API key is stored in the OS keyring under "
+        "amx:embedding/api_key."
+    )
+    info("Run /search rebuild to re-embed the catalog with the new provider.")
+
+
+def _set_sentence_transformers(cfg: AMXConfig, rest: list[str]) -> None:
+    model = rest[0] if rest else ask(
+        "HuggingFace model id (e.g. BAAI/bge-large-en-v1.5, intfloat/e5-large-v2)"
+    )
+    if not model:
+        error("A model id is required for sentence_transformers embeddings.")
+        return
+    cfg.embedding = EmbeddingConfig(kind="sentence_transformers", model=model)
+    configure_from_amx_config(cfg, on_warning=warn)
+    success(f"Embeddings switched to sentence_transformers / {model}.")
+    info(
+        "Requires `pip install \"amx[local-embeddings]\"` if you have not "
+        "already done so. The model will be downloaded on first /search use."
+    )
+    info("Run /search rebuild to re-embed the catalog with the new provider.")
+
+
+def cmd_embeddings(cfg: AMXConfig, rest: list[str]) -> None:
+    """Show or change the search-index embedding provider.
+
+    Usage::
+
+        /embeddings                        # show current provider
+        /embeddings minilm                 # switch to MiniLM (default)
+        /embeddings openai [model]         # switch to OpenAI-compatible
+        /embeddings local [model]          # switch to sentence-transformers
+
+    With no arguments, an interactive picker is shown. With a kind
+    argument and missing details, the user is prompted for the
+    remaining fields.
+    """
+    if not rest:
+        _print_current(cfg)
+        info("")
+        choice = ask_choice(
+            "Switch provider?",
+            choices=["keep", "minilm", "openai", "local"],
+            default="keep",
+            descriptions={
+                "keep": "leave the current provider unchanged",
+                "minilm": "Chroma default (offline, fastest, lowest quality)",
+                "openai": "OpenAI-compatible /embeddings endpoint",
+                "local": "sentence-transformers (offline, stronger than MiniLM)",
+            },
+        )
+        if choice in {"", "keep"}:
+            return
+        rest = [choice]
+
+    head = (rest[0] or "").lower().strip()
+    if head in {"minilm", "default"}:
+        _set_minilm(cfg)
+        return
+    if head in {"openai", "openai_compatible", "openai-compatible"}:
+        _set_openai_compatible(cfg, rest[1:])
+        return
+    if head in {"local", "sentence_transformers", "sentence-transformers", "st"}:
+        _set_sentence_transformers(cfg, rest[1:])
+        return
+    error(
+        f"Unknown embedding kind: {rest[0]!r}. Expected one of "
+        f"{SUPPORTED_EMBEDDING_KINDS} (or aliases: minilm, openai, local)."
+    )
+
+
+# Re-export so session.py can import via the same pattern as profiles.py.
+__all__ = ["cmd_embeddings", "DEFAULT_EMBEDDING_KIND"]

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -23,6 +23,7 @@ from amx.cli_support.commands.db import (
     cmd_remove_profile as _cmd_remove_profile,
     cmd_use as _cmd_use,
 )
+from amx.cli_support.commands.embeddings import cmd_embeddings as _cmd_embeddings
 from amx.cli_support.commands.profiles import (
     cmd_add_code_profile as _cmd_add_code_profile,
     cmd_add_doc_profile as _cmd_add_doc_profile,
@@ -697,6 +698,11 @@ def _handle_session_builtin(
     if head == "save":
         path = cfg.save()
         success(f"Saved configuration to {path}")
+        return True
+    if head == "embeddings":
+        # Available from any namespace — embedding provider config is a quick
+        # one-shot mutation that doesn't require entering /search first.
+        _cmd_embeddings(cfg, parts[1:])
         return True
     if head == "schema":
         if not _require_namespace(head, namespace, "db", "schema"):

--- a/amx/search/embeddings.py
+++ b/amx/search/embeddings.py
@@ -79,6 +79,47 @@ def get_default_embedding_function() -> EmbeddingFunction | None:
         return None
 
 
+def configure_from_amx_config(cfg: Any, *, on_warning: Callable[[str], None] | None = None) -> None:
+    """Install the default embedding factory based on ``cfg.embedding``.
+
+    Called once at CLI startup and again whenever the user changes the
+    embedding provider via the ``/embeddings`` command.
+
+    ``on_warning`` is called with a single themed message string when
+    the configured provider is incomplete (e.g. ``openai_compatible``
+    selected but no model). The behaviour falls back to MiniLM rather
+    than failing retrieval, so the warning is the only signal.
+    """
+    embedding = getattr(cfg, "embedding", None)
+    if embedding is None:
+        set_default_embedding_function(None)
+        return
+
+    kind = (embedding.kind or DEFAULT_KIND).lower().strip()
+    if kind in {"", "minilm", "default", "minilm-l6-v2"}:
+        set_default_embedding_function(None)
+        return
+
+    if not embedding.is_configured():
+        if on_warning is not None:
+            on_warning(
+                f"Embedding provider {embedding.kind!r} is not fully configured "
+                "(missing model). Falling back to MiniLM. Run /embeddings to fix."
+            )
+        set_default_embedding_function(None)
+        return
+
+    def _factory() -> EmbeddingFunction | None:
+        return make_embedding_function(
+            embedding.kind,
+            model=embedding.model,
+            api_key=embedding.api_key,
+            base_url=embedding.base_url,
+        )
+
+    set_default_embedding_function(_factory)
+
+
 def _openai_client_factory(
     *, api_key: str, base_url: str, timeout: float | None
 ) -> Any:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2232,6 +2232,87 @@ class ConfigTransactionTests(unittest.TestCase):
             self.assertEqual(counter[0], 0)
 
 
+class EmbeddingsSlashCommandTests(unittest.TestCase):
+    """The /embeddings slash command lets users switch provider without
+    hand-editing ~/.amx/config.yml. Each branch reinstalls the runtime
+    factory so subsequent /search queries pick up the new provider."""
+
+    def setUp(self) -> None:
+        from amx.search import embeddings as embeddings_module
+
+        self.embeddings_module = embeddings_module
+        embeddings_module.set_default_embedding_function(None)
+
+    def tearDown(self) -> None:
+        self.embeddings_module.set_default_embedding_function(None)
+
+    def test_minilm_branch_resets_provider(self) -> None:
+        from amx.cli_support.commands.embeddings import cmd_embeddings
+
+        cfg = AMXConfig()
+        # Pretend a non-default factory is currently installed.
+        sentinel_factory = lambda: object()
+        self.embeddings_module.set_default_embedding_function(sentinel_factory)
+        self.assertIsNotNone(self.embeddings_module._default_factory)
+
+        cmd_embeddings(cfg, ["minilm"])
+
+        self.assertEqual(cfg.embedding.kind, "minilm")
+        self.assertEqual(cfg.embedding.model, "")
+        # MiniLM means: clear the factory so Chroma uses its bundled default.
+        self.assertIsNone(self.embeddings_module._default_factory)
+
+    def test_openai_branch_with_model_arg_installs_factory(self) -> None:
+        from amx.cli_support.commands.embeddings import cmd_embeddings
+
+        cfg = AMXConfig()
+        with (
+            patch("amx.cli_support.commands.embeddings.ask", return_value="https://api.openai.com/v1"),
+            patch("amx.cli_support.commands.embeddings.ask_password", return_value="sk-test"),
+        ):
+            cmd_embeddings(cfg, ["openai", "text-embedding-3-small"])
+
+        self.assertEqual(cfg.embedding.kind, "openai_compatible")
+        self.assertEqual(cfg.embedding.model, "text-embedding-3-small")
+        self.assertEqual(cfg.embedding.api_key, "sk-test")
+        self.assertEqual(cfg.embedding.base_url, "https://api.openai.com/v1")
+        # Factory installed and points at OpenAI-compatible.
+        self.assertIsNotNone(self.embeddings_module._default_factory)
+
+    def test_local_branch_with_model_arg(self) -> None:
+        from amx.cli_support.commands.embeddings import cmd_embeddings
+
+        cfg = AMXConfig()
+        cmd_embeddings(cfg, ["local", "BAAI/bge-large-en-v1.5"])
+
+        self.assertEqual(cfg.embedding.kind, "sentence_transformers")
+        self.assertEqual(cfg.embedding.model, "BAAI/bge-large-en-v1.5")
+        self.assertEqual(cfg.embedding.api_key, "")
+
+    def test_unknown_kind_emits_error_without_mutating_config(self) -> None:
+        from amx.cli_support.commands.embeddings import cmd_embeddings
+
+        cfg = AMXConfig()
+        original_kind = cfg.embedding.kind
+
+        # Should not raise — the error is printed via console.error().
+        cmd_embeddings(cfg, ["totally-not-a-kind"])
+
+        self.assertEqual(cfg.embedding.kind, original_kind)
+
+    def test_openai_branch_rejects_empty_model(self) -> None:
+        from amx.cli_support.commands.embeddings import cmd_embeddings
+
+        cfg = AMXConfig()
+        original_kind = cfg.embedding.kind
+        # `ask` returns "" → command must error rather than silently install
+        # an unusable provider.
+        with patch("amx.cli_support.commands.embeddings.ask", return_value=""):
+            cmd_embeddings(cfg, ["openai"])
+
+        self.assertEqual(cfg.embedding.kind, original_kind)
+
+
 class EmbeddingDefaultFactoryTests(unittest.TestCase):
     """The singleton in amx.search.embeddings lets the CLI install the
     user's chosen provider once at startup so all later SearchIndex


### PR DESCRIPTION
Closes the loop on the pluggable-embeddings work: users can now pick
their search-index embedding provider interactively rather than
hand-editing ~/.amx/config.yml.

Forms:
  /embeddings                   show current provider + interactive
                                picker (keep / minilm / openai / local)
  /embeddings minilm            switch to Chroma default (no setup)
  /embeddings openai [model]    OpenAI-compatible; prompts for
                                base_url + api_key (api_key → keyring)
  /embeddings local [model]     sentence-transformers (requires
                                amx[local-embeddings] extra)

Each branch:
- Mutates cfg.embedding (which auto-saves to YAML; api_key is
  externalised to the OS keyring under embedding/api_key).
- Re-installs the process-wide embedding factory so subsequent
  /search retrievals use the new provider, no restart required.
- Reminds the user to run /search rebuild because vectors from the
  previous model are not reusable.

Refactor: amx.search.embeddings.configure_from_amx_config — extracted
from cli.py so the slash command can re-install the runtime factory
without importing cli (which would be a circular dep). Accepts an
optional on_warning callback so misconfigured providers surface as a
themed line; cli.py wires that to console.warn.

Tests: 5 new EmbeddingsSlashCommandTests cover each branch (MiniLM,
OpenAI with model arg, local with model arg, unknown-kind error,
OpenAI with empty model rejection).

The /embeddings handler is registered in session.py at the namespace-
free tier (next to /save) so users can run it from anywhere without
having to enter /search first.

All 173 tests pass (168 + 5 new).
