### PR TITLE
feat(llm): retry transient errors (429/timeout/5xx) with exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 ### Added
+- **LLM transient-retry** (`amx/llm/provider.py`): rate-limit (HTTP 429), timeouts, connection-reset, and 5xx upstream errors are now retried up to twice with exponential backoff (1s, 2s) before propagating. Authentication / bad-request errors still propagate immediately so the categorised `ErrorMapper` hint reaches the user fast. The existing Ollama legacy `/v1` 404 fallback is preserved as a first-attempt special case.
+- **`_is_transient_llm_error()` helper**: classifies LLM exceptions by class name (`RateLimitError`, `APITimeoutError`, `APIConnectionError`, `InternalServerError`, `ServiceUnavailableError`, plus stdlib `TimeoutError` / `ConnectionError`) and by substring matching of common transient phrases (`429`, `rate limit`, `timed out`, `connection reset`, `503 service`, `502 bad gateway`, etc.). Available for unit testing and re-use.
+- **5 new `LLMTransientRetryTests`** covering: 429-retried-then-succeeds, persistent timeout exhausts retries (3 total attempts), authentication errors do NOT retry (single attempt), substring-pattern classification for generic `RuntimeError`, and the `_is_transient_llm_error` truth table.
 - **`/embeddings` slash command** (`amx/cli_support/commands/embeddings.py`): users can switch the search-index embedding provider without hand-editing `~/.amx/config.yml`. Forms:
   - `/embeddings` — show the current provider + interactive picker.
   - `/embeddings minilm` — switch to Chroma's bundled default (no setup).

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -282,6 +282,57 @@ def _normalized_api_base(provider: str, api_base: str | None) -> str | None:
     return base
 
 
+MAX_LLM_RETRIES = 2
+LLM_RETRY_BACKOFF_BASE_SEC = 1.0
+_TRANSIENT_LLM_EXCEPTION_NAMES: frozenset[str] = frozenset(
+    {
+        "APITimeoutError",
+        "APIConnectionError",
+        "InternalServerError",
+        "ServiceUnavailableError",
+        "RateLimitError",
+        "Timeout",
+        "ReadTimeout",
+        "ConnectTimeout",
+        "ConnectionError",
+        "ConnectionResetError",
+    }
+)
+_TRANSIENT_LLM_MESSAGE_TOKENS: tuple[str, ...] = (
+    "rate limit",
+    "rate_limit",
+    "429",
+    "timed out",
+    "timeout",
+    "connection reset",
+    "connection aborted",
+    "broken pipe",
+    "service unavailable",
+    "502 bad gateway",
+    "503 service",
+    "504 gateway",
+    "temporary failure",
+)
+
+
+def _is_transient_llm_error(exc: BaseException) -> bool:
+    """Return True for LLM errors worth retrying once with backoff.
+
+    Covers rate-limit (HTTP 429), timeouts, connection-reset, and the common
+    upstream 5xx classes. Authentication / bad-request errors are NOT
+    transient and propagate to the caller after one attempt so the user
+    sees a themed connector-categorised message instead of a 30-second
+    silent retry storm.
+    """
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return True
+    cls_name = exc.__class__.__name__
+    if cls_name in _TRANSIENT_LLM_EXCEPTION_NAMES:
+        return True
+    msg = str(exc).lower()
+    return any(token in msg for token in _TRANSIENT_LLM_MESSAGE_TOKENS)
+
+
 class LLMProvider:
     """Thin wrapper around LiteLLM so every agent uses the same calling convention."""
 
@@ -417,33 +468,70 @@ class LLMProvider:
             )
 
         t0 = time.perf_counter()
-        try:
-            resp = _do_completion(call_api_base)
-        except Exception as exc:
-            # If a legacy config still uses an OpenAI-style Ollama base (/v1), retry once.
-            msg = str(exc).lower()
-            if (
-                self.cfg.provider == "ollama"
-                and "404 page not found" in msg
-                and isinstance(call_api_base, str)
-                and call_api_base.rstrip("/").lower().endswith("/v1")
-            ):
-                fallback_base = call_api_base.rstrip("/")[:-3].rstrip("/")
-                log.warning(
-                    "Ollama returned 404 with api_base=%s; retrying once with %s",
-                    call_api_base,
-                    fallback_base,
-                )
-                try:
-                    resp = _do_completion(fallback_base)
-                    self.cfg.api_base = fallback_base
-                    os.environ["OLLAMA_API_BASE"] = fallback_base
-                except Exception as retry_exc:
-                    log.error("LLM call failed: %s", retry_exc)
-                    raise
-            else:
-                log.error("LLM call failed: %s", exc)
+        resp = None
+        last_exc: BaseException | None = None
+        for attempt in range(MAX_LLM_RETRIES + 1):
+            try:
+                resp = _do_completion(call_api_base)
+                last_exc = None
+                break
+            except Exception as exc:
+                last_exc = exc
+
+                # Provider-specific recovery (only on first attempt): legacy
+                # Ollama configs that still point at an OpenAI-style /v1 path
+                # see 404s. Strip /v1 and retry once before falling through to
+                # the generic transient-retry loop.
+                if attempt == 0:
+                    msg = str(exc).lower()
+                    if (
+                        self.cfg.provider == "ollama"
+                        and "404 page not found" in msg
+                        and isinstance(call_api_base, str)
+                        and call_api_base.rstrip("/").lower().endswith("/v1")
+                    ):
+                        fallback_base = call_api_base.rstrip("/")[:-3].rstrip("/")
+                        log.warning(
+                            "Ollama returned 404 with api_base=%s; retrying once with %s",
+                            call_api_base,
+                            fallback_base,
+                        )
+                        try:
+                            resp = _do_completion(fallback_base)
+                            self.cfg.api_base = fallback_base
+                            os.environ["OLLAMA_API_BASE"] = fallback_base
+                            call_api_base = fallback_base
+                            last_exc = None
+                            break
+                        except Exception as fallback_exc:
+                            last_exc = fallback_exc
+
+                # Transient retry — rate-limit, timeout, 5xx, connection reset.
+                if (
+                    attempt < MAX_LLM_RETRIES
+                    and last_exc is not None
+                    and _is_transient_llm_error(last_exc)
+                ):
+                    wait = LLM_RETRY_BACKOFF_BASE_SEC * (2 ** attempt)
+                    log.warning(
+                        "LLM transient failure (attempt %d/%d) — retrying in %.1fs: %s",
+                        attempt + 1,
+                        MAX_LLM_RETRIES + 1,
+                        wait,
+                        last_exc,
+                    )
+                    time.sleep(wait)
+                    continue
+
+                # Non-transient or out of retries → propagate.
+                log.error("LLM call failed: %s", last_exc)
                 raise
+
+        if resp is None:
+            # Defensive — the loop should either have populated resp or raised.
+            raise last_exc if last_exc is not None else RuntimeError(
+                "LLM completion failed without a recorded exception"
+            )
 
         elapsed_sec = max(0.0, time.perf_counter() - t0)
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2232,6 +2232,154 @@ class ConfigTransactionTests(unittest.TestCase):
             self.assertEqual(counter[0], 0)
 
 
+class LLMTransientRetryTests(unittest.TestCase):
+    """Week-3 polish: LLM provider should retry transient failures (429,
+    timeouts, 5xx, connection reset) once or twice with exponential backoff
+    before giving up, while letting non-transient errors propagate
+    immediately."""
+
+    def setUp(self) -> None:
+        from amx.config import LLMConfig
+        from amx.llm.provider import LLMProvider
+
+        self._llm_cfg = LLMConfig(
+            provider="openai",
+            model="gpt-4o-mini",
+            api_key="sk-test",
+            api_base=None,
+            temperature=0.2,
+            max_tokens=256,
+        )
+        self._provider = LLMProvider(self._llm_cfg)
+        # Speed up the backoff so tests stay snappy.
+        self._sleep_patcher = patch("amx.llm.provider.time.sleep", return_value=None)
+        self._sleep_patcher.start()
+
+    def tearDown(self) -> None:
+        self._sleep_patcher.stop()
+
+    def _patch_litellm_with(self, completion_fn) -> object:
+        fake = SimpleNamespace(completion=completion_fn)
+        return patch("amx.llm.provider._litellm", return_value=fake)
+
+    def _ok_response(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="ok"),
+                    finish_reason="stop",
+                    logprobs=None,
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=10, completion_tokens=5, total_tokens=15
+            ),
+        )
+
+    def test_transient_429_retried_then_succeeds(self) -> None:
+        """A RateLimitError on the first call should be retried; the second
+        call returns a valid response and the chat() call succeeds."""
+
+        class RateLimitError(Exception):
+            pass
+
+        attempts: list[int] = []
+
+        def fake_completion(**_: object) -> object:
+            attempts.append(len(attempts) + 1)
+            if len(attempts) == 1:
+                raise RateLimitError("Rate limit reached for requests")
+            return self._ok_response()
+
+        with self._patch_litellm_with(fake_completion):
+            result = self._provider.chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(len(attempts), 2)
+        self.assertEqual(result.content, "ok")
+
+    def test_transient_timeout_retried_max_two_times_then_raises(self) -> None:
+        """If transient failures persist past MAX_LLM_RETRIES, the final
+        exception propagates so callers can surface it to the user."""
+
+        class APITimeoutError(Exception):
+            pass
+
+        calls = {"count": 0}
+
+        def fake_completion(**_: object) -> object:
+            calls["count"] += 1
+            raise APITimeoutError("Request timed out")
+
+        with self._patch_litellm_with(fake_completion):
+            with self.assertRaises(APITimeoutError):
+                self._provider.chat([{"role": "user", "content": "hi"}])
+
+        # MAX_LLM_RETRIES=2 → 3 total attempts (initial + 2 retries).
+        self.assertEqual(calls["count"], 3)
+
+    def test_non_transient_error_does_not_retry(self) -> None:
+        """Authentication / bad-request style errors must propagate
+        immediately so the user sees the categorised error fast — retrying
+        a 401 would just delay an actionable message."""
+
+        class AuthenticationError(Exception):
+            pass
+
+        calls = {"count": 0}
+
+        def fake_completion(**_: object) -> object:
+            calls["count"] += 1
+            raise AuthenticationError("Incorrect API key")
+
+        with self._patch_litellm_with(fake_completion):
+            with self.assertRaises(AuthenticationError):
+                self._provider.chat([{"role": "user", "content": "hi"}])
+
+        # No retry — should be exactly one attempt.
+        self.assertEqual(calls["count"], 1)
+
+    def test_message_token_pattern_classifies_transient(self) -> None:
+        """Even when the exception class is generic (RuntimeError), the
+        retry layer should fall back to substring matching on common
+        transient phrases."""
+
+        attempts: list[int] = []
+
+        def fake_completion(**_: object) -> object:
+            attempts.append(len(attempts) + 1)
+            if len(attempts) == 1:
+                raise RuntimeError("503 Service Unavailable: upstream busy")
+            return self._ok_response()
+
+        with self._patch_litellm_with(fake_completion):
+            result = self._provider.chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(len(attempts), 2)
+        self.assertEqual(result.content, "ok")
+
+    def test_is_transient_llm_error_classifications(self) -> None:
+        from amx.llm.provider import _is_transient_llm_error
+
+        # Class-name based.
+        class RateLimitError(Exception):
+            pass
+
+        class APIConnectionError(Exception):
+            pass
+
+        self.assertTrue(_is_transient_llm_error(RateLimitError("...")))
+        self.assertTrue(_is_transient_llm_error(APIConnectionError("...")))
+        # Built-in stdlib transients.
+        self.assertTrue(_is_transient_llm_error(TimeoutError()))
+        self.assertTrue(_is_transient_llm_error(ConnectionError()))
+        # Substring-based.
+        self.assertTrue(_is_transient_llm_error(RuntimeError("Read timed out")))
+        self.assertTrue(_is_transient_llm_error(RuntimeError("502 Bad Gateway")))
+        # Non-transients.
+        self.assertFalse(_is_transient_llm_error(ValueError("bad input")))
+        self.assertFalse(_is_transient_llm_error(RuntimeError("invalid api key")))
+
+
 class EmbeddingsSlashCommandTests(unittest.TestCase):
     """The /embeddings slash command lets users switch provider without
     hand-editing ~/.amx/config.yml. Each branch reinstalls the runtime


### PR DESCRIPTION
Until now only Ollama had retry logic (/v1 path-strip on 404). Every
other provider's transient failure — OpenAI rate limits, Anthropic
overload, Gemini 503, network blip mid-stream — surfaced as a single
opaque error to the user. This commit adds a generic transient-retry
loop that wraps the existing _do_completion call.

What changed:
- amx/llm/provider.py:
  - MAX_LLM_RETRIES (=2) and LLM_RETRY_BACKOFF_BASE_SEC (=1.0)
    constants. Total attempts: 3 (initial + 2 retries) with 1s, 2s
    backoff between them.
  - _is_transient_llm_error(exc): classifies by exception class name
    (RateLimitError, APITimeoutError, APIConnectionError, etc., plus
    stdlib TimeoutError / ConnectionError) and substring-match on the
    message ("rate limit", "429", "timed out", "503 service", etc.).
    Authentication / bad-request errors are deliberately NOT
    classified as transient — they propagate immediately so the
    user sees the categorised error fast.
  - chat() retry loop: attempts the call up to MAX_LLM_RETRIES + 1
    times. Existing Ollama /v1 → strip-path special case is
    preserved as a first-attempt-only fallback. Generic transients
    log a one-line "(attempt N/M) — retrying in Xs" warning, then
    sleep with exponential backoff.
- tests/test_regressions.py: 5 new LLMTransientRetryTests cover
  429-retried-then-succeeds, persistent timeout exhausts retries
  (3 attempts), auth errors don't retry, substring-pattern matching
  for generic RuntimeError, and the _is_transient_llm_error truth
  table.

Tests use time.sleep patched to no-op so the suite stays snappy.

All 178 tests pass (173 + 5 new).
