### PR TITLE
feat(cli): make /embeddings discoverable under /search and rework picker UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). From the next release onward, version numbers and entries below `[Unreleased]` are derived from [Conventional Commits](https://www.conventionalcommits.org/) by [`python-semantic-release`](https://python-semantic-release.readthedocs.io/) — manual edits to released sections are no longer expected.
 
 ## [Unreleased]
+### Changed
+- **`/embeddings` now lives under `/search` namespace** so users discover it inside the related tab — matching the pattern used by `/llm-profiles` (only valid inside `/llm`). The command also appears in the `/search` namespace help text.
+- **Improved `/embeddings` picker UX**: the previous "keep" option (which looked ambiguous) is replaced with the current provider's labelled choice (e.g. `MiniLM (--default, current)` or `OpenAI-compatible (current)`); pressing Enter on the default is a no-op. Adds an explicit `Cancel` option for clarity.
+- **Verbose provider labels** in the picker (`MiniLM`, `OpenAI-compatible`, `Local sentence-transformers`) replacing the terse `minilm`/`openai`/`local` aliases. The aliases still work as command arguments.
+- **`/embeddings openai` prompt now lists endpoint examples** for OpenAI, OpenRouter, Together, Mistral, DeepInfra, Azure OpenAI, and local servers (vLLM / LM Studio / llama.cpp). The OpenAI-compatible mode already covers all of these — they only differ in `base_url` and the API key.
+- **`/embeddings local` prompt now lists recommended HuggingFace models** (`BAAI/bge-large-en-v1.5`, `BAAI/bge-m3`, `intfloat/e5-large-v2`, `intfloat/multilingual-e5-large`) so users do not have to hunt for a starting point.
+- **3 new picker tests** covering: default-Enter is a no-op, `Cancel` does not mutate, and the verbose `MiniLM` label routes to the same branch as `/embeddings minilm`.
+
 ### Added
 - **LLM transient-retry** (`amx/llm/provider.py`): rate-limit (HTTP 429), timeouts, connection-reset, and 5xx upstream errors are now retried up to twice with exponential backoff (1s, 2s) before propagating. Authentication / bad-request errors still propagate immediately so the categorised `ErrorMapper` hint reaches the user fast. The existing Ollama legacy `/v1` 404 fallback is preserved as a first-attempt special case.
 - **`_is_transient_llm_error()` helper**: classifies LLM exceptions by class name (`RateLimitError`, `APITimeoutError`, `APIConnectionError`, `InternalServerError`, `ServiceUnavailableError`, plus stdlib `TimeoutError` / `ConnectionError`) and by substring matching of common transient phrases (`429`, `rate limit`, `timed out`, `connection reset`, `503 service`, `502 bad gateway`, etc.). Available for unit testing and re-use.

--- a/amx/cli_support/commands/embeddings.py
+++ b/amx/cli_support/commands/embeddings.py
@@ -33,18 +33,59 @@ from amx.utils.console import (
 )
 
 
+_LABEL_MINILM = "MiniLM"
+_LABEL_OPENAI = "OpenAI-compatible"
+_LABEL_LOCAL = "Local sentence-transformers"
+_LABEL_CANCEL = "Cancel"
+
+# Common OpenAI-compatible providers shown to the user as examples when they
+# pick "OpenAI-compatible". The OpenAI-compatible kind already covers all of
+# these — they only differ in base_url and the API-key value, which is why
+# we surface the URLs here rather than adding bespoke kinds for each.
+_OPENAI_COMPATIBLE_EXAMPLES: list[tuple[str, str]] = [
+    ("OpenAI",       "https://api.openai.com/v1"),
+    ("OpenRouter",   "https://openrouter.ai/api/v1"),
+    ("Together",     "https://api.together.xyz/v1"),
+    ("Mistral",      "https://api.mistral.ai/v1"),
+    ("DeepInfra",    "https://api.deepinfra.com/v1/openai"),
+    ("Azure OpenAI", "https://<resource>.openai.azure.com/openai/deployments/<deployment>"),
+    ("vLLM / LM Studio / llama.cpp (local)", "http://localhost:8000/v1"),
+]
+
+
+def _current_label(cfg: AMXConfig) -> str:
+    emb = cfg.embedding
+    if emb.kind in {"minilm", "default", "minilm-l6-v2", ""}:
+        return f"{_LABEL_MINILM} — default (current)"
+    if emb.kind == "openai_compatible":
+        model = emb.model or "no model set"
+        return f"{_LABEL_OPENAI} — {model} (current)"
+    if emb.kind == "sentence_transformers":
+        model = emb.model or "no model set"
+        return f"{_LABEL_LOCAL} — {model} (current)"
+    return f"{emb.kind} (current)"
+
+
 def _print_current(cfg: AMXConfig) -> None:
     heading("Current search-index embedding provider")
     emb = cfg.embedding
-    info(f"Kind:    {emb.kind}")
-    info(f"Model:   {emb.model or '(none — using provider default)'}")
-    if emb.kind == "openai_compatible":
-        info(f"Base URL: {emb.base_url or DEFAULT_OPENAI_BASE_URL}")
-        info(f"API key:  {'(set, stored in OS keyring)' if emb.api_key else '(unset)'}")
-    if emb.kind == "sentence_transformers":
-        info("Loads via the `local-embeddings` extra (sentence-transformers).")
     if emb.kind in {"minilm", "default", "minilm-l6-v2", ""}:
-        info("MiniLM is Chroma's bundled default — no setup required.")
+        info("MiniLM (--default) — Chroma's bundled all-MiniLM-L6-v2; offline, fastest, lowest quality.")
+        info("No setup required; this is what every fresh install starts with.")
+        return
+    if emb.kind == "openai_compatible":
+        info("OpenAI-compatible /embeddings endpoint.")
+        info(f"  Model:   {emb.model or '(unset — required)'}")
+        info(f"  Base URL: {emb.base_url or DEFAULT_OPENAI_BASE_URL}")
+        info(f"  API key:  {'(set, stored in OS keyring)' if emb.api_key else '(unset — required)'}")
+        return
+    if emb.kind == "sentence_transformers":
+        info("Local sentence-transformers (offline, stronger than MiniLM).")
+        info(f"  Model: {emb.model or '(unset — required)'}")
+        info("Requires `pip install \"amx[local-embeddings]\"`.")
+        return
+    info(f"Kind: {emb.kind}")
+    info(f"Model: {emb.model or '(unset)'}")
 
 
 def _set_minilm(cfg: AMXConfig) -> None:
@@ -55,11 +96,20 @@ def _set_minilm(cfg: AMXConfig) -> None:
 
 
 def _set_openai_compatible(cfg: AMXConfig, rest: list[str]) -> None:
+    info(
+        "OpenAI-compatible mode covers many providers — they all expose the "
+        "same /embeddings shape, only the base URL and API key differ."
+    )
+    info("Examples:")
+    for label, url in _OPENAI_COMPATIBLE_EXAMPLES:
+        info(f"  • {label}: {url}")
+
     model = rest[0] if rest else ask(
-        "Embedding model (e.g. text-embedding-3-small, text-embedding-3-large)"
+        "Embedding model id (e.g. text-embedding-3-small for OpenAI, "
+        "openai/text-embedding-3-small for OpenRouter)"
     )
     if not model:
-        error("A model id is required for openai_compatible embeddings.")
+        error("A model id is required for OpenAI-compatible embeddings.")
         return
     base_url = ask(
         "Base URL (Enter for the default OpenAI endpoint)",
@@ -74,62 +124,108 @@ def _set_openai_compatible(cfg: AMXConfig, rest: list[str]) -> None:
         base_url=base_url,
     )
     configure_from_amx_config(cfg, on_warning=warn)
-    success(f"Embeddings switched to openai_compatible / {model}.")
+    success(f"Embeddings switched to OpenAI-compatible / {model}.")
     info(
         f"Endpoint: {base_url}. The API key is stored in the OS keyring under "
         "amx:embedding/api_key."
     )
-    info("Run /search rebuild to re-embed the catalog with the new provider.")
+    info("Run /rebuild (inside /search) to re-embed the catalog with the new provider.")
 
 
 def _set_sentence_transformers(cfg: AMXConfig, rest: list[str]) -> None:
+    info("Recommended HuggingFace embedding models (offline, stronger than MiniLM):")
+    info("  • BAAI/bge-large-en-v1.5         English, 1024-dim, top-tier on MTEB")
+    info("  • BAAI/bge-m3                    Multilingual, dense + sparse + ColBERT")
+    info("  • intfloat/e5-large-v2           English, 1024-dim, fast")
+    info("  • intfloat/multilingual-e5-large Multilingual, 1024-dim")
+
     model = rest[0] if rest else ask(
-        "HuggingFace model id (e.g. BAAI/bge-large-en-v1.5, intfloat/e5-large-v2)"
+        "HuggingFace model id (e.g. BAAI/bge-large-en-v1.5)"
     )
     if not model:
-        error("A model id is required for sentence_transformers embeddings.")
+        error("A model id is required for local sentence-transformers embeddings.")
         return
     cfg.embedding = EmbeddingConfig(kind="sentence_transformers", model=model)
     configure_from_amx_config(cfg, on_warning=warn)
-    success(f"Embeddings switched to sentence_transformers / {model}.")
+    success(f"Embeddings switched to local sentence-transformers / {model}.")
     info(
         "Requires `pip install \"amx[local-embeddings]\"` if you have not "
         "already done so. The model will be downloaded on first /search use."
     )
-    info("Run /search rebuild to re-embed the catalog with the new provider.")
+    info("Run /rebuild (inside /search) to re-embed the catalog with the new provider.")
 
 
 def cmd_embeddings(cfg: AMXConfig, rest: list[str]) -> None:
     """Show or change the search-index embedding provider.
 
-    Usage::
+    Usage (inside /search namespace)::
 
-        /embeddings                        # show current provider
-        /embeddings minilm                 # switch to MiniLM (default)
-        /embeddings openai [model]         # switch to OpenAI-compatible
-        /embeddings local [model]          # switch to sentence-transformers
+        /embeddings                        # show current provider + interactive picker
+        /embeddings minilm                 # switch to MiniLM (Chroma default)
+        /embeddings openai [model]         # switch to any OpenAI-compatible /embeddings endpoint
+        /embeddings local [model]          # switch to local sentence-transformers
 
-    With no arguments, an interactive picker is shown. With a kind
-    argument and missing details, the user is prompted for the
-    remaining fields.
+    The OpenAI-compatible path covers OpenAI, OpenRouter, Together,
+    Mistral, Azure OpenAI, vLLM, LM Studio, llama.cpp server, and any
+    other provider that exposes the OpenAI ``/embeddings`` shape — the
+    user just plugs in the matching ``base_url`` and ``api_key``.
     """
     if not rest:
         _print_current(cfg)
         info("")
+
+        # Build the picker so the current provider is the default option,
+        # labelled "(current)", and the cancel option is explicit instead of
+        # the previous ambiguous "keep".
+        emb_kind = (cfg.embedding.kind or "minilm").lower()
+        if emb_kind in {"minilm", "default", "minilm-l6-v2", ""}:
+            current_label = f"{_LABEL_MINILM} (--default, current)"
+        elif emb_kind == "openai_compatible":
+            current_label = f"{_LABEL_OPENAI} (current)"
+        elif emb_kind == "sentence_transformers":
+            current_label = f"{_LABEL_LOCAL} (current)"
+        else:
+            current_label = f"{cfg.embedding.kind} (current)"
+
+        # Show the current option only if it is one of the standard kinds;
+        # otherwise the user is on something custom and we still let them
+        # cancel without a no-op "switch to current" entry.
+        choices = [current_label, _LABEL_MINILM, _LABEL_OPENAI, _LABEL_LOCAL, _LABEL_CANCEL]
+        # De-duplicate: if current is already MiniLM, drop the second MiniLM row.
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for item in choices:
+            base = item.split(" (")[0]
+            if base in seen and "current" not in item:
+                continue
+            seen.add(base)
+            deduped.append(item)
+        choices = deduped
+
+        descriptions = {
+            current_label: "leave the current provider unchanged",
+            _LABEL_MINILM: "Chroma's bundled all-MiniLM-L6-v2 (offline, fastest, lowest quality)",
+            _LABEL_OPENAI: "OpenAI / OpenRouter / Together / Mistral / Azure / vLLM / LM Studio / …",
+            _LABEL_LOCAL: "any HuggingFace sentence-transformers model (offline, stronger)",
+            _LABEL_CANCEL: "exit without changing the provider",
+        }
         choice = ask_choice(
             "Switch provider?",
-            choices=["keep", "minilm", "openai", "local"],
-            default="keep",
-            descriptions={
-                "keep": "leave the current provider unchanged",
-                "minilm": "Chroma default (offline, fastest, lowest quality)",
-                "openai": "OpenAI-compatible /embeddings endpoint",
-                "local": "sentence-transformers (offline, stronger than MiniLM)",
-            },
+            choices=choices,
+            default=current_label,
+            descriptions=descriptions,
         )
-        if choice in {"", "keep"}:
+        # Map the verbose label back to a kind alias.
+        if not choice or choice in {current_label, _LABEL_CANCEL}:
             return
-        rest = [choice]
+        if choice == _LABEL_MINILM:
+            rest = ["minilm"]
+        elif choice == _LABEL_OPENAI:
+            rest = ["openai"]
+        elif choice == _LABEL_LOCAL:
+            rest = ["local"]
+        else:
+            return
 
     head = (rest[0] or "").lower().strip()
     if head in {"minilm", "default"}:

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -332,6 +332,9 @@ Commands:
   6) /config [key] [value]                     Show or update search settings
   7) /sync [--schema …] [--table …]            Sync DB structure/comments + cached code evidence
   8) /rebuild                                  Rebuild effective search state and vector index
+  9) /embeddings [kind] [model]                Show or change the search-index embedding provider
+                                               (MiniLM default, OpenAI-compatible, or local sentence-transformers).
+                                               Run /rebuild after switching to re-embed the catalog.
 """
         )
         return
@@ -700,8 +703,12 @@ def _handle_session_builtin(
         success(f"Saved configuration to {path}")
         return True
     if head == "embeddings":
-        # Available from any namespace — embedding provider config is a quick
-        # one-shot mutation that doesn't require entering /search first.
+        # Lives under /search since switching the embedding provider only
+        # affects the search index. The user must enter /search first; this
+        # matches the pattern used by /llm-profiles (only valid inside /llm)
+        # and keeps the namespace boundaries consistent.
+        if not _require_namespace(head, namespace, "search", "embeddings"):
+            return True
         _cmd_embeddings(cfg, parts[1:])
         return True
     if head == "schema":

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2460,6 +2460,59 @@ class EmbeddingsSlashCommandTests(unittest.TestCase):
 
         self.assertEqual(cfg.embedding.kind, original_kind)
 
+    def test_picker_default_is_current_provider_label(self) -> None:
+        """The interactive picker (no args) must default to the current
+        provider's labelled choice rather than a separate ambiguous "keep"
+        option, and selecting that default must be a no-op."""
+        from amx.cli_support.commands.embeddings import cmd_embeddings
+
+        cfg = AMXConfig()
+        original_kind = cfg.embedding.kind  # "minilm" out of the box
+        # Simulate the user pressing Enter (returns the default).
+        with patch(
+            "amx.cli_support.commands.embeddings.ask_choice",
+            side_effect=lambda *_args, **kwargs: kwargs.get("default", ""),
+        ):
+            cmd_embeddings(cfg, [])
+        self.assertEqual(cfg.embedding.kind, original_kind)
+
+    def test_picker_explicit_cancel_does_not_mutate(self) -> None:
+        from amx.cli_support.commands.embeddings import cmd_embeddings, _LABEL_CANCEL
+
+        cfg = AMXConfig()
+        original_kind = cfg.embedding.kind
+        with patch(
+            "amx.cli_support.commands.embeddings.ask_choice",
+            return_value=_LABEL_CANCEL,
+        ):
+            cmd_embeddings(cfg, [])
+        self.assertEqual(cfg.embedding.kind, original_kind)
+
+    def test_picker_minilm_choice_routes_to_minilm_branch(self) -> None:
+        """Selecting the verbose 'MiniLM' label from the picker must route
+        through the same code path as `/embeddings minilm`."""
+        from amx.cli_support.commands.embeddings import cmd_embeddings, _LABEL_MINILM, _LABEL_OPENAI
+        from amx.config import EmbeddingConfig
+
+        cfg = AMXConfig()
+        cfg.embedding = EmbeddingConfig(
+            kind="openai_compatible",
+            model="text-embedding-3-small",
+            api_key="sk-old",
+            base_url="https://api.openai.com/v1",
+        )
+
+        # User picks the MiniLM option from the verbose-label picker.
+        with patch(
+            "amx.cli_support.commands.embeddings.ask_choice",
+            return_value=_LABEL_MINILM,
+        ):
+            cmd_embeddings(cfg, [])
+
+        self.assertEqual(cfg.embedding.kind, "minilm")
+        self.assertEqual(cfg.embedding.model, "")
+        self.assertEqual(cfg.embedding.api_key, "")
+
 
 class EmbeddingDefaultFactoryTests(unittest.TestCase):
     """The singleton in amx.search.embeddings lets the CLI install the


### PR DESCRIPTION
User feedback on the previous /embeddings command:

  1. "I didn't see this under any tabs. Put things like that under a
     related tab for user can see."
  2. "There only 4 options but what if user wants to add another
     embedding models like from openrouter, anthropic etc."
  3. "<keep> option doesn't seem very smart. You can put it like
     'MiniLM' and write --default along with it."

What changed:

(1) Discoverability: /embeddings now requires /search namespace (same
    pattern as /llm-profiles requiring /llm). It also appears in the
    /search namespace help text so users see it when they type /search.

(2) Provider extensibility: the OpenAI-compatible mode already covers
    OpenAI, OpenRouter, Together, Mistral, Azure, vLLM, LM Studio,
    llama.cpp, etc. — they all expose the same /embeddings shape and
    only differ in base_url. The "openai" branch now surfaces those
    endpoints as examples on entry, so users immediately see how to
    plug in OpenRouter etc. (Voyage / Cohere have their own SDKs and
    would need a dedicated adapter — left as future work.)

(3) Picker UX: replaced the ambiguous "keep" option with the current
    provider's labelled choice ("MiniLM (--default, current)",
    "OpenAI-compatible (current)", etc.). Added an explicit "Cancel"
    option for clarity. Verbose labels for the choices match what the
    user types into the help: "MiniLM", "OpenAI-compatible", "Local
    sentence-transformers".

Also: /embeddings local now lists recommended HuggingFace models
(BAAI/bge-large-en-v1.5, bge-m3, e5-large-v2, multilingual-e5-large)
so users have a starting point.

Tests: 3 new picker tests (default-Enter no-op, explicit Cancel no-op,
verbose MiniLM label routes correctly). All 181 tests pass.
