### PR TITLE
feat(search): per-profile Chroma collections eliminate cross-profile pollution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 ### Changed
+- **Per-profile Chroma collections** (`amx/search/index.py`): each DB profile is now mapped to its own Chroma collection (`amx_search_<sha256-prefix>`) instead of sharing a single `amx_search` collection filtered by a `db_profile` metadata field. Cross-profile pollution is now physically impossible regardless of caller discipline. The empty profile name still maps to the legacy `amx_search` collection so callers and tests that have not adopted the per-profile API keep working. The `query()` method no longer needs a `where` clause since the collection is already profile-scoped.
+  - **Migration:** existing users should run `/rebuild` (inside `/search`) to populate the new per-profile collections — old data sitting in the shared `amx_search` collection is no longer queried for non-empty profiles.
+- **`_collection_name_for(db_profile)`** helper: hashes profile names so they always land within Chroma's allowed character set (alnum, dot, dash, underscore; 3–63 chars) regardless of what the user typed (spaces, unicode, slashes).
+- **6 new `PerProfileCollectionTests`** covering: empty-profile maps to the legacy name, deterministic and Chroma-valid hashing, two profiles get distinct names, unicode/special-char profile names hash safely, `upsert_entities` routes rows to the right collection per `db_profile`, and `query()` no longer passes a `where` clause.
+
 - **`/embeddings` now lives under `/search` namespace** so users discover it inside the related tab — matching the pattern used by `/llm-profiles` (only valid inside `/llm`). The command also appears in the `/search` namespace help text.
 - **Improved `/embeddings` picker UX**: the previous "keep" option (which looked ambiguous) is replaced with the current provider's labelled choice (e.g. `MiniLM (--default, current)` or `OpenAI-compatible (current)`); pressing Enter on the default is a no-op. Adds an explicit `Cancel` option for clarity.
 - **Verbose provider labels** in the picker (`MiniLM`, `OpenAI-compatible`, `Local sentence-transformers`) replacing the terse `minilm`/`openai`/`local` aliases. The aliases still work as command arguments.

--- a/amx/search/index.py
+++ b/amx/search/index.py
@@ -1,7 +1,18 @@
-"""Vector index for AMX search catalog entities."""
+"""Vector index for AMX search catalog entities.
+
+Each DB profile is mapped to its own Chroma collection
+(``amx_search_<sha256-prefix>``) so vectors from one profile cannot
+leak into another. The previous design used a single ``amx_search``
+collection filtered by a ``db_profile`` metadata field on every query;
+forgetting the filter anywhere in the codebase risked cross-profile
+pollution. The empty profile name still maps to the legacy
+``amx_search`` collection for back-compat with tests and callers that
+have not adopted the per-profile API yet.
+"""
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -9,13 +20,33 @@ import chromadb
 from chromadb.api.types import EmbeddingFunction
 
 
+_LEGACY_COLLECTION_NAME = "amx_search"
+
+
+def _collection_name_for(db_profile: str) -> str:
+    """Stable, Chroma-valid collection name for *db_profile*.
+
+    Profile names can contain anything (spaces, slashes, unicode),
+    so we hash to keep within Chroma's allowed character set
+    (``[a-zA-Z0-9._-]``, 3–63 chars). Empty profile maps to the
+    legacy ``amx_search`` collection so older data is still readable
+    without forcing an immediate rebuild.
+    """
+    if not db_profile:
+        return _LEGACY_COLLECTION_NAME
+    digest = hashlib.sha256(db_profile.encode("utf-8")).hexdigest()[:16]
+    return f"amx_search_{digest}"
+
+
 class SearchIndex:
-    """Thin wrapper around a Chroma collection for effective catalog rows.
+    """Thin wrapper around per-profile Chroma collections.
 
     The ``embedding_function`` argument lets callers swap in a different
     embedding provider (see :mod:`amx.search.embeddings`); ``None``
-    keeps Chroma's bundled default (``all-MiniLM-L6-v2``, 384-dim) for
-    backwards compatibility.
+    falls back to the process-wide default factory installed by the CLI
+    at startup, and finally to Chroma's bundled MiniLM if no factory is
+    registered (preserving the original behaviour for tests and direct
+    constructors).
     """
 
     def __init__(
@@ -33,57 +64,106 @@ class SearchIndex:
             from amx.search.embeddings import get_default_embedding_function
 
             embedding_function = get_default_embedding_function()
-        kwargs: dict[str, Any] = {
-            "name": "amx_search",
-            "metadata": {"hnsw:space": "cosine"},
-        }
-        if embedding_function is not None:
-            kwargs["embedding_function"] = embedding_function
-        self.collection = self.client.get_or_create_collection(**kwargs)
         self.embedding_function = embedding_function
+        self._collections: dict[str, Any] = {}
+        # Eagerly construct the legacy collection (empty profile key) so the
+        # historical ``self.collection`` attribute keeps working for callers
+        # and tests that have not adopted the per-profile API.
+        self.collection = self._collection_for("")
+
+    def _collection_for(self, db_profile: str) -> Any:
+        """Get or create the Chroma collection for *db_profile*.
+
+        Cached after first access so we do not pay Chroma's
+        ``get_or_create_collection`` cost on every upsert / query.
+        """
+        cache_key = db_profile or ""
+        cached = self._collections.get(cache_key)
+        if cached is not None:
+            return cached
+        name = _collection_name_for(db_profile)
+        kwargs: dict[str, Any] = {
+            "name": name,
+            "metadata": {"hnsw:space": "cosine", "amx_db_profile": db_profile},
+        }
+        if self.embedding_function is not None:
+            kwargs["embedding_function"] = self.embedding_function
+        col = self.client.get_or_create_collection(**kwargs)
+        self._collections[cache_key] = col
+        return col
 
     def upsert_entities(self, entities: list[dict[str, Any]]) -> int:
-        docs: list[str] = []
-        ids: list[str] = []
-        metas: list[dict[str, Any]] = []
+        # Group rows by their db_profile so each collection only ever sees
+        # its own data; cross-profile leaks are physically impossible.
+        by_profile: dict[str, list[dict[str, Any]]] = {}
         for entity in entities:
-            doc = str(entity.get("search_text") or "").strip()
-            entity_id = entity.get("id")
-            if not doc or entity_id is None:
-                continue
-            ids.append(f"entity:{int(entity_id)}")
-            docs.append(doc)
-            metas.append(
-                {
-                    "entity_id": int(entity_id),
-                    "db_profile": str(entity.get("db_profile") or ""),
-                    "schema_name": str(entity.get("schema_name") or ""),
-                    "table_name": str(entity.get("table_name") or ""),
-                    "column_name": str(entity.get("column_name") or ""),
-                    "entity_kind": str(entity.get("entity_kind") or ""),
-                    "effective_source_kind": str(entity.get("effective_source_kind") or ""),
-                }
-            )
-        if ids:
-            self.collection.upsert(ids=ids, documents=docs, metadatas=metas)
-        return len(ids)
+            profile = str(entity.get("db_profile") or "")
+            by_profile.setdefault(profile, []).append(entity)
+
+        total = 0
+        for profile, rows in by_profile.items():
+            docs: list[str] = []
+            ids: list[str] = []
+            metas: list[dict[str, Any]] = []
+            for entity in rows:
+                doc = str(entity.get("search_text") or "").strip()
+                entity_id = entity.get("id")
+                if not doc or entity_id is None:
+                    continue
+                ids.append(f"entity:{int(entity_id)}")
+                docs.append(doc)
+                metas.append(
+                    {
+                        "entity_id": int(entity_id),
+                        "db_profile": str(entity.get("db_profile") or ""),
+                        "schema_name": str(entity.get("schema_name") or ""),
+                        "table_name": str(entity.get("table_name") or ""),
+                        "column_name": str(entity.get("column_name") or ""),
+                        "entity_kind": str(entity.get("entity_kind") or ""),
+                        "effective_source_kind": str(entity.get("effective_source_kind") or ""),
+                    }
+                )
+            if ids:
+                self._collection_for(profile).upsert(ids=ids, documents=docs, metadatas=metas)
+                total += len(ids)
+        return total
 
     def delete_entity_ids(self, entity_ids: list[int]) -> None:
+        """Delete by entity id without knowing the originating db_profile.
+
+        Without the profile we cannot single out the right collection, so
+        we attempt the delete on every collection we have opened in this
+        process. The operation is idempotent on Chroma's side, so
+        deleting an id that does not exist in a given collection is a
+        no-op.
+        """
         ids = [f"entity:{int(entity_id)}" for entity_id in entity_ids if entity_id is not None]
-        if ids:
-            self.collection.delete(ids=ids)
+        if not ids:
+            return
+        for col in list(self._collections.values()):
+            try:
+                col.delete(ids=ids)
+            except Exception:
+                # One collection's failure must not block the others —
+                # callers expect a best-effort delete, and the row is
+                # almost certainly only in one collection anyway.
+                continue
 
     def reset_profile(self, db_profile: str) -> None:
-        rows = self.collection.get(where={"db_profile": db_profile}, include=[])
+        col = self._collection_for(db_profile)
+        rows = col.get(include=[])
         ids = rows.get("ids") or []
         if ids:
-            self.collection.delete(ids=ids)
+            col.delete(ids=ids)
 
     def query(self, question: str, *, db_profile: str, n_results: int = 8) -> list[dict[str, Any]]:
-        res = self.collection.query(
+        col = self._collection_for(db_profile)
+        res = col.query(
             query_texts=[question],
             n_results=max(1, int(n_results)),
-            where={"db_profile": db_profile},
+            # No ``where`` clause needed — the collection is profile-scoped,
+            # so cross-profile pollution is impossible regardless of caller
+            # discipline.
         )
         docs = (res.get("documents") or [[]])[0]
         metas = (res.get("metadatas") or [[]])[0]

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2092,6 +2092,147 @@ class EmbeddingProviderTests(unittest.TestCase):
         self.assertIn("local-embeddings", str(ctx.exception))
 
 
+class PerProfileCollectionTests(unittest.TestCase):
+    """The Week-3 SearchIndex now uses one Chroma collection per db_profile
+    so cross-profile pollution is impossible — these tests pin the naming
+    and isolation guarantees."""
+
+    def test_collection_name_for_empty_profile_is_legacy(self) -> None:
+        from amx.search.index import _collection_name_for
+
+        self.assertEqual(_collection_name_for(""), "amx_search")
+
+    def test_collection_name_is_deterministic_and_chroma_valid(self) -> None:
+        """Same profile in → same collection name out, and the name only
+        contains characters Chroma accepts (alnum, dot, dash, underscore)."""
+        import re
+
+        from amx.search.index import _collection_name_for
+
+        a = _collection_name_for("prod")
+        b = _collection_name_for("prod")
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, "amx_search")  # different from the legacy name
+        self.assertTrue(re.match(r"^[a-zA-Z0-9._-]{3,63}$", a))
+
+    def test_two_profiles_get_distinct_collection_names(self) -> None:
+        from amx.search.index import _collection_name_for
+
+        self.assertNotEqual(
+            _collection_name_for("prod"), _collection_name_for("dev")
+        )
+
+    def test_profile_name_with_unicode_and_spaces_hashes_safely(self) -> None:
+        """Profile names can contain anything users type; the name fed to
+        Chroma must still be a valid identifier."""
+        import re
+
+        from amx.search.index import _collection_name_for
+
+        name = _collection_name_for("müşteri / prod tablosu 🚀")
+        self.assertTrue(re.match(r"^[a-zA-Z0-9._-]{3,63}$", name))
+
+    def test_search_index_routes_upsert_per_profile(self) -> None:
+        """Two profiles' rows must land in two different collections, even
+        within a single ``upsert_entities`` call."""
+        from amx.search import index as index_module
+
+        captured: dict[str, list[dict]] = {}
+
+        class FakeCollection:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+            def upsert(self, *, ids, documents, metadatas):
+                captured.setdefault(self.name, []).extend(metadatas)
+
+            def delete(self, *_, **__):
+                pass
+
+            def get(self, *_, **__):
+                return {"ids": []}
+
+            def query(self, *_, **__):
+                return {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+        class FakeClient:
+            def __init__(self, *, path: str) -> None:  # noqa: ARG002
+                self._collections: dict[str, FakeCollection] = {}
+
+            def get_or_create_collection(self, *, name, **_):
+                col = self._collections.get(name) or FakeCollection(name)
+                self._collections[name] = col
+                return col
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch.object(index_module.chromadb, "PersistentClient", FakeClient):
+                idx = index_module.SearchIndex(persist_dir=td)
+                idx.upsert_entities(
+                    [
+                        {"id": 1, "search_text": "row in prod",
+                         "db_profile": "prod", "schema_name": "s",
+                         "table_name": "t", "column_name": "c",
+                         "entity_kind": "column"},
+                        {"id": 2, "search_text": "row in dev",
+                         "db_profile": "dev", "schema_name": "s",
+                         "table_name": "t", "column_name": "c",
+                         "entity_kind": "column"},
+                    ]
+                )
+
+        prod_name = index_module._collection_name_for("prod")
+        dev_name = index_module._collection_name_for("dev")
+        self.assertIn(prod_name, captured)
+        self.assertIn(dev_name, captured)
+        self.assertEqual(len(captured[prod_name]), 1)
+        self.assertEqual(len(captured[dev_name]), 1)
+        self.assertEqual(captured[prod_name][0]["db_profile"], "prod")
+        self.assertEqual(captured[dev_name][0]["db_profile"], "dev")
+
+    def test_query_does_not_filter_on_db_profile_metadata(self) -> None:
+        """Now that each profile has its own collection, the query layer
+        must NOT pass a ``where`` clause — that was the previous
+        cross-pollution-prone design."""
+        from amx.search import index as index_module
+
+        captured: dict[str, object] = {"explicit_kwargs": {}}
+
+        class FakeCollection:
+            def query(self, *, query_texts, n_results, **kwargs):
+                # We capture the *explicit* kwargs so we can assert that
+                # `where` was not passed. Chroma's API does not require
+                # it to be present at all when each collection is
+                # already profile-scoped.
+                captured["explicit_kwargs"] = dict(kwargs)
+                captured["n_results"] = n_results
+                captured["query_texts"] = query_texts
+                return {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+            def upsert(self, *_, **__):
+                pass
+
+            def delete(self, *_, **__):
+                pass
+
+            def get(self, *_, **__):
+                return {"ids": []}
+
+        class FakeClient:
+            def __init__(self, *, path: str) -> None:  # noqa: ARG002
+                pass
+
+            def get_or_create_collection(self, **_):
+                return FakeCollection()
+
+        with tempfile.TemporaryDirectory() as td:
+            with patch.object(index_module.chromadb, "PersistentClient", FakeClient):
+                idx = index_module.SearchIndex(persist_dir=td)
+                idx.query("what is X?", db_profile="prod", n_results=5)
+
+        self.assertNotIn("where", captured["explicit_kwargs"])
+        self.assertEqual(captured.get("n_results"), 5)
+
+
 class SearchIndexEmbeddingTests(unittest.TestCase):
     """Verify SearchIndex wires the embedding_function param through to Chroma."""
 


### PR DESCRIPTION
Until now AMX kept all DB profiles' search vectors in a single Chroma
collection ("amx_search") and isolated them at query time via a
`where={"db_profile": ...}` filter. Forgetting that filter anywhere
in the codebase risked one profile seeing another's vectors. This
commit moves each profile to its own collection so the isolation
becomes physical instead of disciplinary.

What changed:
- amx/search/index.py:
  - _collection_name_for(db_profile): hashes the profile name to a
    Chroma-valid identifier (`amx_search_<sha256[:16]>`). Profile
    names can contain spaces, unicode, slashes, etc., so we hash
    rather than try to escape. Empty profile keeps the legacy
    `amx_search` name for back-compat with tests and callers that
    have not adopted the per-profile API.
  - SearchIndex now lazily caches one collection per profile in
    self._collections. Eagerly creates the legacy collection too so
    the historical `self.collection` attribute keeps working.
  - upsert_entities() groups rows by db_profile and writes each to
    its own collection.
  - query() drops the `where` clause — the collection is already
    profile-scoped.
  - delete_entity_ids() does a best-effort delete across every
    opened collection since we don't know the source profile.
  - reset_profile() targets the per-profile collection directly.

Migration: existing users should run /rebuild (inside /search) to
populate the new collections; old data in the shared amx_search
collection is no longer queried for non-empty profiles.

Tests: 6 new PerProfileCollectionTests cover legacy-name back-compat,
deterministic + Chroma-valid hashing, distinct names per profile,
unicode-safe hashing, upsert routing, and the where-clause removal.

All 187 tests pass (181 + 6 new).
