### PR TITLE
fix(cli): auto-shift /embeddings into /search and accept /embedding alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project are documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). From the next release onward, version numbers and entries below `[Unreleased]` are derived from [Conventional Commits](https://www.conventionalcommits.org/) by [`python-semantic-release`](https://python-semantic-release.readthedocs.io/) — manual edits to released sections are no longer expected.
 
 ## [Unreleased]
+### Fixed
+- **`/embeddings` from the root tab now auto-shifts into `/search`**, matching the UX every other namespace-scoped command already had (e.g. `/add-db-profile` → "Assumed /db namespace for this command."). Previously typing `/embeddings` from `[ ROOT ]` printed `✗ /embeddings belongs in /search.` and forced the user to manually `/search` first; now it just works.
+- **`/embedding` (singular) is accepted as an alias for `/embeddings`** so the typo `/embedding` no longer hits "Unknown command."
+
 ### Added
 - **`/usage [window]` slash command** (`amx/cli_support/commands/usage.py`): top-level read-only summary of LLM token usage and approximate cost over a time window (`24h` / `7d` / `30d` / `all`, default `7d`). Reads from `~/.amx/history.db` — local-only, no network calls. Aggregates runs by `(provider, model)`, prints input / output / total tokens and an approximate USD cost using a built-in price table covering OpenAI (gpt-4o family, o1, o3-mini, embeddings), Anthropic (Claude 4 Opus / Sonnet / Haiku, 3.5 Sonnet / Haiku, 3 Opus), Gemini (2.0 / 1.5), and DeepSeek. Models without pricing show an em-dash. Provider-prefixed model ids (`openai/gpt-4o`, `openrouter/openai/gpt-4o-mini`) and dated suffixes (`-20250514`, `-v2`) are matched against the table by stripping the prefix / suffix.
 - **11 new `UsageCommandTests`** covering: window normalisation (default + known + unknown fallback), pricing lookup (exact match, provider-prefix stripping, dated-suffix stripping, unknown returns `None`), aggregation grouping, malformed-`tokens_json` skip, cost formatting (known model dollar, unknown em-dash, sub-cent), empty-history warning, and the no-store-initialised path.

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -720,12 +720,14 @@ def _handle_session_builtin(
         # requiring the user to enter any namespace first. No network call.
         _cmd_usage(cfg, parts[1:])
         return True
-    if head == "embeddings":
+    if head in {"embeddings", "embedding"}:
         # Lives under /search since switching the embedding provider only
-        # affects the search index. The user must enter /search first; this
-        # matches the pattern used by /llm-profiles (only valid inside /llm)
-        # and keeps the namespace boundaries consistent.
-        if not _require_namespace(head, namespace, "search", "embeddings"):
+        # affects the search index. ``embedding`` (singular) is accepted as
+        # a typo-friendly alias. When typed at the root tab, the auto-
+        # namespace logic (search_cmd_heads) shifts the user into /search
+        # and prints "Assumed /search namespace for this command." — the
+        # same UX as /add-db-profile.
+        if not _require_namespace(head, namespace, "search", head):
             return True
         _cmd_embeddings(cfg, parts[1:])
         return True
@@ -907,7 +909,9 @@ def run_interactive_session(
         }
     )
     analyze_cmd_heads = frozenset({"run", "run-apply", "apply"})
-    search_cmd_heads = frozenset({"ask", "status", "sources", "config", "sync", "rebuild"})
+    search_cmd_heads = frozenset(
+        {"ask", "status", "sources", "config", "sync", "rebuild", "embeddings", "embedding"}
+    )
     history_cmd_heads = frozenset({"list", "show", "stats", "events", "results", "review"})
 
     prev_sigwinch = signal.getsignal(signal.SIGWINCH)


### PR DESCRIPTION
Two small UX bugs reported by the user:

  1. Typing /embeddings from the root tab printed
     "✗ /embeddings belongs in /search."
     and forced the user to manually /search first. Every other
     namespace-scoped command (e.g. /add-db-profile under /db) auto-
     shifts the namespace and prints
     "ℹ Assumed /search namespace for this command."

  2. Typing the singular /embedding hit "Unknown command. Type /help."
     instead of doing the obvious thing.

Fix:
- Add "embeddings" and "embedding" to search_cmd_heads, the
  frozenset that drives the auto-namespace shift in
  run_interactive_session. The dispatcher now accepts either
  spelling and routes both to cmd_embeddings.
- Update the comment on the dispatcher entry to call out the auto-
  namespace UX so future maintainers know to keep both spellings
  in search_cmd_heads.

All 232 tests still pass — no test changes needed because the auto-
namespace logic is exercised through the live REPL only and the
dispatch entry point already had coverage via the picker tests.
