### PR TITLE
feat(eval): retrieval scoring metrics and smoke harness

### DIFF
--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,61 @@
+# Retrieval evaluation harness
+
+A small kit for measuring AMX search retrieval quality and comparing
+embedding providers (MiniLM / OpenAI-compatible / SentenceTransformers).
+
+## What's here
+
+- `metrics.py` — pure functions for `hit@k`, `reciprocal_rank`,
+  `mean_reciprocal_rank`, `precision@k`, and `ndcg@k`.
+- `test_retrieval_metrics.py` — unit tests for the metrics. Runs in CI
+  on every PR via the standard `pytest` invocation.
+- `test_smoke.py` — end-to-end smoke harness with a fake retriever, so
+  contributors can copy the shape into a real eval script without
+  having to assemble the plumbing from scratch.
+
+## Running
+
+```bash
+# All eval tests (metrics + smoke)
+pytest tests/eval/
+
+# Just the metric unit tests
+pytest tests/eval/test_retrieval_metrics.py
+
+# A specific metric
+pytest tests/eval/test_retrieval_metrics.py::NdcgAtKTests
+```
+
+## Adding a real eval
+
+1. Drop a fixture file into `tests/eval/fixtures/` mapping questions
+   to the set of entity ids you consider relevant for each. We
+   recommend JSON or YAML — pick one and stay consistent.
+2. Write a script (or a `pytest` test) that:
+   - loads the fixture,
+   - constructs a `SearchCatalog` against your real `~/.amx/history.db`
+     (or a frozen copy),
+   - runs each question through `catalog.query(...)`,
+   - projects the result rows down to entity-id strings (e.g.
+     `f"{row['schema_name']}.{row['table_name']}"`),
+   - scores each query with the metrics in `tests/eval/metrics.py`.
+3. To compare embedding providers, run the same script three times
+   under different `cfg.embedding.kind` settings and report the
+   per-query and aggregate metrics side-by-side.
+
+## What the metrics measure
+
+| Metric | What it answers |
+|--------|----------------|
+| `hit@k` | Did the retriever surface *any* correct answer in the top-k? |
+| `reciprocal_rank` | At what position did the first correct answer appear? |
+| `MRR` | Average reciprocal rank across many queries. Sensitive to ranking quality, not just inclusion. |
+| `precision@k` | What fraction of the top-k are correct? (Cares about result *purity*.) |
+| `nDCG@k` | Like precision@k but penalises late-position hits with a logarithmic discount. The standard ranking-quality scalar. |
+
+## Why per-query scoring matters
+
+Aggregate MRR can hide regressions on a small but important slice of
+queries. When comparing providers, also report per-query deltas so a
+better-on-average provider that *worsens* the worst-case query is
+visible.

--- a/tests/eval/__init__.py
+++ b/tests/eval/__init__.py
@@ -1,0 +1,14 @@
+"""Retrieval evaluation harness for AMX search.
+
+This package collects light-weight scoring metrics and a smoke harness
+that exercises the retrieval surface without requiring a live database
+or a populated Chroma collection. Real evals — comparing MiniLM vs
+OpenAI vs SentenceTransformers on an actual corpus — drop fixture files
+into ``tests/eval/fixtures/`` and run::
+
+    pytest tests/eval/
+
+The metrics live in :mod:`tests.eval.metrics` so they can be re-used
+by ad-hoc scripts and downstream notebooks without re-imports of the
+full test suite.
+"""

--- a/tests/eval/metrics.py
+++ b/tests/eval/metrics.py
@@ -1,0 +1,148 @@
+"""Scoring metrics for retrieval evaluation.
+
+The functions here take a *ranked list of result identifiers* (model
+output) and a set of *relevant identifiers* (ground truth) and return
+a single scalar so retrieval changes (a new embedding model, a
+different distance threshold, a new chunking scheme) can be compared
+on apples-to-apples terms.
+
+All functions are pure: no global state, no IO, deterministic.
+
+Identifiers are compared with ``==``; lowercase + strip is the caller's
+responsibility so the metrics never silently rewrite case-sensitive
+ids.
+
+Example::
+
+    >>> hit_at_k(["users", "orders", "events"], {"orders"}, k=2)
+    1.0
+    >>> hit_at_k(["users", "orders", "events"], {"orders"}, k=1)
+    0.0
+    >>> mean_reciprocal_rank(
+    ...     [
+    ...         (["users", "orders"], {"orders"}),
+    ...         (["events", "audit"], {"audit"}),
+    ...     ]
+    ... )
+    0.5
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from math import log2
+
+
+def hit_at_k(
+    ranked: Sequence[str],
+    relevant: Iterable[str],
+    *,
+    k: int,
+) -> float:
+    """Return ``1.0`` if any relevant id appears in the first *k* results,
+    else ``0.0``. This is the simplest possible signal — does retrieval
+    surface *any* correct answer in the top-k window?
+    """
+    if k <= 0:
+        raise ValueError("k must be positive")
+    relevant_set = set(relevant)
+    if not relevant_set:
+        return 0.0
+    for item in ranked[:k]:
+        if item in relevant_set:
+            return 1.0
+    return 0.0
+
+
+def reciprocal_rank(
+    ranked: Sequence[str],
+    relevant: Iterable[str],
+) -> float:
+    """Return ``1 / position`` of the first relevant id (1-indexed), or
+    ``0.0`` if no relevant id appears anywhere in *ranked*. RR is the
+    per-query value you average to get MRR.
+    """
+    relevant_set = set(relevant)
+    if not relevant_set:
+        return 0.0
+    for index, item in enumerate(ranked, start=1):
+        if item in relevant_set:
+            return 1.0 / float(index)
+    return 0.0
+
+
+def mean_reciprocal_rank(
+    queries: Iterable[tuple[Sequence[str], Iterable[str]]],
+) -> float:
+    """Average :func:`reciprocal_rank` across many ``(ranked, relevant)``
+    pairs. Empty input returns ``0.0`` rather than raising — eval scripts
+    typically iterate over fixture files and may legitimately encounter
+    a zero-length set.
+    """
+    rrs: list[float] = []
+    for ranked, relevant in queries:
+        rrs.append(reciprocal_rank(ranked, relevant))
+    if not rrs:
+        return 0.0
+    return sum(rrs) / float(len(rrs))
+
+
+def ndcg_at_k(
+    ranked: Sequence[str],
+    relevant: Iterable[str],
+    *,
+    k: int,
+) -> float:
+    """Normalised Discounted Cumulative Gain at *k* with binary relevance.
+
+    Each relevant hit at position *i* (1-indexed) contributes
+    ``1 / log2(i + 1)``. The result is normalised by the ideal DCG —
+    the score you would get if every relevant id ranked above every
+    irrelevant id — so the value lies in ``[0.0, 1.0]``.
+
+    Returns ``0.0`` when there are no relevant ids or when *k* admits
+    no candidates.
+    """
+    if k <= 0:
+        raise ValueError("k must be positive")
+    relevant_set = set(relevant)
+    if not relevant_set:
+        return 0.0
+    truncated = list(ranked[:k])
+    if not truncated:
+        return 0.0
+
+    dcg = 0.0
+    for index, item in enumerate(truncated, start=1):
+        if item in relevant_set:
+            dcg += 1.0 / log2(index + 1)
+
+    ideal_hits = min(len(relevant_set), k)
+    if ideal_hits == 0:
+        return 0.0
+    idcg = sum(1.0 / log2(i + 1) for i in range(1, ideal_hits + 1))
+    if idcg == 0.0:
+        return 0.0
+    return dcg / idcg
+
+
+def precision_at_k(
+    ranked: Sequence[str],
+    relevant: Iterable[str],
+    *,
+    k: int,
+) -> float:
+    """Fraction of the top-*k* that are relevant. Useful when callers
+    care about the *purity* of the candidate window, not just whether
+    one correct hit slipped in.
+    """
+    if k <= 0:
+        raise ValueError("k must be positive")
+    relevant_set = set(relevant)
+    if not relevant_set:
+        return 0.0
+    window = list(ranked[:k])
+    if not window:
+        return 0.0
+    hits = sum(1 for item in window if item in relevant_set)
+    return float(hits) / float(len(window))

--- a/tests/eval/test_retrieval_metrics.py
+++ b/tests/eval/test_retrieval_metrics.py
@@ -1,0 +1,103 @@
+"""Unit tests for the retrieval evaluation metrics."""
+
+from __future__ import annotations
+
+import unittest
+
+from tests.eval.metrics import (
+    hit_at_k,
+    mean_reciprocal_rank,
+    ndcg_at_k,
+    precision_at_k,
+    reciprocal_rank,
+)
+
+
+class HitAtKTests(unittest.TestCase):
+    def test_hit_in_top_one(self) -> None:
+        self.assertEqual(hit_at_k(["orders", "users"], {"orders"}, k=1), 1.0)
+
+    def test_hit_outside_window(self) -> None:
+        self.assertEqual(hit_at_k(["users", "events", "orders"], {"orders"}, k=2), 0.0)
+
+    def test_no_relevant_returns_zero(self) -> None:
+        self.assertEqual(hit_at_k(["a", "b"], set(), k=2), 0.0)
+
+    def test_invalid_k_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            hit_at_k(["a"], {"a"}, k=0)
+        with self.assertRaises(ValueError):
+            hit_at_k(["a"], {"a"}, k=-1)
+
+
+class ReciprocalRankTests(unittest.TestCase):
+    def test_first_position_is_one(self) -> None:
+        self.assertEqual(reciprocal_rank(["orders", "x", "y"], {"orders"}), 1.0)
+
+    def test_third_position_is_one_third(self) -> None:
+        self.assertAlmostEqual(reciprocal_rank(["x", "y", "orders"], {"orders"}), 1.0 / 3)
+
+    def test_no_match_is_zero(self) -> None:
+        self.assertEqual(reciprocal_rank(["x", "y"], {"orders"}), 0.0)
+
+    def test_returns_first_match_only(self) -> None:
+        # Even though "orders" appears at position 2 and 3, RR uses the
+        # first occurrence.
+        self.assertAlmostEqual(
+            reciprocal_rank(["x", "orders", "orders"], {"orders"}),
+            0.5,
+        )
+
+
+class MeanReciprocalRankTests(unittest.TestCase):
+    def test_average_across_queries(self) -> None:
+        queries = [
+            (["users", "orders"], {"orders"}),  # RR = 0.5
+            (["events", "audit"], {"audit"}),   # RR = 0.5
+            (["x", "y", "z"], {"missing"}),     # RR = 0.0
+        ]
+        # (0.5 + 0.5 + 0.0) / 3 = 1/3
+        self.assertAlmostEqual(mean_reciprocal_rank(queries), 1.0 / 3.0)
+
+    def test_empty_iterable_returns_zero(self) -> None:
+        self.assertEqual(mean_reciprocal_rank([]), 0.0)
+
+
+class NdcgAtKTests(unittest.TestCase):
+    def test_perfect_ranking_returns_one(self) -> None:
+        # Single relevant at top → DCG = IDCG = 1/log2(2) = 1.0
+        self.assertAlmostEqual(ndcg_at_k(["a", "b", "c"], {"a"}, k=3), 1.0)
+
+    def test_relevant_at_position_two(self) -> None:
+        # DCG = 1/log2(3); IDCG = 1/log2(2) = 1.0
+        self.assertAlmostEqual(
+            ndcg_at_k(["x", "a", "b"], {"a"}, k=3),
+            1.0 / 1.5849625007211562,  # log2(3)
+            places=4,
+        )
+
+    def test_no_relevant_in_window(self) -> None:
+        self.assertEqual(ndcg_at_k(["x", "y"], {"a"}, k=2), 0.0)
+
+    def test_multiple_relevant_normalises_against_ideal(self) -> None:
+        # Two relevant items in a 3-window: actual order has them at
+        # positions 1 and 3 (DCG = 1/log2(2) + 1/log2(4) = 1 + 0.5).
+        # Ideal would have them at 1 and 2 (IDCG = 1 + 1/log2(3)).
+        score = ndcg_at_k(["a", "x", "b"], {"a", "b"}, k=3)
+        self.assertGreater(score, 0.0)
+        self.assertLess(score, 1.0)
+
+
+class PrecisionAtKTests(unittest.TestCase):
+    def test_all_top_k_relevant(self) -> None:
+        self.assertEqual(precision_at_k(["a", "b", "c"], {"a", "b"}, k=2), 1.0)
+
+    def test_half_top_k_relevant(self) -> None:
+        self.assertEqual(precision_at_k(["a", "x"], {"a"}, k=2), 0.5)
+
+    def test_none_relevant(self) -> None:
+        self.assertEqual(precision_at_k(["x", "y"], {"a"}, k=2), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/eval/test_smoke.py
+++ b/tests/eval/test_smoke.py
@@ -1,0 +1,115 @@
+"""Smoke test for the retrieval evaluation harness.
+
+Verifies that the metrics-plus-fake-retriever loop works end-to-end so
+contributors can drop a real fixture file into ``tests/eval/fixtures/``
+and re-use the same machinery without fighting the plumbing.
+
+A real eval against the live ``SearchIndex`` belongs in a separate
+suite — it requires a populated catalog and a chosen embedding
+provider. This smoke test runs in milliseconds against an in-memory
+fake retriever so CI does not depend on Chroma state.
+"""
+
+from __future__ import annotations
+
+import unittest
+from collections.abc import Sequence
+
+from tests.eval.metrics import (
+    hit_at_k,
+    mean_reciprocal_rank,
+    ndcg_at_k,
+    precision_at_k,
+)
+
+
+class FakeRetriever:
+    """Returns the answer ranking encoded in *answers* for each question.
+
+    Stand-in for SearchIndex.query — real evals pass a wrapper that
+    calls the live retriever and projects the result down to identifier
+    strings (e.g. ``f"{schema}.{table}"``).
+    """
+
+    def __init__(self, answers: dict[str, list[str]]) -> None:
+        self._answers = answers
+
+    def query(self, question: str, *, k: int) -> Sequence[str]:
+        return list(self._answers.get(question, []))[:k]
+
+
+class EvalHarnessSmokeTests(unittest.TestCase):
+    """Tiny end-to-end exercise of the harness using a fake retriever.
+
+    Real evals follow the same shape: load a fixture mapping each
+    question to its set of relevant entity ids, run the retriever on
+    each question, score the ranked output, aggregate.
+    """
+
+    FIXTURE: dict[str, set[str]] = {
+        # question -> relevant entity ids (any of these in the top-k counts)
+        "what is the orders table?": {"public.orders"},
+        "show me customers": {"public.customers", "crm.customers"},
+        "where is shipment data?": {"public.shipments"},
+    }
+
+    def test_perfect_retriever_scores_one(self) -> None:
+        retriever = FakeRetriever(
+            {
+                "what is the orders table?": ["public.orders", "x", "y"],
+                # The fixture marks BOTH public.customers and crm.customers
+                # as relevant; ranking both at positions 1-2 gives nDCG=1.
+                "show me customers": ["public.customers", "crm.customers", "x"],
+                "where is shipment data?": ["public.shipments", "x"],
+            }
+        )
+
+        per_query_pairs = [
+            (retriever.query(q, k=5), self.FIXTURE[q]) for q in self.FIXTURE
+        ]
+
+        self.assertEqual(mean_reciprocal_rank(per_query_pairs), 1.0)
+        for ranked, relevant in per_query_pairs:
+            self.assertEqual(hit_at_k(ranked, relevant, k=1), 1.0)
+            self.assertAlmostEqual(ndcg_at_k(ranked, relevant, k=3), 1.0, places=2)
+
+    def test_partial_retriever_scores_below_one(self) -> None:
+        # Best result drops to position 2 for one query, position 3 for another.
+        retriever = FakeRetriever(
+            {
+                "what is the orders table?": ["x", "public.orders"],
+                "show me customers": ["x", "y", "public.customers"],
+                "where is shipment data?": ["x", "y", "public.shipments"],
+            }
+        )
+
+        per_query_pairs = [
+            (retriever.query(q, k=5), self.FIXTURE[q]) for q in self.FIXTURE
+        ]
+
+        mrr = mean_reciprocal_rank(per_query_pairs)
+        self.assertLess(mrr, 1.0)
+        self.assertGreater(mrr, 0.0)
+
+        # Hit@1 must be 0 for all three since the top result is wrong.
+        for ranked, relevant in per_query_pairs:
+            self.assertEqual(hit_at_k(ranked, relevant, k=1), 0.0)
+            # But hit@3 catches at least the first two queries.
+            if "orders" in next(iter(relevant)):
+                self.assertEqual(hit_at_k(ranked, relevant, k=2), 1.0)
+
+    def test_empty_results_score_zero(self) -> None:
+        # Retriever returns nothing — every metric must be 0.0 without
+        # raising. Real eval scripts treat this as a hard failure.
+        retriever = FakeRetriever({})
+        per_query_pairs = [
+            (retriever.query(q, k=5), self.FIXTURE[q]) for q in self.FIXTURE
+        ]
+        self.assertEqual(mean_reciprocal_rank(per_query_pairs), 0.0)
+        for ranked, relevant in per_query_pairs:
+            self.assertEqual(hit_at_k(ranked, relevant, k=5), 0.0)
+            self.assertEqual(precision_at_k(ranked, relevant, k=5), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a tests/eval/ package so contributors can measure AMX search
retrieval quality and compare embedding providers (MiniLM vs OpenAI
vs SentenceTransformers) on apples-to-apples terms. Built around
pure-functional scoring primitives so an ad-hoc script can re-import
without dragging in test infrastructure.

What's here:
- tests/eval/metrics.py: hit@k, reciprocal_rank, mean_reciprocal_rank,
  precision@k, ndcg@k. All deterministic, no IO, no globals.
- tests/eval/test_retrieval_metrics.py: 16 unit tests covering edge
  cases: empty input, no relevant items, invalid k, multiple
  relevant items normalised against the ideal ranking, first-match-
  only behaviour for reciprocal_rank.
- tests/eval/test_smoke.py: 4 end-to-end smoke tests exercising the
  metrics through a FakeRetriever stand-in for SearchIndex. Real
  evals follow the same shape — load a fixture, query the retriever,
  score the rankings, aggregate.
- tests/eval/README.md: how to add fixture files, run evals, and
  interpret the metrics. Explicitly notes that aggregate MRR can
  hide regressions on small slices, so per-query deltas matter.

Scope choice: the smoke harness uses an in-memory fake retriever
rather than the live SearchIndex. A real eval needs a populated
catalog and a chosen embedding provider; that work is opt-in and
goes in fixtures, not in the always-run CI suite.

All 271 tests pass (251 + 20 new).
