### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). From the next release onward, version numbers and entries below `[Unreleased]` are derived from [Conventional Commits](https://www.conventionalcommits.org/) by [`python-semantic-release`](https://python-semantic-release.readthedocs.io/) — manual edits to released sections are no longer expected.
 
 ## [Unreleased]
+
+## [0.3.0] — 2026-04-29
 ### Added
 - **Crash reports with secret redaction** (`amx/utils/crash.py`): when the top-level CLI handler catches an unhandled exception (and `AMX_DEBUG` is not set), AMX now writes a sanitized crash report to `~/.amx/logs/crashes/<timestamp>-<request_id>.txt` and prints the path so the user can attach it to a GitHub issue without leaking their DB password or API key. The report contains the timestamp, request id, exception class + message, full traceback, AMX-prefixed env vars, and any caller-supplied extra context — every component runs through `redact_secrets` before being written. Files are `chmod 0o600` on POSIX. The crash-report writer is itself wrapped in a try/except so a redaction failure cannot crash the crash handler.
 - **`redact_secrets(text)` helper** matches and replaces: provider-prefixed API keys (`sk-`, `sk-or-`, `sk-ant-`), Databricks PATs (`dapi…`), AWS access keys (`AKIA…`), GitHub PATs (`ghp_…`, `github_pat_…`), `Authorization: Bearer …` headers, and `password=` / `api_key=` / `access_token=` / `token=` / `secret=` k/v pairs. Best-effort by design — the helper is documented as not exhaustive and users are advised to skim the report before sharing.

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.2.9"
+__version__ = "0.3.0"
 
 __all__ = [
     "AMXApplication",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx"
-version = "0.2.9"
+version = "0.3.0"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
The first tagged release of the production-readiness sweep that
landed across PRs #1–#25 in this session. release.yml verifies that
the pyproject version matches the pushed tag; the previous push of
v0.3.0 failed at that gate because pyproject still read 0.2.9.

What changed:
- pyproject.toml: version 0.2.9 → 0.3.0
- amx/__init__.py: __version__ 0.2.9 → 0.3.0
- CHANGELOG.md: convert the [Unreleased] block into [0.3.0] —
  2026-04-29 so the released changelog section freezes the entries
  shipped this session.

After this lands, the v0.3.0 tag will be deleted and re-pushed at
the new commit so release.yml runs the build → OIDC PyPI publish →
GitHub Release flow.
