### PR TITLE
fix(profiles): no longer pre-fill new DB/LLM profiles with active profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-04-29
+### Fixed
+- **Profile creation no longer pre-fills with the active profile's secrets** (`amx/cli_support/commands/db.py`, `amx/cli_support/commands/profiles.py`): typing `/add-db-profile newname` (or `/add-llm-profile`) for a name that does not exist used to call `interactive_db_block(cfg.db)` (or `interactive_llm_block(cfg.llm)`) — passing the **active** profile as the form's defaults. The "Enter to keep" hints would silently inherit values from a different profile, including the host, password, API key, Databricks PAT, and base URL. If the active profile was Databricks and a user typed `/add-db-profile new-postgres`, pressing Enter would fill the new postgres profile with the Databricks workspace URL.
+- **Cross-backend reset inside the form**: even when editing an existing profile, switching the backend mid-flow (e.g. PostgreSQL → Databricks) now drops every default. Previously, the postgres host could leak into the Databricks form's `host` field as an Enter-to-keep value.
+- **Empty form for new profiles**: brand-new DB and LLM profiles now start every prompt blank rather than inheriting the dataclass placeholders (`host="localhost"`, `user="amx"`, `database="SAP"`, etc.). Example values are surfaced in the prompt label (e.g. `"Database host (e.g. db.example.com)"`) instead of being pre-filled.
+- **Better example placeholders** in `/add-db-profile` prompt labels: postgres, snowflake, databricks, and bigquery prompts now include `(e.g. ...)` hints with obviously-fake examples like `adb-xxxxxxxxxxxxxxxx.0.azuredatabricks.net`, `xy12345.us-east-1`, `my-company-prod`, `/sql/1.0/warehouses/abc1234567890` rather than relying on dataclass defaults.
+
+### Added
+- **4 new `ProfileCreationLeakageTests`** covering: new DB profile gets blank defaults (active Databricks values do not leak), editing an existing DB profile passes existing values through, cross-backend reset clears the host default when switching backends, new LLM profile gets blank defaults (active OpenAI key does not leak).
+
 ## [0.3.0] — 2026-04-29
 ### Added
 - **Crash reports with secret redaction** (`amx/utils/crash.py`): when the top-level CLI handler catches an unhandled exception (and `AMX_DEBUG` is not set), AMX now writes a sanitized crash report to `~/.amx/logs/crashes/<timestamp>-<request_id>.txt` and prints the path so the user can attach it to a GitHub issue without leaking their DB password or API key. The report contains the timestamp, request id, exception class + message, full traceback, AMX-prefixed env vars, and any caller-supplied extra context — every component runs through `redact_secrets` before being written. Files are `chmod 0o600` on POSIX. The crash-report writer is itself wrapped in a try/except so a redaction failure cannot crash the crash handler.

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "AMXApplication",

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -245,7 +245,19 @@ def cmd_use(
 
 
 def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
-    """Interactive prompts to build a DBConfig for any supported backend."""
+    """Interactive prompts to build a DBConfig for any supported backend.
+
+    When ``defaults`` is ``None``, every prompt starts blank — used for
+    new profiles so we never leak fields from an already-configured
+    active profile.
+
+    When ``defaults`` is supplied (editing an existing profile) the
+    user can press Enter to keep each current value. If they switch
+    the backend mid-flow, we reset to a fresh ``DBConfig`` so values
+    from the previous backend (e.g. a Databricks workspace URL) do
+    NOT silently fill into a freshly chosen PostgreSQL profile.
+    """
+    new_profile = defaults is None
     if defaults is None:
         defaults = DBConfig()
     backend = ask_choice(
@@ -260,15 +272,78 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         },
     )
 
+    # Truly-blank defaults for a brand-new profile or after a cross-
+    # backend reset. ``DBConfig()`` carries the dataclass-level
+    # placeholders (``host="localhost"``, ``user="amx"``, etc.), which
+    # would still appear as Enter-to-keep defaults and feel like the
+    # active profile is leaking — so we wipe every connection field.
+    def _blank(active_backend: str) -> DBConfig:
+        return DBConfig(
+            backend=active_backend,
+            host="",
+            port=0,
+            user="",
+            password="",
+            database="",
+            account="",
+            warehouse="",
+            role="",
+            http_path="",
+            access_token="",
+            catalog="",
+            tls_no_verify=False,
+            tls_trusted_ca_file="",
+            project="",
+            dataset="",
+            credentials_path="",
+        )
+
+    # If the user picked a backend different from what ``defaults``
+    # was built for, drop those defaults — they belong to a different
+    # backend and would otherwise leak into the wrong fields.
+    if defaults.backend and backend != defaults.backend:
+        defaults = _blank(backend)
+
+    if new_profile:
+        defaults = _blank(backend)
+
     if backend == "postgresql":
-        host = _ask_update_text("Database host", defaults.host or "localhost", required=True, allow_clear=False)
-        port_raw = _ask_update_text("Port", str(defaults.port or 5432), required=True, allow_clear=False)
+        # New-profile prompts start fully empty so users never silently
+        # inherit a value from a different profile by pressing Enter.
+        # Existing-profile edits keep their current value as the default.
+        host = _ask_update_text(
+            "Database host (e.g. db.example.com)",
+            defaults.host or "",
+            required=True,
+            allow_clear=False,
+        )
+        port_raw = _ask_update_text(
+            "Port (e.g. 5432)",
+            str(defaults.port) if defaults.port else "",
+            required=True,
+            allow_clear=False,
+        )
         while not port_raw.isdigit():
             warn("Port must be a number.")
-            port_raw = _ask_update_text("Port", str(defaults.port or 5432), required=True, allow_clear=False)
-        user = _ask_update_text("Username", defaults.user or "amx", required=True, allow_clear=False)
+            port_raw = _ask_update_text(
+                "Port (e.g. 5432)",
+                str(defaults.port) if defaults.port else "",
+                required=True,
+                allow_clear=False,
+            )
+        user = _ask_update_text(
+            "Username (e.g. amx)",
+            defaults.user or "",
+            required=True,
+            allow_clear=False,
+        )
         password = _ask_update_secret("Password", defaults.password or "", required=True)
-        database = _ask_update_text("Database name", defaults.database or "postgres", required=True, allow_clear=False)
+        database = _ask_update_text(
+            "Database name (e.g. postgres)",
+            defaults.database or "",
+            required=True,
+            allow_clear=False,
+        )
         return replace(
             defaults,
             backend="postgresql",
@@ -280,12 +355,22 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         )
 
     if backend == "snowflake":
-        account = _ask_update_text("Snowflake account identifier (e.g. xy12345.us-east-1)", defaults.account, required=True, allow_clear=False)
-        user = _ask_update_text("Username", defaults.user, required=True, allow_clear=False)
+        account = _ask_update_text(
+            "Snowflake account identifier (e.g. xy12345.us-east-1)",
+            defaults.account,
+            required=True,
+            allow_clear=False,
+        )
+        user = _ask_update_text("Username (e.g. ANALYST)", defaults.user, required=True, allow_clear=False)
         password = _ask_update_secret("Password", defaults.password or "", required=True)
-        database = _ask_update_text("Database name", defaults.database, required=True, allow_clear=False)
-        warehouse = _ask_update_text("Warehouse (optional)", defaults.warehouse or "")
-        role = _ask_update_text("Role (optional)", defaults.role or "")
+        database = _ask_update_text(
+            "Database name (e.g. ANALYTICS)",
+            defaults.database,
+            required=True,
+            allow_clear=False,
+        )
+        warehouse = _ask_update_text("Warehouse (optional, e.g. COMPUTE_WH)", defaults.warehouse or "")
+        role = _ask_update_text("Role (optional, e.g. ANALYST)", defaults.role or "")
         return replace(
             defaults,
             backend="snowflake",
@@ -299,13 +384,13 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
 
     if backend == "databricks":
         host = _ask_update_text(
-            "Databricks host (e.g. adb-xxx.azuredatabricks.net)",
+            "Databricks host (e.g. adb-xxxxxxxxxxxxxxxx.0.azuredatabricks.net)",
             defaults.host,
             required=True,
             allow_clear=False,
         )
         http_path = _ask_update_text(
-            "SQL warehouse HTTP path",
+            "SQL warehouse HTTP path (e.g. /sql/1.0/warehouses/abc1234567890)",
             defaults.http_path,
             required=True,
             allow_clear=False,
@@ -334,9 +419,20 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         )
 
     if backend == "bigquery":
-        project = _ask_update_text("GCP project ID", defaults.project, required=True, allow_clear=False)
-        dataset = _ask_update_text("Default dataset (optional)", defaults.dataset or "")
-        creds = _ask_update_text("Service account JSON path (optional, uses ADC if empty)", defaults.credentials_path or "")
+        project = _ask_update_text(
+            "GCP project ID (e.g. my-company-prod)",
+            defaults.project,
+            required=True,
+            allow_clear=False,
+        )
+        dataset = _ask_update_text(
+            "Default dataset (optional, e.g. analytics)",
+            defaults.dataset or "",
+        )
+        creds = _ask_update_text(
+            "Service account JSON path (optional, e.g. /etc/gcp/sa.json — uses ADC if empty)",
+            defaults.credentials_path or "",
+        )
         return replace(
             defaults,
             backend="bigquery",
@@ -358,9 +454,19 @@ def cmd_add_profile(
         name = rest[0]
     else:
         name = ask("Profile name", default="local")
-    info(f"Creating/updating profile: {name}")
     existing = cfg.db_profiles.get(name)
-    db = interactive_db_block(existing or cfg.db)
+    if existing is not None:
+        info(f"Editing profile: {name}")
+        # Editing an existing profile — keep its current values as
+        # defaults so the user can press Enter to skip unchanged fields.
+        db = interactive_db_block(existing)
+    else:
+        info(f"Creating new profile: {name}")
+        # New profile — every prompt starts blank. We deliberately do
+        # NOT use ``cfg.db`` (the active profile) as defaults here, or a
+        # /add-db-profile would silently pre-fill with the active
+        # profile's host / token / etc.
+        db = interactive_db_block(None)
     cfg.db_profiles[name] = db
     cfg.active_db_profile = name
     cfg.db = db

--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -32,12 +32,37 @@ def default_model(provider: str) -> str:
     }.get(provider, "gpt-4o")
 
 
-def interactive_llm_block(defaults: LLMConfig) -> LLMConfig:
+def interactive_llm_block(defaults: LLMConfig | None = None) -> LLMConfig:
+    """Interactive prompts to build an LLMConfig.
+
+    When ``defaults`` is ``None``, every prompt starts blank and the
+    user explicitly types every value — this is the path used by
+    ``/add-llm-profile`` for a new profile name, so the active
+    profile's API key, model, etc. never silently fill into the new
+    profile.
+
+    When editing an existing profile, the caller passes that profile
+    so the user can press Enter to keep current values.
+    """
+    new_profile = defaults is None
+    if defaults is None:
+        defaults = LLMConfig()
     provider = ask_choice(
         "Select AI provider",
         ["openai", "openrouter", "anthropic", "gemini", "deepseek", "local", "kimi", "ollama"],
         default=defaults.provider or "openai",
     )
+
+    # If the user picked a different provider than the existing
+    # profile's, drop those defaults — model name + api_base + key
+    # belong to the previous provider and would otherwise leak.
+    if defaults.provider and provider != defaults.provider:
+        defaults = LLMConfig(provider=provider)
+
+    # Brand-new profile? Start every prompt empty so values cannot
+    # silently leak from the active profile via Enter-to-keep.
+    if new_profile:
+        defaults = LLMConfig(provider=provider)
     info(
         "Model: use the provider's natural model id. AMX will add any required provider prefix internally."
     )
@@ -157,9 +182,17 @@ def cmd_add_llm_profile(cfg: AMXConfig, rest: list[str]) -> None:
         name = rest[0]
     else:
         name = ask("LLM profile name", default="work")
-    base = cfg.llm_profiles.get(name, cfg.llm)
-    info(f"Creating/updating LLM profile: {name}")
-    llm = interactive_llm_block(replace(base))
+    existing = cfg.llm_profiles.get(name)
+    if existing is not None:
+        info(f"Editing LLM profile: {name}")
+        llm = interactive_llm_block(replace(existing))
+    else:
+        info(f"Creating new LLM profile: {name}")
+        # New profile — every prompt starts blank. We deliberately do
+        # NOT use ``cfg.llm`` (the active profile) as defaults: doing
+        # so would silently pre-fill /add-llm-profile with the active
+        # profile's model name, API key, base URL, and language.
+        llm = interactive_llm_block(None)
     cfg.upsert_llm_profile(name, llm)
     if confirm(f"Activate profile {name} now?", default=True):
         cfg.set_active_llm_profile(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx"
-version = "0.3.0"
+version = "0.3.1"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2092,6 +2092,200 @@ class EmbeddingProviderTests(unittest.TestCase):
         self.assertIn("local-embeddings", str(ctx.exception))
 
 
+class ProfileCreationLeakageTests(unittest.TestCase):
+    """Adding a new DB or LLM profile must NOT pre-fill the form with
+    values from the currently active profile. Before this fix, typing
+    `/add-db-profile new-postgres` while a Databricks profile was
+    active would silently use the Databricks host / http_path / token
+    as Enter-to-keep defaults — a real-world value would land in the
+    new postgres profile if the user pressed Enter.
+    """
+
+    def test_db_add_profile_new_name_does_not_inherit_active_profile(self) -> None:
+        """The active Databricks profile must NOT leak into a freshly
+        created profile of any backend."""
+        from amx.cli_support.commands.db import cmd_add_profile
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = Path(td) / "config.yml"
+            cfg = AMXConfig.load(str(cfg_path))
+            # Use the proper public API so write-through saves do not
+            # overwrite our seeded profile with the initial cfg.db.
+            cfg.upsert_db_profile(
+                "pg-dbr",
+                DBConfig(
+                    backend="databricks",
+                    host="adb-4217046554757008.8.azuredatabricks.net",
+                    http_path="/sql/1.0/warehouses/abc1234",
+                    access_token="dapi-real-token-do-not-leak",
+                    catalog="dap_eu_60_prod",
+                    database="default",
+                ),
+            )
+            cfg.set_active_db_profile("pg-dbr")
+
+            captured: dict[str, object] = {"defaults": "MISSING"}
+
+            def spy(defaults):
+                captured["defaults"] = defaults
+                return DBConfig(
+                    backend="postgresql",
+                    host="db.new.example.com",
+                    user="alice",
+                    password="secret",
+                    database="new_db",
+                )
+
+            with patch(
+                "amx.cli_support.commands.db.interactive_db_block",
+                side_effect=spy,
+            ):
+                cmd_add_profile(cfg, ["brand-new-postgres"])
+
+            self.assertIsNone(captured["defaults"])
+            new_profile = cfg.db_profiles["brand-new-postgres"]
+            self.assertEqual(new_profile.backend, "postgresql")
+            self.assertEqual(new_profile.host, "db.new.example.com")
+            self.assertNotIn("databricks", new_profile.host)
+            self.assertEqual(new_profile.access_token, "")
+            self.assertEqual(new_profile.http_path, "")
+            self.assertEqual(new_profile.catalog, "")
+
+    def test_db_add_profile_existing_name_passes_existing_as_defaults(self) -> None:
+        """Editing an existing profile keeps its values as defaults so
+        the user can press Enter to skip unchanged fields."""
+        from amx.cli_support.commands.db import cmd_add_profile
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = Path(td) / "config.yml"
+            cfg = AMXConfig.load(str(cfg_path))
+            new_db = DBConfig(
+                backend="postgresql",
+                host="db.example.com",
+                user="alice",
+                database="orders",
+                password="secret",
+            )
+            # Wrap setup in a transaction so the autosave in
+            # set_active_db_profile doesn't fire mid-mutation and
+            # overwrite our just-seeded profile with the still-default
+            # cfg.db. (See PR #4 for transactional writes.)
+            with cfg.transaction():
+                cfg.upsert_db_profile("edit-me", new_db)
+                cfg.db = new_db
+                cfg.set_active_db_profile("edit-me")
+
+            captured: dict[str, object] = {}
+
+            def spy(defaults):
+                captured["defaults"] = defaults
+                return cfg.db_profiles["edit-me"]
+
+            with patch(
+                "amx.cli_support.commands.db.interactive_db_block",
+                side_effect=spy,
+            ):
+                cmd_add_profile(cfg, ["edit-me"])
+
+            self.assertIsNotNone(captured["defaults"])
+            self.assertEqual(captured["defaults"].host, "db.example.com")
+
+    def test_interactive_db_block_resets_cross_backend_defaults(self) -> None:
+        """If the caller passes a Databricks profile but the user picks
+        PostgreSQL in the picker, the postgres prompts must NOT inherit
+        the Databricks host / token / catalog."""
+        from amx.cli_support.commands.db import interactive_db_block
+
+        databricks_defaults = DBConfig(
+            backend="databricks",
+            host="adb-4217046554757008.8.azuredatabricks.net",
+            http_path="/sql/1.0/warehouses/abc",
+            access_token="dapi-leaks",
+            catalog="dap_eu_60_prod",
+        )
+
+        # Mock all the prompts: pick PostgreSQL, capture what default
+        # the host prompt was given.
+        host_default_seen = {"value": "MISSING"}
+
+        def fake_ask_choice(*_args, **_kwargs):
+            return "postgresql"
+
+        def fake_update_text(label, current="", **_kwargs):
+            if "Database host" in label:
+                host_default_seen["value"] = current
+            # Port prompt has an .isdigit() validation loop, so it must
+            # get a numeric reply or the loop never exits.
+            if "Port" in label:
+                return "5432"
+            return "user-typed-value"
+
+        def fake_update_secret(*_args, **_kwargs):
+            return "user-typed-secret"
+
+        with (
+            patch("amx.cli_support.commands.db.ask_choice", fake_ask_choice),
+            patch("amx.cli_support.commands.db._ask_update_text", fake_update_text),
+            patch("amx.cli_support.commands.db._ask_update_secret", fake_update_secret),
+            patch("amx.cli_support.commands.db._ask_update_bool", lambda *_a, **_k: False),
+        ):
+            result = interactive_db_block(databricks_defaults)
+
+        # The Databricks host must NOT have been offered as the postgres
+        # default — the cross-backend reset means defaults.host was "".
+        self.assertEqual(host_default_seen["value"], "")
+        self.assertEqual(result.backend, "postgresql")
+
+    def test_llm_add_profile_new_name_does_not_inherit_active_profile(self) -> None:
+        """The active LLM profile's API key, model, and base URL must
+        NOT leak into a freshly created LLM profile."""
+        from amx.cli_support.commands.profiles import cmd_add_llm_profile
+        from amx.config import LLMConfig
+
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = Path(td) / "config.yml"
+            cfg = AMXConfig.load(str(cfg_path))
+            cfg.upsert_llm_profile(
+                "work",
+                LLMConfig(
+                    provider="openai",
+                    model="gpt-4o-mini",
+                    api_key="sk-real-key-do-not-leak-xxxxxxxxxx",
+                    api_base="https://api.openai.com/v1",
+                    language="english",
+                ),
+            )
+            cfg.set_active_llm_profile("work")
+
+            captured: dict[str, object] = {"defaults": "MISSING"}
+
+            def spy(defaults):
+                captured["defaults"] = defaults
+                return LLMConfig(
+                    provider="anthropic",
+                    model="claude-sonnet-4",
+                    api_key="new-anthropic-key",
+                    language="english",
+                )
+
+            with (
+                patch(
+                    "amx.cli_support.commands.profiles.interactive_llm_block",
+                    side_effect=spy,
+                ),
+                patch(
+                    "amx.cli_support.commands.profiles.confirm",
+                    return_value=False,
+                ),
+            ):
+                cmd_add_llm_profile(cfg, ["brand-new-llm"])
+
+            self.assertIsNone(captured["defaults"])
+            new = cfg.llm_profiles["brand-new-llm"]
+            self.assertEqual(new.provider, "anthropic")
+            self.assertNotIn("sk-real-key", new.api_key)
+
+
 class CrashReportSanitizationTests(unittest.TestCase):
     """`write_crash_report` and `redact_secrets` keep DB passwords, API
     keys, and Databricks PATs from leaking into a file the user is


### PR DESCRIPTION
User report: opening AMX showed
  pg-dbr │ databricks │ adb-4217046554757008.8.azuredatabricks.net catalog=dap_eu_60_prod
on a workstation that should have been clean. Tracing the prompt
flow surfaced two real defects.

(1) Active-profile leakage into new profile creation
    /add-db-profile <new-name> called interactive_db_block(cfg.db)
    when no profile of that name existed yet. The form's
    "Enter keeps current" hints would then silently fill in the
    active profile's host, password, Databricks workspace URL,
    PAT, etc. — and these values would land in the new profile if
    the user pressed Enter. Same defect on the LLM side: a freshly
    created /add-llm-profile would inherit the active profile's
    API key, model, and base_url.

(2) Cross-backend leakage inside the form
    Even when editing an existing profile, if the user switched
    backend mid-flow (e.g. PostgreSQL → Databricks) the default
    for the new backend's host was the previous backend's host.
    Pressing Enter at the new Databricks "host" prompt would set
    the postgres host as the Databricks workspace URL.

Fix:
- amx/cli_support/commands/db.py:
  - cmd_add_profile now branches: existing profile → pass it as
    defaults (editing flow); new profile → pass None and the form
    starts blank.
  - interactive_db_block(None) builds a "blank" DBConfig with
    every connection field empty (host="", port=0, user="", etc.)
    instead of inheriting the dataclass placeholders ("localhost"
    / "amx" / "SAP"). The examples shipped in the prompt labels
    (e.g. "Database host (e.g. db.example.com)") are now the only
    UI nudge.
  - When the user picks a backend different from defaults.backend,
    we reset to the same blank shape so cross-backend leak goes
    away even in the editing flow.
- amx/cli_support/commands/profiles.py: same pattern for
  cmd_add_llm_profile and interactive_llm_block(None).

Tests: 4 new ProfileCreationLeakageTests cover the four real-world
flows (new DB profile does not inherit active Databricks profile;
editing existing profile keeps current values; cross-backend reset
clears host; new LLM profile does not inherit active OpenAI key).

Version bump to 0.3.1 (patch — fixes a privacy bug shipped in
v0.3.0). README CHANGELOG updated.

All 299 tests pass (295 + 4 new).
