### PR TITLE
docs(readme): hero, 5-minute quickstart, and screenshot placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Documentation — README hero, 5-minute quickstart, and screenshot slots
+
+The README's first 130 lines were a feature list; new readers had to scroll past architecture diagrams and prerequisite tables to see what AMX actually produces. Restructured so the value proposition + a concrete before/after example + the 30-second quickstart all live above the fold.
+
+- **Hero block** with a one-line value prop and the supported backends / LLM providers.
+- **"What it produces"** mini-example: cryptic `T0001.AUDAT NUMBER(8)` in, reviewed description with confidence + logprob + sources out. Synthetic identifier (no real connection details), so safe to reproduce in talks / posts.
+- **5-minute quickstart** with the four commands that get a new user from `pip install amx` to a reviewed run, plus `amx doctor` for when something looks wrong.
+- The original "Quick Start" section is preserved as **"Detailed setup"** for users who want full control over each step.
+- HTML-comment placeholders (`<!-- TODO: screenshot — ... -->`) at four natural drop-in spots: setup wizard, run review, db-profiles table, /compare diff view. Future PR will fill them in.
+
 ### Added — `/compare --json` for thesis / notebook workflows
 
 Direct continuation of the `/compare --csv` and `--md` flags from the previous PR. The JSON document is shaped specifically for pandas / Jupyter consumption — long-format `per_column` and `aggregate_metrics` arrays so notebooks can `pd.DataFrame(payload["per_column"]).pivot(...)` without reshaping.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
 # AMX — Agentic Metadata Extractor
 
-AI-powered CLI application that automatically infers, reviews, and applies metadata (descriptions, tags) to database assets — tables, views, and materialized views — using a multi-agent system with human-in-the-loop validation.
+> **Stop staring at `T0001.AUDAT NUMBER(8)` wondering what it means.**
+
+AMX walks your database, reads your documentation and codebase, then emits a complete description for every table and column — with confidence scores and a human-in-the-loop review before anything lands in the live DB. Multi-agent (Profile + RAG + Code), supports PostgreSQL / Snowflake / Databricks / BigQuery, talks to OpenAI / Anthropic / Gemini / DeepSeek / OpenRouter / vLLM / Ollama / LM Studio.
+
+<!-- TODO: hero screenshot — paste the AMX banner + first /run wizard here -->
+
+### What it produces
+
+Cryptic identifier in:
+
+```
+sap_s6p.t001.audat   NUMBER(8) NULL
+```
+
+Reviewed description out (after one `/run`):
+
+```
+sap_s6p.t001.audat — Document date. The calendar date the source business event
+was recorded, distinct from posting date (BUDAT) which controls the accounting
+period the transaction lands in.
+
+  confidence: high · logprob: 0.91 · sources: code (3 refs), docs, db profile
+```
+
+The same multi-agent pipeline runs against tables, views, materialized views, and schema-level descriptions.
+
+## Quick start (5 minutes)
+
+```bash
+pip install amx                  # installs all four DB drivers and the LLM SDKs
+amx                              # opens the interactive session
+/setup                           # walks you through DB + LLM profiles
+/run                             # picks scope, runs the agents, opens review
+amx doctor                       # if anything looks weird — diagnoses install + config
+```
+
+That's the happy path. Read on for what each agent does, supported backends, and the full slash-command reference.
+
+<!-- TODO: screenshot — `/setup` wizard prompt sequence -->
+
+<!-- TODO: screenshot — `/run` review screen with Accept / Alternatives / Skip choices -->
 
 ## Problem
 
@@ -48,7 +88,9 @@ For release notes see [CHANGELOG.md](./CHANGELOG.md) and the [GitHub Releases pa
 └────────────────────────────────────────────────────────────┘
 ```
 
-## Quick Start
+## Detailed setup
+
+The 5-minute quick start at the top covers the happy path. This section spells out prerequisites, installation options, and the explicit slash-command sequence for users who want full control.
 
 ### Prerequisites
 
@@ -128,6 +170,16 @@ amx
 /run-apply t001 vbak
 /apply
 ```
+
+<!-- TODO: screenshot — `/db-profiles` table showing one or two profiles with backend column -->
+
+<!-- TODO: screenshot — `/run` mid-flight: agent activity panel + per-column progress -->
+
+<!-- TODO: screenshot — `/run` review wizard: top description, alternatives list, accept/skip prompts -->
+
+<!-- TODO: screenshot — `/history list` after several runs, then `/compare --last 3 --diff` showing the per-column pivot -->
+
+If anything goes wrong — profiles missing, can't connect, multiple `amx` on PATH — run `amx doctor` from any shell. It diagnoses install, config, and connectivity and prints actionable hints next to each ✗.
 
 ## Interactive Commands (inside `amx` session)
 


### PR DESCRIPTION
## Summary

The README's first 130 lines were a feature list; new readers had to scroll past architecture diagrams and prerequisites before seeing what AMX actually produces. This restructures so a brand-new visitor sees:

1. **One-line value prop** — "Stop staring at `T0001.AUDAT NUMBER(8)` wondering what it means."
2. **What it produces** — synthetic before/after showing a cryptic identifier in → a reviewed description with confidence + logprob + sources out.
3. **5-minute quickstart** — four commands from `pip install` to a finished review, plus `amx doctor` for when things look wrong.

…all above the fold. The original detailed walkthrough is preserved under the renamed **"Detailed setup"** section.

## Screenshot slots (TODO for follow-up)

Four `<!-- TODO: screenshot -->` HTML comments at natural spots:
- Hero — banner + first `/run` wizard
- `/setup` wizard prompt sequence
- `/run` review screen with Accept / Alternatives / Skip
- `/db-profiles` table + `/compare --diff` view

You said you'd drop the actual screenshots in once you're back at your machine — these placeholders make it a one-line edit per spot.

## What's NOT in this PR

- No code, test, or config changes — README + CHANGELOG only
- No new commands (the quickstart references existing ones)
- No real connection identifiers (synthetic example uses `sap_s6p.t001.audat`, public SAP table name, no host / warehouse / catalog)

## Test plan

- [x] `pytest tests/` → 401 passed, 19 deselected
- [x] `ruff check / format` → clean
- [x] Pre-push leak scan per memory rule (`grep` for real Databricks host / warehouse IDs / company profile names) → 0 matches
