### PR TITLE
chore(api): pin public Python API surface before 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added — Public Python API contract (`docs/PUBLIC_API.md`)
+
+The structural change with the longest tail of consequences: pinning what's stable before `1.0` ships. Every name documented in the new contract follows SemVer from 1.0 onward; everything else is internal and can move freely.
+
+- **New `docs/PUBLIC_API.md`** — canonical reference for the stable surface (top-level `amx`, `amx.core`, the CLI command set, on-disk config + history schemas, `--json` export shape). Spells out what's NOT public (`amx.cli_support`, `amx.agents`, `amx.search`, `amx.config.AMXConfig` shape, internal helpers).
+- **Explicit `__all__`** added to every module backing `amx.core`: `application.py`, `ask_agent.py`, `inference.py`, `metadata.py`, `state.py`. Each docstring now references the contract doc.
+- **`amx.config` marked INTERNAL** in its module docstring — programmatic users go through `amx.init()` or `amx.core.AMXApplication.load()` instead. The two stable leaks (`CONFIG_SCHEMA_VERSION`, `ConfigSchemaTooNewError`) are called out explicitly.
+- **README's "Programmatic API" example** rewritten to use `amx.init()` instead of importing `AMXConfig` directly, plus a link to `docs/PUBLIC_API.md`.
+- **`tests/test_public_api_contract.py`** locks the contract: 10 cases that fail loudly if a public name is removed, renamed, or its `__all__` declaration silently drifts during a future `ruff format` import sort.
+
 ### Documentation — README hero, 5-minute quickstart, and screenshot slots
 
 The README's first 130 lines were a feature list; new readers had to scroll past architecture diagrams and prerequisite tables to see what AMX actually produces. Restructured so the value proposition + a concrete before/after example + the 30-second quickstart all live above the fold.

--- a/README.md
+++ b/README.md
@@ -576,13 +576,17 @@ See [`CHANGELOG.md`](./CHANGELOG.md) for the complete release history, or the [G
 Run AMX inference without entering the interactive CLI shell:
 
 ```python
-from amx.config import AMXConfig
+import amx
 from amx.core import infer_table_metadata
 
-cfg = AMXConfig.load()
-results = infer_table_metadata(cfg, schema="sap_test", table="adr6")
+app = amx.init()                       # loads ~/.amx/config.yml by default
+results = infer_table_metadata(
+    app.config, schema="sap_test", table="adr6"
+)
 print(results[0])
 ```
+
+The full stable surface — every name guaranteed to keep working across minor versions — is documented in [`docs/PUBLIC_API.md`](./docs/PUBLIC_API.md). Anything not listed there (including most of `amx.config`, `amx.cli_support`, `amx.agents`, `amx.search`, etc.) is internal and may move or change in any release.
 
 ## License
 

--- a/amx/config.py
+++ b/amx/config.py
@@ -1,4 +1,16 @@
-"""Central configuration store shared across all AMX modules."""
+"""Central configuration store shared across all AMX modules.
+
+INTERNAL — not part of the public API. Programmatic users should go
+through :func:`amx.init` or :class:`amx.core.AMXApplication.load`,
+which return a configured application without exposing the
+``AMXConfig`` dataclass shape. The shape is **not** stable across
+minor versions; see ``docs/PUBLIC_API.md``.
+
+Two names *are* stable because they leak through the on-disk config
+schema contract: :data:`CONFIG_SCHEMA_VERSION` and
+:exc:`ConfigSchemaTooNewError` (used by callers who load configs
+themselves and want to render an actionable upgrade message).
+"""
 
 from __future__ import annotations
 

--- a/amx/core/application.py
+++ b/amx/core/application.py
@@ -1,7 +1,8 @@
 """Headless AMX application facade.
 
 This module is the library-first entry point. The CLI should remain a thin
-adapter over these core services.
+adapter over these core services. Part of the **public API** — see
+``docs/PUBLIC_API.md`` for the stability contract.
 """
 
 from __future__ import annotations
@@ -16,6 +17,8 @@ from amx.core.state import StateManager
 from amx.search.catalog import SearchAnswer, SearchCatalog
 from amx.search.service import SearchService
 from amx.storage.sqlite_store import SQLiteHistoryStore, history_store, init_history_store
+
+__all__ = ["AMXApplication"]
 
 
 @dataclass

--- a/amx/core/ask_agent.py
+++ b/amx/core/ask_agent.py
@@ -1,4 +1,10 @@
-"""Tool-based ask agent primitives for headless AMX usage."""
+"""Tool-based ask agent primitives for headless AMX usage.
+
+Part of the **public API** — see ``docs/PUBLIC_API.md`` for the
+stability contract. ``ToolResult`` and ``ReasoningTraceStep`` are
+part of the ``ToolAskResponse`` shape and therefore implicitly
+public (additive field changes only across minor versions).
+"""
 
 from __future__ import annotations
 
@@ -10,6 +16,14 @@ from amx.agents.tools import SchemaExplorer
 from amx.config import AMXConfig
 from amx.db.connector import DatabaseConnector, ProfilingError
 from amx.search.catalog import SearchCatalog
+
+__all__ = [
+    "AskToolbox",
+    "LoopBasedAskAgent",
+    "ReasoningTraceStep",
+    "ToolAskResponse",
+    "ToolResult",
+]
 
 
 @dataclass(frozen=True)

--- a/amx/core/inference.py
+++ b/amx/core/inference.py
@@ -1,4 +1,8 @@
-"""Programmatic metadata inference entrypoints."""
+"""Programmatic metadata inference entrypoints.
+
+Part of the **public API** — see ``docs/PUBLIC_API.md`` for the
+stability contract.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +13,8 @@ from amx.agents.orchestrator import Orchestrator
 from amx.config import AMXConfig
 from amx.db.connector import DatabaseConnector
 from amx.llm.provider import LLMProvider
+
+__all__ = ["infer_table_metadata"]
 
 
 def infer_table_metadata(

--- a/amx/core/metadata.py
+++ b/amx/core/metadata.py
@@ -1,7 +1,14 @@
 """Canonical metadata abstractions for library-first AMX workflows.
 
 The Universal Metadata Interface (UMI) keeps downstream agents focused on
-observable signals instead of backend-specific naming conventions.
+observable signals instead of backend-specific naming conventions. Part of
+the **public API** — see ``docs/PUBLIC_API.md`` for the stability contract.
+
+Public names (re-exported via ``amx.core``): ``AbstractEntity``,
+``UniversalMetadataAdapter``. ``LexicalSignal``, ``StructuralSignal``,
+``StatisticalSignal``, ``SemanticSignal`` are part of the
+``AbstractEntity`` shape and therefore implicitly public — additive
+field changes only across minor versions.
 """
 
 from __future__ import annotations
@@ -10,6 +17,15 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from amx.db.connector import ColumnProfile, TableProfile
+
+__all__ = [
+    "AbstractEntity",
+    "LexicalSignal",
+    "SemanticSignal",
+    "StatisticalSignal",
+    "StructuralSignal",
+    "UniversalMetadataAdapter",
+]
 
 
 @dataclass(frozen=True)

--- a/amx/core/state.py
+++ b/amx/core/state.py
@@ -1,4 +1,8 @@
-"""Write-through state persistence for headless and CLI AMX sessions."""
+"""Write-through state persistence for headless and CLI AMX sessions.
+
+Part of the **public API** — see ``docs/PUBLIC_API.md`` for the
+stability contract.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +12,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from amx.config import AMXConfig
+
+__all__ = ["StateManager"]
 from amx.storage.sqlite_store import SQLiteHistoryStore
 
 

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -1,0 +1,109 @@
+# AMX public Python API
+
+This document defines the **stable Python API contract** for AMX. Anything documented here will follow [Semantic Versioning](https://semver.org/) starting from `1.0.0`:
+
+- **Patch** (`1.0.x`) — bug fixes, no public-API changes.
+- **Minor** (`1.x.0`) — additive only (new names, new optional kwargs, new optional fields on returned dataclasses). Existing code keeps working.
+- **Major** (`x.0.0`) — breaking changes only here, with a `DEPRECATED` notice in a prior minor release whenever practical.
+
+Anything **not** listed in this document is **internal**. Importing it works today but the symbol, signature, location, or behaviour can change in any release without notice. If something internal is genuinely useful to you, open an issue — we'll consider promoting it.
+
+---
+
+## What's public
+
+### Top-level convenience surface
+
+`amx`:
+
+| Symbol | Kind | Stability |
+|---|---|---|
+| `amx.__version__` | `str` | Stable |
+| `amx.init(config_path: str \| None = None) -> AMXApplication` | function | Stable |
+| `amx.AMXApplication` | class (lazy re-export) | Stable |
+| `amx.AbstractEntity` | class (lazy re-export) | Stable |
+| `amx.UniversalMetadataAdapter` | class (lazy re-export) | Stable |
+
+These are re-exports of names defined in `amx.core` for one-line scripts. Library code should prefer importing from `amx.core` directly.
+
+### `amx.core` — library-first API
+
+Every name listed in `amx/core/__init__.py.__all__` is part of the public contract:
+
+| Symbol | Kind | What it does |
+|---|---|---|
+| `amx.core.AMXApplication` | dataclass | Composable runtime that owns a config, a history store, and the active agents. Built via `AMXApplication.load(config_path)` for the typical case. |
+| `amx.core.AskToolbox` | dataclass | Tool registry the loop-based ask agent calls into (schema explorer, catalog, etc.). |
+| `amx.core.LoopBasedAskAgent` | class | Headless re-implementation of `/ask` for scripts and notebooks. |
+| `amx.core.ToolAskResponse` | dataclass | Structured response from the loop-based ask agent (answer, intent, tool trace, confidence). |
+| `amx.core.AbstractEntity` | dataclass | Backend-neutral entity abstraction used by the Universal Metadata Interface. |
+| `amx.core.UniversalMetadataAdapter` | class | Maps backend-specific column / table profiles into `AbstractEntity`. |
+| `amx.core.StateManager` | class | Write-through persistence for config + SQLite-backed state across sessions. |
+| `amx.core.infer_table_metadata(cfg, schema, table, *, include_rag, include_codebase)` | function | One-call programmatic metadata inference. Returns a list of suggestion dicts ready for review. |
+
+### CLI
+
+The `amx` console script (defined under `[project.scripts]` in `pyproject.toml`) is part of the public API:
+
+- The set of slash commands documented in `README.md` is the contract.
+- Slash command **flags** (`--db-profile`, `--last`, `--diff`, `--csv`, …) are stable within a major version.
+- Output is **rendered for humans** — no contract on column order, terminal styling, or table widths. Scripts that need to consume AMX output should use the export flags (`--csv`, `--md`, `--json`) where available.
+
+### On-disk formats
+
+These are part of the public contract because users depend on them across upgrades:
+
+- `~/.amx/config.yml` — schema is versioned (`schema_version: N` field, see `amx.config.CONFIG_SCHEMA_VERSION`). When AMX bumps the schema, an older binary refuses to load a newer config rather than silently mangling it (raises `ConfigSchemaTooNewError`).
+- `~/.amx/history.db` — SQLite tables (`analysis_runs`, `run_results`, `app_events`, etc.) accept additive migrations within a major version. Column types and the meaning of existing columns are stable.
+- `--json` export shape (see `tests/eval/README.md`) — the keys `schema_version`, `run_summary`, `per_column`, `aggregate_metrics` are stable.
+
+---
+
+## What's internal
+
+Everything else. Highlights:
+
+| Module | Why it's internal |
+|---|---|
+| `amx.cli`, `amx.cli_support.*` | CLI plumbing, refactored frequently |
+| `amx.cli_*` (top-level shims like `amx.cli_db`, `amx.cli_run`) | Backwards-compat shims that re-export from `amx.cli_support.commands.*`; will be removed in a future major release. Use the underlying modules only at your own risk; prefer `amx.core.*` for programmatic access. |
+| `amx.agents.*` | Profile / RAG / Code agent internals. The orchestrator decides what gets called and how — directly instantiating these from user code couples you to the agent contract. |
+| `amx.search._agent.*`, `amx.search._catalog.*` | Already underscore-prefixed. Do not import. |
+| `amx.search.agent`, `amx.search.catalog`, `amx.search.service` | Public-shaped names but not part of the contract — use `amx.core.AMXApplication` to get a configured `SearchService`. |
+| `amx.db.*`, `amx.llm.*`, `amx.docs.*`, `amx.codebase.*` | Backend adapters; tightly coupled to the active config. |
+| `amx.storage.*` | History store implementation. `amx.core.AMXApplication` exposes the configured store via `app.history_store`. |
+| `amx.utils.*` | Internal helpers (Rich console wrappers, logging, token counting). |
+| `amx.config.AMXConfig` | Used internally; configure programmatically by passing a path to `amx.init(...)` or by editing `~/.amx/config.yml`. The dataclass shape is **not** stable. |
+
+---
+
+## How to write code that survives upgrades
+
+```python
+# Good — uses only public surface.
+from amx.core import AMXApplication, infer_table_metadata
+
+app = AMXApplication.load("~/.amx/config.yml")
+suggestions = infer_table_metadata(
+    app.config, "sales", "orders", include_rag=True, include_codebase=False
+)
+```
+
+```python
+# Risky — imports an internal symbol whose location may move.
+from amx.search.service import SearchService   # internal
+from amx.agents.orchestrator import Orchestrator   # internal
+
+# The replacement when this breaks:
+from amx.core import AMXApplication
+app = AMXApplication.load(...)
+service = app.search_service          # configured for you
+```
+
+---
+
+## Pre-1.0 caveat
+
+While AMX is at `0.x`, the contract above is **best-effort**. We will avoid breaking the listed symbols whenever possible and will flag any necessary breakage in `CHANGELOG.md` under `BREAKING CHANGE`. The hard guarantees kick in at `1.0.0`.
+
+If a stability guarantee here matters to you for production use, open an issue — we'd rather hear it now than break you later.

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -1,0 +1,173 @@
+"""Lock down the AMX public Python API contract.
+
+Anything documented in ``docs/PUBLIC_API.md`` is a stable contract
+once we ship 1.0. These tests fail loudly if a public name is
+accidentally removed or renamed — turning a silent breakage into a
+red CI run on the PR that introduced it.
+
+What's covered:
+
+* ``amx.__all__`` and the lazy ``amx.<name>`` surface.
+* ``amx.core.__all__`` and every name re-exported through it.
+* The ``CONFIG_SCHEMA_VERSION`` and ``ConfigSchemaTooNewError`` leak
+  from ``amx.config`` because they're part of the on-disk schema
+  contract (see ``docs/PUBLIC_API.md``).
+
+What's NOT covered (deliberately): individual method signatures,
+dataclass field shapes. Those evolve additively within a major
+version; locking them down here would prevent legitimate growth.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+
+class TopLevelAmxSurfaceTests(unittest.TestCase):
+    def test_version_is_a_string(self) -> None:
+        import amx
+
+        self.assertIsInstance(amx.__version__, str)
+        self.assertTrue(amx.__version__)
+
+    def test_top_level_all_lists_expected_public_names(self) -> None:
+        import amx
+
+        self.assertEqual(
+            set(amx.__all__),
+            {"AMXApplication", "AbstractEntity", "UniversalMetadataAdapter", "__version__", "init"},
+        )
+
+    def test_lazy_attributes_resolve(self) -> None:
+        import amx
+
+        self.assertTrue(callable(amx.init))
+        self.assertTrue(hasattr(amx.AMXApplication, "load"))
+        self.assertTrue(amx.AbstractEntity.__name__ == "AbstractEntity")
+        self.assertTrue(amx.UniversalMetadataAdapter.__name__ == "UniversalMetadataAdapter")
+
+    def test_unknown_top_level_attribute_raises(self) -> None:
+        import amx
+
+        with self.assertRaises(AttributeError):
+            _ = amx.NotAPublicSymbol  # type: ignore[attr-defined]
+
+
+class CoreSurfaceTests(unittest.TestCase):
+    """Every name in ``amx.core.__all__`` is part of the public API.
+
+    This test fails if a public symbol is removed, renamed, or moved
+    out of ``amx.core``. It does NOT fail when symbols are *added* to
+    the surface — that's an additive (minor-version) change.
+    """
+
+    EXPECTED_PUBLIC_NAMES: frozenset[str] = frozenset(
+        {
+            "AMXApplication",
+            "AbstractEntity",
+            "AskToolbox",
+            "LoopBasedAskAgent",
+            "StateManager",
+            "ToolAskResponse",
+            "UniversalMetadataAdapter",
+            "infer_table_metadata",
+        }
+    )
+
+    def test_core_all_includes_every_documented_public_name(self) -> None:
+        import amx.core as core
+
+        missing = self.EXPECTED_PUBLIC_NAMES - set(core.__all__)
+        self.assertFalse(
+            missing,
+            f"docs/PUBLIC_API.md lists names that are no longer in "
+            f"amx.core.__all__: {sorted(missing)}",
+        )
+
+    def test_each_public_core_name_resolves(self) -> None:
+        import amx.core as core
+
+        for name in self.EXPECTED_PUBLIC_NAMES:
+            with self.subTest(name=name):
+                obj = getattr(core, name)
+                self.assertIsNotNone(obj, f"{name} resolved to None")
+
+    def test_core_unknown_attribute_raises(self) -> None:
+        import amx.core as core
+
+        with self.assertRaises(AttributeError):
+            _ = core.NotAPublicSymbol  # type: ignore[attr-defined]
+
+
+class ConfigSchemaContractTests(unittest.TestCase):
+    """The on-disk config schema constants are part of the public contract.
+
+    Although ``AMXConfig`` itself is internal (its dataclass shape
+    isn't stable), :data:`CONFIG_SCHEMA_VERSION` and
+    :exc:`ConfigSchemaTooNewError` leak through the on-disk schema
+    contract documented in ``docs/PUBLIC_API.md`` and need to stay
+    importable from ``amx.config`` across minor versions.
+    """
+
+    def test_schema_version_constant_is_an_int(self) -> None:
+        from amx.config import CONFIG_SCHEMA_VERSION
+
+        self.assertIsInstance(CONFIG_SCHEMA_VERSION, int)
+        self.assertGreaterEqual(CONFIG_SCHEMA_VERSION, 1)
+
+    def test_schema_error_is_a_runtime_error_subclass(self) -> None:
+        from amx.config import ConfigSchemaTooNewError
+
+        self.assertTrue(issubclass(ConfigSchemaTooNewError, RuntimeError))
+
+
+class CoreModuleAllListsTests(unittest.TestCase):
+    """Each module backing the public surface declares its own ``__all__``.
+
+    A missing ``__all__`` means ``from amx.core.foo import *`` brings
+    in helpers / private helpers, which then become *de facto* public
+    on the next ``ruff format`` import sort. The explicit list pins
+    what's intentionally public per module.
+    """
+
+    EXPECTED: dict[str, set[str]] = {
+        "amx.core.application": {"AMXApplication"},
+        "amx.core.ask_agent": {
+            "AskToolbox",
+            "LoopBasedAskAgent",
+            "ReasoningTraceStep",
+            "ToolAskResponse",
+            "ToolResult",
+        },
+        "amx.core.inference": {"infer_table_metadata"},
+        "amx.core.metadata": {
+            "AbstractEntity",
+            "LexicalSignal",
+            "SemanticSignal",
+            "StatisticalSignal",
+            "StructuralSignal",
+            "UniversalMetadataAdapter",
+        },
+        "amx.core.state": {"StateManager"},
+    }
+
+    def test_each_public_module_declares_all(self) -> None:
+        import importlib
+
+        for module_name, expected in self.EXPECTED.items():
+            with self.subTest(module=module_name):
+                mod = importlib.import_module(module_name)
+                self.assertTrue(
+                    hasattr(mod, "__all__"),
+                    f"{module_name} should declare __all__ to pin its "
+                    f"public surface; see docs/PUBLIC_API.md.",
+                )
+                missing = expected - set(mod.__all__)
+                self.assertFalse(
+                    missing,
+                    f"{module_name}.__all__ is missing public names: {sorted(missing)}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Pins the **public Python API contract** before 1.0 ships. This is the structural change with the longest tail of consequences — once 1.0 ships, every name a user can `import amx.X` becomes a contract. Locking it down explicitly now prevents silent drift through `ruff format` import sorts or casual `from x import *` patterns.

**Public contract** (now formal in `docs/PUBLIC_API.md`):
- Top-level: `amx.__version__`, `amx.init`, `amx.AMXApplication`, `amx.AbstractEntity`, `amx.UniversalMetadataAdapter`
- All 8 names in `amx.core.__all__`
- The `amx` CLI command + flags
- On-disk schemas: `config.yml` `schema_version`, `history.db` tables, `/compare --json` shape

**Explicitly internal** (callable but unstable):
- `amx.cli`, `amx.cli_support.*`, `amx.cli_*` shims
- `amx.agents.*`, `amx.search.*`, `amx.storage.*`, `amx.db.*`, `amx.llm.*`, `amx.docs.*`, `amx.codebase.*`, `amx.utils.*`
- `amx.config.AMXConfig` dataclass shape (the two leaks `CONFIG_SCHEMA_VERSION` + `ConfigSchemaTooNewError` are stable because the on-disk schema needs them)

## What changed in code

- **New `docs/PUBLIC_API.md`** — full contract reference with stability rules (additive minor, breaking only at major).
- **`__all__` declarations** added to every public-API backing module (`amx/core/application.py`, `ask_agent.py`, `inference.py`, `metadata.py`, `state.py`).
- **`amx/config.py` docstring** marks the module as INTERNAL with a pointer to `amx.init()` / `AMXApplication.load()` for programmatic access.
- **README's Programmatic API example** rewritten to use only public symbols, plus a link to the contract doc.
- **`tests/test_public_api_contract.py`** — 10 cases that fail loudly if a public name is removed, renamed, or its `__all__` silently drifts.

## Test plan

- [x] `pytest tests/test_public_api_contract.py` → 10/10 pass
- [x] `pytest tests/` → 411 passed, 19 deselected (was 401; +10 from the new contract tests)
- [x] `ruff check / format` → clean
- [x] `python -c "import amx; print(amx.AMXApplication, amx.init)"` → resolves end-to-end
- [x] Pre-push leak scan per memory rule → 0 matches
