### PR TITLE
fix(doctor): dispatch /doctor correctly from every namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — `/doctor` now works from every namespace, not just `/search`
+
+`/doctor` was registered with `cross_namespace=True` in the slash registry (so it appeared in autocomplete from every tab), but its dispatch was incomplete. Inside `/search` the verb fell through to `["search", "ask", "doctor"]` — sending the literal string "doctor" to the search agent as a question, which silently "looked like it worked." From any other namespace (`/db`, `/llm`, `/code`, …) the verb hit Click as `[namespace, "doctor"]`, an unknown subcommand.
+
+- **Root cause**: `session.session_to_click_args` had no entry for `doctor` in its `shortcut_map`, so the function couldn't translate `/doctor` to the top-level Click subcommand. The slash registry's `cross_namespace=True` only controls help/autocomplete visibility — runtime dispatch is a separate code path.
+- **Fix**: one-line addition (`"doctor": ["doctor"]`) to `shortcut_map`. Now `/doctor [--skip-network]` dispatches to the top-level Click subcommand from any namespace, exactly the same way `amx doctor` from a shell does.
+- **4 new regression tests** (`tests/test_doctor_and_schema.py::DoctorCrossNamespaceDispatchTests`) cover the dispatch from root, `/search`, every other namespace, and the `--skip-network` flag passthrough. Each fails on `main` without the fix.
+
 ### Added — Public Python API contract (`docs/PUBLIC_API.md`)
 
 The structural change with the longest tail of consequences: pinning what's stable before `1.0` ships. Every name documented in the new contract follows SemVer from 1.0 onward; everything else is internal and can move freely.

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -860,6 +860,14 @@ def session_to_click_args(namespace: str, parts: list[str]) -> list[str] | None:
         "setup": ["setup"],
         "config": ["config"],
         "help": ["--help"],
+        # /doctor is cross-namespace: registered as a top-level Click
+        # subcommand and listed in _ROOT_BUILTINS with cross_namespace=True.
+        # Without this entry, typing `/doctor` from /llm, /db, etc. would
+        # fall through to `[namespace, "doctor"]` which Click rejects, and
+        # from /search it would fall through to `["search", "ask",
+        # "doctor"]` — sending the literal string "doctor" to the search
+        # agent as a question, which silently "looks like it worked".
+        "doctor": ["doctor"],
     }
     if head == "search" and len(parts) > 1:
         if parts[1] in {

--- a/tests/test_doctor_and_schema.py
+++ b/tests/test_doctor_and_schema.py
@@ -199,5 +199,49 @@ class DoctorEndToEndTests(unittest.TestCase):
             self.assertIn("amx on PATH", result.output)
 
 
+class DoctorCrossNamespaceDispatchTests(unittest.TestCase):
+    """`/doctor` must work from every namespace tab, not just /search.
+
+    Regression guard: registering ``cross_namespace=True`` in the slash
+    registry was not enough — without an entry in
+    ``session.shortcut_map``, ``/doctor`` from /search fell through to
+    ``["search", "ask", "doctor"]`` (sent the literal "doctor" string to
+    the search agent as a question), and from any other namespace fell
+    through to ``[namespace, "doctor"]`` which Click rejected.
+    """
+
+    def test_dispatch_from_root_namespace(self) -> None:
+        from amx.cli_support.session import session_to_click_args
+
+        self.assertEqual(session_to_click_args("", ["doctor"]), ["doctor"])
+
+    def test_dispatch_from_search_namespace(self) -> None:
+        from amx.cli_support.session import session_to_click_args
+
+        # The bug specifically masqueraded as "works under search"
+        # because /search swallows unknown verbs as questions.
+        self.assertEqual(session_to_click_args("search", ["doctor"]), ["doctor"])
+
+    def test_dispatch_from_other_namespaces(self) -> None:
+        from amx.cli_support.session import session_to_click_args
+
+        for ns in ("db", "metadata", "docs", "llm", "code", "analyze", "history"):
+            with self.subTest(namespace=ns):
+                self.assertEqual(
+                    session_to_click_args(ns, ["doctor"]),
+                    ["doctor"],
+                    f"/doctor must dispatch to top-level click "
+                    f"`doctor` from /{ns}, not get swallowed.",
+                )
+
+    def test_skip_network_flag_passed_through(self) -> None:
+        from amx.cli_support.session import session_to_click_args
+
+        self.assertEqual(
+            session_to_click_args("llm", ["doctor", "--skip-network"]),
+            ["doctor", "--skip-network"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

You spotted a real bug — thanks. `/doctor` was registered with `cross_namespace=True` in the slash registry, so the autocomplete dropdown listed it under every tab, but the runtime dispatcher had no clue how to translate it. Two failure modes:

| From | What `session_to_click_args` returned | What actually happened |
|---|---|---|
| `/search` | `["search", "ask", "doctor"]` | Sent the literal string "doctor" to the search agent as a question. Looked like it worked. |
| `/db`, `/llm`, `/code`, `/docs`, `/metadata`, `/analyze`, `/history` | `[namespace, "doctor"]` | Click rejected as an unknown subcommand. |

**Root cause**: `session.shortcut_map` had no entry for `doctor`. The slash registry's `cross_namespace=True` flag only controls help / autocomplete visibility — runtime dispatch is a separate translation table.

**Fix**: one line — `"doctor": ["doctor"]` in `shortcut_map`. Now `/doctor` (and `/doctor --skip-network`) dispatches to the top-level Click subcommand the same way `amx doctor` does from a shell.

## Test plan

- [x] `pytest tests/test_doctor_and_schema.py::DoctorCrossNamespaceDispatchTests` → 4 new cases pass (root, /search, all 7 other namespaces, `--skip-network` passthrough). Each fails on `main` without the fix — verified by reverting just `session.py` and re-running the tests.
- [x] `pytest tests/` → 415 passed, 19 deselected (was 411; +4 from the new dispatch tests)
- [x] `ruff check / format` → clean
- [x] Pre-push leak scan → 0 matches
