### PR TITLE
fix(llm): auto-fall back when provider rejects logprobs (Gemini Flash etc.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — Auto-fallback when the LLM provider rejects logprobs
+
+User report: with `gemini/gemini-flash-latest` configured, every `/run` and `/connect` test failed with `litellm.BadRequestError: GeminiException BadRequestError - "Logprobs is not enabled for this model"`. AMX defaults `force_logprobs: true` (the confidence-band system depends on token logprobs for calibrated scoring), but several models reject the parameter outright — Gemini Flash, OpenAI o-series, some OpenRouter-fronted Anthropic models. Pre-fix the 400 wasn't classified as fatal so AMX retried the same call 3× (all 400) before surfacing the error.
+
+- **New `_is_logprobs_unsupported_error` detector** matches the seven phrasings providers use ("Logprobs is not enabled for this model", "logprobs not supported", "does not support logprobs", etc.). Catches the verbatim Gemini Flash error from the user's report.
+- **Recovery branch in `chat()`**: when the detector fires AND the failing call had `logprobs=True`, AMX strips the logprob keys (`logprobs`, `top_logprobs`, `num_probs`) and retries the same call once. The retry succeeds; the run continues with heuristic confidence scoring instead of calibrated token logprobs.
+- **Session-level disable flag** (`_logprobs_runtime_disabled`) — set after the first successful fallback so subsequent calls in the same session skip logprobs upfront. Prevents a long `/run` from triggering the same 400 + retry cycle for every column.
+- **One-time INFO log** explains the trade-off: "Provider gemini/gemini-flash-latest rejected logprobs=True. Disabling logprobs for this session and retrying. Confidence bands will use heuristic scoring instead of calibrated token logprobs."
+- **3 new tests** (`LLMTransientRetryTests`): detector pattern coverage, the auto-retry-without-logprobs path, the second-call-skips-upfront behaviour. End-to-end script with the user's verbatim error message validates the flow.
+
 ### Fixed — PostgreSQL "leave database blank" actually works now
 
 User report: the `/add-db-profile` wizard advertised `database` as optional ("leave blank to pick at command time"), then `/connect` rejected the saved profile with "PostgreSQL connection requires a database name." The wizard's promise was never wired up in the URL builder — the resulting URL had no database segment, libpq silently fell back to a database named after the user, and the connection failed.

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -242,6 +242,34 @@ _FATAL_MESSAGE_PATTERNS: tuple[tuple[str, str], ...] = (
 )
 
 
+# Error fragments emitted by providers that don't support logprobs at
+# all (Gemini Flash, OpenAI o-series, some Anthropic via OpenRouter).
+# We catch these specifically so AMX can retry the SAME call without
+# the ``logprobs=True`` request flag, instead of treating the 400 as a
+# fatal error and aborting the whole run.
+_LOGPROBS_UNSUPPORTED_PATTERNS: tuple[str, ...] = (
+    "logprobs is not enabled for this model",  # Gemini Flash exact text
+    "logprobs is not supported",
+    "logprobs not supported",
+    "logprobs are not supported",
+    "logprob is not supported",
+    "does not support logprobs",
+    "logprobs parameter is not supported",
+)
+
+
+def _is_logprobs_unsupported_error(exc: BaseException) -> bool:
+    """True when the exception indicates the model rejected ``logprobs=True``.
+
+    Detection is message-based because providers wrap the rejection
+    inside provider-specific exception types (``GeminiException``,
+    ``BadRequestError``, etc.) — the only reliable signal is the
+    inner JSON body.
+    """
+    msg = str(exc).lower()
+    return any(pat in msg for pat in _LOGPROBS_UNSUPPORTED_PATTERNS)
+
+
 def _classify_fatal_llm_error(exc: BaseException) -> FatalLLMError | None:
     """Return ``FatalLLMError`` when ``exc`` is non-retryable, else None.
 
@@ -598,9 +626,15 @@ class LLMProvider:
     def supports_logprobs(self) -> bool:
         """Whether AMX should request logprobs for this profile.
 
-        Defaults to True (force-enable), but can be overridden per profile by
-        setting ``force_logprobs`` on the LLM config object.
+        Defaults to True (force-enable), can be overridden per profile via
+        ``force_logprobs`` on the LLM config, AND is auto-disabled at
+        runtime when the provider rejects the request (see
+        ``_logprobs_runtime_disabled`` set by ``chat()`` when it sees a
+        ``Logprobs is not enabled for this model`` 400 from Gemini /
+        OpenAI o-series / etc.).
         """
+        if getattr(self, "_logprobs_runtime_disabled", False):
+            return False
         return bool(getattr(self.cfg, "force_logprobs", True))
 
     @property
@@ -683,6 +717,13 @@ class LLMProvider:
         mt = max_tokens or self.cfg.max_tokens
         extra: dict[str, Any] = dict(kwargs)
 
+        # Honor a runtime-discovered disable flag — set lower in the
+        # exception path when a provider returns
+        # ``Logprobs is not enabled for this model`` (Gemini Flash,
+        # OpenAI o-series, some others). Without this, every subsequent
+        # call in the same session would re-trigger the same 400.
+        if use_logprobs and getattr(self, "_logprobs_runtime_disabled", False):
+            use_logprobs = False
         if use_logprobs:
             # Force-request logprobs regardless of provider capability metadata.
             extra["logprobs"] = True
@@ -743,6 +784,37 @@ class LLMProvider:
                 break
             except Exception as exc:
                 last_exc = exc
+
+                # Logprobs-not-supported recovery: Gemini Flash, OpenAI
+                # o-series, and a few OpenRouter-fronted models reject
+                # ``logprobs=True`` with a 400. Strip the flag, set the
+                # session-level disable so subsequent calls skip it
+                # upfront, and retry the same call once.
+                if (
+                    extra.get("logprobs")
+                    and _is_logprobs_unsupported_error(exc)
+                    and not getattr(self, "_logprobs_runtime_disabled", False)
+                ):
+                    log.info(
+                        "Provider %s/%s rejected logprobs=True. Disabling "
+                        "logprobs for this session and retrying. Confidence "
+                        "bands will use heuristic scoring instead of "
+                        "calibrated token logprobs.",
+                        self.cfg.provider,
+                        self.cfg.model,
+                    )
+                    self._logprobs_runtime_disabled = True
+                    for key in ("logprobs", "top_logprobs", "num_probs"):
+                        extra.pop(key, None)
+                    try:
+                        resp = _do_completion(call_api_base)
+                        last_exc = None
+                        break
+                    except Exception as logprobs_retry_exc:
+                        last_exc = logprobs_retry_exc
+                        # Fall through to the standard classification path
+                        # so the user sees the real underlying issue if
+                        # the retry also fails.
 
                 # Fatal errors (auth / quota / payment / model-not-found) are
                 # not transient — every retry will fail the same way. Raise

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -4496,6 +4496,92 @@ class LLMTransientRetryTests(unittest.TestCase):
         # MAX_LLM_RETRIES=2 → 3 total attempts (initial + 2 retries).
         self.assertEqual(calls["count"], 3)
 
+    # ── Logprobs auto-fallback ──────────────────────────────────────────
+
+    def test_logprobs_unsupported_error_detector_matches_gemini_message(self) -> None:
+        """The user-reported Gemini Flash error verbatim must be detected.
+        Other phrasings producers might use ("logprobs not supported"
+        etc.) are also covered by the pattern set."""
+        from amx.llm.provider import _is_logprobs_unsupported_error
+
+        gemini_msg = (
+            "litellm.BadRequestError: GeminiException BadRequestError - {\n"
+            '  "error": {\n'
+            '    "code": 400,\n'
+            '    "message": "Logprobs is not enabled for this model",\n'
+            '    "status": "INVALID_ARGUMENT"\n  }\n}'
+        )
+        self.assertTrue(_is_logprobs_unsupported_error(RuntimeError(gemini_msg)))
+        self.assertTrue(_is_logprobs_unsupported_error(RuntimeError("logprobs not supported")))
+        self.assertTrue(_is_logprobs_unsupported_error(RuntimeError("does not support logprobs")))
+        # Unrelated 400 must NOT match — we don't want to swallow real
+        # bad-request errors as if they were logprobs issues.
+        self.assertFalse(_is_logprobs_unsupported_error(RuntimeError("invalid request: bad model")))
+
+    def test_chat_retries_without_logprobs_when_provider_rejects_them(self) -> None:
+        """User report 2026-05-02: gemini/gemini-flash-latest returned a
+        400 with ``Logprobs is not enabled for this model``. Pre-fix
+        AMX retried 3× with the same flag (all failing) and finally
+        surfaced the error. Post-fix the provider strips ``logprobs``
+        from the second attempt and the call succeeds.
+        """
+
+        class BadRequestError(Exception):
+            pass
+
+        calls: list[dict] = []
+
+        def fake_completion(**kwargs):
+            calls.append(dict(kwargs))
+            if "logprobs" in kwargs:
+                raise BadRequestError(
+                    'GeminiException BadRequestError - {"error": {"code": 400, '
+                    '"message": "Logprobs is not enabled for this model"}}'
+                )
+            return self._ok_response()
+
+        with self._patch_litellm_with(fake_completion):
+            result = self._provider.chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(result.content, "ok")
+        # Exactly two calls: first with logprobs (rejected), second without.
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(calls[0].get("logprobs"))
+        self.assertNotIn("logprobs", calls[1])
+        # And the runtime-disable flag is now set so subsequent chats
+        # in this session skip the logprobs request upfront.
+        self.assertTrue(getattr(self._provider, "_logprobs_runtime_disabled", False))
+        self.assertFalse(self._provider.supports_logprobs)
+
+    def test_subsequent_chat_after_logprobs_rejection_skips_logprobs_upfront(self) -> None:
+        """Once the runtime-disable flag is set, the NEXT chat() call
+        must not request logprobs at all — otherwise every call in a
+        long /run would hit the same 400, retry once, and continue.
+        """
+
+        class BadRequestError(Exception):
+            pass
+
+        seen_logprobs_keys: list[bool] = []
+
+        def fake_completion(**kwargs):
+            seen_logprobs_keys.append("logprobs" in kwargs)
+            if "logprobs" in kwargs:
+                raise BadRequestError("Logprobs is not enabled for this model")
+            return self._ok_response()
+
+        with self._patch_litellm_with(fake_completion):
+            self._provider.chat([{"role": "user", "content": "hi"}])
+            # Reset the per-call tracking before the second call so we
+            # measure only the second invocation's logprobs flag.
+            calls_after = list(seen_logprobs_keys)
+            self._provider.chat([{"role": "user", "content": "again"}])
+
+        # First chat: 1st attempt with logprobs (rejected) + 2nd without (ok).
+        self.assertEqual(calls_after, [True, False])
+        # Second chat: single attempt, logprobs already disabled.
+        self.assertEqual(seen_logprobs_keys[len(calls_after) :], [False])
+
     @pytest.mark.live
     def test_non_transient_error_does_not_retry(self) -> None:
         """Authentication / bad-request style errors must propagate


### PR DESCRIPTION
## What was happening

Your log showed `gemini/gemini-flash-latest` returning:

```
BadRequestError - {
  "error": {
    "code": 400,
    "message": "Logprobs is not enabled for this model",
    "status": "INVALID_ARGUMENT"
  }
}
```

AMX defaults `force_logprobs: true` because its confidence-band system uses calibrated token logprobs for scoring (`high` / `medium` / `low` bands map to weighted probability thresholds). Several models reject `logprobs=True` outright though — Gemini Flash, OpenAI o-series, and a few OpenRouter-fronted Anthropic models. Pre-fix the 400 didn't match any fatal-error pattern so AMX retried the same call 3× (all 400) before surfacing the error to you.

## Fix

- **`_is_logprobs_unsupported_error` detector** matches seven phrasings producers use, including your verbatim Gemini Flash text.
- **Recovery branch in `chat()`** strips `logprobs` / `top_logprobs` / `num_probs` from the request and retries once. The retry succeeds; confidence bands fall back to heuristic scoring.
- **Session-level `_logprobs_runtime_disabled` flag** so subsequent calls in the same `/run` don't keep triggering the 400 + retry cycle for every column.
- **One-time INFO log** explains the trade-off: `Provider gemini/gemini-flash-latest rejected logprobs=True. Disabling logprobs for this session and retrying. Confidence bands will use heuristic scoring instead of calibrated token logprobs.`

## Walk-through I did before declaring done

Per the new "walk the user-flow before declaring a CLI fix done" memory rule (added in PR #54), I replayed your exact error string against a fake LiteLLM client end-to-end:

```
✓ Detector recognises the user's verbatim Gemini error
✓ First chat() — auto-retry without logprobs:
    attempts (with logprobs?) = [True, False]
✓ Second chat() — must skip logprobs upfront:
    attempts (with logprobs?) = [False]
```

## Test plan

- [x] `pytest tests/` → **424 passed**, 19 deselected (was 421; +3 new)
- [x] `ruff check / format` → clean
- [x] Pre-push leak scan → 0 matches
- [x] End-to-end script with your verbatim error message validates the flow

## Trade-off you should know about

When AMX falls back to heuristic confidence scoring (because the model rejects logprobs), the `confidence` band on saved descriptions still surfaces (`high` / `medium` / `low`) but uses a heuristic mapping instead of calibrated token logprobs. This means:
- Comparisons across models with mixed logprobs support are still meaningful but slightly noisier
- The thesis-grade calibration claim only holds for models that DO support logprobs (OpenAI gpt-4o, OpenRouter passthrough to Claude, etc.)
- Worth picking a logprobs-supporting model for runs you want to chart formally
