### PR TITLE
fix(run): show auto-apply prompt for single-asset chat-mode runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — `auto-apply` is reachable for single-asset `/run`
+
+User report: "where is auto-apply, has been returning past, why did you delete it?". Auto-apply was **not** deleted — the run-wide `Review strategy` prompt that contains it was just hidden when the user picked a single asset.
+
+The gate at `analyze_flow.py:592` was `if not use_batch and total_assets > 1:`. With `total_assets == 1` the prompt was skipped entirely; `review_strategy` silently defaulted to `"individual"` and the user only ever saw the per-table review-mode prompt (`one-by-one` / `accept-all-high` / `accept-all` / `reject-all`) — none of which auto-apply. The gate predates this session (commit `cbd66087`, 2026-04-29).
+
+- **Lift the `total_assets > 1` part of the gate.** The prompt now fires for any chat-mode `/run` scope, so users running a single table can pick `auto-apply` (`Skip human review — write the top LLM suggestion directly`) the same way multi-asset users could.
+- **Batch mode still skips** the prompt because batch reviews everything at the end regardless of strategy — leaving `not use_batch` as the only condition.
+- The existing safety warning fires when `auto-apply` is selected with `/run` (no `--apply`): "auto-apply selected but /run was used (without --apply). The top suggestions will be marked accepted in the catalog, but nothing will be written to the DB. Use /run-apply to actually persist the comments."
+
 ### Fixed — Nested pause/resume in LiveDisplay (the "Only one live display may be active at once" error after `accept-all` review)
 
 User report: after picking `accept-all` for a column-review prompt during `/run`, AMX printed `✗ Only one live display may be active at once` and then drew two stacked panels.

--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -589,7 +589,17 @@ def execute_analyze_run(
                 )
 
             review_strategy = "individual"
-            if not use_batch and total_assets > 1:
+            # Show the run-wide strategy prompt for any chat-mode run,
+            # including single-asset scopes. The pre-2026-05-02 gate
+            # (``total_assets > 1``) skipped this prompt entirely when
+            # the user picked a single table — silently defaulting to
+            # "individual" and hiding the ``auto-apply`` option for the
+            # very flow it was built for: "I trust the agents, just
+            # write the top suggestion to the DB and don't make me
+            # click through a per-column review for one table." Batch
+            # mode still skips because batch reviews everything at the
+            # end regardless of strategy.
+            if not use_batch:
                 review_strategy = ask_choice(
                     "Review strategy",
                     ["individual", "deferred", "auto-apply"],


### PR DESCRIPTION
## Diagnosis

Auto-apply was **not** deleted. The run-wide `Review strategy` prompt that contains it was just hidden when the user's scope was a single asset.

The gate at `analyze_flow.py:592`:

```python
if not use_batch and total_assets > 1:    # ← total_assets > 1 hides auto-apply
    review_strategy = ask_choice(
        "Review strategy",
        ["individual", "deferred", "auto-apply"],
        ...
    )
```

With `total_assets == 1`, the prompt was skipped entirely; `review_strategy` silently defaulted to `"individual"` and the user only ever saw the per-table review-mode prompt (`one-by-one`/`accept-all-high`/`accept-all`/`reject-all`) — none of which short-circuit human review the way auto-apply does.

`git blame` confirms the gate predates this session (commit `cbd66087`, 2026-04-29) and auto-apply was added the next day (`f0886b5`) without lifting it.

## Fix

Lift the `total_assets > 1` part of the gate. Batch mode still skips because batch reviews everything at the end regardless of strategy.

```python
if not use_batch:    # ← any chat-mode scope, including single-asset
    review_strategy = ask_choice(
        "Review strategy",
        ["individual", "deferred", "auto-apply"],
        ...
    )
```

## What you'll see now

```
/run
  → pick scope: 1 asset
  → dedup question
  → completion mode (chat)
  → coverage filter
  → Review strategy
      1. individual    Assess each asset (table) as it becomes ready (default)
      2. deferred      Process everything first, then review all together at the end
      3. auto-apply    Skip human review — write the top LLM suggestion directly.
                       Fastest, but no chance to edit or reject. Use only when you
                       trust the agents (and ideally only with /run-apply on a
                       non-prod DB).
```

The existing safety warning still fires when auto-apply is picked with `/run` (without `--apply`): "auto-apply selected but /run was used... use /run-apply to actually persist the comments."

## Test plan

- [x] `pytest tests/` → **428 passed**, 19 deselected
- [x] `ruff check / format` → clean
- [x] Pre-push leak scan → 0 matches
- [x] Logic walkthrough confirms: 1 asset + chat → auto-apply now offered; multi-asset + chat → unchanged (still offered); batch mode → still skipped (intended)
