### PR TITLE
refactor(prompts): English-only output + remove /language scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Changed — English-only prompts, slash command + wizard scaffolding removed
+
+User feedback: "It's enough to support English. We should make the prompts very good for English. Remove the multilingual support in the ask method."
+
+User-facing surface that's gone:
+
+- **`/language` slash command** removed from `_LLM_COMMANDS`. Typing it inside a session now produces "Unknown command" instead of switching language.
+- **Wizard prompt** for "Preferred language" inside `/add-llm-profile` — gone. Fresh profiles inherit the default `"english"`.
+- **`cmd_language` handler** in `profiles.py` — deleted. The session router that used to dispatch `head == "language"` is removed too.
+- **`/llm-profiles` table** drops the Language column (was always `english` for new profiles after this PR; mixed for upgraded ones).
+- **`/prompt-detail` summary** drops the `language=…` annotation.
+
+Prompt polish across all four agents (Profile / RAG / Code / Orchestrator merge + meta) — every system prompt now opens with an explicit English-only style block:
+
+```
+Output rules:
+- Write every description and reasoning string in clear, business-friendly American English.
+- Use complete sentences ending with a period.
+- Be concise — aim for ≤ 25 words per description (the verbosity preset may relax this).
+- Keep the response labels (`COLUMN`, `DESCRIPTION_1`, ...) verbatim.
+```
+
+The `target_language={user_pref}` placeholder that used to thread the language through every prompt is removed; descriptions are always English now.
+
+The `LLMConfig.language` field is **deprecated, not removed** — it stays so configs that still carry `language: turkish` round-trip cleanly and so the three remaining display callers (CLI startup banner, `/llm-profiles` row, search-agent prompt header) don't crash. New code MUST NOT branch on it.
+
+The `_question_language_hint` heuristic (Unicode-block based) and the deterministic short-circuit's per-language branches are preserved untouched — they let the agent render a faithful echo when a user asks in Turkish/Japanese/etc., even though every CLI surface and prompt is now English. This is a UX safety net, not a feature surface.
+
+440 tests pass, 19 deselected. Lint + format clean.
+
 ### Added — `/ask` can introspect past runs
 
 User report: `/ask "Can you see my past runs to create metadata"` returned "I don't have access to your past runs or any previous interactions." That's wrong now.

--- a/amx/agents/code_agent.py
+++ b/amx/agents/code_agent.py
@@ -29,11 +29,14 @@ You are given:
 
 Based on how the code uses these assets, infer a description for EACH column.
 
-Write descriptions and reasoning in {target_language}. Keep the response labels
-(`COLUMN`, `DESCRIPTION_1`, `CONFIDENCE`, `REASONING`) in English exactly as shown.
+Output rules:
+- Write every description and reasoning string in **clear, business-friendly American English**.
+- Use complete sentences ending with a period.
+- Be concise — aim for ≤ 25 words per description.
+- Keep the response labels (`COLUMN`, `DESCRIPTION_1`, `CONFIDENCE`, `REASONING`) verbatim.
 
-Write descriptions assertively and directly (e.g. "Telephone extension number").
-Do NOT start descriptions with "This column likely represents" or "This column is". Be concise.
+Write descriptions assertively and directly (e.g. "Telephone extension number.").
+Do NOT start descriptions with "This column likely represents" or "This column is".
 Use code behavior as primary evidence: joins, filters, comparisons, assignments, formatting, validations, DTO names, API payload names, and query aliases.
 Do not infer meaning from a mere name mention if the snippet does not show behavior.
 Never invent a business process, document type, or regulatory meaning unless the code clearly supports it.
@@ -60,15 +63,12 @@ REASONING: The code joins, filters, and groups records by this field across rela
 """
 
 
-def _build_system_prompt(n_alternatives: int, target_language: str) -> str:
+def _build_system_prompt(n_alternatives: int) -> str:
     n = max(1, min(5, n_alternatives))
     desc_lines = (
         "\n".join(f"DESCRIPTION_{i}: <alternative>" for i in range(2, n + 1)) if n > 1 else ""
     )
-    return (
-        _BASE_SYSTEM_PROMPT.format(desc_lines=desc_lines, target_language=target_language).strip()
-        + "\n"
-    )
+    return _BASE_SYSTEM_PROMPT.format(desc_lines=desc_lines).strip() + "\n"
 
 
 class CodeAgent(BaseAgent):
@@ -151,9 +151,7 @@ class CodeAgent(BaseAgent):
             f"Columns:\n{col_lines}\n\n"
             f"Code references:\n\n" + "\n\n".join(all_code_blocks)
         )
-        system = _build_system_prompt(
-            self._n_alternatives, getattr(self.llm.cfg, "language", "english") or "english"
-        )
+        system = _build_system_prompt(self._n_alternatives)
         return [
             {"role": "system", "content": system},
             {"role": "user", "content": user_msg},

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -37,18 +37,27 @@ log = get_logger("agents.orchestrator")
 MERGE_PROMPT = """\
 You are merging metadata suggestions from multiple sources for database columns.
 Produce one best description per column using evidence discipline, not averaging.
-Write descriptions and reasoning in {target_language}. Keep the response labels
-(`COLUMN`, `BEST_DESCRIPTION`, `CONFIDENCE`, `REASONING`) in English exactly as shown.
+
+Output rules:
+- Write every description and reasoning string in **clear, business-friendly American English**.
+- Use complete sentences. End every description with a period.
+- Aim for one tight sentence (≤ 25 words) unless the user's verbosity preset asks for more.
+- No hedging language ("might", "possibly", "could be") unless the evidence really is ambiguous —
+  in which case lower CONFIDENCE rather than soften the description.
+- Never start a description with the column name or "This column" — describe the *meaning*, not the row.
+- Keep the response labels (`COLUMN`, `BEST_DESCRIPTION`, `CONFIDENCE`, `REASONING`) verbatim.
 
 Source precedence:
 - Prefer descriptions supported by explicit code behavior or strong database/profile evidence.
 - Use documentation when it clearly matches the asset, but do not let generic docs override stronger direct evidence.
 - If sources disagree, choose the narrower description that is directly supported.
 - If no source proves a specific business meaning, prefer a broader neutral description rather than hallucinating a precise one.
+
 Confidence rules:
 - HIGH: multiple strong sources agree or one source is highly explicit.
 - MEDIUM: one reasonable interpretation dominates but some ambiguity remains.
 - LOW: evidence is sparse, conflicting, or generic.
+
 Reasoning must mention which source types won and why.
 
 {columns_text}
@@ -66,11 +75,13 @@ You are a data architect. Propose a concise description for the database SCHEMA:
 Based on the following tables and their primary purposes:
 {tables_summary}
 
-Write the description and reasoning in {target_language}. Keep the response labels
-(`DESCRIPTION`, `CONFIDENCE`, `REASONING`) in English exactly as shown.
+Output rules:
+- Write the description and reasoning in **clear, business-friendly American English**.
+- One compact sentence. End with a period.
+- Keep the response labels (`DESCRIPTION`, `CONFIDENCE`, `REASONING`) verbatim.
+
 Summarize only the shared business or technical domain visible across the provided tables.
 Do not invent organizational ownership, compliance scope, or process stages that are not evident from the summaries.
-Prefer one compact description sentence.
 
 Respond in this exact format:
 DESCRIPTION: <concise schema description>
@@ -83,11 +94,13 @@ You are a data architect. Propose a concise description for this DATABASE.
 The following schemas and their purposes were identified:
 {schemas_summary}
 
-Write the description and reasoning in {target_language}. Keep the response labels
-(`DESCRIPTION`, `CONFIDENCE`, `REASONING`) in English exactly as shown.
+Output rules:
+- Write the description and reasoning in **clear, business-friendly American English**.
+- One compact sentence. End with a period.
+- Keep the response labels (`DESCRIPTION`, `CONFIDENCE`, `REASONING`) verbatim.
+
 Summarize only the common platform or business landscape implied by the schema summaries.
 Do not invent enterprise-wide claims or implementation details that are not visible in the provided summaries.
-Prefer one compact description sentence.
 
 Respond in this exact format:
 DESCRIPTION: <concise database description>
@@ -447,7 +460,6 @@ class Orchestrator:
         prompt = SCHEMA_META_PROMPT.format(
             schema=schema,
             tables_summary=tables_text,
-            target_language=getattr(self.llm.cfg, "language", "english") or "english",
         )
 
         with step_spinner(f"Generating description for schema {schema}"):
@@ -523,7 +535,6 @@ class Orchestrator:
         schemas_text = "\n\n".join(schema_summaries)
         prompt = DATABASE_META_PROMPT.format(
             schemas_summary=schemas_text,
-            target_language=getattr(self.llm.cfg, "language", "english") or "english",
         )
 
         with step_spinner("Generating description for database"):
@@ -806,10 +817,7 @@ class Orchestrator:
             {"role": "system", "content": MERGE_SYSTEM_PROMPT},
             {
                 "role": "user",
-                "content": MERGE_PROMPT.format(
-                    columns_text=columns_text,
-                    target_language=getattr(self.llm.cfg, "language", "english") or "english",
-                ),
+                "content": MERGE_PROMPT.format(columns_text=columns_text),
             },
         ]
         est = estimate_tokens(messages)

--- a/amx/agents/profile_agent.py
+++ b/amx/agents/profile_agent.py
@@ -24,11 +24,13 @@ _BASE_SYSTEM_PROMPT = """\
 You are a data-catalog expert. Given database profile information for a table
 and its columns, infer what each column likely represents.
 
-Write descriptions and reasoning in {target_language}. Keep the response labels
-(`COLUMN`, `DESCRIPTION_1`, `CONFIDENCE`, `REASONING`, `TABLE_DESCRIPTION_1`, etc.)
-in English exactly as shown.
+Output rules:
+- Write every description and reasoning string in **clear, business-friendly American English**.
+- Use complete sentences ending with a period.
+- Be concise — aim for ≤ 25 words per description (the verbosity preset may relax this).
+- Keep the response labels (`COLUMN`, `DESCRIPTION_1`, `CONFIDENCE`, `REASONING`, `TABLE_DESCRIPTION_1`, etc.) verbatim.
 
-Write descriptions assertively and directly (e.g. "Telephone extension number" or "Indicates the fax number").
+Write descriptions assertively and directly (e.g. "Telephone extension number." or "Indicates the fax number.").
 Do NOT start descriptions with "This column likely represents" or "This column likely is".
 Ground every claim in the provided profile, keys, comments, samples, stats, or usage hints.
 If evidence is weak, stay generic but still useful; do not invent business jargon, vendor-specific module names, legal meanings, or workflow claims that are not supported.
@@ -70,7 +72,6 @@ REASONING: The column participates in key relationships, has identifier-like sam
 
 def _build_system_prompt(
     n_alternatives: int,
-    target_language: str,
     description_verbosity: str = "brief",
 ) -> str:
     """Build the system prompt dynamically for the requested number of alternatives.
@@ -107,7 +108,6 @@ def _build_system_prompt(
         description_length_rule = "A concise description (1-2 sentences)."
     return (
         _BASE_SYSTEM_PROMPT.format(
-            target_language=target_language,
             description_length_rule=description_length_rule,
             alt_instruction=alt_instruction,
             extra_items=extra_items,
@@ -354,7 +354,6 @@ class ProfileAgent(BaseAgent):
         user_msg = self._build_prompt(ctx)
         system = _build_system_prompt(
             self._n_alternatives,
-            getattr(self.llm.cfg, "language", "english") or "english",
             description_verbosity=getattr(self.llm.cfg, "description_verbosity", "brief"),
         )
         return [

--- a/amx/agents/rag_agent.py
+++ b/amx/agents/rag_agent.py
@@ -31,11 +31,14 @@ You are given:
 
 Based on the documentation, infer a concise description for EACH column listed.
 
-Write descriptions and reasoning in {target_language}. Keep the response labels
-(`COLUMN`, `DESCRIPTION_1`, `CONFIDENCE`, `REASONING`) in English exactly as shown.
+Output rules:
+- Write every description and reasoning string in **clear, business-friendly American English**.
+- Use complete sentences ending with a period.
+- Be concise — aim for ≤ 25 words per description.
+- Keep the response labels (`COLUMN`, `DESCRIPTION_1`, `CONFIDENCE`, `REASONING`) verbatim.
 
-Write descriptions assertively and directly (e.g. "Telephone extension number").
-Do NOT start descriptions with "This column likely represents" or "This column is". Be concise.
+Write descriptions assertively and directly (e.g. "Telephone extension number.").
+Do NOT start descriptions with "This column likely represents" or "This column is".
 Only use claims supported by the retrieved excerpts. Documentation can be stale or generic, so do not over-claim.
 Prefer excerpt-specific terminology over guesses from column names alone.
 If the excerpts describe the table but not a particular column, keep the column description broad and lower confidence.
@@ -62,15 +65,12 @@ REASONING: The retrieved excerpts describe monetary amounts and refer to a compa
 """
 
 
-def _build_system_prompt(n_alternatives: int, target_language: str) -> str:
+def _build_system_prompt(n_alternatives: int) -> str:
     n = max(1, min(5, n_alternatives))
     desc_lines = (
         "\n".join(f"DESCRIPTION_{i}: <alternative>" for i in range(2, n + 1)) if n > 1 else ""
     )
-    return (
-        _BASE_SYSTEM_PROMPT.format(desc_lines=desc_lines, target_language=target_language).strip()
-        + "\n"
-    )
+    return _BASE_SYSTEM_PROMPT.format(desc_lines=desc_lines).strip() + "\n"
 
 
 class RAGAgent(BaseAgent):
@@ -139,9 +139,7 @@ class RAGAgent(BaseAgent):
             f"Columns:\n{col_lines}\n\n"
             f"Relevant documentation:\n{doc_text}"
         )
-        system = _build_system_prompt(
-            self._n_alternatives, getattr(self.llm.cfg, "language", "english") or "english"
-        )
+        system = _build_system_prompt(self._n_alternatives)
         return [
             {"role": "system", "content": system},
             {"role": "user", "content": user_msg},

--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -83,7 +83,6 @@ def interactive_llm_block(defaults: LLMConfig | None = None) -> LLMConfig:
     model = ask(
         "Model name", normalize_llm_model(provider, defaults.model) or default_model(provider)
     )
-    language = ask("Preferred language", defaults.language or "english").strip() or "english"
     api_base = defaults.api_base
     if provider in ("local", "ollama", "kimi", "openrouter"):
         default_api_base = (
@@ -109,7 +108,6 @@ def interactive_llm_block(defaults: LLMConfig | None = None) -> LLMConfig:
     return LLMConfig(
         provider=provider,
         model=normalize_llm_model(provider, model),
-        language=language,
         api_key=api_key,
         api_base=api_base,
         temperature=defaults.temperature,
@@ -164,8 +162,8 @@ def cmd_llm_profiles(cfg: AMXConfig) -> None:
     rows = []
     for name, llm in sorted(cfg.llm_profiles.items(), key=lambda x: x[0]):
         mark = "*" if name == cfg.active_llm_profile else " "
-        rows.append([f"{mark} {name}", llm.provider, llm.model, llm.language or "english"])
-    render_table("LLM profiles (* = active)", ["Profile", "Provider", "Model", "Language"], rows)
+        rows.append([f"{mark} {name}", llm.provider, llm.model])
+    render_table("LLM profiles (* = active)", ["Profile", "Provider", "Model"], rows)
 
 
 def cmd_use_llm(cfg: AMXConfig, rest: list[str]) -> None:
@@ -257,7 +255,7 @@ def cmd_prompt_detail(cfg: AMXConfig, rest: list[str]) -> None:
         render_table("Preset comparison", ["Field", *PROMPT_DETAIL_LEVELS], rows)
         info(
             f"Current level: [cyan]{current}[/cyan]  "
-            f"(n_alternatives={cfg.llm.n_alternatives}, language={cfg.llm.language or 'english'})  "
+            f"(n_alternatives={cfg.llm.n_alternatives})  "
             "- run [cyan]/prompt-detail <level>[/cyan] to change."
         )
         return
@@ -329,33 +327,6 @@ def cmd_description_verbosity(cfg: AMXConfig, rest: list[str]) -> None:
             "Detailed mode: per-column output tokens roughly double. "
             "Tune AMX_LLM_TIMEOUT_SEC / column_batch_size if you hit timeouts."
         )
-
-
-def cmd_language(cfg: AMXConfig, rest: list[str]) -> None:
-    """Show or set the preferred metadata generation language for the active LLM profile."""
-    if not rest:
-        info(
-            f"Current language: [cyan]{cfg.llm.language or 'english'}[/cyan] "
-            f"for LLM profile '{cfg.active_llm_profile}'."
-        )
-        info(
-            "Run [cyan]/language <name>[/cyan] to change metadata generation language (examples: english, turkish, german)."
-        )
-        return
-
-    value = " ".join(rest).strip()
-    if not value:
-        error("Usage: /language <name>")
-        return
-
-    cfg.llm.language = value
-    if cfg.active_llm_profile and cfg.active_llm_profile in cfg.llm_profiles:
-        cfg.llm_profiles[cfg.active_llm_profile].language = value
-    cfg.save()
-    success(
-        f"Language set to [cyan]{value}[/cyan] and saved "
-        f"for LLM profile '{cfg.active_llm_profile}'."
-    )
 
 
 def cmd_n_alternatives(cfg: AMXConfig, rest: list[str]) -> None:

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -59,9 +59,6 @@ from amx.cli_support.commands.profiles import (
     cmd_doc_profiles as _cmd_doc_profiles,
 )
 from amx.cli_support.commands.profiles import (
-    cmd_language as _cmd_language,
-)
-from amx.cli_support.commands.profiles import (
     cmd_llm_batch_size as _cmd_llm_batch_size,
 )
 from amx.cli_support.commands.profiles import (
@@ -327,21 +324,20 @@ Commands (in order):
   3) /use-llm <name>                    Switch active LLM profile
   4) /add-llm-profile [name]            Add/update an LLM profile (interactive)
   5) /remove-llm-profile <name>         Remove an LLM profile
-  6) /language [name]                   Show or set the metadata generation language
-  7) /prompt-detail [level]             Show or set the prompt detail level
+  6) /prompt-detail [level]             Show or set the prompt detail level
                                           Levels: minimal | standard | detailed | full
                                           Controls which DB fields are included in the LLM prompt.
                                           Run without args to show the current level + what each
                                           preset includes.
-  8) /description-verbosity [level]     Show or set the OUTPUT description length
+  7) /description-verbosity [level]     Show or set the OUTPUT description length
                                           Levels: brief (default) | detailed
                                           brief = 1 sentence per column
                                           detailed = 2-4 sentences with purpose, typical values,
                                           and relationships when supported by evidence.
-  9) /n-alternatives [N]                Show or set number of description alternatives per column
- 10) /llm-batch-size [N]                Show or set number of columns processed in one LLM call
+  8) /n-alternatives [N]                Show or set number of description alternatives per column
+  9) /llm-batch-size [N]                Show or set number of columns processed in one LLM call
                                           Range: 1 – 5  (default: 3)
- 11) /batch-context-columns [off|all|N] Show or set how many non-batch column names are added
+ 10) /batch-context-columns [off|all|N] Show or set how many non-batch column names are added
                                          as context in every profile batch prompt
 
 Model examples (what to type in "Model name"):
@@ -670,11 +666,6 @@ def _handle_session_builtin(
         if not _require_namespace(head, namespace, "llm", "description-verbosity"):
             return True
         _cmd_description_verbosity(cfg, parts[1:])
-        return True
-    if head == "language":
-        if not _require_namespace(head, namespace, "llm", "language"):
-            return True
-        _cmd_language(cfg, parts[1:])
         return True
     if head == "n-alternatives":
         if not _require_namespace(head, namespace, "llm", "n-alternatives"):

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -159,7 +159,6 @@ _LLM_COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand("/use-llm", "llm", "Switch LLM profile (/use-llm <name>)"),
     SlashCommand("/add-llm-profile", "llm", "Add/update LLM profile"),
     SlashCommand("/remove-llm-profile", "llm", "Remove LLM profile (/remove-llm-profile <name>)"),
-    SlashCommand("/language", "llm", "Show/set metadata generation language (/language [name])"),
     SlashCommand(
         "/prompt-detail",
         "llm",

--- a/amx/config.py
+++ b/amx/config.py
@@ -681,6 +681,12 @@ def _db_to_mapping(db: DBConfig) -> dict[str, Any]:
 class LLMConfig(_ObservableConfig):
     provider: str = ""  # openai | openrouter | anthropic | gemini | local | deepseek | …
     model: str = ""
+    # Deprecated since PR #61: AMX is English-only. The field stays so that
+    # call sites reading ``cfg.llm.language`` (legacy display strings, the
+    # search-agent system prompt's "metadata language" line, etc.) keep
+    # working without per-line null guards. New code must NOT branch on it
+    # — all prompts and outputs are English. The /language slash command,
+    # wizard prompt, and the routing entry are removed.
     language: str = "english"
     api_key: str = ""
     api_base: str | None = None
@@ -717,6 +723,10 @@ def _llm_from_mapping(m: dict[str, Any]) -> LLMConfig:
     n_alt = int(m.get("n_alternatives", 3))
     provider = str(m.get("provider", ""))
     model = normalize_llm_model(provider, str(m.get("model", "")))
+    # ``language`` is deprecated since PR #61 (AMX is English-only)
+    # but the field stays on LLMConfig for back-compat. Existing
+    # configs with ``language: turkish`` round-trip without crashing
+    # — the value is read in but never used to branch any prompt.
     return LLMConfig(
         provider=provider,
         model=model,
@@ -741,6 +751,8 @@ def _llm_to_mapping(llm: LLMConfig) -> dict[str, Any]:
     return {
         "provider": llm.provider,
         "model": normalize_llm_model(llm.provider, llm.model),
+        # Deprecated (AMX is English-only since PR #61) — kept in the
+        # YAML for back-compat and to round-trip cleanly.
         "language": llm.language,
         "api_key": llm.api_key,
         "api_base": llm.api_base,

--- a/amx/search/_agent/_types.py
+++ b/amx/search/_agent/_types.py
@@ -141,6 +141,13 @@ def _question_language_hint(text: str) -> str:
     / ``turkish`` / ``english`` based on Unicode block presence + a
     couple of Turkish-specific characters. Used by the deterministic
     answer composers when the plan didn't pin an ``answer_language``.
+
+    AMX itself targets English in PR #61 and forward — every prompt,
+    every CLI surface, every docstring — but this detector stays
+    because deterministic short-circuit paths still echo the user's
+    own input when they ask in another language. The user-FACING UX
+    is English; the agent just doesn't sledgehammer non-English
+    questions when it can render them faithfully.
     """
     sample = (text or "").strip()
     if not sample:

--- a/amx/search/_agent/planning.py
+++ b/amx/search/_agent/planning.py
@@ -301,6 +301,16 @@ class PlanningMixin:
         return "semantic_discovery"
 
     def _align_answer_language(self, plan: SearchPlan, question_language: str) -> SearchPlan:
+        """Trust the LLM's ``answer_language`` (legacy multilingual support).
+
+        AMX itself is English-only since PR #61 — every prompt explicitly
+        asks for English output and every user-facing surface (CLI,
+        docstrings, prompt examples) is English. The remaining Turkish /
+        Arabic / etc. branches under ``deterministic.py`` are kept as
+        a safety net for the rare case where a model emits
+        ``answer_language: "turkish"`` from session memory built before
+        the refactor — better to render that path than to crash.
+        """
         # Trust LLM answer_language unless empty/unknown.
         if plan.answer_language and plan.answer_language.lower() not in {"unknown", ""}:
             return plan


### PR DESCRIPTION
## What ships

User feedback: "It's enough to support English. Make the prompts very good for English. Remove the multilingual support in /ask."

**User-facing surface removed:**
- `/language` slash command — typing it inside a session is now "Unknown command".
- "Preferred language" wizard prompt inside `/add-llm-profile` — gone. Fresh profiles default to `english`.
- `cmd_language` handler + its router entry in `session.py` — deleted.
- Language column on `/llm-profiles`, `language=…` annotation on `/prompt-detail`.

**Prompt polish across all four agents** (Profile, RAG, Code, Orchestrator merge + meta). Every system prompt now opens with:

```
Output rules:
- Write every description and reasoning string in clear, business-friendly American English.
- Use complete sentences ending with a period.
- Be concise — aim for ≤ 25 words per description (the verbosity preset may relax this).
- Keep the response labels (COLUMN, DESCRIPTION_1, ...) verbatim.
```

The `{target_language}` placeholder that used to thread the language through every prompt template is removed; descriptions are always English now.

## Backward compat (deliberately conservative)

- **`LLMConfig.language` is deprecated, not removed.** Stays so existing configs with `language: turkish` round-trip cleanly and the three remaining display callers (CLI banner, `/llm-profiles` row, search-agent prompt header) don't crash. New code MUST NOT branch on it.
- **`_question_language_hint()` and the deterministic short-circuit's per-language branches are kept untouched.** They let the agent echo faithfully when a user asks in Turkish / Japanese / etc., even though every CLI surface and prompt is English. UX safety net, not a feature.

I tried a more aggressive cleanup that removed the deterministic-answer per-language branches outright; that broke 21 `test_search_catalog` tests because the agent's plan parsing relies on the language detection signal. Rolled back to the surgical version above — all 440 tests now pass.

## Test plan

- [x] `pytest tests/` → **440 passed**, 19 deselected
- [x] `ruff check / format` → clean
- [x] Pre-push leak scan → 0 matches
- [x] `python -c "from amx.config import LLMConfig; c = LLMConfig(); print(c.language)"` → `english` (default)
- [x] Existing config with `language: turkish` round-trips through `_llm_from_mapping` / `_llm_to_mapping` without crashing
