### PR TITLE
fix(history): /list runs a wizard like /run, flags stay for power users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Changed — `/history list` runs a wizard like `/run`
+
+User feedback: "I don't like `/list --some-flag` style. If we serve options, ask the user — like `/run` does."
+
+`/history list` with no flags now runs a short interactive wizard that matches `/run`'s pattern:
+
+```
+> /list
+  How many runs to show?: 20
+  Which runs to list?
+    1. only /run invocations  /ask chat sessions are resumable threads —
+       see /session list. — default (Enter)
+    2. include /ask sessions too  Show every command in history; useful for debugging.
+  > 1
+                       Recent /run invocations
+  ┏━━━━┳──────────────────┳━━━━━━━━━┳…
+```
+
+- Both flags become optional; **power users keep them** for scripting (`/list -n 5 --include-asks` skips the wizard entirely; `/list -n 5` skips only the limit prompt).
+- Detection uses Click's `ParameterSource` — if the user typed the flag, `ParameterSource.COMMANDLINE`; if it was filled by the default, `ParameterSource.DEFAULT`. The wizard fires only for params still at default.
+- Falls back to a manual `is None` check on Click versions that don't expose `ParameterSource` (defensive — doesn't crash if the introspection import fails).
+
+**1 new test** in `AskHistoryToolsTests` covers the three paths: bare `/list` (both prompts), `/list -n 5` (only asks prompt), `/list -n 5 --include-asks` (zero prompts).
+
 ### Changed — Run history vs ask sessions split + readable timestamps
 
 User reports two issues with `/ask` history responses:

--- a/amx/cli_support/commands/history.py
+++ b/amx/cli_support/commands/history.py
@@ -52,19 +52,73 @@ def register_history_commands(
         """Inspect local SQLite history (runs, tokens, results, events, comparisons)."""
 
     @history.command("list")
-    @click.option("-n", "--limit", default=20, help="Number of runs to show.")
+    @click.option("-n", "--limit", type=int, default=None, help="Number of runs to show.")
     @click.option(
-        "--include-asks",
-        is_flag=True,
-        default=False,
+        "--include-asks/--no-include-asks",
+        "include_asks",
+        default=None,
         help=(
             "Also include /ask invocations (search.ask) in the listing. "
             "By default the list shows only /run invocations because /ask "
             "chat sessions belong in /session list (with resume support)."
         ),
     )
-    def history_list(limit: int, include_asks: bool) -> None:
+    @click.pass_context
+    def history_list(ctx: click.Context, limit: int | None, include_asks: bool | None) -> None:
+        """List recent runs.
+
+        Bare ``/list`` runs a short wizard (matches ``/run``'s pattern):
+        the user picks how many rows to show and whether to include
+        ``/ask`` chat sessions. Power users skip the wizard with
+        explicit flags (``/list -n 5``, ``/list --include-asks``).
+        """
         from datetime import datetime as _dt
+
+        from amx.utils.console import ask, ask_choice
+
+        # Wizard for any value the user didn't pin via a flag. Click's
+        # parameter-source check tells us whether ``--limit`` /
+        # ``--include-asks`` were typed on the command line.
+        # ParameterSource.DEFAULT means we're free to ask; .COMMANDLINE
+        # means the user gave an explicit value (scripts, power users).
+        try:
+            from click.core import ParameterSource
+
+            limit_src = ctx.get_parameter_source("limit")
+            asks_src = ctx.get_parameter_source("include_asks")
+            limit_from_user = limit_src == ParameterSource.COMMANDLINE
+            asks_from_user = asks_src == ParameterSource.COMMANDLINE
+        except Exception:
+            limit_from_user = limit is not None
+            asks_from_user = include_asks is not None
+
+        if not limit_from_user:
+            raw = ask("How many runs to show?", default="20").strip()
+            try:
+                limit = max(1, int(raw))
+            except ValueError:
+                warn(f"Could not parse '{raw}' as a number; using 20.")
+                limit = 20
+        else:
+            limit = int(limit) if limit else 20
+
+        if not asks_from_user:
+            choice = ask_choice(
+                "Which runs to list?",
+                ["only /run invocations", "include /ask sessions too"],
+                default="only /run invocations",
+                descriptions={
+                    "only /run invocations": (
+                        "/ask chat sessions are resumable threads — see /session list."
+                    ),
+                    "include /ask sessions too": (
+                        "Show every command in history; useful for debugging."
+                    ),
+                },
+            )
+            include_asks = choice == "include /ask sessions too"
+        else:
+            include_asks = bool(include_asks)
 
         hs = history_store()
         if hs is None:

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -997,6 +997,82 @@ class AskHistoryToolsTests(unittest.TestCase):
         self.assertIn("presentation_hint", payload)
         self.assertIn("compact table", payload["presentation_hint"].lower())
 
+    def test_history_list_runs_wizard_when_no_flags_passed(self) -> None:
+        """User feedback 2026-05-02: /history list should ask the user
+        (like /run) when there are options to choose from, instead of
+        forcing flag syntax. Bare ``/history list`` now prompts for
+        limit + include-asks; explicit flags skip the matching prompt.
+        """
+        from amx.cli import main
+
+        prompts: list[tuple[str, str]] = []
+
+        def fake_ask(question: str, default: str = "") -> str:
+            prompts.append(("ask", question))
+            return default
+
+        def fake_choice(question, choices, default="", descriptions=None):
+            prompts.append(("choice", question))
+            return default
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = CliRunner()
+
+            # Bare /history list — both prompts must fire.
+            with (
+                patch("amx.utils.console.ask", side_effect=fake_ask),
+                patch("amx.utils.console.ask_choice", side_effect=fake_choice),
+            ):
+                runner.invoke(
+                    main,
+                    ["--config", str(Path(tmp) / "noconfig.yml"), "history", "list"],
+                    env={"AMX_SESSION_CHILD": "1"},
+                    catch_exceptions=False,
+                )
+            self.assertEqual(
+                [k for k, _ in prompts],
+                ["ask", "choice"],
+                "Bare /list must ask 'how many runs' THEN 'include /ask sessions'.",
+            )
+
+            # -n 5 explicit → only the asks prompt fires.
+            prompts.clear()
+            with (
+                patch("amx.utils.console.ask", side_effect=fake_ask),
+                patch("amx.utils.console.ask_choice", side_effect=fake_choice),
+            ):
+                runner.invoke(
+                    main,
+                    ["--config", str(Path(tmp) / "noconfig.yml"), "history", "list", "-n", "5"],
+                    env={"AMX_SESSION_CHILD": "1"},
+                    catch_exceptions=False,
+                )
+            self.assertEqual([k for k, _ in prompts], ["choice"])
+
+            # Both flags explicit → zero prompts (power user / scripts).
+            prompts.clear()
+            with (
+                patch("amx.utils.console.ask", side_effect=fake_ask),
+                patch("amx.utils.console.ask_choice", side_effect=fake_choice),
+            ):
+                runner.invoke(
+                    main,
+                    [
+                        "--config",
+                        str(Path(tmp) / "noconfig.yml"),
+                        "history",
+                        "list",
+                        "-n",
+                        "5",
+                        "--include-asks",
+                    ],
+                    env={"AMX_SESSION_CHILD": "1"},
+                    catch_exceptions=False,
+                )
+            self.assertEqual(
+                prompts, [], "Power-user invocation with both flags must skip the wizard."
+            )
+
     def test_list_chat_sessions_returns_resumable_threads(self) -> None:
         """``/ask`` chat sessions live in chat_sessions / chat_turns and
         are resumable via ``/session resume <id>`` — surface them via


### PR DESCRIPTION
## What you said

> "I don't like `/list --some-flag` style. If we serve options, ask the user — like `/run` does."

## Fix

`/history list` with no flags now prompts interactively, matching `/run`'s pattern:

```
> /list
  How many runs to show?: 20
  Which runs to list?
    1. only /run invocations  /ask chat sessions are resumable threads —
       see /session list. — default (Enter)
    2. include /ask sessions too  Show every command in history; useful
       for debugging.
  > 1
                       Recent /run invocations
  ...
```

Both flags become optional. Power-user / scripted use still works:

| Invocation | Limit prompt | Asks prompt |
|---|---|---|
| `/list` | ✓ | ✓ |
| `/list -n 5` | skipped | ✓ |
| `/list --include-asks` | ✓ | skipped |
| `/list -n 5 --include-asks` | skipped | skipped |

**Detection**: Click's `ctx.get_parameter_source(name)` returns `ParameterSource.COMMANDLINE` if the user typed the flag, `ParameterSource.DEFAULT` if it was filled by the default. The wizard fires only for params still at default. Falls back to a plain `is None` check if the import fails (defensive).

## Test plan

- [x] 1 new test in `AskHistoryToolsTests` covering all three paths (bare → 2 prompts; `-n 5` → 1 prompt; both flags → 0 prompts)
- [x] `pytest tests/` → **444 passed**, 19 deselected
- [x] `ruff check / format` → clean
- [x] Pre-push leak scan → 0 matches
- [x] End-to-end walkthrough via CliRunner with `ask` / `ask_choice` mocked, asserts the prompt count for each invocation shape
