### PR TITLE
feat(ask): stream model thinking into transient panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added — Live model thinking in `/ask`
+
+User feedback: "We don't serve model's thinking here but we can. If we show true parts of model's thinkings it really looks well. But we don't keep them in screen after thinkings completed because it can increase crowded in chat."
+
+`/ask` now streams the model's real reasoning into the existing transient thinking panel while the answer is being composed, then wipes the panel the moment the answer prints — so the chat scrollback stays uncluttered but the user sees the model actually thinking.
+
+**Engagement is automatic**: when the active LLM is a reasoning-capable model — Anthropic Claude with extended thinking (Sonnet 3.7+, Sonnet/Opus 4+), DeepSeek-reasoner, or OpenAI o-series — the agent calls switch to streaming and pipe `delta.reasoning_content` chunks into the panel. For other models the call path is unchanged: the existing static "Search Agent: thinking with tools" spinner shows, no errors, no empty panel.
+
+**Provider layer (`amx/llm/provider.py`)**:
+- `LLMProvider.chat()` accepts a new `on_thinking: Callable[[str], None] | None` callback. When supplied AND the model emits reasoning, the call switches to `stream=True` and the callback fires with the running accumulated reasoning text.
+- For Anthropic, the streamed call adds `thinking={"type": "enabled", "budget_tokens": cfg.llm.thinking_budget}`, forces `temperature=1` (Anthropic API requirement), drops `logprobs` (incompatible with extended thinking), and bumps `max_tokens` if needed so visible output has headroom above the thinking budget.
+- Streamed chunks are reassembled (content, tool calls split by index, finish_reason, usage) into a response-shaped object so the existing parsing path — fatal-empty-content guard, tool-call extraction, usage dict — works unchanged. `ChatResult` gains `thinking_content: str` and `thinking_tokens: int` fields.
+- New `_supports_thinking(provider, model)` helper sniffs Anthropic Claude 3.7/4 Sonnet, Claude 4 Opus, DeepSeek-reasoner, OpenAI reasoning models, and OpenRouter routes for those.
+
+**Display layer (`amx/utils/live_display.py`)**:
+- `LiveDisplay.update_thinking(text)` is the new public entry point. It stores the most recent ~600 chars of reasoning and refreshes the panel. `_render_thinking()` now returns a `Group` of the existing one-line spinner + a dim-italic, indented snippet of the last few lines of streamed reasoning.
+- The text is cleared on `stop_thinking()` and on `start()` so it never leaks between turns. `transient=True` on the underlying `Live` continues to wipe the whole region when the run ends.
+
+**Wiring (`amx/search/tool_agent.py`, `amx/search/_agent/short_circuits.py`)**:
+- `run_tool_agent` and `_run_tool_loop` accept an optional `display` kwarg. The loop builds a single `on_thinking` closure and threads it through both `llm.chat` calls (the iterative tool-call rounds AND the budget-cap closing call), so the panel keeps streaming continuously across iterations instead of flickering between tool calls.
+- `short_circuits` resolves `get_display()` next to the existing `step_spinner("Search Agent: thinking with tools")` block and forwards it into the agent. `step_spinner` continues to manage `set_thinking`/`stop_thinking` lifecycle — the new code only feeds text into a panel that's already open.
+
+**Config**: one new field on `LLMConfig` — `thinking_budget: int = 1024` — round-trips through `_llm_to_mapping`/`_llm_from_mapping`. No new flag, no `--show-thinking`; the feature is on whenever the model emits reasoning.
+
+**Not persisted**: thinking content and `thinking_tokens` are intentionally NOT written to the SQLite history. Persisting would defeat the "uncluttered chat" goal that motivated the feature in the first place. They live in `ChatResult` for the duration of the call, render to the live panel, and are gone.
+
 ### Changed — `/history list` runs a wizard like `/run`
 
 User feedback: "I don't like `/list --some-flag` style. If we serve options, ask the user — like `/run` does."

--- a/amx/config.py
+++ b/amx/config.py
@@ -708,6 +708,10 @@ class LLMConfig(_ObservableConfig):
     logprob_high: float = 0.85
     logprob_medium: float = 0.50
     force_logprobs: bool = True
+    # Token budget for the model's internal reasoning (Anthropic extended
+    # thinking). Only consumed when the model supports reasoning AND a caller
+    # passes ``on_thinking`` to ``LLMProvider.chat``; otherwise ignored.
+    thinking_budget: int = 1024
 
     @property
     def prompt_detail_cfg(self) -> PromptDetail:
@@ -744,6 +748,7 @@ def _llm_from_mapping(m: dict[str, Any]) -> LLMConfig:
         logprob_high=float(m.get("logprob_high", 0.85)),
         logprob_medium=float(m.get("logprob_medium", 0.50)),
         force_logprobs=bool(m.get("force_logprobs", True)),
+        thinking_budget=int(m.get("thinking_budget", 1024)),
     )
 
 
@@ -767,6 +772,7 @@ def _llm_to_mapping(llm: LLMConfig) -> dict[str, Any]:
         "logprob_high": llm.logprob_high,
         "logprob_medium": llm.logprob_medium,
         "force_logprobs": llm.force_logprobs,
+        "thinking_budget": llm.thinking_budget,
     }
 
 

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -9,7 +9,7 @@ import re
 import time
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Any
+from typing import Any, Callable
 
 from amx.config import LLMConfig, normalize_llm_model
 from amx.utils.logging import get_logger
@@ -137,6 +137,11 @@ class ChatResult:
     finish_reason: str | None = None
     confidence_score: float | None = None
     tool_calls: list[ToolCall] | None = None
+    # Visible reasoning text produced by the model when extended thinking /
+    # reasoning is enabled (Anthropic ``thinking`` blocks, DeepSeek-reasoner
+    # ``reasoning_content``, etc.). Empty for the default non-streaming path.
+    thinking_content: str = ""
+    thinking_tokens: int = 0
 
     def __str__(self) -> str:  # noqa: D105
         return self.content
@@ -515,6 +520,209 @@ def _is_openai_reasoning_style_model(model: str) -> bool:
     )
 
 
+def _supports_thinking(provider: str, model: str) -> bool:
+    """Whether this provider/model emits a stream of reasoning content.
+
+    True for Anthropic Claude with extended thinking (Sonnet 3.7+, Sonnet/Opus
+    4+), DeepSeek-reasoner, and OpenAI reasoning models. OpenRouter routes
+    these too, so we sniff the model substring there as well.
+    """
+    p = (provider or "").lower()
+    m = (model or "").lower()
+    if p == "anthropic":
+        return any(
+            tag in m
+            for tag in (
+                "claude-sonnet-4",
+                "claude-opus-4",
+                "claude-3-7-sonnet",
+                "claude-3.7-sonnet",
+            )
+        )
+    if p == "deepseek":
+        return "reasoner" in m
+    if p == "openai":
+        return _is_openai_reasoning_style_model(model)
+    if p == "openrouter":
+        return any(
+            tag in m
+            for tag in (
+                "claude-sonnet-4",
+                "claude-opus-4",
+                "claude-3-7-sonnet",
+                "deepseek-reasoner",
+                "/o1",
+                "/o3",
+                "gpt-5",
+            )
+        )
+    return False
+
+
+# ── Streamed-response shim ──────────────────────────────────────────────────
+#
+# When ``chat()`` runs in streaming mode (``on_thinking`` callback supplied
+# AND model supports reasoning), we consume the LiteLLM stream inline and
+# repackage the final state as a non-streamed-shape object so the rest of
+# the response-parsing path (logprobs, tool_calls, finish_reason, usage)
+# stays unchanged. These minimal classes mirror the attribute access
+# pattern LiteLLM uses on its own response objects.
+
+
+class _StreamedFunction:
+    def __init__(self, name: str, arguments: str) -> None:
+        self.name = name
+        self.arguments = arguments
+
+
+class _StreamedToolCall:
+    def __init__(self, id_: str, name: str, arguments: str) -> None:
+        self.id = id_
+        self.function = _StreamedFunction(name, arguments)
+
+
+class _StreamedMessage:
+    def __init__(self, content: str, tool_calls: list[_StreamedToolCall]) -> None:
+        self.content = content
+        self.tool_calls = tool_calls
+
+
+class _StreamedChoice:
+    def __init__(
+        self,
+        content: str,
+        tool_calls: list[_StreamedToolCall],
+        finish_reason: str | None,
+    ) -> None:
+        self.message = _StreamedMessage(content, tool_calls)
+        self.finish_reason = finish_reason
+        self.logprobs = None
+
+
+class _StreamedUsage:
+    def __init__(
+        self, prompt: int, completion: int, total: int, thinking: int
+    ) -> None:
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.total_tokens = total
+        self.thinking_tokens = thinking
+
+
+class _StreamedResponse:
+    def __init__(
+        self,
+        content: str,
+        thinking_content: str,
+        tool_calls: list[_StreamedToolCall],
+        finish_reason: str | None,
+        usage: _StreamedUsage | None,
+    ) -> None:
+        self.choices = [_StreamedChoice(content, tool_calls, finish_reason)]
+        self.usage = usage
+        self.thinking_content = thinking_content
+        self.thinking_tokens = usage.thinking_tokens if usage else 0
+
+
+def _consume_thinking_stream(
+    iterator: Any, on_thinking: Callable[[str], None]
+) -> _StreamedResponse:
+    """Drain a LiteLLM stream, fire ``on_thinking`` deltas, and rebuild a response.
+
+    Reasoning text arrives as ``delta.reasoning_content`` chunks (LiteLLM
+    normalizes this across Anthropic ``thinking_blocks`` and DeepSeek/OpenAI
+    ``reasoning_content``). Tool calls arrive split by ``index`` and we
+    reassemble each by id/name/arguments-suffix. Usage typically arrives in a
+    trailing chunk with no choices.
+    """
+    content_parts: list[str] = []
+    thinking_parts: list[str] = []
+    tool_slots: dict[int, dict[str, str]] = {}
+    finish_reason: str | None = None
+    prompt_tokens = 0
+    completion_tokens = 0
+    total_tokens = 0
+    thinking_tokens = 0
+
+    for chunk in iterator:
+        usage = getattr(chunk, "usage", None)
+        if usage is not None:
+            prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or prompt_tokens)
+            completion_tokens = int(
+                getattr(usage, "completion_tokens", 0) or completion_tokens
+            )
+            total_tokens = int(getattr(usage, "total_tokens", 0) or total_tokens)
+            details = getattr(usage, "completion_tokens_details", None)
+            if details is not None:
+                thinking_tokens = int(
+                    getattr(details, "reasoning_tokens", 0) or thinking_tokens
+                )
+
+        choices = getattr(chunk, "choices", None) or []
+        if not choices:
+            continue
+        choice0 = choices[0]
+        delta = getattr(choice0, "delta", None)
+        if delta is not None:
+            rc = getattr(delta, "reasoning_content", None) or ""
+            if rc:
+                thinking_parts.append(rc)
+                try:
+                    on_thinking("".join(thinking_parts))
+                except Exception as cb_exc:
+                    log.debug("on_thinking callback raised: %s", cb_exc)
+
+            cc = getattr(delta, "content", None) or ""
+            if cc:
+                content_parts.append(cc)
+
+            raw_tcs = getattr(delta, "tool_calls", None) or []
+            for tc in raw_tcs:
+                idx = int(getattr(tc, "index", 0) or 0)
+                slot = tool_slots.setdefault(
+                    idx, {"id": "", "name": "", "arguments": ""}
+                )
+                tid = getattr(tc, "id", None)
+                if tid:
+                    slot["id"] = str(tid)
+                fn = getattr(tc, "function", None)
+                if fn is not None:
+                    nm = getattr(fn, "name", None)
+                    if nm:
+                        slot["name"] = str(nm)
+                    args_chunk = getattr(fn, "arguments", None)
+                    if args_chunk:
+                        slot["arguments"] += str(args_chunk)
+
+        fr = getattr(choice0, "finish_reason", None)
+        if fr:
+            finish_reason = str(fr)
+
+    tool_calls_list: list[_StreamedToolCall] = [
+        _StreamedToolCall(
+            slot["id"] or f"tool_stream_{idx}",
+            slot["name"],
+            slot["arguments"] or "{}",
+        )
+        for idx, slot in sorted(tool_slots.items())
+        if slot["name"]
+    ]
+
+    usage_obj: _StreamedUsage | None = None
+    if prompt_tokens or completion_tokens or total_tokens or thinking_tokens:
+        usage_obj = _StreamedUsage(
+            prompt_tokens, completion_tokens, total_tokens, thinking_tokens
+        )
+
+    return _StreamedResponse(
+        content="".join(content_parts),
+        thinking_content="".join(thinking_parts),
+        tool_calls=tool_calls_list,
+        finish_reason=finish_reason,
+        usage=usage_obj,
+    )
+
+
 def _normalized_api_base(provider: str, api_base: str | None) -> str | None:
     """Normalize provider-specific base URLs to avoid common endpoint mismatches."""
     if not api_base:
@@ -711,11 +919,36 @@ class LLMProvider:
         temperature: float | None = None,
         max_tokens: int | None = None,
         use_logprobs: bool = True,
+        on_thinking: Callable[[str], None] | None = None,
         **kwargs: Any,
     ) -> ChatResult:
         model = self.model_name
         mt = max_tokens or self.cfg.max_tokens
         extra: dict[str, Any] = dict(kwargs)
+        # Engage streaming + reasoning when the caller wants live thinking
+        # AND the model actually emits reasoning. Other models silently fall
+        # through to the existing non-streaming path with no behavior change.
+        use_streaming = on_thinking is not None and _supports_thinking(
+            self.cfg.provider, model
+        )
+        if use_streaming:
+            if self.cfg.provider == "anthropic":
+                budget = max(1024, int(getattr(self.cfg, "thinking_budget", 1024)))
+                extra["thinking"] = {"type": "enabled", "budget_tokens": budget}
+                # Anthropic requires ``max_tokens > thinking.budget_tokens``;
+                # leave headroom so the model has room for visible output.
+                if mt < budget + 512:
+                    mt = budget + 512
+                # Anthropic's extended-thinking API rejects temperature != 1
+                # and is incompatible with logprobs. Override both rather
+                # than letting the request fail.
+                temperature = 1.0
+                use_logprobs = False
+                for k in ("logprobs", "top_logprobs"):
+                    extra.pop(k, None)
+            # Ask the provider to emit a final usage chunk so we can capture
+            # reasoning_tokens for telemetry.
+            extra.setdefault("stream_options", {"include_usage": True})
 
         # Honor a runtime-discovered disable flag — set lower in the
         # exception path when a provider returns
@@ -764,15 +997,26 @@ class LLMProvider:
 
         def _do_completion(api_base_override: str | None) -> Any:
             explicit_api_key = self.cfg.api_key if self.cfg.provider == "openrouter" else None
-            return _litellm().completion(
+            kwargs_for_call = dict(extra)
+            if use_streaming:
+                kwargs_for_call["stream"] = True
+            raw = _litellm().completion(
                 model=model,
                 messages=messages,
                 temperature=temperature or self.cfg.temperature,
                 max_tokens=mt,
                 api_key=explicit_api_key,
                 api_base=api_base_override,
-                **extra,
+                **kwargs_for_call,
             )
+            if use_streaming:
+                # Consume the stream inside the retry context: any mid-stream
+                # error surfaces as the same exception class as a non-streamed
+                # failure, so the existing transient-retry / fatal-error
+                # classification keeps working.
+                assert on_thinking is not None  # guarded by ``use_streaming``
+                return _consume_thinking_stream(raw, on_thinking)
+            return raw
 
         t0 = time.perf_counter()
         resp = None
@@ -901,6 +1145,9 @@ class LLMProvider:
                 "total_tokens": getattr(raw_usage, "total_tokens", 0) or 0,
                 "model_processing_sec": elapsed_sec,
             }
+            tt = int(getattr(raw_usage, "thinking_tokens", 0) or 0)
+            if tt:
+                usage_dict["thinking_tokens"] = tt
         else:
             usage_dict = {"model_processing_sec": elapsed_sec}
 
@@ -1041,6 +1288,8 @@ class LLMProvider:
             finish_reason=finish,
             confidence_score=confidence_score,
             tool_calls=parsed_tool_calls,
+            thinking_content=str(getattr(resp, "thinking_content", "") or ""),
+            thinking_tokens=int(getattr(resp, "thinking_tokens", 0) or 0),
         )
 
     def test_result(self) -> LLMTestResult:

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -7,9 +7,10 @@ import math
 import os
 import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any
 
 from amx.config import LLMConfig, normalize_llm_model
 from amx.utils.logging import get_logger
@@ -600,9 +601,7 @@ class _StreamedChoice:
 
 
 class _StreamedUsage:
-    def __init__(
-        self, prompt: int, completion: int, total: int, thinking: int
-    ) -> None:
+    def __init__(self, prompt: int, completion: int, total: int, thinking: int) -> None:
         self.prompt_tokens = prompt
         self.completion_tokens = completion
         self.total_tokens = total
@@ -648,15 +647,11 @@ def _consume_thinking_stream(
         usage = getattr(chunk, "usage", None)
         if usage is not None:
             prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or prompt_tokens)
-            completion_tokens = int(
-                getattr(usage, "completion_tokens", 0) or completion_tokens
-            )
+            completion_tokens = int(getattr(usage, "completion_tokens", 0) or completion_tokens)
             total_tokens = int(getattr(usage, "total_tokens", 0) or total_tokens)
             details = getattr(usage, "completion_tokens_details", None)
             if details is not None:
-                thinking_tokens = int(
-                    getattr(details, "reasoning_tokens", 0) or thinking_tokens
-                )
+                thinking_tokens = int(getattr(details, "reasoning_tokens", 0) or thinking_tokens)
 
         choices = getattr(chunk, "choices", None) or []
         if not choices:
@@ -679,9 +674,7 @@ def _consume_thinking_stream(
             raw_tcs = getattr(delta, "tool_calls", None) or []
             for tc in raw_tcs:
                 idx = int(getattr(tc, "index", 0) or 0)
-                slot = tool_slots.setdefault(
-                    idx, {"id": "", "name": "", "arguments": ""}
-                )
+                slot = tool_slots.setdefault(idx, {"id": "", "name": "", "arguments": ""})
                 tid = getattr(tc, "id", None)
                 if tid:
                     slot["id"] = str(tid)
@@ -710,9 +703,7 @@ def _consume_thinking_stream(
 
     usage_obj: _StreamedUsage | None = None
     if prompt_tokens or completion_tokens or total_tokens or thinking_tokens:
-        usage_obj = _StreamedUsage(
-            prompt_tokens, completion_tokens, total_tokens, thinking_tokens
-        )
+        usage_obj = _StreamedUsage(prompt_tokens, completion_tokens, total_tokens, thinking_tokens)
 
     return _StreamedResponse(
         content="".join(content_parts),
@@ -928,9 +919,7 @@ class LLMProvider:
         # Engage streaming + reasoning when the caller wants live thinking
         # AND the model actually emits reasoning. Other models silently fall
         # through to the existing non-streaming path with no behavior change.
-        use_streaming = on_thinking is not None and _supports_thinking(
-            self.cfg.provider, model
-        )
+        use_streaming = on_thinking is not None and _supports_thinking(self.cfg.provider, model)
         if use_streaming:
             if self.cfg.provider == "anthropic":
                 budget = max(1024, int(getattr(self.cfg, "thinking_budget", 1024)))

--- a/amx/search/_agent/short_circuits.py
+++ b/amx/search/_agent/short_circuits.py
@@ -277,7 +277,14 @@ class ShortCircuitsMixin:
             if assistant_summary:
                 prior_turns.append({"role": "assistant", "content": assistant_summary})
         try:
+            from amx.utils.live_display import get_display
+
+            display = get_display()
             t0 = time.monotonic()
+            # ``step_spinner`` opens the thinking panel; the tool agent then
+            # streams the model's reasoning text into it via ``display`` so
+            # the user sees real thinking content rather than a blank
+            # spinner. The panel clears the moment the loop returns.
             with step_spinner("Search Agent: thinking with tools"):
                 result = run_tool_agent(
                     cfg=self.cfg,
@@ -286,6 +293,7 @@ class ShortCircuitsMixin:
                     question=clean_question,
                     answer_language=question_language,
                     session_memory=prior_turns,
+                    display=display if display.is_active else None,
                 )
             elapsed = round(time.monotonic() - t0, 4)
         except Exception as exc:

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -319,7 +319,7 @@ def run_tool_agent(
     question: str,
     answer_language: str,
     session_memory: list[dict[str, Any]] | None = None,
-    display: "LiveDisplay | None" = None,
+    display: LiveDisplay | None = None,
 ) -> ToolAgentResult:
     """Run the tool-calling loop and return the final synthesised answer.
 
@@ -356,7 +356,7 @@ def _run_tool_loop(
     question: str,
     answer_language: str,
     session_memory: list[dict[str, Any]] | None,
-    display: "LiveDisplay | None" = None,
+    display: LiveDisplay | None = None,
 ) -> ToolAgentResult:
     # Pre-fetch the schema list once; if it succeeds we put it into the
     # system prompt so the LLM doesn't have to spend a tool call discovering
@@ -387,9 +387,7 @@ def _run_tool_loop(
 
     # Single closure shared across iterations so the thinking panel keeps
     # streaming continuously even as we hop between LLM calls + tool calls.
-    on_thinking = (
-        (lambda text: display.update_thinking(text)) if display is not None else None
-    )
+    on_thinking = (lambda text: display.update_thinking(text)) if display is not None else None
 
     for iteration in range(_MAX_ITERATIONS):
         iterations = iteration + 1

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -20,12 +20,15 @@ against — so it doesn't have to hallucinate.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from amx.config import AMXConfig
 from amx.llm.provider import LLMProvider
 from amx.search.agent_tools import ToolBox
 from amx.search.catalog import SearchCatalog
+
+if TYPE_CHECKING:
+    from amx.utils.live_display import LiveDisplay
 
 # Maximum number of tool-call iterations before we force the LLM to answer.
 # A typical question takes 1–3 tool calls; 6 gives headroom for chained
@@ -316,6 +319,7 @@ def run_tool_agent(
     question: str,
     answer_language: str,
     session_memory: list[dict[str, Any]] | None = None,
+    display: "LiveDisplay | None" = None,
 ) -> ToolAgentResult:
     """Run the tool-calling loop and return the final synthesised answer.
 
@@ -323,6 +327,10 @@ def run_tool_agent(
     builds in ``SearchAgent._memory_summary``. We forward it as a prelude
     user/assistant exchange so the model can resolve "it" / "that table" /
     "bu tablo" without re-asking the user.
+
+    ``display`` is forwarded to the LLM call so reasoning models can stream
+    their thinking text into the live thinking panel; for models that don't
+    expose reasoning, it's a no-op.
     """
     # Use ``with`` so the live DB connector (SQLAlchemy engine + connection
     # pool) is disposed at the end of every question. Without this, each
@@ -336,6 +344,7 @@ def run_tool_agent(
             question=question,
             answer_language=answer_language,
             session_memory=session_memory,
+            display=display,
         )
 
 
@@ -347,6 +356,7 @@ def _run_tool_loop(
     question: str,
     answer_language: str,
     session_memory: list[dict[str, Any]] | None,
+    display: "LiveDisplay | None" = None,
 ) -> ToolAgentResult:
     # Pre-fetch the schema list once; if it succeeds we put it into the
     # system prompt so the LLM doesn't have to spend a tool call discovering
@@ -375,6 +385,12 @@ def _run_tool_loop(
     iterations = 0
     tools_schema = ToolBox.schemas()
 
+    # Single closure shared across iterations so the thinking panel keeps
+    # streaming continuously even as we hop between LLM calls + tool calls.
+    on_thinking = (
+        (lambda text: display.update_thinking(text)) if display is not None else None
+    )
+
     for iteration in range(_MAX_ITERATIONS):
         iterations = iteration + 1
         result = llm.chat(
@@ -384,6 +400,7 @@ def _run_tool_loop(
             use_logprobs=False,
             tools=tools_schema,
             tool_choice="auto",
+            on_thinking=on_thinking,
         )
         # Aggregate usage across iterations.
         for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
@@ -437,6 +454,7 @@ def _run_tool_loop(
             temperature=0.0,
             max_tokens=_AGENT_MAX_TOKENS,
             use_logprobs=False,
+            on_thinking=on_thinking,
         )
         for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
             aggregated_usage[key] += int((result.usage or {}).get(key, 0) or 0)

--- a/amx/utils/live_display.py
+++ b/amx/utils/live_display.py
@@ -82,6 +82,12 @@ class LiveDisplay:
         self._thinking: bool = False
         self._thinking_label: str = ""
         self._thinking_start: float = 0.0
+        # Streaming reasoning text from the model. Populated by
+        # ``update_thinking`` while a chat call streams reasoning deltas;
+        # cleared on ``stop_thinking`` and ``start`` so it never leaks
+        # between turns. Capped to the most recent slice so the panel
+        # height stays bounded.
+        self._thinking_text: str = ""
         self._collapsed: bool = False
         self._session_start: float = 0.0
 
@@ -117,6 +123,7 @@ class LiveDisplay:
         self._context_model = model
         self._activities.clear()
         self._thinking = False
+        self._thinking_text = ""
         self._collapsed = False
         self._session_start = time.monotonic()
         self._total_tokens_in = 0
@@ -316,10 +323,28 @@ class LiveDisplay:
         self._thinking = True
         self._thinking_label = label
         self._thinking_start = time.monotonic()
+        self._thinking_text = ""
+        self._refresh()
+
+    def update_thinking(self, text: str) -> None:
+        """Replace the streaming reasoning snippet shown under the spinner.
+
+        Callers pass the full accumulated reasoning so far; we keep only the
+        tail (~600 chars) so the panel never grows unbounded as the model
+        continues to think.
+        """
+        if not text:
+            return
+        with self._lock:
+            tail = text[-600:] if len(text) > 600 else text
+            if tail == self._thinking_text:
+                return
+            self._thinking_text = tail
         self._refresh()
 
     def stop_thinking(self) -> None:
         self._thinking = False
+        self._thinking_text = ""
         self._refresh()
 
     def toggle_collapse(self) -> None:
@@ -374,14 +399,25 @@ class LiveDisplay:
         header_text = Text.from_markup(f"  {left}  {right}  {time_str}  {tok_str}")
         return Panel(header_text, box=box.HEAVY, style="dim", height=3)
 
-    def _render_thinking(self) -> Text:
+    def _render_thinking(self) -> Group | Text:
         elapsed = time.monotonic() - self._thinking_start
         dots = "." * (int(elapsed * 2) % 4)
         collapsed_hint = "[dim](Tab to expand)[/dim]" if self._collapsed else ""
-        return Text.from_markup(
+        header = Text.from_markup(
             f"  [bold yellow]⟳[/bold yellow] {self._thinking_label}{dots} "
             f"[dim]({elapsed:.0f}s)[/dim] {collapsed_hint}"
         )
+        if not self._thinking_text:
+            return header
+        # Show the last few lines of streamed reasoning, dim-italic and
+        # indented so it reads as ambient model chatter rather than answer
+        # text. ``transient=True`` on the Live wipes it on stop().
+        snippet = self._thinking_text.replace("\r", "")
+        lines = [ln for ln in snippet.split("\n") if ln.strip()]
+        tail_lines = lines[-3:] if len(lines) > 3 else lines
+        body = Text("\n".join(f"    {ln}" for ln in tail_lines), style="dim italic")
+        body.overflow = "fold"
+        return Group(header, body)
 
     def _render_activity_tree(self) -> Tree:
         tree = Tree("[bold]Pipeline[/bold]", guide_style="dim")


### PR DESCRIPTION
## Summary
- `/ask` streams the model's real reasoning into the existing transient thinking panel and wipes it the moment the answer prints — chat scrollback stays clean, but the user sees the model actually think instead of a static spinner.
- Engages automatically for reasoning-capable models (Anthropic Claude w/ extended thinking on Sonnet 3.7 / Sonnet+Opus 4, DeepSeek-reasoner, OpenAI o-series). Other models keep the existing spinner-only behavior with zero risk.
- One new opt-in `LLMConfig.thinking_budget` knob (default 1024). No new flag, no new command, no SQLite history schema change — thinking is intentionally ephemeral.

## Files
- `amx/llm/provider.py` — `chat()` gains `on_thinking` callback; when supplied + supported, switches to `stream=True`, fires deltas, reassembles tool calls / content / usage into a response-shaped wrapper so the existing parser path is untouched. New `_supports_thinking()` helper. `ChatResult` gains `thinking_content` + `thinking_tokens`.
- `amx/utils/live_display.py` — new `update_thinking(text)` public method; `_render_thinking()` returns a Group of spinner-header + dim-italic indented snippet of the last few reasoning lines; cleared on `stop_thinking()` / `start()`.
- `amx/search/tool_agent.py` — `run_tool_agent` / `_run_tool_loop` accept optional `display`; one `on_thinking` closure shared across iterations so the panel streams continuously instead of flickering between tool calls.
- `amx/search/_agent/short_circuits.py` — resolves `get_display()` once and forwards into the agent; `step_spinner` still owns the thinking-panel lifecycle.
- `amx/config.py` — `LLMConfig.thinking_budget: int = 1024`; round-trips through YAML.
- `CHANGELOG.md` — full Unreleased entry.

## Test plan
- [x] `pytest -q` — all 444 tests pass.
- [x] Smoke test with fake litellm stream: confirms `on_thinking` deltas accumulate, tool-call chunks split by `index` reassemble correctly, `ChatResult.thinking_content` / `thinking_tokens` populate, `usage` dict gets `thinking_tokens`, finish_reason propagates, and non-reasoning models take the unchanged non-streaming path.
- [x] LiveDisplay lifecycle smoke: `update_thinking` populates, `_render_thinking()` returns a Group without crashing, `stop_thinking()` clears state.
- [ ] Manual `/ask` against the real Anthropic profile — verify thinking streams live, panel clears on answer, no flicker between tool-call iterations. (Owner to run; can't be exercised non-interactively.)
- [ ] Manual `/ask` with a non-reasoning model (e.g. `gpt-4o-mini`) — confirm the existing static spinner still shows and no errors surface.
