### PR TITLE
fix(ask): OpenRouter rejects effort+max_tokens together; raise mt floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — OpenRouter reasoning request rejected by API (400) + token-budget exhaustion
+
+Real-run report after the previous OpenRouter fix landed:
+
+```
+litellm.BadRequestError: OpenrouterException — {"error":{"message":"Only one of
+\"reasoning.effort\" and \"reasoning.max_tokens\" can be specified","code":400}}
+```
+
+…followed by the existing fatal-empty-content guard:
+
+```
+Model `openrouter/moonshotai/kimi-k2-thinking` returned 0 visible characters and
+used all 900 output tokens — this almost always means a reasoning model burnt
+the budget on internal thinking.
+```
+
+Two issues:
+
+1. The previous fix sent both `reasoning.effort` and `reasoning.max_tokens` together. OpenRouter's API rejects that combination — they're mutually exclusive at the request layer, despite the docs implying otherwise. Now sends `effort` only (works across every reasoning route OpenRouter currently fronts: o-series, gpt-5, kimi-k2-thinking, Claude extended thinking, deepseek-reasoner).
+2. The OpenAI-direct path raises `max_tokens` to `_DEFAULT_REASONING_FLOOR` (16384) before reasoning calls so the model doesn't burn its whole output budget on internal thinking. OpenRouter routes never hit that branch, so kimi-k2-thinking with the agent's default `_AGENT_MAX_TOKENS=1500` exhausted itself thinking before producing visible output. The OpenRouter streaming branch now applies the same floor.
+
+Default `AMX_REASONING_EFFORT` for the OpenRouter path drops from `medium` → `low` so token burn stays bounded by default. Users who want more thinking depth can set `AMX_REASONING_EFFORT=high`.
+
 ### Fixed — Live thinking now actually works for OpenRouter routes
 
 User report: "I tested with `kimi-k2-thinking` and `o4-mini`, neither showed me thinking. provider is openrouter for all."

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -940,21 +940,40 @@ class LLMProvider:
                     extra.pop(k, None)
             elif self.cfg.provider == "openrouter":
                 # OpenRouter omits reasoning tokens from responses by default —
-                # without this opt-in the stream contains content but no
+                # without an opt-in the stream contains content but no
                 # ``reasoning_content`` deltas, so the thinking panel stays
-                # empty even though everything else is wired up. ``effort``
-                # covers OpenAI-style routes (o-series, gpt-5); ``max_tokens``
-                # covers Anthropic-style budget routes (Claude). OpenRouter
-                # accepts both in the same request and applies whichever the
-                # downstream provider expects. See:
-                # https://openrouter.ai/docs/use-cases/reasoning-tokens
-                effort = os.getenv("AMX_REASONING_EFFORT", "medium").strip().lower()
+                # empty even though everything else is wired up.
+                #
+                # The OpenRouter API enforces ``effort`` XOR ``max_tokens`` and
+                # 400s if both are sent ("Only one of reasoning.effort and
+                # reasoning.max_tokens can be specified"). We pick ``effort``
+                # because it works across every reasoning route OpenRouter
+                # currently fronts (o-series, gpt-5, kimi-k2-thinking, Claude
+                # extended-thinking, deepseek-reasoner) — the downstream
+                # provider gets the right knob set for it. Users wanting
+                # explicit Anthropic budget control should use the Anthropic
+                # provider directly.
+                effort = os.getenv("AMX_REASONING_EFFORT", "low").strip().lower()
                 if effort not in ("low", "medium", "high"):
-                    effort = "medium"
-                extra.setdefault(
-                    "reasoning",
-                    {"effort": effort, "max_tokens": budget, "exclude": False},
-                )
+                    effort = "low"
+                extra.setdefault("reasoning", {"effort": effort})
+                # Reasoning models burn output tokens on internal thinking
+                # before producing visible content — without a generous
+                # ``max_tokens`` floor the model exhausts its budget mid-
+                # thought and returns empty content with finish_reason=length,
+                # which the existing guard surfaces as a fatal "0 visible
+                # characters" error. Match the OpenAI-direct behaviour at
+                # the bottom of this method so OpenRouter routes get the
+                # same headroom.
+                floor = int(os.getenv("AMX_LLM_MIN_MAX_TOKENS", str(_DEFAULT_REASONING_FLOOR)))
+                if mt < floor:
+                    log.debug(
+                        "Raising max_tokens %d → %d for OpenRouter reasoning model %s",
+                        mt,
+                        floor,
+                        model,
+                    )
+                    mt = floor
                 # logprobs are unsupported on most reasoning routes; drop to
                 # avoid 400s before the streamed call goes out.
                 use_logprobs = False


### PR DESCRIPTION
## Summary
Real-run report after the previous OpenRouter fix landed:

```
litellm.BadRequestError: OpenrouterException — {"error":{"message":"Only one of
\"reasoning.effort\" and \"reasoning.max_tokens\" can be specified","code":400}}
```

…followed by the existing fatal-empty-content guard because the model burned its 900-token budget on internal thinking and returned no visible output.

## Two bugs

1. **OpenRouter enforces `effort` XOR `max_tokens`** at the request layer despite the docs suggesting both work. The previous fix sent both. Now sends `effort` only — it works across every reasoning route OpenRouter currently fronts (o-series, gpt-5, kimi-k2-thinking, Claude extended thinking, deepseek-reasoner). The downstream provider gets the right knob set. Users wanting precise Anthropic `budget_tokens` control should use the Anthropic provider directly.
2. **No `max_tokens` floor for OpenRouter reasoning routes.** The OpenAI-direct path raises `max_tokens` to `_DEFAULT_REASONING_FLOOR` (16384) so reasoning models don't exhaust their budget thinking before producing visible output — OpenRouter routes never hit that branch. The OpenRouter streaming branch now applies the same floor (overridable via `AMX_LLM_MIN_MAX_TOKENS`).

Default `AMX_REASONING_EFFORT` drops `medium` → `low` for the OpenRouter path so token burn stays bounded by default. Users wanting more thinking depth can set `AMX_REASONING_EFFORT=high`.

## Test plan
- [x] Smoke test confirms reasoning kwarg shape is `{effort: low}` only (no `max_tokens`), `mt` is floored to 16384, env override of `AMX_REASONING_EFFORT` flows through.
- [x] Anthropic-direct path verified unchanged (still uses `thinking={budget_tokens: ...}`, never sends `reasoning`).
- [x] `pytest -q tests/` — all 444 tests pass.
- [ ] Manual `/ask` against `openrouter/moonshotai/kimi-k2-thinking` — request no longer 400s, panel populates with reasoning, visible answer prints.
- [ ] Manual `/ask` against `openrouter/openai/o4-mini` — same.
