### PR TITLE
feat(db): add 6 new backends (MySQL, Oracle, MSSQL, Redshift, ClickHouse, DuckDB) + extended object model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[code-intel]" pytest pytest-cov
+          python -m pip install -e ".[all,code-intel]" pytest pytest-cov
       - name: Run tests
         run: pytest -ra
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added — six new database backends + extended object model
+
+AMX now ships adapters for **MySQL, Oracle, SQL Server, Redshift, ClickHouse,
+and DuckDB**, bringing the supported backend count to 10. Each adapter exposes
+the object types its backend treats as first-class — not just tables and views.
+
+* **DuckDB**: tables, views, sequences, functions, **macros** (DuckDB's
+  parameterised SQL primitive). Single-file or `:memory:` connection.
+* **MySQL/MariaDB**: stored procedures, functions, triggers, **events**
+  (MySQL's scheduled jobs), partition strategy, storage engine.
+* **Oracle**: materialized views, procedures, functions, **packages** (PL/SQL
+  bundles, Oracle-distinctive), triggers, sequences, synonyms, user-defined
+  types. Service-name-first connection with SID fallback.
+* **SQL Server**: procedures, functions (FN/TF/IF subtypes), triggers,
+  sequences, synonyms. Comments via `sp_addextendedproperty` /
+  `sp_updateextendedproperty` (the IF EXISTS branch handles add-vs-update
+  in a single block).
+* **Redshift**: materialized views, stored procedures, UDFs, **datashares**
+  (Redshift's cross-cluster sharing primitive), **external tables** (Spectrum).
+  Analytics metadata exposes the Redshift-specific `diststyle` / `sortkey1` /
+  encoding signals that drive performance tuning.
+* **ClickHouse**: materialized views, user-defined functions, **dictionaries**
+  (ClickHouse's external lookup primitive), skipping indices, MergeTree engine
+  metadata.
+
+The **existing 4 adapters were back-filled** with the same extended object
+surface where applicable: PostgreSQL gets procedures/functions/sequences/
+triggers/UDTs; Snowflake gets procedures/functions/sequences/tasks/stages
+(volumes)/shares (datashares)/external tables; Databricks gets user
+functions, **volumes** (Unity Catalog file storage), and external tables;
+BigQuery gets routines and external tables.
+
+Under the hood: `BackendCapabilities` grew 13 new flags, `DatabaseAdapter`
+gained matching `list_*` methods (default `[]`), and `DatabaseConnector`
+surfaces them through capability-gated wrappers. Comment write-back works
+on every backend whose dialect supports it — including SQL Server's
+extended-properties mechanism and ClickHouse's `ALTER … MODIFY COMMENT`.
+
+### Changed — database drivers now ship as optional extras (BREAKING for installs)
+
+Database driver dependencies (psycopg2, snowflake-*, databricks-*,
+sqlalchemy-bigquery, google-cloud-bigquery, pymysql, oracledb, pyodbc,
+redshift_connector, clickhouse-connect, duckdb-engine) have moved out of
+`[project.dependencies]` into `[project.optional-dependencies]` extras.
+This trims the default install by ~50MB+ and keeps users who only target
+one or two backends from carrying the rest.
+
+**Migration**: existing users must reinstall with the extras they need:
+
+```bash
+pip install amx[postgresql,snowflake]   # multiple backends
+pip install amx[all]                    # everything (matches old behaviour)
+```
+
+`get_adapter()` now raises `MissingDriverError` (a subclass of `ImportError`)
+with the exact `pip install amx[<extra>]` hint when a backend is selected
+without its driver — no more bare `ModuleNotFoundError`.
+
 ### Fixed — OpenRouter reasoning request rejected by API (400) + token-budget exhaustion
 
 Real-run report after the previous OpenRouter fix landed:

--- a/README.md
+++ b/README.md
@@ -325,14 +325,25 @@ AMX scans/ingests these extensions:
 
 ## Supported database backends
 
-| Backend | Config (`backend` in `~/.amx/config.yml`) | Notes |
-|---------|-------------------------------------------|--------|
-| PostgreSQL | `postgresql` | Default; `COMMENT ON TABLE/COLUMN` |
-| Snowflake | `snowflake` | Account, warehouse, role; Snowflake `COMMENT` syntax |
-| Databricks | `databricks` | SQL warehouse HTTP path + personal access token; Unity Catalog optional |
-| BigQuery | `bigquery` | GCP project, dataset; table/schema/column descriptions via `ALTER … SET OPTIONS`; project-level descriptions are not supported through SQL write-back |
+| Backend | Config (`backend`) | Install | Notes |
+|---------|--------------------|---------|-------|
+| PostgreSQL | `postgresql` | `pip install amx[postgresql]` | `COMMENT ON TABLE/COLUMN/SCHEMA/DATABASE`; back-fills procedures, functions, sequences, triggers, UDTs |
+| Snowflake | `snowflake` | `pip install amx[snowflake]` | Account, warehouse, role; Snowflake `COMMENT`; back-fills procedures, functions, sequences, tasks, stages, shares, external tables |
+| Databricks | `databricks` | `pip install amx[databricks]` | SQL warehouse HTTP path + PAT; Unity Catalog; back-fills user functions, **volumes**, external tables |
+| BigQuery | `bigquery` | `pip install amx[bigquery]` | GCP project + dataset; descriptions via `ALTER … SET OPTIONS`; back-fills routines (procedures + functions), external tables |
+| MySQL / MariaDB | `mysql` | `pip install amx[mysql]` | `ALTER TABLE … COMMENT`; surfaces stored procedures, functions, triggers, **events** (scheduled jobs), partition strategy, storage engine |
+| Oracle | `oracle` | `pip install amx[oracle]` | `service_name` (preferred) or SID; surfaces materialized views, procedures, functions, **packages** (Oracle-distinctive), triggers, sequences, synonyms, UDTs |
+| SQL Server | `mssql` | `pip install amx[mssql]` (requires ODBC Driver 18) | Comments via `sp_addextendedproperty` / `sp_updateextendedproperty`; surfaces procedures, functions (FN/TF/IF), triggers, sequences, synonyms, partitions |
+| Redshift | `redshift` | `pip install amx[redshift]` | PG-compatible `COMMENT ON`; surfaces materialized views, procedures, UDFs, **datashares**, **external tables** (Spectrum); analytics metadata includes diststyle/sortkey/encoding |
+| ClickHouse | `clickhouse` | `pip install amx[clickhouse]` | `ALTER TABLE … MODIFY COMMENT` (21.x+); surfaces materialized views, UDFs, **dictionaries** (ClickHouse-distinctive), skipping indices, MergeTree engine info |
+| DuckDB | `duckdb` | `pip install amx[duckdb]` | Single-file or `:memory:`; surfaces sequences, functions, **macros** (DuckDB-distinctive), attached databases (Parquet/S3/Postgres scanner) |
 
-Introspection and profiling use backend-specific SQL where needed; metadata write-back uses each platform’s supported description/comment mechanism. Each adapter advertises its capabilities so unsupported operations fail clearly instead of being counted as applied. For example, BigQuery project-level descriptions are blocked before connection, and Databricks catalog comments require a configured Unity Catalog name.
+> Each backend driver is now an optional extra. Pick what you use:
+> `pip install amx[postgresql,duckdb]` — or grab everything with `pip install amx[all]`.
+
+Introspection and profiling use backend-specific SQL where needed; metadata write-back uses each platform's supported description/comment mechanism. Each adapter advertises its capabilities so unsupported operations fail clearly instead of being counted as applied. For example, BigQuery project-level descriptions are blocked before connection, MySQL has no `COMMENT ON SCHEMA` so schema comments raise rather than silently no-op, and DuckDB schema-level comments are unsupported in DuckDB 1.x.
+
+Beyond tables and views, each adapter exposes the object types that are first-class on its backend: stored procedures, user functions, sequences, triggers, scheduled jobs/tasks/events, packages (Oracle), synonyms (Oracle / SQL Server), user-defined types, dictionaries (ClickHouse), macros (DuckDB), volumes (Databricks Unity Catalog), datashares (Snowflake / Redshift), and external tables (Snowflake / Databricks / BigQuery / Redshift Spectrum / DuckDB Parquet). Capability flags on `BackendCapabilities` gate which list operations the connector even attempts, so unsupported types short-circuit cleanly.
 
 ## Supported LLM Providers
 

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -559,7 +559,9 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         )
         while not port_raw.isdigit():
             warn("Port must be a number.")
-            port_raw = _ask_update_text("Port (e.g. 3306)", "3306", required=True, allow_clear=False)
+            port_raw = _ask_update_text(
+                "Port (e.g. 3306)", "3306", required=True, allow_clear=False
+            )
         user = _ask_update_text(
             "Username (e.g. analyst)", defaults.user or "", required=True, allow_clear=False
         )
@@ -593,7 +595,9 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         )
         while not port_raw.isdigit():
             warn("Port must be a number.")
-            port_raw = _ask_update_text("Port (e.g. 1521)", "1521", required=True, allow_clear=False)
+            port_raw = _ask_update_text(
+                "Port (e.g. 1521)", "1521", required=True, allow_clear=False
+            )
         user = _ask_update_text(
             "Username (e.g. APP_USER)", defaults.user or "", required=True, allow_clear=False
         )
@@ -637,7 +641,9 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         )
         while not port_raw.isdigit():
             warn("Port must be a number.")
-            port_raw = _ask_update_text("Port (e.g. 1433)", "1433", required=True, allow_clear=False)
+            port_raw = _ask_update_text(
+                "Port (e.g. 1433)", "1433", required=True, allow_clear=False
+            )
         user = _ask_update_text(
             "Username (e.g. sa)", defaults.user or "", required=True, allow_clear=False
         )
@@ -686,7 +692,9 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         )
         while not port_raw.isdigit():
             warn("Port must be a number.")
-            port_raw = _ask_update_text("Port (e.g. 5439)", "5439", required=True, allow_clear=False)
+            port_raw = _ask_update_text(
+                "Port (e.g. 5439)", "5439", required=True, allow_clear=False
+            )
         user = _ask_update_text(
             "Username (e.g. admin)", defaults.user or "", required=True, allow_clear=False
         )
@@ -733,9 +741,7 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             port_raw = _ask_update_text(
                 f"Port (default {default_port})", default_port, required=True, allow_clear=False
             )
-        user = _ask_update_text(
-            "Username (default: 'default')", defaults.user or "default"
-        )
+        user = _ask_update_text("Username (default: 'default')", defaults.user or "default")
         password = _ask_update_secret(
             "Password (blank for the default 'no password' user)",
             defaults.password or "",

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -352,6 +352,12 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             "snowflake": "Account, warehouse, role - Snowflake COMMENT",
             "databricks": "SQL warehouse HTTP path + token - Unity Catalog",
             "bigquery": "GCP project + dataset - table/column descriptions via OPTIONS",
+            "mysql": "Host/port user/password - MySQL/MariaDB; ALTER TABLE COMMENT",
+            "oracle": "Host/port user/password + service_name - Oracle DB; ALL_* catalogs",
+            "mssql": "Host/port user/password + ODBC driver - SQL Server / Azure SQL",
+            "redshift": "Host/port user/password - Amazon Redshift; PG-compatible + Spectrum",
+            "clickhouse": "Host/port user/password - ClickHouse; system.* catalogs, MergeTree engines",
+            "duckdb": "Single-file or in-memory; no host/auth (analytical, embedded)",
         },
     )
 
@@ -379,6 +385,12 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             project="",
             dataset="",
             credentials_path="",
+            service_name="",
+            driver="",
+            encrypt=True,
+            trust_server_certificate=False,
+            cluster_identifier="",
+            secure=False,
         )
 
     # If the user picked a backend different from what ``defaults``
@@ -532,6 +544,231 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             credentials_path=creds,
         )
 
+    if backend == "mysql":
+        host = _ask_update_text(
+            "Database host (e.g. db.example.com)",
+            defaults.host or "",
+            required=True,
+            allow_clear=False,
+        )
+        port_raw = _ask_update_text(
+            "Port (e.g. 3306)",
+            str(defaults.port) if defaults.port and defaults.port != 5432 else "3306",
+            required=True,
+            allow_clear=False,
+        )
+        while not port_raw.isdigit():
+            warn("Port must be a number.")
+            port_raw = _ask_update_text("Port (e.g. 3306)", "3306", required=True, allow_clear=False)
+        user = _ask_update_text(
+            "Username (e.g. analyst)", defaults.user or "", required=True, allow_clear=False
+        )
+        password = _ask_update_secret("Password", defaults.password or "", required=True)
+        database = _ask_update_text(
+            "Database name (optional — leave blank to pick at command time)",
+            defaults.database or "",
+        )
+        return replace(
+            defaults,
+            backend="mysql",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            database=database,
+        )
+
+    if backend == "oracle":
+        host = _ask_update_text(
+            "Database host (e.g. ora.example.com)",
+            defaults.host or "",
+            required=True,
+            allow_clear=False,
+        )
+        port_raw = _ask_update_text(
+            "Port (e.g. 1521)",
+            str(defaults.port) if defaults.port and defaults.port != 5432 else "1521",
+            required=True,
+            allow_clear=False,
+        )
+        while not port_raw.isdigit():
+            warn("Port must be a number.")
+            port_raw = _ask_update_text("Port (e.g. 1521)", "1521", required=True, allow_clear=False)
+        user = _ask_update_text(
+            "Username (e.g. APP_USER)", defaults.user or "", required=True, allow_clear=False
+        )
+        password = _ask_update_secret("Password", defaults.password or "", required=True)
+        service_name = _ask_update_text(
+            "Service name (preferred for Oracle Cloud / RAC, e.g. XEPDB1) — "
+            "leave blank to use SID instead",
+            defaults.service_name or "",
+        )
+        database = ""
+        if not service_name:
+            database = _ask_update_text(
+                "SID (used when service_name is blank, e.g. XE)",
+                defaults.database or "",
+                required=True,
+                allow_clear=False,
+            )
+        return replace(
+            defaults,
+            backend="oracle",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            service_name=service_name,
+            database=database,
+        )
+
+    if backend == "mssql":
+        host = _ask_update_text(
+            "Database host (e.g. mssql.example.com)",
+            defaults.host or "",
+            required=True,
+            allow_clear=False,
+        )
+        port_raw = _ask_update_text(
+            "Port (e.g. 1433)",
+            str(defaults.port) if defaults.port and defaults.port != 5432 else "1433",
+            required=True,
+            allow_clear=False,
+        )
+        while not port_raw.isdigit():
+            warn("Port must be a number.")
+            port_raw = _ask_update_text("Port (e.g. 1433)", "1433", required=True, allow_clear=False)
+        user = _ask_update_text(
+            "Username (e.g. sa)", defaults.user or "", required=True, allow_clear=False
+        )
+        password = _ask_update_secret("Password", defaults.password or "", required=True)
+        database = _ask_update_text(
+            "Database name (optional — leave blank to pick at command time)",
+            defaults.database or "",
+        )
+        driver = _ask_update_text(
+            "ODBC driver name (default: 'ODBC Driver 18 for SQL Server')",
+            defaults.driver or "",
+        )
+        encrypt = _ask_update_bool(
+            "Encrypt the connection? (set False only for legacy on-prem servers without TLS)",
+            bool(defaults.encrypt),
+        )
+        trust = _ask_update_bool(
+            "Trust the server certificate? (use True only with self-signed certs)",
+            bool(defaults.trust_server_certificate),
+        )
+        return replace(
+            defaults,
+            backend="mssql",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            database=database,
+            driver=driver,
+            encrypt=encrypt,
+            trust_server_certificate=trust,
+        )
+
+    if backend == "redshift":
+        host = _ask_update_text(
+            "Cluster endpoint (e.g. my-cluster.xxx.eu-west-1.redshift.amazonaws.com)",
+            defaults.host or "",
+            required=True,
+            allow_clear=False,
+        )
+        port_raw = _ask_update_text(
+            "Port (e.g. 5439)",
+            str(defaults.port) if defaults.port and defaults.port != 5432 else "5439",
+            required=True,
+            allow_clear=False,
+        )
+        while not port_raw.isdigit():
+            warn("Port must be a number.")
+            port_raw = _ask_update_text("Port (e.g. 5439)", "5439", required=True, allow_clear=False)
+        user = _ask_update_text(
+            "Username (e.g. admin)", defaults.user or "", required=True, allow_clear=False
+        )
+        password = _ask_update_secret("Password", defaults.password or "", required=True)
+        database = _ask_update_text(
+            "Database name (e.g. dev — leave blank to pick at command time)",
+            defaults.database or "",
+        )
+        cluster = _ask_update_text(
+            "Cluster identifier (optional, only needed for IAM auth)",
+            defaults.cluster_identifier or "",
+        )
+        return replace(
+            defaults,
+            backend="redshift",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            database=database,
+            cluster_identifier=cluster,
+        )
+
+    if backend == "clickhouse":
+        host = _ask_update_text(
+            "ClickHouse host (e.g. ch.example.com)",
+            defaults.host or "",
+            required=True,
+            allow_clear=False,
+        )
+        secure = _ask_update_bool(
+            "Use HTTPS? (8443 / cloud) — answer No for plain HTTP (8123 / on-prem)",
+            bool(defaults.secure),
+        )
+        default_port = "8443" if secure else "8123"
+        port_raw = _ask_update_text(
+            f"Port (default {default_port})",
+            str(defaults.port) if defaults.port and defaults.port != 5432 else default_port,
+            required=True,
+            allow_clear=False,
+        )
+        while not port_raw.isdigit():
+            warn("Port must be a number.")
+            port_raw = _ask_update_text(
+                f"Port (default {default_port})", default_port, required=True, allow_clear=False
+            )
+        user = _ask_update_text(
+            "Username (default: 'default')", defaults.user or "default"
+        )
+        password = _ask_update_secret(
+            "Password (blank for the default 'no password' user)",
+            defaults.password or "",
+            required=False,
+        )
+        database = _ask_update_text(
+            "Database (e.g. analytics — leave blank to pick at command time)",
+            defaults.database or "",
+        )
+        return replace(
+            defaults,
+            backend="clickhouse",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            database=database,
+            secure=secure,
+        )
+
+    if backend == "duckdb":
+        database = _ask_update_text(
+            "Path to .duckdb file (or ':memory:' for an ephemeral database)",
+            defaults.database or ":memory:",
+            required=True,
+            allow_clear=False,
+        )
+        return replace(
+            defaults,
+            backend="duckdb",
+            database=database,
+        )
+
     return defaults
 
 
@@ -643,6 +880,40 @@ def cmd_inspect(cfg: AMXConfig, rest: list[str]) -> None:
             f"  Project: {profile.project}, dataset: {profile.dataset or '(any)'}, "
             f"credentials: {profile.credentials_path or '(ADC)'}"
         )
+    elif profile.backend == "mysql":
+        info(
+            f"  Host: {profile.host}:{profile.port}, user: {profile.user}, "
+            f"db: {profile.database or '(unpinned)'}"
+        )
+    elif profile.backend == "oracle":
+        target = (
+            f"service_name={profile.service_name}"
+            if profile.service_name
+            else f"SID={profile.database or '(unpinned)'}"
+        )
+        info(f"  Host: {profile.host}:{profile.port}, user: {profile.user}, {target}")
+    elif profile.backend == "mssql":
+        info(
+            f"  Host: {profile.host}:{profile.port}, user: {profile.user}, "
+            f"db: {profile.database or '(unpinned)'}, "
+            f"driver: {profile.driver or '(default ODBC 18)'}, "
+            f"encrypt: {profile.encrypt}, trust_server_cert: {profile.trust_server_certificate}"
+        )
+    elif profile.backend == "redshift":
+        info(
+            f"  Host: {profile.host}:{profile.port}, user: {profile.user}, "
+            f"db: {profile.database or '(unpinned)'}"
+            + (f", cluster_id: {profile.cluster_identifier}" if profile.cluster_identifier else "")
+        )
+    elif profile.backend == "clickhouse":
+        scheme = "https" if profile.secure else "http"
+        info(
+            f"  Host: {profile.host}:{profile.port} ({scheme}), "
+            f"user: {profile.user or 'default'}, "
+            f"db: {profile.database or '(unpinned)'}"
+        )
+    elif profile.backend == "duckdb":
+        info(f"  File: {profile.database or ':memory:'}")
 
     # Connection test using the existing typed result so categorised
     # error hints from amx.core.errors flow through unchanged.

--- a/amx/config.py
+++ b/amx/config.py
@@ -34,7 +34,18 @@ from amx.storage.secrets import (
     parse_reference,
 )
 
-SUPPORTED_BACKENDS = ("postgresql", "snowflake", "databricks", "bigquery")
+SUPPORTED_BACKENDS = (
+    "postgresql",
+    "snowflake",
+    "databricks",
+    "bigquery",
+    "mysql",
+    "oracle",
+    "mssql",
+    "redshift",
+    "clickhouse",
+    "duckdb",
+)
 DISABLED_PROFILE = "__none__"
 PROFILING_MODES = ("full", "sampled", "metadata")
 SUPPORTED_EMBEDDING_KINDS = ("minilm", "openai_compatible", "sentence_transformers")
@@ -445,10 +456,43 @@ class DBConfig(_ObservableConfig):
     dataset: str = ""
     credentials_path: str = ""
 
+    # Oracle — service name vs SID is exposed explicitly so users can
+    # match what their DBA provided. ``database`` field is reused for SID
+    # when ``service_name`` is blank.
+    service_name: str = ""
+
+    # SQL Server — ``driver`` is the ODBC driver name (e.g. "ODBC Driver
+    # 18 for SQL Server"), required by pyodbc. ``encrypt`` /
+    # ``trust_server_certificate`` cover the most-asked TLS knobs.
+    driver: str = ""
+    encrypt: bool = True
+    trust_server_certificate: bool = False
+
+    # Redshift — optional; only used by IAM-auth code paths. Standard
+    # username/password auth uses the inherited ``host``/``user`` fields.
+    cluster_identifier: str = ""
+
+    # ClickHouse — HTTPS toggle. HTTP port is 8123, HTTPS is 8443.
+    secure: bool = False
+
     # Profiling guardrails
     profiling_mode: str = "full"  # full | sampled | metadata
     profiling_max_rows: int = 1_000_000  # skip full column scans above this row estimate (0=off)
     profiling_sample_size: int = 5
+
+    def _effective_port(self, default: int) -> int:
+        """Resolve the port for a non-PostgreSQL backend.
+
+        ``port`` defaults to 5432 at the dataclass level for PostgreSQL
+        back-compat. For every other backend, treat that legacy value
+        as "no port set" and substitute the canonical default (3306 for
+        MySQL, 1521 for Oracle, 1433 for SQL Server, …). Users who
+        actively picked a port via the wizard get their value through
+        unchanged.
+        """
+        if self.port and self.port != 5432:
+            return self.port
+        return default
 
     @property
     def url(self) -> str:
@@ -490,6 +534,90 @@ class DBConfig(_ObservableConfig):
                 url += f"?credentials_path={quote_plus(self.credentials_path)}"
             return url
 
+        if self.backend == "mysql":
+            # PyMySQL dialect. ``database`` is optional — same "leave
+            # blank to pick at command time" pattern as PG.
+            port = self._effective_port(3306)
+            url = (
+                f"mysql+pymysql://{quote_plus(self.user)}:{quote_plus(self.password)}"
+                f"@{self.host}:{port}"
+            )
+            if self.database:
+                url += f"/{quote_plus(self.database)}"
+            return url
+
+        if self.backend == "oracle":
+            # python-oracledb (thin mode by default). Service name is
+            # preferred over SID for modern Oracle Cloud / RAC setups; we
+            # fall back to ``database`` (treated as SID) when blank.
+            port = self._effective_port(1521)
+            base = (
+                f"oracle+oracledb://{quote_plus(self.user)}:{quote_plus(self.password)}"
+                f"@{self.host}:{port}"
+            )
+            if self.service_name:
+                return f"{base}/?service_name={quote_plus(self.service_name)}"
+            if self.database:
+                return f"{base}/{quote_plus(self.database)}"
+            return base
+
+        if self.backend == "mssql":
+            # pyodbc dialect. The ODBC driver name is mandatory at the
+            # SQLAlchemy URL level — fall back to a sensible default
+            # so a fresh profile can connect without the user having to
+            # know the exact driver string up front.
+            driver = self.driver or "ODBC Driver 18 for SQL Server"
+            port = self._effective_port(1433)
+            params: list[str] = [f"driver={quote_plus(driver)}"]
+            if self.encrypt:
+                params.append("Encrypt=yes")
+            else:
+                params.append("Encrypt=no")
+            if self.trust_server_certificate:
+                params.append("TrustServerCertificate=yes")
+            url = (
+                f"mssql+pyodbc://{quote_plus(self.user)}:{quote_plus(self.password)}"
+                f"@{self.host}:{port}"
+            )
+            if self.database:
+                url += f"/{quote_plus(self.database)}"
+            return f"{url}?{'&'.join(params)}"
+
+        if self.backend == "redshift":
+            # Uses the redshift_connector SQLAlchemy dialect. URL shape
+            # mirrors PG; cluster_identifier is appended when set so IAM
+            # auth code paths can pick it up.
+            port = self._effective_port(5439)
+            url = (
+                f"redshift+redshift_connector://{quote_plus(self.user)}:"
+                f"{quote_plus(self.password)}@{self.host}:{port}"
+            )
+            if self.database:
+                url += f"/{quote_plus(self.database)}"
+            if self.cluster_identifier:
+                url += f"?cluster_identifier={quote_plus(self.cluster_identifier)}"
+            return url
+
+        if self.backend == "clickhouse":
+            # clickhouse-sqlalchemy with the HTTP transport — works
+            # against ClickHouse Cloud and on-prem deployments. Port
+            # defaults differ for HTTPS vs HTTP.
+            scheme = "clickhouse+https" if self.secure else "clickhouse+http"
+            port = self._effective_port(8443 if self.secure else 8123)
+            url = (
+                f"{scheme}://{quote_plus(self.user or 'default')}:"
+                f"{quote_plus(self.password)}@{self.host}:{port}"
+            )
+            if self.database:
+                url += f"/{quote_plus(self.database)}"
+            return url
+
+        if self.backend == "duckdb":
+            # File-based or in-memory. ``database`` carries the path
+            # (or ``:memory:``). No host/port/user/password.
+            target = self.database or ":memory:"
+            return f"duckdb:///{target}"
+
         # Default: PostgreSQL. When the user leaves ``database`` blank
         # (the ``/add-db-profile`` wizard advertises it as optional —
         # "leave blank to pick at command time"), fall back to the
@@ -526,6 +654,29 @@ class DBConfig(_ObservableConfig):
         if self.backend == "bigquery":
             ds = f".{self.dataset}" if self.dataset else f" {unpinned_label}"
             return f"{self.project}{ds}"
+        if self.backend == "oracle":
+            target = self.service_name or self.database or unpinned_label
+            port = self._effective_port(1521)
+            return f"{target} @ {self.host}:{port} (user {self.user})"
+        if self.backend == "mssql":
+            db = self.database or unpinned_label
+            port = self._effective_port(1433)
+            return f"{db} @ {self.host}:{port} (user {self.user})"
+        if self.backend == "mysql":
+            db = self.database or unpinned_label
+            port = self._effective_port(3306)
+            return f"{db} @ {self.host}:{port} (user {self.user})"
+        if self.backend == "redshift":
+            db = self.database or unpinned_label
+            port = self._effective_port(5439)
+            return f"{db} @ {self.host}:{port} (user {self.user})"
+        if self.backend == "clickhouse":
+            db = self.database or unpinned_label
+            scheme = "https" if self.secure else "http"
+            port = self._effective_port(8443 if self.secure else 8123)
+            return f"{db} @ {self.host}:{port} ({scheme}, user {self.user or 'default'})"
+        if self.backend == "duckdb":
+            return f"DuckDB file: {self.database or ':memory:'}"
         db = self.database or unpinned_label
         return f"{db} @ {self.host}:{self.port} (user {self.user})"
 
@@ -545,6 +696,22 @@ class DBConfig(_ObservableConfig):
             return bool(self.host and (self.access_token or self.password))
         if self.backend == "bigquery":
             return bool(self.project)
+        if self.backend == "mysql":
+            return bool(self.host and self.user)
+        if self.backend == "oracle":
+            return bool(self.host and self.user and (self.service_name or self.database))
+        if self.backend == "mssql":
+            return bool(self.host and self.user)
+        if self.backend == "redshift":
+            return bool(self.host and self.user)
+        if self.backend == "clickhouse":
+            # ClickHouse defaults the user to ``default`` if blank, so a
+            # bare host is enough to attempt a connection.
+            return bool(self.host)
+        if self.backend == "duckdb":
+            # File path or ``:memory:`` is enough; an empty ``database``
+            # field is interpreted as in-memory by ``DBConfig.url``.
+            return True
         return False
 
     def is_database_pinned(self) -> bool:
@@ -563,6 +730,22 @@ class DBConfig(_ObservableConfig):
             return bool(self.catalog)
         if self.backend == "bigquery":
             return bool(self.dataset)
+        if self.backend == "mysql":
+            return bool(self.database)
+        if self.backend == "oracle":
+            return bool(self.service_name or self.database)
+        if self.backend == "mssql":
+            return bool(self.database)
+        if self.backend == "redshift":
+            return bool(self.database)
+        if self.backend == "clickhouse":
+            return bool(self.database)
+        if self.backend == "duckdb":
+            # The ``database`` field IS the file path; ``:memory:`` and
+            # any explicit path both count as "pinned" because the user
+            # made an active choice (vs. PG where blank means "pick
+            # later").
+            return True
         return False
 
     def is_configured(self) -> bool:
@@ -607,6 +790,12 @@ def _db_from_mapping(m: dict[str, Any]) -> DBConfig:
         project=str(m.get("project", "")),
         dataset=str(m.get("dataset", "")),
         credentials_path=str(m.get("credentials_path", "")),
+        service_name=str(m.get("service_name", "")),
+        driver=str(m.get("driver", "")),
+        encrypt=bool(m.get("encrypt", True)),
+        trust_server_certificate=bool(m.get("trust_server_certificate", False)),
+        cluster_identifier=str(m.get("cluster_identifier", "")),
+        secure=bool(m.get("secure", False)),
         profiling_mode=str(m.get("profiling_mode", "full")),
         profiling_max_rows=int(m.get("profiling_max_rows", 1_000_000)),
         profiling_sample_size=int(m.get("profiling_sample_size", 5)),
@@ -655,6 +844,68 @@ def _db_to_mapping(db: DBConfig) -> dict[str, Any]:
                 "project": db.project,
                 "dataset": db.dataset,
                 "credentials_path": db.credentials_path,
+            }
+        )
+    elif db.backend == "mysql":
+        base.update(
+            {
+                "host": db.host,
+                "port": db.port or 3306,
+                "user": db.user,
+                "password": db.password,
+                "database": db.database,
+            }
+        )
+    elif db.backend == "oracle":
+        base.update(
+            {
+                "host": db.host,
+                "port": db.port or 1521,
+                "user": db.user,
+                "password": db.password,
+                "service_name": db.service_name,
+                "database": db.database,
+            }
+        )
+    elif db.backend == "mssql":
+        base.update(
+            {
+                "host": db.host,
+                "port": db.port or 1433,
+                "user": db.user,
+                "password": db.password,
+                "database": db.database,
+                "driver": db.driver,
+                "encrypt": db.encrypt,
+                "trust_server_certificate": db.trust_server_certificate,
+            }
+        )
+    elif db.backend == "redshift":
+        base.update(
+            {
+                "host": db.host,
+                "port": db.port or 5439,
+                "user": db.user,
+                "password": db.password,
+                "database": db.database,
+                "cluster_identifier": db.cluster_identifier,
+            }
+        )
+    elif db.backend == "clickhouse":
+        base.update(
+            {
+                "host": db.host,
+                "port": db.port or (8443 if db.secure else 8123),
+                "user": db.user,
+                "password": db.password,
+                "database": db.database,
+                "secure": db.secure,
+            }
+        )
+    elif db.backend == "duckdb":
+        base.update(
+            {
+                "database": db.database,
             }
         )
     else:

--- a/amx/config.py
+++ b/amx/config.py
@@ -708,11 +708,11 @@ class DBConfig(_ObservableConfig):
             # ClickHouse defaults the user to ``default`` if blank, so a
             # bare host is enough to attempt a connection.
             return bool(self.host)
-        if self.backend == "duckdb":
-            # File path or ``:memory:`` is enough; an empty ``database``
-            # field is interpreted as in-memory by ``DBConfig.url``.
-            return True
-        return False
+        # DuckDB: file path or ``:memory:`` is enough; an empty ``database``
+        # field is interpreted as in-memory by ``DBConfig.url``. Every other
+        # backend has been handled above, so a non-duckdb fallthrough means
+        # "not configured".
+        return self.backend == "duckdb"
 
     def is_database_pinned(self) -> bool:
         """True when the profile pins a specific database / catalog / dataset.
@@ -740,13 +740,12 @@ class DBConfig(_ObservableConfig):
             return bool(self.database)
         if self.backend == "clickhouse":
             return bool(self.database)
-        if self.backend == "duckdb":
-            # The ``database`` field IS the file path; ``:memory:`` and
-            # any explicit path both count as "pinned" because the user
-            # made an active choice (vs. PG where blank means "pick
-            # later").
-            return True
-        return False
+        # DuckDB: the ``database`` field IS the file path; ``:memory:`` and
+        # any explicit path both count as "pinned" because the user made an
+        # active choice (vs. PG where blank means "pick later"). Every other
+        # backend has been handled above, so non-duckdb fallthrough means
+        # "not pinned".
+        return self.backend == "duckdb"
 
     def is_configured(self) -> bool:
         """Back-compat: True when the profile is connection-ready.

--- a/amx/core/errors.py
+++ b/amx/core/errors.py
@@ -128,6 +128,30 @@ class ErrorMapper:
                 "The SQL warehouse certificate could not be verified by the local trust store.",
                 "Configure a trusted CA bundle in the DB profile, or only as a last resort enable TLS no-verify for that profile.",
             )
+        # ODBC driver-not-found is an install issue, not a config issue —
+        # flag it before the connector even fires actionable_profile_error.
+        if "im002" in lower or (
+            "data source name not found" in lower and "no default driver specified" in lower
+        ):
+            return ActionableError(
+                f"{backend_label} ODBC driver missing",
+                "pyodbc could not locate the ODBC driver named in the profile.",
+                "Install Microsoft's ODBC Driver 18 for SQL Server (`brew install msodbcsql18` on macOS, see Microsoft docs on Linux), or set the `driver` field on the profile to a driver you do have.",
+            )
+        # Oracle ORA-NNNNN / ClickHouse Code: NNN — give the user the
+        # error code to grep for if no specific handler matched.
+        if backend_l == "oracle" and "ora-" in lower:
+            return ActionableError(
+                "Oracle returned an error code",
+                msg.split(".")[0],
+                "Look up the ORA- code in the Oracle Error Messages reference for the exact remedy.",
+            )
+        if backend_l == "clickhouse" and "code:" in lower:
+            return ActionableError(
+                "ClickHouse returned an error code",
+                msg.split("(")[0],
+                "Look up the Code in ClickHouse's docs/en/sql-reference/error-codes for the exact remedy.",
+            )
 
         # Authentication — wrong credentials, expired token, bad role
         if _matches_any(lower, _AUTH_PATTERNS):
@@ -159,7 +183,7 @@ class ErrorMapper:
             return ActionableError(
                 f"{backend_label} database not found",
                 "The driver connected to the host but cannot find the configured database / catalog.",
-                "Check the database name in the active profile (PostgreSQL: database, Snowflake: database, Databricks: catalog, BigQuery: project) and confirm the user has access to it.",
+                "Check the database name in the active profile (PostgreSQL/MySQL/SQL Server/Redshift: database, Snowflake: database, Databricks: catalog, BigQuery: project, Oracle: service_name or SID, ClickHouse: database, DuckDB: file path) and confirm the user has access to it.",
             )
 
         if (

--- a/amx/db/adapters/__init__.py
+++ b/amx/db/adapters/__init__.py
@@ -10,30 +10,136 @@ if TYPE_CHECKING:
 
 _BACKEND_REGISTRY: dict[str, type[DatabaseAdapter]] = {}
 
-SUPPORTED_BACKENDS = ("postgresql", "snowflake", "databricks", "bigquery")
+SUPPORTED_BACKENDS = (
+    "postgresql",
+    "snowflake",
+    "databricks",
+    "bigquery",
+    "mysql",
+    "oracle",
+    "mssql",
+    "redshift",
+    "clickhouse",
+    "duckdb",
+)
+
+# Each backend lives in its own optional-dependencies extra in
+# pyproject.toml. When a user picks a backend without installing the
+# driver, ``_ensure_registry()`` catches the ImportError and raises an
+# actionable ``MissingDriverError`` instead of a raw ``ModuleNotFoundError``.
+_BACKEND_EXTRAS: dict[str, str] = {
+    "postgresql": "postgresql",
+    "snowflake": "snowflake",
+    "databricks": "databricks",
+    "bigquery": "bigquery",
+    "mysql": "mysql",
+    "oracle": "oracle",
+    "mssql": "mssql",
+    "redshift": "redshift",
+    "clickhouse": "clickhouse",
+    "duckdb": "duckdb",
+}
+
+
+class MissingDriverError(ImportError):
+    """Raised when a backend's optional driver dependency is not installed.
+
+    Surfaces the concrete `pip install amx[<extra>]` remediation so the
+    user is never left staring at a generic ``ModuleNotFoundError``.
+    """
+
+
+def _import_adapter(backend: str) -> type[DatabaseAdapter]:
+    """Import the adapter class for *backend*, translating ImportError
+    into a user-actionable :class:`MissingDriverError`.
+    """
+    try:
+        if backend == "postgresql":
+            from amx.db.adapters.postgresql import PostgreSQLAdapter
+
+            return PostgreSQLAdapter
+        if backend == "snowflake":
+            from amx.db.adapters.snowflake import SnowflakeAdapter
+
+            return SnowflakeAdapter
+        if backend == "databricks":
+            from amx.db.adapters.databricks import DatabricksAdapter
+
+            return DatabricksAdapter
+        if backend == "bigquery":
+            from amx.db.adapters.bigquery import BigQueryAdapter
+
+            return BigQueryAdapter
+        if backend == "mysql":
+            from amx.db.adapters.mysql import MySQLAdapter
+
+            return MySQLAdapter
+        if backend == "oracle":
+            from amx.db.adapters.oracle import OracleAdapter
+
+            return OracleAdapter
+        if backend == "mssql":
+            from amx.db.adapters.mssql import MSSQLAdapter
+
+            return MSSQLAdapter
+        if backend == "redshift":
+            from amx.db.adapters.redshift import RedshiftAdapter
+
+            return RedshiftAdapter
+        if backend == "clickhouse":
+            from amx.db.adapters.clickhouse import ClickHouseAdapter
+
+            return ClickHouseAdapter
+        if backend == "duckdb":
+            from amx.db.adapters.duckdb import DuckDBAdapter
+
+            return DuckDBAdapter
+    except ImportError as exc:
+        extra = _BACKEND_EXTRAS.get(backend, backend)
+        raise MissingDriverError(
+            f"The {backend!r} backend requires its optional driver. Install it with:\n"
+            f"    pip install amx[{extra}]\n"
+            f"(Underlying import error: {exc})"
+        ) from exc
+    raise ValueError(
+        f"Unknown database backend {backend!r}. Supported: {', '.join(SUPPORTED_BACKENDS)}"
+    )
 
 
 def _ensure_registry() -> None:
+    """Lazy-fill the registry on first use.
+
+    Each adapter import is wrapped so a missing driver only fails the
+    backends the user actually picks — not every import on startup.
+    """
     if _BACKEND_REGISTRY:
         return
-    from amx.db.adapters.bigquery import BigQueryAdapter
-    from amx.db.adapters.databricks import DatabricksAdapter
-    from amx.db.adapters.postgresql import PostgreSQLAdapter
-    from amx.db.adapters.snowflake import SnowflakeAdapter
+    # Insert sentinels so ``get_adapter`` knows which backends are valid
+    # without forcing a driver import for every one of them at startup.
+    for name in SUPPORTED_BACKENDS:
+        _BACKEND_REGISTRY[name] = _AdapterPlaceholder  # type: ignore[assignment]
 
-    _BACKEND_REGISTRY["postgresql"] = PostgreSQLAdapter
-    _BACKEND_REGISTRY["snowflake"] = SnowflakeAdapter
-    _BACKEND_REGISTRY["databricks"] = DatabricksAdapter
-    _BACKEND_REGISTRY["bigquery"] = BigQueryAdapter
+
+class _AdapterPlaceholder:
+    """Marker type — replaced with the real adapter class on first use."""
 
 
 def get_adapter(cfg: DBConfig) -> DatabaseAdapter:
-    """Return the correct adapter instance for *cfg.backend*."""
+    """Return the correct adapter instance for *cfg.backend*.
+
+    Imports the adapter module on demand so users only pay the driver
+    cost for the backends they actually use. Missing-driver errors are
+    translated into :class:`MissingDriverError` with a concrete
+    ``pip install amx[<extra>]`` hint.
+    """
     _ensure_registry()
     backend = getattr(cfg, "backend", "postgresql") or "postgresql"
-    cls = _BACKEND_REGISTRY.get(backend)
-    if cls is None:
+    if backend not in _BACKEND_REGISTRY:
         raise ValueError(
             f"Unknown database backend {backend!r}. Supported: {', '.join(SUPPORTED_BACKENDS)}"
         )
+    cls = _BACKEND_REGISTRY[backend]
+    if cls is _AdapterPlaceholder:
+        cls = _import_adapter(backend)
+        _BACKEND_REGISTRY[backend] = cls
     return cls(cfg)

--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -30,6 +30,23 @@ class BackendCapabilities:
     full_profiling: bool = True
     sampled_profiling: bool = True
     full_scan_when_row_count_unknown: bool = True
+    # Extended object-type capabilities. Each flag gates a corresponding
+    # ``list_<object>()`` call on :class:`DatabaseAdapter`. Defaulting to
+    # False keeps existing adapters intact — they opt in by setting the
+    # flags True after implementing the matching list method.
+    stored_procedures: bool = False
+    functions: bool = False
+    sequences: bool = False
+    triggers: bool = False
+    events: bool = False
+    packages: bool = False
+    synonyms: bool = False
+    user_defined_types: bool = False
+    dictionaries: bool = False
+    macros: bool = False
+    volumes: bool = False
+    datashares: bool = False
+    external_tables: bool = False
     comment_asset_keywords: frozenset[str] = field(
         default_factory=lambda: frozenset({"TABLE", "VIEW"})
     )
@@ -230,6 +247,76 @@ class DatabaseAdapter(ABC):
     ) -> list[str] | None:
         """Backend-specific view listing. ``None`` → SQLAlchemy fallback."""
         return None
+
+    # ── Extended object types ─────────────────────────────────────────────
+    #
+    # Each ``list_<object>()`` returns an empty list by default. Adapters
+    # that support the object type override the method AND set the
+    # matching ``BackendCapabilities`` flag to True. The connector layer
+    # gates calls on the flag so unsupported backends never run a query.
+    #
+    # All return shapes are uniform: a list of dicts with the keys
+    # ``name`` (required), ``type``, ``definition``, ``comment``, and
+    # ``metadata``. Adapters fill what they can — extra keys in
+    # ``metadata`` are passed through to downstream search/indexing.
+
+    def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        """Stored procedures in *schema*. Override when the backend supports them."""
+        return []
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        """User-defined functions / UDFs in *schema*."""
+        return []
+
+    def list_sequences(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        """Sequences in *schema*. (Most warehouses skip this; OLTP backends use it heavily.)"""
+        return []
+
+    def list_triggers(
+        self, engine: Engine, schema: str, table: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Triggers in *schema*. Pass *table* to scope to one table."""
+        return []
+
+    def list_events(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        """Scheduled events / tasks / jobs (MySQL events, Snowflake tasks, BigQuery
+        scheduled queries, SQL Server Agent jobs).
+        """
+        return []
+
+    def list_packages(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        """PL/SQL packages — Oracle-specific."""
+        return []
+
+    def list_synonyms(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        """Synonyms — Oracle and SQL Server expose these as object aliases."""
+        return []
+
+    def list_user_defined_types(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        """Composite / domain / enum types declared in *schema*."""
+        return []
+
+    def list_dictionaries(self, engine: Engine, database: str) -> list[dict[str, Any]]:
+        """ClickHouse dictionaries — external lookup tables refreshed from a source."""
+        return []
+
+    def list_macros(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        """DuckDB macros — parameterized SQL or table-returning functions."""
+        return []
+
+    def list_volumes(
+        self, engine: Engine, catalog: str, schema: str
+    ) -> list[dict[str, Any]]:
+        """Unity Catalog volumes (Databricks) or stages (Snowflake) — file-storage assets."""
+        return []
+
+    def list_datashares(self, engine: Engine) -> list[dict[str, Any]]:
+        """Datashares (Redshift) / shares (Snowflake) / Delta Sharing recipients (Databricks)."""
+        return []
+
+    def list_external_tables(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        """External tables — Redshift Spectrum, BigQuery external tables, DuckDB Parquet/S3."""
+        return []
 
     # ── Analytics metadata ────────────────────────────────────────────────
 

--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -304,9 +304,7 @@ class DatabaseAdapter(ABC):
         """DuckDB macros — parameterized SQL or table-returning functions."""
         return []
 
-    def list_volumes(
-        self, engine: Engine, catalog: str, schema: str
-    ) -> list[dict[str, Any]]:
+    def list_volumes(self, engine: Engine, catalog: str, schema: str) -> list[dict[str, Any]]:
         """Unity Catalog volumes (Databricks) or stages (Snowflake) — file-storage assets."""
         return []
 

--- a/amx/db/adapters/bigquery.py
+++ b/amx/db/adapters/bigquery.py
@@ -19,6 +19,9 @@ class BigQueryAdapter(DatabaseAdapter):
         relationships=True,
         row_count_stats=True,
         full_scan_when_row_count_unknown=False,
+        stored_procedures=True,
+        functions=True,
+        external_tables=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
     )
 
@@ -170,6 +173,101 @@ class BigQueryAdapter(DatabaseAdapter):
         except Exception as exc:
             actionable = self.actionable_profile_error(exc)
             raise RuntimeError(actionable or str(exc)) from exc
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def _routine_query(self, schema: str, kind: str) -> str:
+        # ``kind`` is BigQuery's ROUTINE_TYPE: 'PROCEDURE' or 'FUNCTION'
+        # (the latter covers SQL UDFs and JS UDFs both).
+        return (
+            f"SELECT routine_name, routine_definition, ddl, language, "
+            f"data_type, last_altered "
+            f"FROM `{getattr(self.cfg, 'project', '')}`.`{schema}`.INFORMATION_SCHEMA.ROUTINES "
+            f"WHERE routine_type = '{kind}' "
+            f"ORDER BY routine_name"
+        )
+
+    def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(text(self._routine_query(schema, "PROCEDURE"))).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "procedure",
+                "definition": str(r[2] or r[1]) if (r[2] or r[1]) else None,
+                "comment": None,
+                "metadata": {
+                    "language": str(r[3]) if r[3] else None,
+                    "last_altered": str(r[5]) if r[5] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(text(self._routine_query(schema, "FUNCTION"))).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "function",
+                "definition": str(r[2] or r[1]) if (r[2] or r[1]) else None,
+                "comment": None,
+                "metadata": {
+                    "language": str(r[3]) if r[3] else None,
+                    "return_type": str(r[4]) if r[4] else None,
+                    "last_altered": str(r[5]) if r[5] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_external_tables(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # BigQuery external tables (EXTERNAL) and BigLake tables both
+        # show table_type='EXTERNAL'. Storage URIs / format come from
+        # INFORMATION_SCHEMA.EXTERNAL_TABLE_OPTIONS as JSON-ish strings.
+        project = getattr(self.cfg, "project", "")
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        f"SELECT table_name "
+                        f"FROM `{project}`.`{schema}`.INFORMATION_SCHEMA.TABLES "
+                        f"WHERE table_type = 'EXTERNAL' "
+                        f"ORDER BY table_name"
+                    )
+                ).fetchall()
+            except Exception:
+                return []
+            opts_by_table: dict[str, dict[str, str]] = {}
+            try:
+                opt_rows = conn.execute(
+                    text(
+                        f"SELECT table_name, option_name, option_value "
+                        f"FROM `{project}`.`{schema}`.INFORMATION_SCHEMA.EXTERNAL_TABLE_OPTIONS"
+                    )
+                ).fetchall()
+                for orow in opt_rows:
+                    bucket = opts_by_table.setdefault(str(orow[0]), {})
+                    bucket[str(orow[1])] = str(orow[2])
+            except Exception:
+                pass
+        return [
+            {
+                "name": str(r[0]),
+                "type": "external_table",
+                "definition": None,
+                "comment": None,
+                "metadata": opts_by_table.get(str(r[0]), {}),
+            }
+            for r in rows
+        ]
 
     # ── Analytics metadata ────────────────────────────────────────────────
 

--- a/amx/db/adapters/clickhouse.py
+++ b/amx/db/adapters/clickhouse.py
@@ -1,0 +1,402 @@
+"""ClickHouse backend adapter.
+
+Driven by ``clickhouse-sqlalchemy`` over the HTTP transport (the
+default port 8123, or 8443 with ``secure=True``). ClickHouse calls
+its top-level scope a "database", not a "schema" — the adapter
+treats them interchangeably so the rest of AMX doesn't have to
+care.
+
+Object types exposed:
+
+* Tables, views, materialized views — first-class on ClickHouse and
+  surfaced through ``system.tables`` filtered by engine name.
+* User-defined functions (SQL UDFs and executable UDFs) via
+  ``system.functions``.
+* Dictionaries (``system.dictionaries``) — ClickHouse's external
+  lookup primitive, no equivalent on any other backend.
+* Data-skipping indices (``system.data_skipping_indices``) — these
+  are not B-tree indexes; they prune granules during scans.
+* Storage engine, partition info, on-disk size, and TTL settings
+  surface in :meth:`get_analytics_metadata`.
+
+ClickHouse does NOT enforce foreign keys (the constraint declaration
+exists for documentation only), so ``relationships=False``. There
+are no triggers, no stored procedures, and no sequences. Comment
+write-back is supported on table/view/column/database since
+ClickHouse 21.x.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
+
+
+class ClickHouseAdapter(DatabaseAdapter):
+    name = "clickhouse"
+    capabilities = BackendCapabilities(
+        # CH stores DB-level comments since 22.x. Keep True; users on
+        # earlier versions see a soft failure logged as warning.
+        database_comments=True,
+        # CH databases ARE the schema scope — no separate schema-level
+        # COMMENT.
+        schema_comments=False,
+        materialized_view_comments=True,
+        materialized_views=True,
+        relationships=False,  # FKs declared but not enforced
+        row_count_stats=True,
+        functions=True,
+        dictionaries=True,
+        comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
+    )
+
+    def create_engine(self) -> Engine:
+        return create_engine(self.cfg.url, pool_pre_ping=True)
+
+    def actionable_profile_error(self, exc: Exception) -> str | None:
+        msg = str(exc).lower()
+        if "code: 516" in msg or "authentication failed" in msg:
+            return (
+                "ClickHouse refused the credentials (Code 516). Check the "
+                "username/password — note ClickHouse defaults the user to "
+                "`default` with a blank password."
+            )
+        if "code: 81" in msg or "database" in msg and "doesn't exist" in msg:
+            return (
+                "ClickHouse refused: the `database` field on this profile "
+                "points at a database that doesn't exist on this server. "
+                "Edit the profile or create the database first."
+            )
+        if "code: 192" in msg or "connection refused" in msg:
+            return (
+                "ClickHouse server is not reachable. Check the host/port — "
+                "HTTP defaults to 8123, HTTPS to 8443."
+            )
+        if "code: 497" in msg or "not enough privileges" in msg:
+            return (
+                "ClickHouse denied access. Grant the user SELECT on the "
+                "target database and on `system.*` tables for introspection."
+            )
+        return None
+
+    def system_schemas(self) -> frozenset[str]:
+        # CH ships ``system`` (user-visible read-only catalogs),
+        # ``information_schema`` / ``INFORMATION_SCHEMA`` (mirrored
+        # under both casings), and an internal ``__inner__`` namespace
+        # for materialized-view backing tables.
+        return frozenset({"system", "information_schema", "INFORMATION_SCHEMA"})
+
+    def quote_identifier(self, name: str) -> str:
+        # CH supports both backticks and double quotes; backticks are
+        # idiomatic and don't conflict with string literals.
+        escaped = name.replace("`", "\\`")
+        return f"`{escaped}`"
+
+    def list_databases(self, engine: Engine) -> list[str]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT name FROM system.databases "
+                    "WHERE name NOT IN ('system','information_schema','INFORMATION_SCHEMA') "
+                    "ORDER BY name"
+                )
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    def list_schemas(self, engine: Engine, catalog: str = "") -> list[str] | None:
+        # CH's "schema" IS its "database". Surface them as schemas so
+        # the rest of AMX (which thinks in schemas) works without a
+        # special case.
+        return self.list_databases(engine)
+
+    def list_tables(
+        self, engine: Engine, schema: str, catalog: str = ""
+    ) -> list[str] | None:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT name FROM system.tables "
+                    "WHERE database = :db "
+                    "AND engine NOT LIKE '%View' "
+                    "ORDER BY name"
+                ),
+                {"db": schema},
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    def list_views(
+        self, engine: Engine, schema: str, catalog: str = ""
+    ) -> list[str] | None:
+        # ``View`` engine is a non-materialized view; the materialized
+        # variants are ``MaterializedView`` and ``WindowView`` — picked
+        # up separately by ``list_materialized_views``.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT name FROM system.tables "
+                    "WHERE database = :db AND engine = 'View' "
+                    "ORDER BY name"
+                ),
+                {"db": schema},
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    def list_materialized_views(self, engine: Engine, schema: str) -> list[str]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT name FROM system.tables "
+                    "WHERE database = :db "
+                    "AND engine IN ('MaterializedView','WindowView','LiveView') "
+                    "ORDER BY name"
+                ),
+                {"db": schema},
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    # ── Column profiling ──────────────────────────────────────────────────
+
+    def column_stats_sql(self, fqn: str, quoted_col: str) -> str:
+        # CH counts NULLs with countIf and offers exact distinct via
+        # uniqExact (uniq is approximate). For wide cardinality columns
+        # the connector should switch to sampled mode at the gate level.
+        return (
+            f"SELECT "
+            f"  countIf({quoted_col} IS NULL) AS null_cnt, "
+            f"  uniqExact({quoted_col}) AS dist_cnt, "
+            f"  toString(min({quoted_col})) AS min_val, "
+            f"  toString(max({quoted_col})) AS max_val "
+            f"FROM {fqn}"
+        )
+
+    def column_sample_sql(self, fqn: str, quoted_col: str) -> str:
+        return (
+            f"SELECT DISTINCT toString({quoted_col}) FROM {fqn} "
+            f"WHERE {quoted_col} IS NOT NULL LIMIT :lim"
+        )
+
+    # ── Table stats ───────────────────────────────────────────────────────
+
+    def get_table_stats(self, engine: Engine, schema: str, table: str) -> dict[str, int]:
+        # ``system.parts`` aggregates rows / bytes per active part.
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT sum(rows) FROM system.parts "
+                    "WHERE database = :db AND table = :tbl AND active = 1"
+                ),
+                {"db": schema, "tbl": table},
+            ).fetchone()
+        n = int(row[0]) if row and row[0] is not None else 0
+        return {"seq_scan": 0, "idx_scan": 0, "n_live_tup": n}
+
+    def stats_label(self) -> str:
+        return "system.parts (active parts only)"
+
+    # ── Schema (database) comments ───────────────────────────────────────
+
+    def get_schema_comment(self, engine: Engine, schema: str) -> str | None:
+        # CH stores DB comments in system.databases.comment (22.5+). On
+        # older versions the column doesn't exist — degrade silently.
+        try:
+            with engine.connect() as conn:
+                row = conn.execute(
+                    text("SELECT comment FROM system.databases WHERE name = :db"),
+                    {"db": schema},
+                ).fetchone()
+            return str(row[0]) if row and row[0] else None
+        except Exception:
+            return None
+
+    def get_database_comment(self, engine: Engine) -> str | None:
+        # Same field — CH conflates "database" and "schema".
+        return self.get_schema_comment(engine, self.cfg.database)
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # CH UDFs are global, not schema-scoped — but ``schema`` is
+        # accepted for API parity with PG/SF/etc. The list comes from
+        # system.functions filtered to user-defined entries.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT name, create_query "
+                    "FROM system.functions "
+                    "WHERE origin = 'SQLUserDefined' OR origin = 'ExecutableUserDefined' "
+                    "ORDER BY name"
+                )
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "function",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": None,
+                "metadata": {"scope": "global"},
+            }
+            for r in rows
+        ]
+
+    def list_dictionaries(self, engine: Engine, database: str) -> list[dict[str, Any]]:
+        # ClickHouse dictionaries — external lookup tables refreshed
+        # from a source (file, MySQL, MongoDB, S3, ...). They live in a
+        # database scope; an empty ``database`` arg lists across all
+        # user-visible databases.
+        sql = (
+            "SELECT name, database, source, layout_type, key_types, status, "
+            "element_count, bytes_allocated "
+            "FROM system.dictionaries"
+        )
+        params: dict[str, Any] = {}
+        if database:
+            sql += " WHERE database = :db"
+            params["db"] = database
+        sql += " ORDER BY database, name"
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql), params).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "dictionary",
+                "definition": None,
+                "comment": None,
+                "metadata": {
+                    "database": str(r[1]) if r[1] else None,
+                    "source": str(r[2]) if r[2] else None,
+                    "layout": str(r[3]) if r[3] else None,
+                    "key_types": list(r[4]) if r[4] else [],
+                    "status": str(r[5]) if r[5] else None,
+                    "element_count": int(r[6]) if r[6] is not None else None,
+                    "bytes_allocated": int(r[7]) if r[7] is not None else None,
+                },
+            }
+            for r in rows
+        ]
+
+    # ── Analytics metadata (★ ClickHouse engine + parts surface) ─────────
+
+    def get_analytics_metadata(self, engine: Engine, schema: str, table: str) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        warnings: list[str] = []
+
+        with engine.connect() as conn:
+            try:
+                row = conn.execute(
+                    text(
+                        "SELECT engine, partition_key, sorting_key, primary_key, "
+                        "sampling_key, total_rows, total_bytes, metadata_modification_time "
+                        "FROM system.tables "
+                        "WHERE database = :db AND name = :tbl"
+                    ),
+                    {"db": schema, "tbl": table},
+                ).fetchone()
+                if row:
+                    eng = str(row[0]) if row[0] else ""
+                    out["storage_format"] = eng or "native"
+                    if "MaterializedView" in eng:
+                        out["table_type"] = "materialized_view"
+                    elif "View" in eng:
+                        out["table_type"] = "view"
+                    else:
+                        out["table_type"] = "managed"
+                    if row[1]:
+                        out["partition_keys"] = [
+                            c.strip() for c in str(row[1]).split(",") if c.strip()
+                        ]
+                        out["partition_strategy"] = "expression"
+                    if row[2]:
+                        out["clustering_keys"] = [
+                            c.strip() for c in str(row[2]).split(",") if c.strip()
+                        ]
+                    if row[6] is not None:
+                        out["storage_bytes"] = int(row[6])
+                    if row[7]:
+                        out["last_modified"] = str(row[7])
+                    out["clickhouse"] = {
+                        "engine": eng,
+                        "primary_key": str(row[3]) if row[3] else None,
+                        "sampling_key": str(row[4]) if row[4] else None,
+                        "total_rows": int(row[5]) if row[5] is not None else None,
+                    }
+            except Exception as exc:
+                warnings.append(f"system.tables: {exc}")
+
+            # Skipping indices — different concept from B-tree indexes
+            # but the closest analogue.
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT name, type, expr "
+                        "FROM system.data_skipping_indices "
+                        "WHERE database = :db AND table = :tbl"
+                    ),
+                    {"db": schema, "tbl": table},
+                ).fetchall()
+                if rows:
+                    out["indexes"] = [
+                        {
+                            "name": str(r[0]),
+                            "columns": [str(r[2])] if r[2] else [],
+                            "unique": False,  # skipping indices aren't unique
+                            "type": str(r[1]) if r[1] else None,
+                        }
+                        for r in rows
+                    ]
+            except Exception as exc:
+                warnings.append(f"data_skipping_indices: {exc}")
+
+            # Files / part count
+            try:
+                row = conn.execute(
+                    text(
+                        "SELECT count(), sum(bytes_on_disk) "
+                        "FROM system.parts "
+                        "WHERE database = :db AND table = :tbl AND active = 1"
+                    ),
+                    {"db": schema, "tbl": table},
+                ).fetchone()
+                if row and row[0]:
+                    out["storage_files_count"] = int(row[0])
+                    if row[1] is not None:
+                        out["storage_bytes"] = int(row[1])
+            except Exception as exc:
+                warnings.append(f"system.parts: {exc}")
+
+        if warnings:
+            out["warnings"] = warnings
+        return out
+
+    # ── Comment writing ───────────────────────────────────────────────────
+
+    def set_table_comment_sql(self, schema: str, table: str, asset_keyword: str) -> str:
+        # CH 21+ supports ALTER TABLE ... MODIFY COMMENT for tables and
+        # views. Materialized views use the same syntax with the
+        # MATERIALIZED VIEW keyword.
+        fqn = self.fully_qualified_name(schema, table)
+        return f"ALTER {asset_keyword} {fqn} MODIFY COMMENT :cmt"
+
+    def set_column_comment_sql(self, schema: str, table: str, column: str) -> str:
+        fqn = self.fully_qualified_name(schema, table)
+        return (
+            f"ALTER TABLE {fqn} COMMENT COLUMN {self.quote_identifier(column)} :cmt"
+        )
+
+    def set_schema_comment_sql(self, schema: str) -> str:
+        # CH conflates schema and database; capability flag is False.
+        raise self.unsupported("set_schema_comment_sql")
+
+    def set_database_comment_sql(self) -> str:
+        return f"ALTER DATABASE {self.quote_identifier(self.cfg.database)} MODIFY COMMENT :cmt"
+
+    def comment_sql_with_params(
+        self, stmt_template: str, comment: str
+    ) -> tuple[str, dict[str, Any]]:
+        # CH's HTTP interface handles named binds inconsistently for
+        # DDL; safer to inline the literal.
+        literal = self.quote_literal(comment)
+        return stmt_template.replace(":cmt", literal), {}

--- a/amx/db/adapters/clickhouse.py
+++ b/amx/db/adapters/clickhouse.py
@@ -113,9 +113,7 @@ class ClickHouseAdapter(DatabaseAdapter):
         # special case.
         return self.list_databases(engine)
 
-    def list_tables(
-        self, engine: Engine, schema: str, catalog: str = ""
-    ) -> list[str] | None:
+    def list_tables(self, engine: Engine, schema: str, catalog: str = "") -> list[str] | None:
         with engine.connect() as conn:
             rows = conn.execute(
                 text(
@@ -128,9 +126,7 @@ class ClickHouseAdapter(DatabaseAdapter):
             ).fetchall()
         return [str(r[0]) for r in rows]
 
-    def list_views(
-        self, engine: Engine, schema: str, catalog: str = ""
-    ) -> list[str] | None:
+    def list_views(self, engine: Engine, schema: str, catalog: str = "") -> list[str] | None:
         # ``View`` engine is a non-materialized view; the materialized
         # variants are ``MaterializedView`` and ``WindowView`` — picked
         # up separately by ``list_materialized_views``.
@@ -382,9 +378,7 @@ class ClickHouseAdapter(DatabaseAdapter):
 
     def set_column_comment_sql(self, schema: str, table: str, column: str) -> str:
         fqn = self.fully_qualified_name(schema, table)
-        return (
-            f"ALTER TABLE {fqn} COMMENT COLUMN {self.quote_identifier(column)} :cmt"
-        )
+        return f"ALTER TABLE {fqn} COMMENT COLUMN {self.quote_identifier(column)} :cmt"
 
     def set_schema_comment_sql(self, schema: str) -> str:
         # CH conflates schema and database; capability flag is False.

--- a/amx/db/adapters/databricks.py
+++ b/amx/db/adapters/databricks.py
@@ -25,6 +25,9 @@ class DatabricksAdapter(DatabaseAdapter):
         relationships=False,
         row_count_stats=True,
         full_scan_when_row_count_unknown=False,
+        functions=True,
+        volumes=True,  # ★ Unity Catalog volumes — distinctively Databricks
+        external_tables=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW"}),
     )
     trusted_ca_env_vars = (
@@ -388,6 +391,114 @@ class DatabricksAdapter(DatabaseAdapter):
 
         if warnings:
             out["warnings"] = warnings
+        return out
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def _qualify(self, catalog: str, schema: str) -> str:
+        # Build a Unity Catalog 3-level reference for SHOW commands.
+        cat = catalog or getattr(self.cfg, "catalog", "") or ""
+        if cat:
+            return f"`{cat}`.`{schema}`"
+        return f"`{schema}`"
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        catalog = getattr(self.cfg, "catalog", "") or ""
+        sql = f"SHOW USER FUNCTIONS IN {self._qualify(catalog, schema)}"
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(text(sql)).fetchall()
+            except Exception:
+                return []
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            mapping = row._mapping if hasattr(row, "_mapping") else {}
+            # SHOW USER FUNCTIONS returns a single-column ``function`` field
+            # carrying the fully-qualified name.
+            full = mapping.get("function") or (row[0] if len(row) else None)
+            if not full:
+                continue
+            name = str(full).split(".")[-1]
+            out.append(
+                {
+                    "name": name,
+                    "type": "function",
+                    "definition": None,
+                    "comment": None,
+                    "metadata": {"qualified_name": str(full)},
+                }
+            )
+        return out
+
+    def list_volumes(
+        self, engine: Engine, catalog: str, schema: str
+    ) -> list[dict[str, Any]]:
+        # ★ Unity Catalog volumes — managed or external file storage,
+        # the headline Databricks-distinctive object type.
+        sql = f"SHOW VOLUMES IN {self._qualify(catalog, schema)}"
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(text(sql)).fetchall()
+            except Exception:
+                return []
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            mapping = row._mapping if hasattr(row, "_mapping") else {}
+            name = mapping.get("volume_name") or mapping.get("name")
+            if name is None and len(row):
+                name = row[0]
+            if name is None:
+                continue
+            out.append(
+                {
+                    "name": str(name),
+                    "type": str(mapping.get("volume_type") or "volume").lower(),
+                    "definition": None,
+                    "comment": str(mapping.get("comment")) if mapping.get("comment") else None,
+                    "metadata": {
+                        k: str(v)
+                        for k, v in mapping.items()
+                        if k not in ("volume_name", "name", "comment") and v is not None
+                    },
+                }
+            )
+        return out
+
+    def list_external_tables(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # No clean per-schema "show external tables" — we filter the
+        # standard SHOW TABLES output by DESCRIBE TABLE EXTENDED Type.
+        catalog = getattr(self.cfg, "catalog", "") or ""
+        out: list[dict[str, Any]] = []
+        try:
+            tables = self.list_tables(engine, schema, catalog) or []
+        except Exception:
+            return []
+        for t in tables:
+            try:
+                fqn = self.fully_qualified_name(schema, t)
+                with engine.connect() as conn:
+                    rows = conn.execute(text(f"DESCRIBE TABLE EXTENDED {fqn}")).fetchall()
+                location = None
+                kind = None
+                for r in rows:
+                    rd = dict(r._mapping) if hasattr(r, "_mapping") else dict(r)
+                    name = str(rd.get("col_name") or "").strip()
+                    if name == "Type":
+                        kind = str(rd.get("data_type") or "").lower()
+                    elif name == "Location":
+                        location = str(rd.get("data_type") or "")
+                if kind == "external":
+                    out.append(
+                        {
+                            "name": t,
+                            "type": "external_table",
+                            "definition": None,
+                            "comment": None,
+                            "metadata": {"location": location},
+                        }
+                    )
+            except Exception:
+                continue
         return out
 
     # ── Comment writing ───────────────────────────────────────────────────

--- a/amx/db/adapters/databricks.py
+++ b/amx/db/adapters/databricks.py
@@ -430,9 +430,7 @@ class DatabricksAdapter(DatabaseAdapter):
             )
         return out
 
-    def list_volumes(
-        self, engine: Engine, catalog: str, schema: str
-    ) -> list[dict[str, Any]]:
+    def list_volumes(self, engine: Engine, catalog: str, schema: str) -> list[dict[str, Any]]:
         # ★ Unity Catalog volumes — managed or external file storage,
         # the headline Databricks-distinctive object type.
         sql = f"SHOW VOLUMES IN {self._qualify(catalog, schema)}"

--- a/amx/db/adapters/duckdb.py
+++ b/amx/db/adapters/duckdb.py
@@ -137,9 +137,7 @@ class DuckDBAdapter(DatabaseAdapter):
         try:
             with engine.connect() as conn:
                 row = conn.execute(
-                    text(
-                        f"SELECT COUNT(*) FROM {self.fully_qualified_name(schema, table)}"
-                    )
+                    text(f"SELECT COUNT(*) FROM {self.fully_qualified_name(schema, table)}")
                 ).fetchone()
             n = int(row[0]) if row else 0
         except Exception:
@@ -154,9 +152,7 @@ class DuckDBAdapter(DatabaseAdapter):
     def get_schema_comment(self, engine: Engine, schema: str) -> str | None:
         with engine.connect() as conn:
             row = conn.execute(
-                text(
-                    "SELECT comment FROM duckdb_schemas() WHERE schema_name = :schema"
-                ),
+                text("SELECT comment FROM duckdb_schemas() WHERE schema_name = :schema"),
                 {"schema": schema},
             ).fetchone()
         return str(row[0]) if row and row[0] else None

--- a/amx/db/adapters/duckdb.py
+++ b/amx/db/adapters/duckdb.py
@@ -1,0 +1,273 @@
+"""DuckDB backend adapter.
+
+DuckDB is a single-file (or in-memory) embedded analytical database.
+The connection target lives in ``DBConfig.database`` — either a path
+to a ``.duckdb`` file or the literal string ``:memory:``. There is no
+host / port / user / password.
+
+What this adapter exposes:
+
+* Tables and views via SQLAlchemy inspector + ``duckdb_tables()`` /
+  ``duckdb_views()`` for fully-qualified names (DuckDB supports
+  ``catalog.schema.table`` once a database is attached).
+* Sequences via ``duckdb_sequences()``.
+* Functions and macros — DuckDB's macros are parameterized SQL or
+  table-returning expressions and have no equivalent in any other
+  backend, so they get their own list method.
+* External tables (Parquet / CSV files exposed as views via
+  ``read_parquet`` / ``read_csv``) — surfaced as views since DuckDB
+  doesn't carry a separate ``EXTERNAL`` table type.
+* Standard ``COMMENT ON TABLE / COLUMN / SCHEMA`` write-back.
+
+DuckDB has no row-level FK enforcement, no triggers, no stored
+procedures, and no concept of materialized views, so those
+capabilities stay False.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
+
+
+class DuckDBAdapter(DatabaseAdapter):
+    name = "duckdb"
+    capabilities = BackendCapabilities(
+        # DuckDB has no DATABASE-level comment ("database" is a file)
+        # and no schema-level comment yet (NotImplemented as of 1.5).
+        database_comments=False,
+        schema_comments=False,
+        materialized_views=False,
+        relationships=False,  # no FK enforcement
+        row_count_stats=True,
+        functions=True,
+        sequences=True,
+        macros=True,
+    )
+
+    def create_engine(self) -> Engine:
+        # ``DBConfig.url`` already produces ``duckdb:///<path>`` or
+        # ``duckdb:///:memory:``. ``pool_pre_ping`` is irrelevant for
+        # the embedded driver but harmless.
+        return create_engine(self.cfg.url)
+
+    def actionable_profile_error(self, exc: Exception) -> str | None:
+        msg = str(exc).lower()
+        if "io error" in msg and "cannot open file" in msg:
+            return (
+                "DuckDB cannot open the database file. Check that the path in "
+                "the profile exists and is readable, or use ':memory:' for an "
+                "ephemeral database."
+            )
+        if "is being used by another process" in msg:
+            return (
+                "Another process holds an exclusive lock on the DuckDB file. "
+                "Close the other connection (or use a separate file) and retry."
+            )
+        if "table" in msg and "does not exist" in msg:
+            return "Referenced table is missing or hasn't been created in this database."
+        return None
+
+    def system_schemas(self) -> frozenset[str]:
+        # DuckDB ships ``information_schema``, ``pg_catalog``, ``system``,
+        # and the per-connection ``temp`` schema. ``main`` is the user-
+        # visible default.
+        return frozenset({"information_schema", "pg_catalog", "system", "temp"})
+
+    def list_schemas(self, engine: Engine, catalog: str = "") -> list[str] | None:
+        # SQLAlchemy's DuckDB dialect returns catalog-qualified schema
+        # names (e.g. ``mydb.analytics``, ``system.information_schema``)
+        # which the system_schemas filter doesn't know how to match.
+        # Query ``duckdb_schemas()`` directly and filter on the
+        # ``internal`` flag so user-visible schemas across all attached
+        # databases come back as bare names.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT schema_name FROM duckdb_schemas() "
+                    "WHERE NOT internal ORDER BY schema_name"
+                )
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    def list_databases(self, engine: Engine) -> list[str]:
+        # DuckDB lets you ATTACH multiple files (Parquet datasets, the
+        # Postgres scanner, SQLite, etc.). Each shows up in
+        # ``duckdb_databases()`` and is a legitimate top-level scope to
+        # browse.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT database_name FROM duckdb_databases() "
+                    "WHERE NOT internal ORDER BY database_name"
+                )
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    # ── Column profiling ──────────────────────────────────────────────────
+
+    def column_stats_sql(self, fqn: str, quoted_col: str) -> str:
+        # DuckDB casts most types to VARCHAR cleanly; for binary blobs
+        # the cast is best-effort. Same shape as PG.
+        return (
+            f"SELECT "
+            f"  COUNT(*) FILTER (WHERE {quoted_col} IS NULL) AS null_cnt, "
+            f"  COUNT(DISTINCT {quoted_col}) AS dist_cnt, "
+            f"  CAST(MIN({quoted_col}) AS VARCHAR) AS min_val, "
+            f"  CAST(MAX({quoted_col}) AS VARCHAR) AS max_val "
+            f"FROM {fqn}"
+        )
+
+    def column_sample_sql(self, fqn: str, quoted_col: str) -> str:
+        return (
+            f"SELECT DISTINCT CAST({quoted_col} AS VARCHAR) FROM {fqn} "
+            f"WHERE {quoted_col} IS NOT NULL LIMIT :lim"
+        )
+
+    # ── Table stats ───────────────────────────────────────────────────────
+
+    def get_table_stats(self, engine: Engine, schema: str, table: str) -> dict[str, int]:
+        # DuckDB doesn't track scan counters the way PG's
+        # ``pg_stat_user_tables`` does. Return a row-count estimate so
+        # the connector at least has something to gate full scans on.
+        try:
+            with engine.connect() as conn:
+                row = conn.execute(
+                    text(
+                        f"SELECT COUNT(*) FROM {self.fully_qualified_name(schema, table)}"
+                    )
+                ).fetchone()
+            n = int(row[0]) if row else 0
+        except Exception:
+            n = 0
+        return {"seq_scan": 0, "idx_scan": 0, "n_live_tup": n}
+
+    def stats_label(self) -> str:
+        return "row count (no scan counters)"
+
+    # ── Schema comments ───────────────────────────────────────────────────
+
+    def get_schema_comment(self, engine: Engine, schema: str) -> str | None:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT comment FROM duckdb_schemas() WHERE schema_name = :schema"
+                ),
+                {"schema": schema},
+            ).fetchone()
+        return str(row[0]) if row and row[0] else None
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def list_sequences(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT sequence_name, comment, start_value, increment_by, "
+                    "min_value, max_value, cycle "
+                    "FROM duckdb_sequences() WHERE schema_name = :schema "
+                    "ORDER BY sequence_name"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "sequence",
+                "definition": None,
+                "comment": str(r[1]) if r[1] else None,
+                "metadata": {
+                    "start": int(r[2]) if r[2] is not None else None,
+                    "increment": int(r[3]) if r[3] is not None else None,
+                    "min": int(r[4]) if r[4] is not None else None,
+                    "max": int(r[5]) if r[5] is not None else None,
+                    "cycle": bool(r[6]) if r[6] is not None else False,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # DuckDB exposes ~1000 built-in functions; restrict to user-defined
+        # ones (function_type = 'macro' is handled separately by
+        # list_macros). Internal functions live in ``main`` / ``pg_catalog``
+        # and are noisy — filter by schema and skip the ``internal`` flag.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT function_name, function_type, return_type, parameters, comment "
+                    "FROM duckdb_functions() "
+                    "WHERE schema_name = :schema AND NOT internal "
+                    "AND function_type IN ('scalar','aggregate','table','pragma') "
+                    "ORDER BY function_name"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": str(r[1]),
+                "definition": None,
+                "comment": str(r[4]) if r[4] else None,
+                "metadata": {
+                    "return_type": str(r[2]) if r[2] else None,
+                    "parameters": list(r[3]) if r[3] else [],
+                },
+            }
+            for r in rows
+        ]
+
+    def list_macros(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # ``duckdb_functions()`` reports macros via ``function_type='macro'``
+        # and ``function_type='table_macro'``. They get their own listing
+        # so downstream tooling can distinguish "real UDF" from "stored
+        # SQL snippet" — a DuckDB-distinctive feature.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT function_name, function_type, macro_definition, parameters, comment "
+                    "FROM duckdb_functions() "
+                    "WHERE schema_name = :schema "
+                    "AND function_type IN ('macro','table_macro') "
+                    "ORDER BY function_name"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": str(r[1]),
+                "definition": str(r[2]) if r[2] else None,
+                "comment": str(r[4]) if r[4] else None,
+                "metadata": {"parameters": list(r[3]) if r[3] else []},
+            }
+            for r in rows
+        ]
+
+    # ── Comment writing ───────────────────────────────────────────────────
+
+    def set_table_comment_sql(self, schema: str, table: str, asset_keyword: str) -> str:
+        # DuckDB accepts standard ``COMMENT ON TABLE/VIEW``. It does NOT
+        # accept ``MATERIALIZED VIEW`` (no support), but the connector
+        # already gates that via capabilities so we never get called with
+        # that keyword.
+        fqn = self.fully_qualified_name(schema, table)
+        return f"COMMENT ON {asset_keyword} {fqn} IS :cmt"
+
+    def set_column_comment_sql(self, schema: str, table: str, column: str) -> str:
+        fqn = self.fully_qualified_name(schema, table)
+        return f"COMMENT ON COLUMN {fqn}.{self.quote_identifier(column)} IS :cmt"
+
+    def set_schema_comment_sql(self, schema: str) -> str:
+        # DuckDB 1.x raises ``NotImplementedException`` for COMMENT ON
+        # SCHEMA; the matching capability flag is False so the connector
+        # never calls this, but we still raise here for safety.
+        raise self.unsupported("set_schema_comment_sql")
+
+    def set_database_comment_sql(self) -> str:
+        # DuckDB has no DATABASE-level COMMENT — a "database" is a file.
+        raise self.unsupported("set_database_comment_sql")

--- a/amx/db/adapters/mssql.py
+++ b/amx/db/adapters/mssql.py
@@ -594,6 +594,4 @@ class MSSQLAdapter(DatabaseAdapter):
 
     def set_database_comment_sql(self) -> str:
         # Database-level extended properties have no level filters.
-        return self._build_extended_property_sql(
-            level0type=None, level0name=None
-        )
+        return self._build_extended_property_sql(level0type=None, level0name=None)

--- a/amx/db/adapters/mssql.py
+++ b/amx/db/adapters/mssql.py
@@ -1,0 +1,599 @@
+"""SQL Server (Microsoft SQL Server / Azure SQL) backend adapter.
+
+Driven by the pyodbc SQLAlchemy dialect. Connection requires a
+locally-installed ODBC driver (typically ``ODBC Driver 18 for SQL
+Server``) — the wizard prompts for the driver name and the URL
+builder defaults to ODBC 18 when blank.
+
+What this adapter exposes:
+
+* Tables, views, indexed views (the closest equivalent to a
+  materialized view).
+* Stored procedures (``sys.procedures``).
+* Functions — scalar (FN), table-valued (TF), inline TVF (IF) — all
+  surfaced as ``functions`` with ``metadata.subtype`` to distinguish.
+* Triggers (``sys.triggers``).
+* Sequences (``sys.sequences``).
+* Synonyms (``sys.synonyms`` — SQL Server's named aliases for
+  remote/local objects).
+* Extended properties as comments — see write-back notes below.
+* Partition strategy, row-count estimate, and on-disk size in
+  :meth:`get_analytics_metadata`.
+
+Write-back: SQL Server has no ``COMMENT ON`` statement. Object
+descriptions live in ``sys.extended_properties`` under the
+``MS_Description`` name, written by ``sp_addextendedproperty`` and
+updated by ``sp_updateextendedproperty``. The two are not
+interchangeable — adding twice errors, and updating a non-existent
+property errors. We use a single ``MERGE``-style block that
+``IF EXISTS`` checks before picking which proc to call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
+
+
+class MSSQLAdapter(DatabaseAdapter):
+    name = "mssql"
+    capabilities = BackendCapabilities(
+        # SQL Server stores all comments as extended properties, including
+        # at the database level. Setting True so the connector exposes
+        # them, but write-back is special-cased (see comment_sql_with_params).
+        database_comments=True,
+        schema_comments=True,
+        materialized_view_comments=False,
+        materialized_views=False,  # use list_external_tables for indexed views? No — they're regular views
+        relationships=True,
+        row_count_stats=True,
+        stored_procedures=True,
+        functions=True,
+        sequences=True,
+        triggers=True,
+        synonyms=True,
+        comment_asset_keywords=frozenset({"TABLE", "VIEW"}),
+    )
+
+    def create_engine(self) -> Engine:
+        return create_engine(self.cfg.url, pool_pre_ping=True)
+
+    def actionable_profile_error(self, exc: Exception) -> str | None:
+        msg = str(exc).lower()
+        if "im002" in msg or "data source name not found" in msg:
+            return (
+                "ODBC driver not found. Install Microsoft's ODBC Driver 18 for "
+                "SQL Server (or set the `driver` field on the profile to a "
+                "driver you do have). On macOS: `brew install msodbcsql18`. "
+                "On Linux: see Microsoft's installation guide."
+            )
+        if "login failed for user" in msg:
+            return (
+                "SQL Server refused the credentials. Check the username/password, "
+                "and that the login is mapped to a user in the target database "
+                "with at least VIEW DEFINITION + SELECT permissions."
+            )
+        if "cannot open database" in msg:
+            return (
+                "SQL Server refused: the `database` field on this profile points "
+                "at a database that doesn't exist or that the login can't access. "
+                "Edit the profile, or grant CONNECT on the target database."
+            )
+        if "ssl provider" in msg or "encryption" in msg:
+            return (
+                "TLS handshake failed. Set `trust_server_certificate=true` on the "
+                "profile if you're using a self-signed certificate, or set "
+                "`encrypt=false` for legacy on-prem servers without TLS."
+            )
+        return None
+
+    def system_schemas(self) -> frozenset[str]:
+        # ``sys`` and ``INFORMATION_SCHEMA`` are server-defined; ``guest``
+        # and the ``db_*`` role-mapping schemas are noise. ``dbo`` is the
+        # user-visible default and stays.
+        return frozenset(
+            {
+                "sys",
+                "INFORMATION_SCHEMA",
+                "guest",
+                "db_owner",
+                "db_accessadmin",
+                "db_securityadmin",
+                "db_ddladmin",
+                "db_backupoperator",
+                "db_datareader",
+                "db_datawriter",
+                "db_denydatareader",
+                "db_denydatawriter",
+            }
+        )
+
+    def quote_identifier(self, name: str) -> str:
+        # SQL Server brackets. Bracket-in-name is escaped by doubling
+        # the closing bracket per T-SQL rules.
+        escaped = name.replace("]", "]]")
+        return f"[{escaped}]"
+
+    def list_databases(self, engine: Engine) -> list[str]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT name FROM sys.databases "
+                    "WHERE database_id > 4 "  # exclude master/tempdb/model/msdb
+                    "AND state_desc = 'ONLINE' "
+                    "ORDER BY name"
+                )
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    # ── Column profiling ──────────────────────────────────────────────────
+
+    def column_stats_sql(self, fqn: str, quoted_col: str) -> str:
+        # SQL Server doesn't have FILTER. Use SUM(CASE ...) for null
+        # count and CONVERT for the text cast (some types like
+        # geography / geometry need special handling, but CONVERT to
+        # NVARCHAR(MAX) covers the common cases).
+        return (
+            f"SELECT "
+            f"  SUM(CASE WHEN {quoted_col} IS NULL THEN 1 ELSE 0 END) AS null_cnt, "
+            f"  COUNT(DISTINCT {quoted_col}) AS dist_cnt, "
+            f"  CONVERT(NVARCHAR(MAX), MIN({quoted_col})) AS min_val, "
+            f"  CONVERT(NVARCHAR(MAX), MAX({quoted_col})) AS max_val "
+            f"FROM {fqn}"
+        )
+
+    def column_sample_sql(self, fqn: str, quoted_col: str) -> str:
+        # ``LIMIT`` doesn't exist on SQL Server. Use ``TOP`` with a
+        # subquery so the parameter binds. pyodbc binds via ``?``, but
+        # SQLAlchemy translates ``:lim`` to the right driver style.
+        return (
+            f"SELECT DISTINCT TOP (:lim) CONVERT(NVARCHAR(MAX), {quoted_col}) "
+            f"FROM {fqn} WHERE {quoted_col} IS NOT NULL"
+        )
+
+    # ── Table stats ───────────────────────────────────────────────────────
+
+    def get_table_stats(self, engine: Engine, schema: str, table: str) -> dict[str, int]:
+        # ``sys.dm_db_partition_stats.row_count`` is a fast estimate that
+        # avoids a full scan. Sum across partitions for the in-row data
+        # index (index_id IN (0,1)).
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT COALESCE(SUM(p.row_count), 0) "
+                    "FROM sys.dm_db_partition_stats p "
+                    "JOIN sys.objects o ON o.object_id = p.object_id "
+                    "JOIN sys.schemas s ON s.schema_id = o.schema_id "
+                    "WHERE s.name = :schema AND o.name = :table "
+                    "AND p.index_id IN (0, 1)"
+                ),
+                {"schema": schema, "table": table},
+            ).fetchone()
+        n = int(row[0]) if row and row[0] is not None else 0
+        return {"seq_scan": 0, "idx_scan": 0, "n_live_tup": n}
+
+    def stats_label(self) -> str:
+        return "sys.dm_db_partition_stats (estimate)"
+
+    # ── Schema / database comments ────────────────────────────────────────
+
+    def get_schema_comment(self, engine: Engine, schema: str) -> str | None:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT CAST(value AS NVARCHAR(MAX)) "
+                    "FROM sys.extended_properties ep "
+                    "JOIN sys.schemas s ON s.schema_id = ep.major_id "
+                    "WHERE ep.name = 'MS_Description' "
+                    "AND ep.class = 3 "  # 3 = schema
+                    "AND s.name = :schema"
+                ),
+                {"schema": schema},
+            ).fetchone()
+        return str(row[0]) if row and row[0] else None
+
+    def get_database_comment(self, engine: Engine) -> str | None:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT CAST(value AS NVARCHAR(MAX)) "
+                    "FROM sys.extended_properties "
+                    "WHERE name = 'MS_Description' AND class = 0"
+                )
+            ).fetchone()
+        return str(row[0]) if row and row[0] else None
+
+    # ── Incoming foreign keys ─────────────────────────────────────────────
+
+    def get_incoming_foreign_keys(
+        self, engine: Engine, schema: str, table: str
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT
+                        src_s.name AS source_schema,
+                        src_t.name AS source_table,
+                        src_c.name AS source_column,
+                        tgt_c.name AS target_column
+                    FROM sys.foreign_keys fk
+                    JOIN sys.foreign_key_columns fkc
+                         ON fkc.constraint_object_id = fk.object_id
+                    JOIN sys.objects src_t ON src_t.object_id = fk.parent_object_id
+                    JOIN sys.schemas src_s ON src_s.schema_id = src_t.schema_id
+                    JOIN sys.columns src_c
+                         ON src_c.object_id = fk.parent_object_id
+                        AND src_c.column_id  = fkc.parent_column_id
+                    JOIN sys.objects tgt_t ON tgt_t.object_id = fk.referenced_object_id
+                    JOIN sys.schemas tgt_s ON tgt_s.schema_id = tgt_t.schema_id
+                    JOIN sys.columns tgt_c
+                         ON tgt_c.object_id = fk.referenced_object_id
+                        AND tgt_c.column_id  = fkc.referenced_column_id
+                    WHERE tgt_s.name = :schema
+                      AND tgt_t.name = :table
+                    ORDER BY src_s.name, src_t.name, src_c.name
+                    """
+                ),
+                {"schema": schema, "table": table},
+            ).fetchall()
+        return [
+            {
+                "source_schema": str(r[0]),
+                "source_table": str(r[1]),
+                "source_column": str(r[2]),
+                "target_column": str(r[3]),
+            }
+            for r in rows
+        ]
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT p.name, OBJECT_DEFINITION(p.object_id) AS body, "
+                    "p.create_date, p.modify_date, "
+                    "(SELECT CAST(value AS NVARCHAR(MAX)) "
+                    "  FROM sys.extended_properties ep "
+                    "  WHERE ep.major_id = p.object_id "
+                    "    AND ep.minor_id = 0 "
+                    "    AND ep.name = 'MS_Description') AS comment "
+                    "FROM sys.procedures p "
+                    "JOIN sys.schemas s ON s.schema_id = p.schema_id "
+                    "WHERE s.name = :schema "
+                    "ORDER BY p.name"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "procedure",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[4]) if r[4] else None,
+                "metadata": {
+                    "created": str(r[2]) if r[2] else None,
+                    "modified": str(r[3]) if r[3] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # FN = scalar, TF = multi-statement table-valued, IF = inline TVF.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT o.name, o.type, OBJECT_DEFINITION(o.object_id) AS body, "
+                    "o.create_date, o.modify_date "
+                    "FROM sys.objects o "
+                    "JOIN sys.schemas s ON s.schema_id = o.schema_id "
+                    "WHERE s.name = :schema AND o.type IN ('FN','TF','IF') "
+                    "ORDER BY o.name"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        type_map = {"FN": "scalar", "TF": "table_valued", "IF": "inline_tvf"}
+        return [
+            {
+                "name": str(r[0]),
+                "type": "function",
+                "definition": str(r[2]) if r[2] else None,
+                "comment": None,
+                "metadata": {
+                    "subtype": type_map.get(str(r[1]).strip(), str(r[1]).strip()),
+                    "created": str(r[3]) if r[3] else None,
+                    "modified": str(r[4]) if r[4] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_sequences(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT seq.name, t.name AS data_type, seq.start_value, "
+                    "seq.increment, seq.minimum_value, seq.maximum_value, seq.is_cycling "
+                    "FROM sys.sequences seq "
+                    "JOIN sys.schemas s ON s.schema_id = seq.schema_id "
+                    "JOIN sys.types t ON t.user_type_id = seq.user_type_id "
+                    "WHERE s.name = :schema "
+                    "ORDER BY seq.name"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "sequence",
+                "definition": None,
+                "comment": None,
+                "metadata": {
+                    "data_type": str(r[1]),
+                    "start": int(r[2]) if r[2] is not None else None,
+                    "increment": int(r[3]) if r[3] is not None else None,
+                    "min": int(r[4]) if r[4] is not None else None,
+                    "max": int(r[5]) if r[5] is not None else None,
+                    "cycle": bool(r[6]),
+                },
+            }
+            for r in rows
+        ]
+
+    def list_triggers(
+        self, engine: Engine, schema: str, table: str | None = None
+    ) -> list[dict[str, Any]]:
+        sql = (
+            "SELECT t.name, parent.name AS table_name, "
+            "OBJECT_DEFINITION(t.object_id) AS body, t.is_disabled "
+            "FROM sys.triggers t "
+            "JOIN sys.objects parent ON parent.object_id = t.parent_id "
+            "JOIN sys.schemas s ON s.schema_id = parent.schema_id "
+            "WHERE t.parent_class = 1 AND s.name = :schema"  # 1 = OBJECT_OR_COLUMN
+        )
+        params: dict[str, Any] = {"schema": schema}
+        if table:
+            sql += " AND parent.name = :table"
+            params["table"] = table
+        sql += " ORDER BY t.name"
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql), params).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "trigger",
+                "definition": str(r[2]) if r[2] else None,
+                "comment": None,
+                "metadata": {
+                    "table": str(r[1]),
+                    "disabled": bool(r[3]),
+                },
+            }
+            for r in rows
+        ]
+
+    def list_synonyms(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT syn.name, syn.base_object_name "
+                    "FROM sys.synonyms syn "
+                    "JOIN sys.schemas s ON s.schema_id = syn.schema_id "
+                    "WHERE s.name = :schema "
+                    "ORDER BY syn.name"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "synonym",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": None,
+                "metadata": {"target": str(r[1]) if r[1] else None},
+            }
+            for r in rows
+        ]
+
+    # ── Analytics metadata ────────────────────────────────────────────────
+
+    def get_analytics_metadata(self, engine: Engine, schema: str, table: str) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        warnings: list[str] = []
+
+        with engine.connect() as conn:
+            try:
+                row = conn.execute(
+                    text(
+                        """
+                        SELECT
+                            o.create_date,
+                            o.modify_date,
+                            o.type_desc,
+                            (SELECT SUM(au.total_pages) * 8 * 1024
+                             FROM sys.allocation_units au
+                             JOIN sys.partitions p
+                                  ON (au.container_id = p.partition_id AND au.type IN (1,3))
+                             WHERE p.object_id = o.object_id) AS storage_bytes
+                        FROM sys.objects o
+                        JOIN sys.schemas s ON s.schema_id = o.schema_id
+                        WHERE s.name = :schema AND o.name = :table
+                        """
+                    ),
+                    {"schema": schema, "table": table},
+                ).fetchone()
+                if row:
+                    out["last_modified"] = str(row[1]) if row[1] else ""
+                    type_desc = (str(row[2]) if row[2] else "").lower()
+                    if "user_table" in type_desc:
+                        out["table_type"] = "managed"
+                    elif "view" in type_desc:
+                        out["table_type"] = "view"
+                    if row[3] is not None:
+                        out["storage_bytes"] = int(row[3])
+            except Exception as exc:
+                warnings.append(f"table info: {exc}")
+
+            # Partition columns — present when the table is partitioned by a
+            # partition function. Returns the leading partition column name.
+            try:
+                rows = conn.execute(
+                    text(
+                        """
+                        SELECT c.name, ps.name AS partition_scheme
+                        FROM sys.indexes i
+                        JOIN sys.objects o ON o.object_id = i.object_id
+                        JOIN sys.schemas s ON s.schema_id = o.schema_id
+                        JOIN sys.index_columns ic
+                             ON ic.object_id = i.object_id
+                            AND ic.index_id = i.index_id
+                            AND ic.partition_ordinal > 0
+                        JOIN sys.columns c
+                             ON c.object_id = i.object_id AND c.column_id = ic.column_id
+                        JOIN sys.partition_schemes ps ON ps.data_space_id = i.data_space_id
+                        WHERE s.name = :schema AND o.name = :table
+                        ORDER BY ic.partition_ordinal
+                        """
+                    ),
+                    {"schema": schema, "table": table},
+                ).fetchall()
+                if rows:
+                    out["partition_keys"] = [str(r[0]) for r in rows]
+                    out["partition_strategy"] = "range"
+            except Exception as exc:
+                warnings.append(f"partitions: {exc}")
+
+            # Indexes
+            try:
+                rows = conn.execute(
+                    text(
+                        """
+                        SELECT i.name, i.is_unique, c.name
+                        FROM sys.indexes i
+                        JOIN sys.objects o ON o.object_id = i.object_id
+                        JOIN sys.schemas s ON s.schema_id = o.schema_id
+                        JOIN sys.index_columns ic
+                             ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+                        JOIN sys.columns c
+                             ON c.object_id = i.object_id AND c.column_id = ic.column_id
+                        WHERE s.name = :schema AND o.name = :table
+                          AND i.name IS NOT NULL
+                        ORDER BY i.name, ic.key_ordinal
+                        """
+                    ),
+                    {"schema": schema, "table": table},
+                ).fetchall()
+                idx_map: dict[str, dict[str, Any]] = {}
+                for r in rows:
+                    name = str(r[0])
+                    bucket = idx_map.setdefault(
+                        name, {"name": name, "columns": [], "unique": bool(r[1])}
+                    )
+                    bucket["columns"].append(str(r[2]))
+                if idx_map:
+                    out["indexes"] = list(idx_map.values())
+            except Exception as exc:
+                warnings.append(f"indexes: {exc}")
+
+        out.setdefault("storage_format", "native")
+        if warnings:
+            out["warnings"] = warnings
+        return out
+
+    # ── Comment writing ───────────────────────────────────────────────────
+    #
+    # SQL Server uses ``sp_addextendedproperty`` to create and
+    # ``sp_updateextendedproperty`` to update — adding twice errors and
+    # updating a non-existent property errors. We emit a single block
+    # that branches on existence via ``IF EXISTS``, so the same SQL
+    # works for both create and update paths.
+    #
+    # The :cmt placeholder bind is supported by pyodbc because
+    # ``sp_addextendedproperty`` takes ``@value`` as a bound parameter.
+    # We use named binds for readability; SQLAlchemy translates them
+    # to the driver's positional-bind style.
+
+    def _build_extended_property_sql(
+        self,
+        level0type: str | None,
+        level0name: str | None,
+        level1type: str | None = None,
+        level1name: str | None = None,
+        level2type: str | None = None,
+        level2name: str | None = None,
+    ) -> str:
+        """Return a T-SQL block that adds-or-updates ``MS_Description``
+        on the targeted object, using sp_addextendedproperty when the
+        property is missing and sp_updateextendedproperty when present.
+
+        Levels follow Microsoft's nomenclature: level0 is the schema,
+        level1 is the table/view/proc, level2 is the column.
+        """
+
+        def _q(v: str | None) -> str:
+            if v is None:
+                return "NULL"
+            return self.quote_literal(v)
+
+        params = (
+            f"@name = N'MS_Description', @value = :cmt, "
+            f"@level0type = {_q(level0type)}, @level0name = {_q(level0name)}, "
+            f"@level1type = {_q(level1type)}, @level1name = {_q(level1name)}, "
+            f"@level2type = {_q(level2type)}, @level2name = {_q(level2name)}"
+        )
+
+        # Build the EXISTS predicate against sys.fn_listextendedproperty.
+        # Empty string for ``default`` arg means "not specified" — we
+        # have to pass the literal positional args matching the levels
+        # we filled.
+        exists_args = (
+            f"N'MS_Description', "
+            f"{_q(level0type)}, {_q(level0name)}, "
+            f"{_q(level1type)}, {_q(level1name)}, "
+            f"{_q(level2type)}, {_q(level2name)}"
+        )
+
+        return (
+            f"IF EXISTS (SELECT 1 FROM sys.fn_listextendedproperty({exists_args})) "
+            f"EXEC sp_updateextendedproperty {params} "
+            f"ELSE EXEC sp_addextendedproperty {params}"
+        )
+
+    def set_table_comment_sql(self, schema: str, table: str, asset_keyword: str) -> str:
+        # asset_keyword is "TABLE" or "VIEW"; sys.fn_listextendedproperty
+        # accepts both as level1 type names.
+        return self._build_extended_property_sql(
+            level0type="SCHEMA",
+            level0name=schema,
+            level1type=asset_keyword,
+            level1name=table,
+        )
+
+    def set_column_comment_sql(self, schema: str, table: str, column: str) -> str:
+        return self._build_extended_property_sql(
+            level0type="SCHEMA",
+            level0name=schema,
+            level1type="TABLE",  # works for views too in this proc
+            level1name=table,
+            level2type="COLUMN",
+            level2name=column,
+        )
+
+    def set_schema_comment_sql(self, schema: str) -> str:
+        return self._build_extended_property_sql(
+            level0type="SCHEMA",
+            level0name=schema,
+        )
+
+    def set_database_comment_sql(self) -> str:
+        # Database-level extended properties have no level filters.
+        return self._build_extended_property_sql(
+            level0type=None, level0name=None
+        )

--- a/amx/db/adapters/mysql.py
+++ b/amx/db/adapters/mysql.py
@@ -1,0 +1,434 @@
+"""MySQL / MariaDB backend adapter.
+
+Driven by the PyMySQL SQLAlchemy dialect. The adapter reads metadata
+out of ``information_schema`` (tables, views, routines, triggers,
+events, indexes, FKs, partitions) and surfaces:
+
+* Tables (BASE TABLE) and views.
+* Stored procedures and functions via ``information_schema.ROUTINES``.
+* Triggers (table-scoped DML triggers).
+* Events — MySQL's scheduled jobs, no equivalent on most warehouses.
+* Storage engine, row-count estimate, partition info, and on-disk
+  size in :meth:`get_analytics_metadata`.
+
+MySQL does NOT support:
+
+* Schema-level ``COMMENT ON SCHEMA`` (no syntax). Schema comments
+  are dropped at write time — capability flag is False.
+* Materialized views.
+* Sequences (``AUTO_INCREMENT`` is the equivalent and isn't a
+  first-class object).
+
+Comments are written via ``ALTER TABLE`` for table-level and
+``ALTER TABLE ... MODIFY COLUMN`` for column-level. The latter
+requires re-stating the full column definition, so the connector
+only calls it after fetching the current type — handled below by
+overriding :meth:`comment_sql_with_params` to inject the cached
+column type.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
+
+
+class MySQLAdapter(DatabaseAdapter):
+    name = "mysql"
+    capabilities = BackendCapabilities(
+        database_comments=False,  # MySQL has no DATABASE-level comment
+        schema_comments=False,  # MySQL schemas == databases; no separate COMMENT
+        materialized_views=False,
+        materialized_view_comments=False,
+        relationships=True,
+        row_count_stats=True,
+        stored_procedures=True,
+        functions=True,
+        triggers=True,
+        events=True,
+        comment_asset_keywords=frozenset({"TABLE", "VIEW"}),
+    )
+
+    def create_engine(self) -> Engine:
+        return create_engine(self.cfg.url, pool_pre_ping=True)
+
+    def actionable_profile_error(self, exc: Exception) -> str | None:
+        msg = str(exc).lower()
+        if "access denied for user" in msg:
+            return (
+                "MySQL refused the credentials. Check the username/password "
+                "in the profile, or grant the required privileges with "
+                "`GRANT SELECT ON <db>.* TO '<user>'@'<host>';`."
+            )
+        if "unknown database" in msg:
+            return (
+                "MySQL refused: the `database` field on this profile points "
+                "at a database that doesn't exist on this server. Edit the "
+                "profile, or leave the field blank to pick a database at "
+                "command time."
+            )
+        if "can't connect to mysql server" in msg:
+            return (
+                "MySQL refused the TCP connection. Check the host/port, "
+                "and that the server is configured to accept remote logins "
+                "(skip-networking must be off)."
+            )
+        if "1142" in msg or "command denied" in msg:
+            return (
+                "MySQL denied the introspection query. The user needs SELECT "
+                "on `information_schema` and the target schema, plus PROCESS "
+                "privilege for some `SHOW` commands."
+            )
+        return None
+
+    def system_schemas(self) -> frozenset[str]:
+        return frozenset({"mysql", "information_schema", "performance_schema", "sys"})
+
+    def quote_identifier(self, name: str) -> str:
+        # MySQL uses backticks. Doubling escapes embedded backticks.
+        escaped = name.replace("`", "``")
+        return f"`{escaped}`"
+
+    def list_databases(self, engine: Engine) -> list[str]:
+        # In MySQL, "database" and "schema" are synonyms; this lists the
+        # user-visible top-level scopes (excluding the system DBs).
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA "
+                    "WHERE SCHEMA_NAME NOT IN "
+                    "('mysql','information_schema','performance_schema','sys') "
+                    "ORDER BY SCHEMA_NAME"
+                )
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    # ── Column profiling ──────────────────────────────────────────────────
+
+    def column_stats_sql(self, fqn: str, quoted_col: str) -> str:
+        # MySQL's CHAR coercion is forgiving for most types. Wrap MIN/MAX
+        # in CAST for binary / spatial types where the implicit cast
+        # would error.
+        return (
+            f"SELECT "
+            f"  SUM(CASE WHEN {quoted_col} IS NULL THEN 1 ELSE 0 END) AS null_cnt, "
+            f"  COUNT(DISTINCT {quoted_col}) AS dist_cnt, "
+            f"  CAST(MIN({quoted_col}) AS CHAR) AS min_val, "
+            f"  CAST(MAX({quoted_col}) AS CHAR) AS max_val "
+            f"FROM {fqn}"
+        )
+
+    def column_sample_sql(self, fqn: str, quoted_col: str) -> str:
+        return (
+            f"SELECT DISTINCT CAST({quoted_col} AS CHAR) FROM {fqn} "
+            f"WHERE {quoted_col} IS NOT NULL LIMIT :lim"
+        )
+
+    # ── Table stats ───────────────────────────────────────────────────────
+
+    def get_table_stats(self, engine: Engine, schema: str, table: str) -> dict[str, int]:
+        # ``TABLE_ROWS`` is precise for MyISAM and an estimate for InnoDB
+        # (so it should be treated as a hint, not a count). Surface it
+        # under ``n_live_tup`` to match the PG vocabulary.
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT TABLE_ROWS FROM information_schema.TABLES "
+                    "WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table"
+                ),
+                {"schema": schema, "table": table},
+            ).fetchone()
+        n = int(row[0]) if row and row[0] is not None else 0
+        return {"seq_scan": 0, "idx_scan": 0, "n_live_tup": n}
+
+    def stats_label(self) -> str:
+        return "information_schema.TABLES (estimate for InnoDB)"
+
+    # ── Incoming foreign keys ─────────────────────────────────────────────
+
+    def get_incoming_foreign_keys(
+        self, engine: Engine, schema: str, table: str
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT
+                        kcu.TABLE_SCHEMA   AS source_schema,
+                        kcu.TABLE_NAME     AS source_table,
+                        kcu.COLUMN_NAME    AS source_column,
+                        kcu.REFERENCED_COLUMN_NAME AS target_column
+                    FROM information_schema.KEY_COLUMN_USAGE kcu
+                    WHERE kcu.REFERENCED_TABLE_SCHEMA = :schema
+                      AND kcu.REFERENCED_TABLE_NAME   = :table
+                    ORDER BY kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME
+                    """
+                ),
+                {"schema": schema, "table": table},
+            ).fetchall()
+        return [
+            {
+                "source_schema": str(r[0]),
+                "source_table": str(r[1]),
+                "source_column": str(r[2]),
+                "target_column": str(r[3]),
+            }
+            for r in rows
+        ]
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT ROUTINE_NAME, ROUTINE_DEFINITION, ROUTINE_COMMENT, "
+                    "DATA_TYPE, CREATED, LAST_ALTERED "
+                    "FROM information_schema.ROUTINES "
+                    "WHERE ROUTINE_SCHEMA = :schema AND ROUTINE_TYPE = 'PROCEDURE' "
+                    "ORDER BY ROUTINE_NAME"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "procedure",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {
+                    "return_type": str(r[3]) if r[3] else None,
+                    "created": str(r[4]) if r[4] else None,
+                    "last_altered": str(r[5]) if r[5] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT ROUTINE_NAME, ROUTINE_DEFINITION, ROUTINE_COMMENT, "
+                    "DATA_TYPE, CREATED, LAST_ALTERED "
+                    "FROM information_schema.ROUTINES "
+                    "WHERE ROUTINE_SCHEMA = :schema AND ROUTINE_TYPE = 'FUNCTION' "
+                    "ORDER BY ROUTINE_NAME"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "function",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {
+                    "return_type": str(r[3]) if r[3] else None,
+                    "created": str(r[4]) if r[4] else None,
+                    "last_altered": str(r[5]) if r[5] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_triggers(
+        self, engine: Engine, schema: str, table: str | None = None
+    ) -> list[dict[str, Any]]:
+        sql = (
+            "SELECT TRIGGER_NAME, EVENT_MANIPULATION, ACTION_TIMING, "
+            "EVENT_OBJECT_TABLE, ACTION_STATEMENT "
+            "FROM information_schema.TRIGGERS "
+            "WHERE TRIGGER_SCHEMA = :schema"
+        )
+        params: dict[str, Any] = {"schema": schema}
+        if table:
+            sql += " AND EVENT_OBJECT_TABLE = :table"
+            params["table"] = table
+        sql += " ORDER BY TRIGGER_NAME"
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql), params).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "trigger",
+                "definition": str(r[4]) if r[4] else None,
+                "comment": None,
+                "metadata": {
+                    "event": str(r[1]) if r[1] else None,
+                    "timing": str(r[2]) if r[2] else None,
+                    "table": str(r[3]) if r[3] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_events(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT EVENT_NAME, EVENT_BODY, EVENT_DEFINITION, EVENT_TYPE, "
+                    "STATUS, EVENT_COMMENT, INTERVAL_VALUE, INTERVAL_FIELD, "
+                    "STARTS, ENDS "
+                    "FROM information_schema.EVENTS "
+                    "WHERE EVENT_SCHEMA = :schema "
+                    "ORDER BY EVENT_NAME"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": str(r[3]) if r[3] else "event",
+                "definition": str(r[2]) if r[2] else None,
+                "comment": str(r[5]) if r[5] else None,
+                "metadata": {
+                    "body": str(r[1]) if r[1] else None,
+                    "status": str(r[4]) if r[4] else None,
+                    "interval_value": str(r[6]) if r[6] is not None else None,
+                    "interval_field": str(r[7]) if r[7] else None,
+                    "starts": str(r[8]) if r[8] else None,
+                    "ends": str(r[9]) if r[9] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    # ── Analytics metadata ────────────────────────────────────────────────
+
+    def get_analytics_metadata(self, engine: Engine, schema: str, table: str) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        warnings: list[str] = []
+
+        with engine.connect() as conn:
+            try:
+                row = conn.execute(
+                    text(
+                        "SELECT ENGINE, TABLE_TYPE, DATA_LENGTH, INDEX_LENGTH, "
+                        "UPDATE_TIME, CREATE_OPTIONS, TABLE_COMMENT "
+                        "FROM information_schema.TABLES "
+                        "WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table"
+                    ),
+                    {"schema": schema, "table": table},
+                ).fetchone()
+                if row:
+                    engine_name = (str(row[0]) if row[0] else "").lower()
+                    table_type = (str(row[1]) if row[1] else "").lower()
+                    data_len = int(row[2] or 0)
+                    idx_len = int(row[3] or 0)
+                    if data_len or idx_len:
+                        out["storage_bytes"] = data_len + idx_len
+                    if row[4]:
+                        out["last_modified"] = str(row[4])
+                    if engine_name:
+                        out.setdefault("storage_format", engine_name)
+                    if table_type == "view":
+                        out["table_type"] = "view"
+                    elif "system" in table_type:
+                        out["table_type"] = "system"
+                    else:
+                        out["table_type"] = "managed"
+            except Exception as exc:
+                warnings.append(f"table info: {exc}")
+
+            # Partition info — only present on partitioned tables.
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT DISTINCT PARTITION_METHOD, PARTITION_EXPRESSION "
+                        "FROM information_schema.PARTITIONS "
+                        "WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table "
+                        "AND PARTITION_NAME IS NOT NULL"
+                    ),
+                    {"schema": schema, "table": table},
+                ).fetchall()
+                if rows:
+                    method = str(rows[0][0] or "").lower()
+                    expr = str(rows[0][1] or "")
+                    if method:
+                        out["partition_strategy"] = method
+                    if expr:
+                        # Best-effort: split by comma if it's a column list.
+                        out["partition_keys"] = [
+                            c.strip().strip("`") for c in expr.split(",") if c.strip()
+                        ]
+            except Exception as exc:
+                warnings.append(f"partitions: {exc}")
+
+            # Indexes from STATISTICS (one row per (index, column)).
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE, SEQ_IN_INDEX "
+                        "FROM information_schema.STATISTICS "
+                        "WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table "
+                        "ORDER BY INDEX_NAME, SEQ_IN_INDEX"
+                    ),
+                    {"schema": schema, "table": table},
+                ).fetchall()
+                idx_map: dict[str, dict[str, Any]] = {}
+                for r in rows:
+                    name = str(r[0])
+                    bucket = idx_map.setdefault(
+                        name, {"name": name, "columns": [], "unique": int(r[2] or 0) == 0}
+                    )
+                    bucket["columns"].append(str(r[1]))
+                if idx_map:
+                    out["indexes"] = list(idx_map.values())
+            except Exception as exc:
+                warnings.append(f"indexes: {exc}")
+
+        if warnings:
+            out["warnings"] = warnings
+        return out
+
+    # ── Comment writing ───────────────────────────────────────────────────
+    #
+    # MySQL has no ``COMMENT ON`` statement. Instead:
+    # * ``ALTER TABLE <fqn> COMMENT = '...'`` for table comments.
+    # * ``ALTER TABLE <fqn> MODIFY COLUMN <col> <type> COMMENT '...'``
+    #   for column comments — and the type clause is mandatory.
+    #
+    # The connector calls ``set_table_comment_sql`` / ``set_column_comment_sql``
+    # to get a *template* and fills the ``:cmt`` bind via
+    # ``comment_sql_with_params``. MySQL doesn't accept named binds in
+    # DDL, so we override ``comment_sql_with_params`` to inline the
+    # comment as a quoted literal.
+
+    def set_table_comment_sql(self, schema: str, table: str, asset_keyword: str) -> str:
+        # ``asset_keyword`` is "TABLE" or "VIEW"; both use the same
+        # ALTER-with-COMMENT shape on MySQL.
+        fqn = self.fully_qualified_name(schema, table)
+        return f"ALTER {asset_keyword} {fqn} COMMENT = :cmt"
+
+    def set_column_comment_sql(self, schema: str, table: str, column: str) -> str:
+        # We don't know the column's type at template-build time. The
+        # caller is expected to fetch the type and stitch it in via
+        # ``comment_sql_with_params`` (which we override to also accept
+        # a ``column_type`` key in extras). Placeholder ``__TYPE__``
+        # gets replaced when params are bound.
+        fqn = self.fully_qualified_name(schema, table)
+        col = self.quote_identifier(column)
+        return f"ALTER TABLE {fqn} MODIFY COLUMN {col} __TYPE__ COMMENT :cmt"
+
+    def set_schema_comment_sql(self, schema: str) -> str:
+        # MySQL has no schema-level COMMENT; the matching capability
+        # flag is False so the connector should never call this.
+        raise self.unsupported("set_schema_comment_sql")
+
+    def set_database_comment_sql(self) -> str:
+        raise self.unsupported("set_database_comment_sql")
+
+    def comment_sql_with_params(
+        self, stmt_template: str, comment: str
+    ) -> tuple[str, dict[str, Any]]:
+        # Inline the comment as a quoted literal — MySQL doesn't accept
+        # ``?`` / ``:cmt`` binds in DDL on every driver/version combo.
+        # Type-stitching for column comments is handled by the caller
+        # before this is invoked (see :meth:`set_column_comment_sql`).
+        literal = self.quote_literal(comment)
+        return stmt_template.replace(":cmt", literal), {}

--- a/amx/db/adapters/oracle.py
+++ b/amx/db/adapters/oracle.py
@@ -1,0 +1,589 @@
+"""Oracle Database backend adapter.
+
+Driven by python-oracledb in thin mode (no Instant Client needed).
+Connection accepts either ``service_name`` (preferred for Oracle Cloud
+/ RAC / modern setups) or falls back to ``database`` as a SID.
+
+Object types exposed beyond the standard tables/views/columns:
+
+* Materialized views (``ALL_MVIEWS``) — Oracle has first-class support.
+* Stored procedures and functions (``ALL_PROCEDURES`` filtered by
+  ``OBJECT_TYPE``).
+* Packages (``ALL_OBJECTS WHERE OBJECT_TYPE='PACKAGE'``) — Oracle
+  groups related procedures and functions into named packages, a
+  feature with no equivalent on most other backends.
+* Triggers (``ALL_TRIGGERS``).
+* Sequences (``ALL_SEQUENCES``).
+* Synonyms (``ALL_SYNONYMS``) — Oracle's named aliases for objects.
+* User-defined types (``ALL_TYPES``) — composite, collection, REF
+  types.
+* Partition info, tablespace, and storage size in
+  :meth:`get_analytics_metadata`.
+
+Schema = user in Oracle. There is no ``COMMENT ON SCHEMA`` and no
+database-level COMMENT — both raise ``unsupported``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
+
+
+# Oracle ships with a long list of system schemas. Filtering them out
+# of the schema picker is the difference between "12 user schemas" and
+# "120 schemas, 90% of which are XDB / APEX / OLAP support".
+_ORACLE_SYSTEM_SCHEMAS = frozenset(
+    {
+        "SYS",
+        "SYSTEM",
+        "OUTLN",
+        "MDSYS",
+        "CTXSYS",
+        "XDB",
+        "WMSYS",
+        "OLAPSYS",
+        "DBSNMP",
+        "GSMADMIN_INTERNAL",
+        "LBACSYS",
+        "OJVMSYS",
+        "ORDSYS",
+        "ORDDATA",
+        "ORDPLUGINS",
+        "SI_INFORMTN_SCHEMA",
+        "DVF",
+        "DVSYS",
+        "AUDSYS",
+        "APPQOSSYS",
+        "DIP",
+        "ORACLE_OCM",
+        "ANONYMOUS",
+        "REMOTE_SCHEDULER_AGENT",
+        "SYSBACKUP",
+        "SYSDG",
+        "SYSKM",
+        "SYSRAC",
+        "SYS$UMF",
+        "GGSYS",
+        "GSMCATUSER",
+        "GSMUSER",
+        "GSMROOTUSER",
+        "MDDATA",
+        "FLOWS_FILES",
+    }
+)
+
+
+class OracleAdapter(DatabaseAdapter):
+    name = "oracle"
+    capabilities = BackendCapabilities(
+        database_comments=False,
+        schema_comments=False,
+        materialized_view_comments=True,
+        materialized_views=True,
+        relationships=True,
+        row_count_stats=True,
+        stored_procedures=True,
+        functions=True,
+        sequences=True,
+        triggers=True,
+        packages=True,
+        synonyms=True,
+        user_defined_types=True,
+        comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
+    )
+
+    def create_engine(self) -> Engine:
+        return create_engine(self.cfg.url, pool_pre_ping=True)
+
+    def actionable_profile_error(self, exc: Exception) -> str | None:
+        msg = str(exc).lower()
+        if "ora-01017" in msg or "invalid username/password" in msg:
+            return (
+                "Oracle refused the credentials (ORA-01017). Check the "
+                "username/password and the case-sensitivity setting on the "
+                "server (12c+ defaults to case-sensitive passwords)."
+            )
+        if "ora-12541" in msg or "no listener" in msg:
+            return (
+                "Oracle listener is not reachable (ORA-12541). Check the "
+                "host/port and that the listener is running on the server."
+            )
+        if "ora-12514" in msg or "service" in msg and "not currently known" in msg:
+            return (
+                "Oracle listener doesn't know the service (ORA-12514). Set "
+                "`service_name` on the profile to match the value from "
+                "`lsnrctl status` on the server."
+            )
+        if "ora-00942" in msg or "table or view does not exist" in msg:
+            return (
+                "Oracle reported that a referenced table or view doesn't "
+                "exist (ORA-00942). The user may need SELECT_CATALOG_ROLE "
+                "for full introspection, or the object lives in a schema "
+                "the user can't see."
+            )
+        if "ora-01918" in msg or "user does not exist" in msg:
+            return (
+                "Oracle reported that the user doesn't exist (ORA-01918). "
+                "Check the username — Oracle stores it in upper case unless "
+                "quoted at create time."
+            )
+        return None
+
+    def system_schemas(self) -> frozenset[str]:
+        return _ORACLE_SYSTEM_SCHEMAS
+
+    def list_databases(self, engine: Engine) -> list[str]:
+        # Oracle's "schema = user" model means there's no separate
+        # database list; surface the user-visible schemas (owners with
+        # at least one table) as the closest analogue. The system-schema
+        # IN list is built from a static frozenset, not user input, so
+        # the literal interpolation is safe.
+        in_list = ", ".join(f"'{s}'" for s in sorted(_ORACLE_SYSTEM_SCHEMAS))
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    f"SELECT DISTINCT OWNER FROM ALL_TABLES "
+                    f"WHERE OWNER NOT IN ({in_list}) "
+                    f"ORDER BY OWNER"
+                )
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    # ── Column profiling ──────────────────────────────────────────────────
+
+    def column_stats_sql(self, fqn: str, quoted_col: str) -> str:
+        # Oracle's TO_CHAR coerces NUMBER/DATE/TIMESTAMP cleanly. CLOB
+        # and LONG types need DBMS_LOB.SUBSTR but those are rare in
+        # day-to-day OLTP — we accept the failure mode and let the
+        # profiler skip those columns.
+        return (
+            f"SELECT "
+            f"  SUM(CASE WHEN {quoted_col} IS NULL THEN 1 ELSE 0 END) AS null_cnt, "
+            f"  COUNT(DISTINCT {quoted_col}) AS dist_cnt, "
+            f"  TO_CHAR(MIN({quoted_col})) AS min_val, "
+            f"  TO_CHAR(MAX({quoted_col})) AS max_val "
+            f"FROM {fqn}"
+        )
+
+    def column_sample_sql(self, fqn: str, quoted_col: str) -> str:
+        # ROWNUM is the cross-version Oracle equivalent of LIMIT.
+        return (
+            f"SELECT * FROM ("
+            f"  SELECT DISTINCT TO_CHAR({quoted_col}) AS v FROM {fqn} "
+            f"  WHERE {quoted_col} IS NOT NULL"
+            f") WHERE ROWNUM <= :lim"
+        )
+
+    # ── Table stats ───────────────────────────────────────────────────────
+
+    def get_table_stats(self, engine: Engine, schema: str, table: str) -> dict[str, int]:
+        # NUM_ROWS is from the optimiser stats, refreshed by ANALYZE or
+        # DBMS_STATS. It can be stale — surface it anyway, the search
+        # agent should treat it as an estimate.
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT NUM_ROWS FROM ALL_TABLES "
+                    "WHERE OWNER = :owner AND TABLE_NAME = :tname"
+                ),
+                {"owner": schema.upper(), "tname": table.upper()},
+            ).fetchone()
+        n = int(row[0]) if row and row[0] is not None else 0
+        return {"seq_scan": 0, "idx_scan": 0, "n_live_tup": n}
+
+    def stats_label(self) -> str:
+        return "ALL_TABLES.NUM_ROWS (optimiser stats; may be stale)"
+
+    # ── Materialized views ────────────────────────────────────────────────
+
+    def list_materialized_views(self, engine: Engine, schema: str) -> list[str]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT MVIEW_NAME FROM ALL_MVIEWS "
+                    "WHERE OWNER = :owner ORDER BY MVIEW_NAME"
+                ),
+                {"owner": schema.upper()},
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    # ── Incoming foreign keys ─────────────────────────────────────────────
+
+    def get_incoming_foreign_keys(
+        self, engine: Engine, schema: str, table: str
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT
+                        src_cc.OWNER     AS source_schema,
+                        src_cc.TABLE_NAME AS source_table,
+                        src_cc.COLUMN_NAME AS source_column,
+                        tgt_cc.COLUMN_NAME AS target_column
+                    FROM ALL_CONSTRAINTS src
+                    JOIN ALL_CONS_COLUMNS src_cc
+                         ON src_cc.OWNER = src.OWNER
+                        AND src_cc.CONSTRAINT_NAME = src.CONSTRAINT_NAME
+                    JOIN ALL_CONS_COLUMNS tgt_cc
+                         ON tgt_cc.OWNER = src.R_OWNER
+                        AND tgt_cc.CONSTRAINT_NAME = src.R_CONSTRAINT_NAME
+                        AND tgt_cc.POSITION = src_cc.POSITION
+                    WHERE src.CONSTRAINT_TYPE = 'R'
+                      AND tgt_cc.OWNER = :owner
+                      AND tgt_cc.TABLE_NAME = :tname
+                    ORDER BY src_cc.OWNER, src_cc.TABLE_NAME, src_cc.COLUMN_NAME
+                    """
+                ),
+                {"owner": schema.upper(), "tname": table.upper()},
+            ).fetchall()
+        return [
+            {
+                "source_schema": str(r[0]),
+                "source_table": str(r[1]),
+                "source_column": str(r[2]),
+                "target_column": str(r[3]),
+            }
+            for r in rows
+        ]
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # ALL_PROCEDURES rows are duplicated when a procedure lives
+        # inside a package — restrict to standalone procedures
+        # (OBJECT_TYPE='PROCEDURE', PROCEDURE_NAME IS NULL).
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT OBJECT_NAME "
+                    "FROM ALL_PROCEDURES "
+                    "WHERE OWNER = :owner AND OBJECT_TYPE = 'PROCEDURE' "
+                    "AND PROCEDURE_NAME IS NULL "
+                    "ORDER BY OBJECT_NAME"
+                ),
+                {"owner": schema.upper()},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "procedure",
+                "definition": None,
+                "comment": None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT OBJECT_NAME "
+                    "FROM ALL_PROCEDURES "
+                    "WHERE OWNER = :owner AND OBJECT_TYPE = 'FUNCTION' "
+                    "AND PROCEDURE_NAME IS NULL "
+                    "ORDER BY OBJECT_NAME"
+                ),
+                {"owner": schema.upper()},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "function",
+                "definition": None,
+                "comment": None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
+    def list_packages(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # Packages are first-class — list them with their member
+        # procedure/function names rolled into the metadata so consumers
+        # get the contained-procedure surface for free.
+        with engine.connect() as conn:
+            pkg_rows = conn.execute(
+                text(
+                    "SELECT OBJECT_NAME, STATUS "
+                    "FROM ALL_OBJECTS "
+                    "WHERE OWNER = :owner AND OBJECT_TYPE = 'PACKAGE' "
+                    "ORDER BY OBJECT_NAME"
+                ),
+                {"owner": schema.upper()},
+            ).fetchall()
+            members_by_pkg: dict[str, list[dict[str, str]]] = {}
+            if pkg_rows:
+                pkg_names = [str(r[0]) for r in pkg_rows]
+                # ALL_PROCEDURES rows where OBJECT_TYPE=PACKAGE and
+                # PROCEDURE_NAME IS NOT NULL list the package members.
+                for pkg_name in pkg_names:
+                    member_rows = conn.execute(
+                        text(
+                            "SELECT PROCEDURE_NAME "
+                            "FROM ALL_PROCEDURES "
+                            "WHERE OWNER = :owner AND OBJECT_NAME = :pkg "
+                            "AND PROCEDURE_NAME IS NOT NULL "
+                            "ORDER BY PROCEDURE_NAME"
+                        ),
+                        {"owner": schema.upper(), "pkg": pkg_name},
+                    ).fetchall()
+                    members_by_pkg[pkg_name] = [
+                        {"name": str(m[0])} for m in member_rows
+                    ]
+        return [
+            {
+                "name": str(r[0]),
+                "type": "package",
+                "definition": None,
+                "comment": None,
+                "metadata": {
+                    "status": str(r[1]),
+                    "members": members_by_pkg.get(str(r[0]), []),
+                },
+            }
+            for r in pkg_rows
+        ]
+
+    def list_sequences(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT SEQUENCE_NAME, MIN_VALUE, MAX_VALUE, INCREMENT_BY, "
+                    "CYCLE_FLAG, CACHE_SIZE, LAST_NUMBER "
+                    "FROM ALL_SEQUENCES "
+                    "WHERE SEQUENCE_OWNER = :owner "
+                    "ORDER BY SEQUENCE_NAME"
+                ),
+                {"owner": schema.upper()},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "sequence",
+                "definition": None,
+                "comment": None,
+                "metadata": {
+                    "min": int(r[1]) if r[1] is not None else None,
+                    "max": int(r[2]) if r[2] is not None else None,
+                    "increment": int(r[3]) if r[3] is not None else None,
+                    "cycle": str(r[4]) == "Y",
+                    "cache_size": int(r[5]) if r[5] is not None else None,
+                    "last_number": int(r[6]) if r[6] is not None else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_triggers(
+        self, engine: Engine, schema: str, table: str | None = None
+    ) -> list[dict[str, Any]]:
+        sql = (
+            "SELECT TRIGGER_NAME, TRIGGER_TYPE, TRIGGERING_EVENT, "
+            "TABLE_NAME, STATUS, TRIGGER_BODY "
+            "FROM ALL_TRIGGERS "
+            "WHERE OWNER = :owner"
+        )
+        params: dict[str, Any] = {"owner": schema.upper()}
+        if table:
+            sql += " AND TABLE_NAME = :tname"
+            params["tname"] = table.upper()
+        sql += " ORDER BY TRIGGER_NAME"
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql), params).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "trigger",
+                "definition": str(r[5]) if r[5] else None,
+                "comment": None,
+                "metadata": {
+                    "trigger_type": str(r[1]) if r[1] else None,
+                    "event": str(r[2]) if r[2] else None,
+                    "table": str(r[3]) if r[3] else None,
+                    "status": str(r[4]) if r[4] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_synonyms(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT SYNONYM_NAME, TABLE_OWNER, TABLE_NAME, DB_LINK "
+                    "FROM ALL_SYNONYMS "
+                    "WHERE OWNER = :owner "
+                    "ORDER BY SYNONYM_NAME"
+                ),
+                {"owner": schema.upper()},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "synonym",
+                "definition": None,
+                "comment": None,
+                "metadata": {
+                    "target_owner": str(r[1]) if r[1] else None,
+                    "target": str(r[2]) if r[2] else None,
+                    "db_link": str(r[3]) if r[3] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_user_defined_types(
+        self, engine: Engine, schema: str
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT TYPE_NAME, TYPECODE, ATTRIBUTES "
+                    "FROM ALL_TYPES "
+                    "WHERE OWNER = :owner "
+                    "AND PREDEFINED = 'NO' "
+                    "ORDER BY TYPE_NAME"
+                ),
+                {"owner": schema.upper()},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": str(r[1]).lower() if r[1] else "udt",
+                "definition": None,
+                "comment": None,
+                "metadata": {
+                    "attribute_count": int(r[2]) if r[2] is not None else None,
+                },
+            }
+            for r in rows
+        ]
+
+    # ── Analytics metadata ────────────────────────────────────────────────
+
+    def get_analytics_metadata(self, engine: Engine, schema: str, table: str) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        warnings: list[str] = []
+
+        with engine.connect() as conn:
+            try:
+                row = conn.execute(
+                    text(
+                        "SELECT TABLESPACE_NAME, NUM_ROWS, LAST_ANALYZED, "
+                        "TEMPORARY, EXTERNAL "
+                        "FROM ALL_TABLES "
+                        "WHERE OWNER = :owner AND TABLE_NAME = :tname"
+                    ),
+                    {"owner": schema.upper(), "tname": table.upper()},
+                ).fetchone()
+                if row:
+                    if row[2]:
+                        out["last_modified"] = str(row[2])
+                    if str(row[3]) == "Y":
+                        out["table_type"] = "temporary"
+                    elif str(row[4]) == "YES":
+                        out["table_type"] = "external"
+                    else:
+                        out["table_type"] = "managed"
+                    out["storage_format"] = "native"
+            except Exception as exc:
+                warnings.append(f"table info: {exc}")
+
+            # Partition info
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT PARTITIONING_TYPE, "
+                        "(SELECT LISTAGG(COLUMN_NAME, ',') WITHIN GROUP (ORDER BY COLUMN_POSITION) "
+                        " FROM ALL_PART_KEY_COLUMNS k "
+                        " WHERE k.OWNER = pt.OWNER AND k.NAME = pt.TABLE_NAME) AS pkeys "
+                        "FROM ALL_PART_TABLES pt "
+                        "WHERE OWNER = :owner AND TABLE_NAME = :tname"
+                    ),
+                    {"owner": schema.upper(), "tname": table.upper()},
+                ).fetchone()
+                if rows and rows[0]:
+                    out["partition_strategy"] = str(rows[0]).lower()
+                    if rows[1]:
+                        out["partition_keys"] = [
+                            c.strip() for c in str(rows[1]).split(",") if c.strip()
+                        ]
+            except Exception as exc:
+                warnings.append(f"partitions: {exc}")
+
+            # Storage size
+            try:
+                row = conn.execute(
+                    text(
+                        "SELECT SUM(BYTES) FROM DBA_SEGMENTS "
+                        "WHERE OWNER = :owner AND SEGMENT_NAME = :tname"
+                    ),
+                    {"owner": schema.upper(), "tname": table.upper()},
+                ).fetchone()
+                if row and row[0] is not None:
+                    out["storage_bytes"] = int(row[0])
+            except Exception as exc:
+                # DBA_SEGMENTS often requires SELECT_CATALOG_ROLE — non-fatal.
+                warnings.append(f"storage size (DBA_SEGMENTS access?): {exc}")
+
+            # Indexes
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT i.INDEX_NAME, i.UNIQUENESS, ic.COLUMN_NAME, ic.COLUMN_POSITION "
+                        "FROM ALL_INDEXES i "
+                        "JOIN ALL_IND_COLUMNS ic "
+                        "  ON ic.INDEX_OWNER = i.OWNER AND ic.INDEX_NAME = i.INDEX_NAME "
+                        "WHERE i.TABLE_OWNER = :owner AND i.TABLE_NAME = :tname "
+                        "ORDER BY i.INDEX_NAME, ic.COLUMN_POSITION"
+                    ),
+                    {"owner": schema.upper(), "tname": table.upper()},
+                ).fetchall()
+                idx_map: dict[str, dict[str, Any]] = {}
+                for r in rows:
+                    name = str(r[0])
+                    bucket = idx_map.setdefault(
+                        name, {"name": name, "columns": [], "unique": str(r[1]) == "UNIQUE"}
+                    )
+                    bucket["columns"].append(str(r[2]))
+                if idx_map:
+                    out["indexes"] = list(idx_map.values())
+            except Exception as exc:
+                warnings.append(f"indexes: {exc}")
+
+        if warnings:
+            out["warnings"] = warnings
+        return out
+
+    # ── Comment writing ───────────────────────────────────────────────────
+
+    def set_table_comment_sql(self, schema: str, table: str, asset_keyword: str) -> str:
+        # Oracle's COMMENT statement: ``COMMENT ON TABLE <fqn> IS '...'``.
+        # MATERIALIZED VIEW is also accepted.
+        fqn = self.fully_qualified_name(schema, table)
+        return f"COMMENT ON {asset_keyword} {fqn} IS :cmt"
+
+    def set_column_comment_sql(self, schema: str, table: str, column: str) -> str:
+        fqn = self.fully_qualified_name(schema, table)
+        return f"COMMENT ON COLUMN {fqn}.{self.quote_identifier(column)} IS :cmt"
+
+    def set_schema_comment_sql(self, schema: str) -> str:
+        # Oracle has no schema-level COMMENT — schema = user.
+        raise self.unsupported("set_schema_comment_sql")
+
+    def set_database_comment_sql(self) -> str:
+        raise self.unsupported("set_database_comment_sql")
+
+    def comment_sql_with_params(
+        self, stmt_template: str, comment: str
+    ) -> tuple[str, dict[str, Any]]:
+        # Oracle's COMMENT ON DDL doesn't accept binds in every driver
+        # mode — inline the literal to be safe.
+        literal = self.quote_literal(comment)
+        return stmt_template.replace(":cmt", literal), {}

--- a/amx/db/adapters/oracle.py
+++ b/amx/db/adapters/oracle.py
@@ -33,7 +33,6 @@ from sqlalchemy.engine import Engine
 
 from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
 
-
 # Oracle ships with a long list of system schemas. Filtering them out
 # of the schema picker is the difference between "12 user schemas" and
 # "120 schemas, 90% of which are XDB / APEX / OLAP support".
@@ -188,8 +187,7 @@ class OracleAdapter(DatabaseAdapter):
         with engine.connect() as conn:
             row = conn.execute(
                 text(
-                    "SELECT NUM_ROWS FROM ALL_TABLES "
-                    "WHERE OWNER = :owner AND TABLE_NAME = :tname"
+                    "SELECT NUM_ROWS FROM ALL_TABLES WHERE OWNER = :owner AND TABLE_NAME = :tname"
                 ),
                 {"owner": schema.upper(), "tname": table.upper()},
             ).fetchone()
@@ -204,10 +202,7 @@ class OracleAdapter(DatabaseAdapter):
     def list_materialized_views(self, engine: Engine, schema: str) -> list[str]:
         with engine.connect() as conn:
             rows = conn.execute(
-                text(
-                    "SELECT MVIEW_NAME FROM ALL_MVIEWS "
-                    "WHERE OWNER = :owner ORDER BY MVIEW_NAME"
-                ),
+                text("SELECT MVIEW_NAME FROM ALL_MVIEWS WHERE OWNER = :owner ORDER BY MVIEW_NAME"),
                 {"owner": schema.upper()},
             ).fetchall()
         return [str(r[0]) for r in rows]
@@ -333,9 +328,7 @@ class OracleAdapter(DatabaseAdapter):
                         ),
                         {"owner": schema.upper(), "pkg": pkg_name},
                     ).fetchall()
-                    members_by_pkg[pkg_name] = [
-                        {"name": str(m[0])} for m in member_rows
-                    ]
+                    members_by_pkg[pkg_name] = [{"name": str(m[0])} for m in member_rows]
         return [
             {
                 "name": str(r[0]),
@@ -438,9 +431,7 @@ class OracleAdapter(DatabaseAdapter):
             for r in rows
         ]
 
-    def list_user_defined_types(
-        self, engine: Engine, schema: str
-    ) -> list[dict[str, Any]]:
+    def list_user_defined_types(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         with engine.connect() as conn:
             rows = conn.execute(
                 text(

--- a/amx/db/adapters/postgresql.py
+++ b/amx/db/adapters/postgresql.py
@@ -17,6 +17,11 @@ class PostgreSQLAdapter(DatabaseAdapter):
         materialized_views=True,
         relationships=True,
         row_count_stats=True,
+        stored_procedures=True,
+        functions=True,
+        sequences=True,
+        triggers=True,
+        user_defined_types=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
     )
 
@@ -223,6 +228,172 @@ class PostgreSQLAdapter(DatabaseAdapter):
                 "source_table": str(r[1]),
                 "source_column": str(r[2]),
                 "target_column": str(r[3]),
+            }
+            for r in rows
+        ]
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # PG 11+ distinguishes procedures (prokind='p') from functions
+        # ('f') and aggregates ('a'). Older PG only has functions, so
+        # this returns [] there — capability flag is True regardless.
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT p.proname, pg_get_functiondef(p.oid), "
+                        "obj_description(p.oid, 'pg_proc') "
+                        "FROM pg_proc p "
+                        "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                        "WHERE n.nspname = :schema AND p.prokind = 'p' "
+                        "ORDER BY p.proname"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "procedure",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT p.proname, pg_get_functiondef(p.oid), "
+                        "obj_description(p.oid, 'pg_proc'), l.lanname "
+                        "FROM pg_proc p "
+                        "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                        "JOIN pg_language l ON l.oid = p.prolang "
+                        "WHERE n.nspname = :schema AND p.prokind = 'f' "
+                        "ORDER BY p.proname"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+            except Exception:
+                # Pre-PG 11: prokind doesn't exist; fall back to all
+                # functions in the schema.
+                rows = conn.execute(
+                    text(
+                        "SELECT p.proname, NULL, obj_description(p.oid, 'pg_proc'), 'sql' "
+                        "FROM pg_proc p "
+                        "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                        "WHERE n.nspname = :schema "
+                        "ORDER BY p.proname"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "function",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {"language": str(r[3]) if r[3] else None},
+            }
+            for r in rows
+        ]
+
+    def list_sequences(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT c.relname, "
+                    "  obj_description(c.oid, 'pg_class') AS comment, "
+                    "  s.seqstart, s.seqincrement, s.seqmin, s.seqmax, s.seqcycle "
+                    "FROM pg_class c "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "LEFT JOIN pg_sequence s ON s.seqrelid = c.oid "
+                    "WHERE n.nspname = :schema AND c.relkind = 'S' "
+                    "ORDER BY c.relname"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "sequence",
+                "definition": None,
+                "comment": str(r[1]) if r[1] else None,
+                "metadata": {
+                    "start": int(r[2]) if r[2] is not None else None,
+                    "increment": int(r[3]) if r[3] is not None else None,
+                    "min": int(r[4]) if r[4] is not None else None,
+                    "max": int(r[5]) if r[5] is not None else None,
+                    "cycle": bool(r[6]) if r[6] is not None else False,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_triggers(
+        self, engine: Engine, schema: str, table: str | None = None
+    ) -> list[dict[str, Any]]:
+        sql = (
+            "SELECT t.tgname, c.relname AS table_name, "
+            "  pg_get_triggerdef(t.oid) AS def, t.tgenabled "
+            "FROM pg_trigger t "
+            "JOIN pg_class c ON c.oid = t.tgrelid "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = :schema AND NOT t.tgisinternal"
+        )
+        params: dict[str, Any] = {"schema": schema}
+        if table:
+            sql += " AND c.relname = :table"
+            params["table"] = table
+        sql += " ORDER BY t.tgname"
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql), params).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "trigger",
+                "definition": str(r[2]) if r[2] else None,
+                "comment": None,
+                "metadata": {
+                    "table": str(r[1]),
+                    "enabled": str(r[3]) != "D",  # 'D' = disabled
+                },
+            }
+            for r in rows
+        ]
+
+    def list_user_defined_types(
+        self, engine: Engine, schema: str
+    ) -> list[dict[str, Any]]:
+        # typtype: 'c'=composite, 'd'=domain, 'e'=enum, 'r'=range,
+        # 'm'=multirange. Skip table-row composites by filtering on
+        # typrelid=0 OR the relation isn't a table.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT t.typname, t.typtype, obj_description(t.oid, 'pg_type') "
+                    "FROM pg_type t "
+                    "JOIN pg_namespace n ON n.oid = t.typnamespace "
+                    "WHERE n.nspname = :schema "
+                    "AND t.typtype IN ('c','d','e','r','m') "
+                    "AND (t.typrelid = 0 OR (SELECT relkind FROM pg_class WHERE oid = t.typrelid) != 'r') "
+                    "ORDER BY t.typname"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        type_map = {"c": "composite", "d": "domain", "e": "enum", "r": "range", "m": "multirange"}
+        return [
+            {
+                "name": str(r[0]),
+                "type": type_map.get(str(r[1]), str(r[1])),
+                "definition": None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {},
             }
             for r in rows
         ]

--- a/amx/db/adapters/postgresql.py
+++ b/amx/db/adapters/postgresql.py
@@ -367,9 +367,7 @@ class PostgreSQLAdapter(DatabaseAdapter):
             for r in rows
         ]
 
-    def list_user_defined_types(
-        self, engine: Engine, schema: str
-    ) -> list[dict[str, Any]]:
+    def list_user_defined_types(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         # typtype: 'c'=composite, 'd'=domain, 'e'=enum, 'r'=range,
         # 'm'=multirange. Skip table-row composites by filtering on
         # typrelid=0 OR the relation isn't a table.

--- a/amx/db/adapters/redshift.py
+++ b/amx/db/adapters/redshift.py
@@ -1,0 +1,421 @@
+"""Amazon Redshift backend adapter.
+
+Driven by ``sqlalchemy-redshift`` over ``redshift_connector``.
+PostgreSQL wire-compatible — standard ``COMMENT ON``, the same
+``pg_catalog`` shape — but the analytically-interesting metadata
+lives in Redshift-specific ``SVV_*`` / ``STV_*`` views:
+
+* Distribution style and sort key (``SVV_TABLE_INFO``) — central to
+  Redshift performance tuning. Both surface in ``get_analytics_metadata``.
+* Column compression / encoding (``SVV_COLUMNS.compression``).
+* Materialized views (``STV_MV_INFO``).
+* External tables / Spectrum (``SVV_EXTERNAL_TABLES``,
+  ``SVV_EXTERNAL_SCHEMAS``) — querying S3 via the AWS Glue catalog.
+* Datashares (``SVV_DATASHARES``) — Redshift's cross-cluster sharing
+  primitive, no equivalent on PG.
+* Stored procedures + UDFs via ``pg_proc`` (PG-compatible catalogs).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
+
+
+class RedshiftAdapter(DatabaseAdapter):
+    name = "redshift"
+    capabilities = BackendCapabilities(
+        materialized_view_comments=True,
+        materialized_views=True,
+        relationships=True,
+        row_count_stats=True,
+        stored_procedures=True,
+        functions=True,
+        external_tables=True,
+        datashares=True,
+        comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
+    )
+
+    def create_engine(self) -> Engine:
+        return create_engine(self.cfg.url, pool_pre_ping=True)
+
+    def actionable_profile_error(self, exc: Exception) -> str | None:
+        msg = str(exc).lower()
+        if "password authentication failed" in msg:
+            return (
+                "Redshift refused the credentials. Check the username/password, "
+                "and that the user has CONNECT on the target database."
+            )
+        if "could not translate host name" in msg or "name or service not known" in msg:
+            return (
+                "Redshift cluster endpoint did not resolve. Check the host "
+                "(should look like `<id>.<region>.redshift.amazonaws.com`) "
+                "and your VPC/security group allows the connection."
+            )
+        if "permission denied" in msg or "must be owner" in msg:
+            return (
+                "Redshift denied access to a system view. Some `SVV_*` views "
+                "require SELECT on system tables — grant SELECT on "
+                "PG_CATALOG.* or run profiling as a higher-privileged role."
+            )
+        if "database" in msg and "does not exist" in msg:
+            return (
+                "Redshift refused: the `database` field on this profile points "
+                "at a database that doesn't exist on the cluster. Edit the "
+                "profile or create the database first."
+            )
+        return None
+
+    def system_schemas(self) -> frozenset[str]:
+        return frozenset(
+            {"pg_catalog", "pg_toast", "pg_internal", "information_schema", "catalog_history"}
+        )
+
+    def list_databases(self, engine: Engine) -> list[str]:
+        # Redshift Serverless / RA3 list visible databases via pg_database
+        # (PG-compatible) PLUS datashare-attached databases via
+        # SVV_REDSHIFT_DATABASES on newer versions.
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT database_name FROM SVV_REDSHIFT_DATABASES "
+                        "ORDER BY database_name"
+                    )
+                ).fetchall()
+            except Exception:
+                rows = conn.execute(
+                    text(
+                        "SELECT datname FROM pg_database "
+                        "WHERE datistemplate = false ORDER BY datname"
+                    )
+                ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    # ── Column profiling (PG-compatible) ─────────────────────────────────
+
+    def column_stats_sql(self, fqn: str, quoted_col: str) -> str:
+        # Redshift accepts FILTER and ::text casts identically to PG.
+        return (
+            f"SELECT "
+            f"  COUNT(*) FILTER (WHERE {quoted_col} IS NULL) AS null_cnt, "
+            f"  COUNT(DISTINCT {quoted_col}) AS dist_cnt, "
+            f"  MIN({quoted_col}::text) AS min_val, "
+            f"  MAX({quoted_col}::text) AS max_val "
+            f"FROM {fqn}"
+        )
+
+    def column_sample_sql(self, fqn: str, quoted_col: str) -> str:
+        return (
+            f"SELECT DISTINCT {quoted_col}::text FROM {fqn} "
+            f"WHERE {quoted_col} IS NOT NULL LIMIT :lim"
+        )
+
+    # ── Table stats ───────────────────────────────────────────────────────
+
+    def get_table_stats(self, engine: Engine, schema: str, table: str) -> dict[str, int]:
+        # SVV_TABLE_INFO.tbl_rows is the cluster-managed estimate.
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT COALESCE(tbl_rows, 0) FROM SVV_TABLE_INFO "
+                    "WHERE schema = :schema AND \"table\" = :table"
+                ),
+                {"schema": schema, "table": table},
+            ).fetchone()
+        n = int(row[0]) if row and row[0] is not None else 0
+        return {"seq_scan": 0, "idx_scan": 0, "n_live_tup": n}
+
+    def stats_label(self) -> str:
+        return "SVV_TABLE_INFO.tbl_rows"
+
+    def list_materialized_views(self, engine: Engine, schema: str) -> list[str]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT name FROM STV_MV_INFO "
+                    "WHERE schema = :schema ORDER BY name"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [str(r[0]) for r in rows]
+
+    # ── Schema comments (PG-compatible) ──────────────────────────────────
+
+    def get_schema_comment(self, engine: Engine, schema: str) -> str | None:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT obj_description(n.oid, 'pg_namespace') "
+                    "FROM pg_namespace n WHERE n.nspname = :schema"
+                ),
+                {"schema": schema},
+            ).fetchone()
+        return str(row[0]) if row and row[0] else None
+
+    def get_database_comment(self, engine: Engine) -> str | None:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT shobj_description(d.oid, 'pg_database') "
+                    "FROM pg_database d WHERE d.datname = current_database()"
+                )
+            ).fetchone()
+        return str(row[0]) if row and row[0] else None
+
+    # ── Incoming foreign keys (informational on Redshift) ────────────────
+
+    def get_incoming_foreign_keys(
+        self, engine: Engine, schema: str, table: str
+    ) -> list[dict[str, Any]]:
+        # Redshift accepts FK declarations but doesn't enforce them.
+        # The PG metadata catalogs still carry the relationships, so the
+        # PG query shape works.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT
+                        src_ns.nspname  AS source_schema,
+                        src.relname     AS source_table,
+                        src_col.attname AS source_column,
+                        tgt_col.attname AS target_column
+                    FROM pg_constraint con
+                    JOIN pg_class src ON src.oid = con.conrelid
+                    JOIN pg_namespace src_ns ON src_ns.oid = src.relnamespace
+                    JOIN pg_class tgt ON tgt.oid = con.confrelid
+                    JOIN pg_namespace tgt_ns ON tgt_ns.oid = tgt.relnamespace
+                    JOIN pg_attribute src_col
+                         ON src_col.attrelid = src.oid AND src_col.attnum = ANY(con.conkey)
+                    JOIN pg_attribute tgt_col
+                         ON tgt_col.attrelid = tgt.oid AND tgt_col.attnum = ANY(con.confkey)
+                    WHERE con.contype = 'f'
+                      AND tgt_ns.nspname = :schema
+                      AND tgt.relname    = :table
+                    ORDER BY src_ns.nspname, src.relname, src_col.attname
+                    """
+                ),
+                {"schema": schema, "table": table},
+            ).fetchall()
+        return [
+            {
+                "source_schema": str(r[0]),
+                "source_table": str(r[1]),
+                "source_column": str(r[2]),
+                "target_column": str(r[3]),
+            }
+            for r in rows
+        ]
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT p.proname, pg_get_functiondef(p.oid) AS body, "
+                    "obj_description(p.oid, 'pg_proc') AS comment "
+                    "FROM pg_proc p "
+                    "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                    "WHERE n.nspname = :schema "
+                    "AND p.prokind = 'p' "  # 'p' = procedure (Redshift adopted PG 11+ semantics)
+                    "ORDER BY p.proname"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "procedure",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # Includes both Python UDFs and SQL UDFs. Filter out aggregates
+        # and window functions since they don't map cleanly.
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT p.proname, pg_get_functiondef(p.oid) AS body, "
+                        "obj_description(p.oid, 'pg_proc') AS comment, "
+                        "p.prolang::regtype AS language "
+                        "FROM pg_proc p "
+                        "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                        "WHERE n.nspname = :schema "
+                        "AND p.prokind = 'f' "
+                        "ORDER BY p.proname"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+            except Exception:
+                # Some Redshift versions don't expose prokind. Fall back
+                # to the prouserdefined flag.
+                rows = conn.execute(
+                    text(
+                        "SELECT p.proname, NULL, NULL, NULL "
+                        "FROM pg_proc p "
+                        "JOIN pg_namespace n ON n.oid = p.pronamespace "
+                        "WHERE n.nspname = :schema "
+                        "AND p.prouserdefined = true "
+                        "ORDER BY p.proname"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "function",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {"language": str(r[3]) if r[3] else None},
+            }
+            for r in rows
+        ]
+
+    def list_external_tables(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # External tables are tied to external schemas (Glue / Hive /
+        # Redshift Spectrum). SVV_EXTERNAL_TABLES is the right view.
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT tablename, location, input_format, output_format, "
+                    "serialization_lib "
+                    "FROM SVV_EXTERNAL_TABLES "
+                    "WHERE schemaname = :schema "
+                    "ORDER BY tablename"
+                ),
+                {"schema": schema},
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": "external_table",
+                "definition": None,
+                "comment": None,
+                "metadata": {
+                    "location": str(r[1]) if r[1] else None,
+                    "input_format": str(r[2]) if r[2] else None,
+                    "output_format": str(r[3]) if r[3] else None,
+                    "serde": str(r[4]) if r[4] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    def list_datashares(self, engine: Engine) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT share_name, share_type, share_owner, source_database, "
+                    "consumer_namespace, status "
+                    "FROM SVV_DATASHARES "
+                    "ORDER BY share_name"
+                )
+            ).fetchall()
+        return [
+            {
+                "name": str(r[0]),
+                "type": str(r[1]) if r[1] else "datashare",
+                "definition": None,
+                "comment": None,
+                "metadata": {
+                    "owner": str(r[2]) if r[2] else None,
+                    "source_database": str(r[3]) if r[3] else None,
+                    "consumer_namespace": str(r[4]) if r[4] else None,
+                    "status": str(r[5]) if r[5] else None,
+                },
+            }
+            for r in rows
+        ]
+
+    # ── Analytics metadata (★ Redshift-specific dist/sort/encoding) ──────
+
+    def get_analytics_metadata(self, engine: Engine, schema: str, table: str) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        warnings: list[str] = []
+
+        with engine.connect() as conn:
+            try:
+                row = conn.execute(
+                    text(
+                        "SELECT diststyle, sortkey1, encoded, "
+                        "size, tbl_rows, unsorted, stats_off, "
+                        "vacuum_sort_benefit "
+                        "FROM SVV_TABLE_INFO "
+                        "WHERE schema = :schema AND \"table\" = :table"
+                    ),
+                    {"schema": schema, "table": table},
+                ).fetchone()
+                if row:
+                    if row[0]:
+                        # diststyle is e.g. 'EVEN', 'KEY(<col>)', 'ALL', 'AUTO(...)'
+                        out["partition_strategy"] = (
+                            "key" if str(row[0]).upper().startswith("KEY") else str(row[0]).lower()
+                        )
+                    if row[1]:
+                        out["clustering_keys"] = [str(row[1])]
+                    if row[3] is not None:
+                        # SVV_TABLE_INFO.size is in 1MB blocks.
+                        out["storage_bytes"] = int(row[3]) * 1024 * 1024
+                    out["table_type"] = "managed"
+                    out["storage_format"] = "native"
+                    metadata_extras = {
+                        "diststyle": str(row[0]) if row[0] else None,
+                        "sortkey1": str(row[1]) if row[1] else None,
+                        "encoded": str(row[2]) if row[2] else None,
+                        "unsorted_pct": float(row[5]) if row[5] is not None else None,
+                        "stats_off": float(row[6]) if row[6] is not None else None,
+                        "vacuum_sort_benefit": float(row[7]) if row[7] is not None else None,
+                    }
+                    out["redshift_table_info"] = {
+                        k: v for k, v in metadata_extras.items() if v is not None
+                    }
+            except Exception as exc:
+                warnings.append(f"SVV_TABLE_INFO: {exc}")
+
+            # Per-column compression / encoding.
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT column_name, encoding "
+                        "FROM SVV_COLUMNS "
+                        "WHERE table_schema = :schema AND table_name = :table "
+                        "ORDER BY ordinal_position"
+                    ),
+                    {"schema": schema, "table": table},
+                ).fetchall()
+                if rows:
+                    out["column_encodings"] = {
+                        str(r[0]): str(r[1]) for r in rows if r[1]
+                    }
+            except Exception as exc:
+                warnings.append(f"column encodings: {exc}")
+
+        if warnings:
+            out["warnings"] = warnings
+        return out
+
+    # ── Comment writing (PG-compatible) ──────────────────────────────────
+
+    def set_table_comment_sql(self, schema: str, table: str, asset_keyword: str) -> str:
+        fqn = self.fully_qualified_name(schema, table)
+        return f"COMMENT ON {asset_keyword} {fqn} IS :cmt"
+
+    def set_column_comment_sql(self, schema: str, table: str, column: str) -> str:
+        fqn = self.fully_qualified_name(schema, table)
+        return f"COMMENT ON COLUMN {fqn}.{self.quote_identifier(column)} IS :cmt"
+
+    def set_schema_comment_sql(self, schema: str) -> str:
+        return f"COMMENT ON SCHEMA {self.quote_identifier(schema)} IS :cmt"
+
+    def set_database_comment_sql(self) -> str:
+        return f"COMMENT ON DATABASE {self.quote_identifier(self.cfg.database)} IS :cmt"

--- a/amx/db/adapters/redshift.py
+++ b/amx/db/adapters/redshift.py
@@ -82,10 +82,7 @@ class RedshiftAdapter(DatabaseAdapter):
         with engine.connect() as conn:
             try:
                 rows = conn.execute(
-                    text(
-                        "SELECT database_name FROM SVV_REDSHIFT_DATABASES "
-                        "ORDER BY database_name"
-                    )
+                    text("SELECT database_name FROM SVV_REDSHIFT_DATABASES ORDER BY database_name")
                 ).fetchall()
             except Exception:
                 rows = conn.execute(
@@ -123,7 +120,7 @@ class RedshiftAdapter(DatabaseAdapter):
             row = conn.execute(
                 text(
                     "SELECT COALESCE(tbl_rows, 0) FROM SVV_TABLE_INFO "
-                    "WHERE schema = :schema AND \"table\" = :table"
+                    'WHERE schema = :schema AND "table" = :table'
                 ),
                 {"schema": schema, "table": table},
             ).fetchone()
@@ -136,10 +133,7 @@ class RedshiftAdapter(DatabaseAdapter):
     def list_materialized_views(self, engine: Engine, schema: str) -> list[str]:
         with engine.connect() as conn:
             rows = conn.execute(
-                text(
-                    "SELECT name FROM STV_MV_INFO "
-                    "WHERE schema = :schema ORDER BY name"
-                ),
+                text("SELECT name FROM STV_MV_INFO WHERE schema = :schema ORDER BY name"),
                 {"schema": schema},
             ).fetchall()
         return [str(r[0]) for r in rows]
@@ -351,7 +345,7 @@ class RedshiftAdapter(DatabaseAdapter):
                         "size, tbl_rows, unsorted, stats_off, "
                         "vacuum_sort_benefit "
                         "FROM SVV_TABLE_INFO "
-                        "WHERE schema = :schema AND \"table\" = :table"
+                        'WHERE schema = :schema AND "table" = :table'
                     ),
                     {"schema": schema, "table": table},
                 ).fetchone()
@@ -394,9 +388,7 @@ class RedshiftAdapter(DatabaseAdapter):
                     {"schema": schema, "table": table},
                 ).fetchall()
                 if rows:
-                    out["column_encodings"] = {
-                        str(r[0]): str(r[1]) for r in rows if r[1]
-                    }
+                    out["column_encodings"] = {str(r[0]): str(r[1]) for r in rows if r[1]}
             except Exception as exc:
                 warnings.append(f"column encodings: {exc}")
 

--- a/amx/db/adapters/snowflake.py
+++ b/amx/db/adapters/snowflake.py
@@ -18,6 +18,13 @@ class SnowflakeAdapter(DatabaseAdapter):
         relationships=True,
         row_count_stats=True,
         full_scan_when_row_count_unknown=False,
+        stored_procedures=True,
+        functions=True,
+        sequences=True,
+        events=True,  # SHOW TASKS — Snowflake's scheduled jobs
+        volumes=True,  # SHOW STAGES — Snowflake's file-storage primitive
+        datashares=True,
+        external_tables=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
     )
 
@@ -194,6 +201,106 @@ class SnowflakeAdapter(DatabaseAdapter):
         except Exception as exc:
             actionable = self.actionable_profile_error(exc)
             raise RuntimeError(actionable or str(exc)) from exc
+
+    # ── Extended object types ─────────────────────────────────────────────
+
+    def _show_to_dicts(
+        self,
+        engine: Engine,
+        sql: str,
+        type_label: str,
+        name_keys: tuple[str, ...] = ("name", "NAME"),
+        comment_keys: tuple[str, ...] = ("comment", "COMMENT"),
+        extra_keys: tuple[str, ...] = (),
+    ) -> list[dict[str, Any]]:
+        """Run a Snowflake ``SHOW`` statement and reshape the rows into the
+        adapter's uniform list-result dict shape. ``SHOW`` returns rows
+        with mixed-case column names that depend on the object type;
+        we look at both upper- and lower-case variants to be safe.
+        """
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql)).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            mapping = row._mapping if hasattr(row, "_mapping") else {}
+
+            def _pick(keys: tuple[str, ...]) -> Any:
+                for k in keys:
+                    if k in mapping and mapping[k] is not None:
+                        return mapping[k]
+                return None
+
+            name = _pick(name_keys)
+            if name is None:
+                continue
+            extras: dict[str, Any] = {}
+            for k in extra_keys:
+                v = mapping.get(k)
+                if v is None:
+                    v = mapping.get(k.upper())
+                if v is not None:
+                    extras[k.lower()] = v if isinstance(v, (str, int, float, bool)) else str(v)
+            out.append(
+                {
+                    "name": str(name),
+                    "type": type_label,
+                    "definition": None,
+                    "comment": str(_pick(comment_keys)) if _pick(comment_keys) else None,
+                    "metadata": extras,
+                }
+            )
+        return out
+
+    def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        sql = f"SHOW PROCEDURES IN SCHEMA {self.quote_identifier(schema)}"
+        return self._show_to_dicts(
+            engine, sql, "procedure", extra_keys=("arguments", "language")
+        )
+
+    def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        sql = f"SHOW USER FUNCTIONS IN SCHEMA {self.quote_identifier(schema)}"
+        return self._show_to_dicts(
+            engine, sql, "function", extra_keys=("arguments", "language")
+        )
+
+    def list_sequences(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        sql = f"SHOW SEQUENCES IN SCHEMA {self.quote_identifier(schema)}"
+        return self._show_to_dicts(
+            engine, sql, "sequence", extra_keys=("interval", "next_value")
+        )
+
+    def list_events(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        # Snowflake "tasks" are scheduled SQL statements — the closest
+        # analogue to MySQL events / SQL Server Agent jobs.
+        sql = f"SHOW TASKS IN SCHEMA {self.quote_identifier(schema)}"
+        return self._show_to_dicts(
+            engine, sql, "task", extra_keys=("schedule", "state", "warehouse", "definition")
+        )
+
+    def list_volumes(
+        self, engine: Engine, catalog: str, schema: str
+    ) -> list[dict[str, Any]]:
+        # Snowflake stages — internal or external file-storage. ``catalog``
+        # arg is unused (Snowflake stages are schema-scoped).
+        sql = f"SHOW STAGES IN SCHEMA {self.quote_identifier(schema)}"
+        return self._show_to_dicts(
+            engine, sql, "stage", extra_keys=("type", "url", "cloud", "region")
+        )
+
+    def list_datashares(self, engine: Engine) -> list[dict[str, Any]]:
+        # SHOW SHARES is account-level. Listing both inbound and
+        # outbound shares; the ``kind`` column distinguishes.
+        return self._show_to_dicts(
+            engine, "SHOW SHARES", "share", name_keys=("name", "NAME"),
+            extra_keys=("kind", "owner_account", "to_accounts", "listing_global_name"),
+        )
+
+    def list_external_tables(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
+        sql = f"SHOW EXTERNAL TABLES IN SCHEMA {self.quote_identifier(schema)}"
+        return self._show_to_dicts(
+            engine, sql, "external_table",
+            extra_keys=("location", "file_format_name", "auto_refresh"),
+        )
 
     # ── Analytics metadata ────────────────────────────────────────────────
 

--- a/amx/db/adapters/snowflake.py
+++ b/amx/db/adapters/snowflake.py
@@ -220,17 +220,17 @@ class SnowflakeAdapter(DatabaseAdapter):
         """
         with engine.connect() as conn:
             rows = conn.execute(text(sql)).fetchall()
+
+        def _pick(mapping: Any, keys: tuple[str, ...]) -> Any:
+            for k in keys:
+                if k in mapping and mapping[k] is not None:
+                    return mapping[k]
+            return None
+
         out: list[dict[str, Any]] = []
         for row in rows:
             mapping = row._mapping if hasattr(row, "_mapping") else {}
-
-            def _pick(keys: tuple[str, ...]) -> Any:
-                for k in keys:
-                    if k in mapping and mapping[k] is not None:
-                        return mapping[k]
-                return None
-
-            name = _pick(name_keys)
+            name = _pick(mapping, name_keys)
             if name is None:
                 continue
             extras: dict[str, Any] = {}
@@ -240,12 +240,13 @@ class SnowflakeAdapter(DatabaseAdapter):
                     v = mapping.get(k.upper())
                 if v is not None:
                     extras[k.lower()] = v if isinstance(v, (str, int, float, bool)) else str(v)
+            comment = _pick(mapping, comment_keys)
             out.append(
                 {
                     "name": str(name),
                     "type": type_label,
                     "definition": None,
-                    "comment": str(_pick(comment_keys)) if _pick(comment_keys) else None,
+                    "comment": str(comment) if comment else None,
                     "metadata": extras,
                 }
             )
@@ -253,21 +254,15 @@ class SnowflakeAdapter(DatabaseAdapter):
 
     def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         sql = f"SHOW PROCEDURES IN SCHEMA {self.quote_identifier(schema)}"
-        return self._show_to_dicts(
-            engine, sql, "procedure", extra_keys=("arguments", "language")
-        )
+        return self._show_to_dicts(engine, sql, "procedure", extra_keys=("arguments", "language"))
 
     def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         sql = f"SHOW USER FUNCTIONS IN SCHEMA {self.quote_identifier(schema)}"
-        return self._show_to_dicts(
-            engine, sql, "function", extra_keys=("arguments", "language")
-        )
+        return self._show_to_dicts(engine, sql, "function", extra_keys=("arguments", "language"))
 
     def list_sequences(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         sql = f"SHOW SEQUENCES IN SCHEMA {self.quote_identifier(schema)}"
-        return self._show_to_dicts(
-            engine, sql, "sequence", extra_keys=("interval", "next_value")
-        )
+        return self._show_to_dicts(engine, sql, "sequence", extra_keys=("interval", "next_value"))
 
     def list_events(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         # Snowflake "tasks" are scheduled SQL statements — the closest
@@ -277,9 +272,7 @@ class SnowflakeAdapter(DatabaseAdapter):
             engine, sql, "task", extra_keys=("schedule", "state", "warehouse", "definition")
         )
 
-    def list_volumes(
-        self, engine: Engine, catalog: str, schema: str
-    ) -> list[dict[str, Any]]:
+    def list_volumes(self, engine: Engine, catalog: str, schema: str) -> list[dict[str, Any]]:
         # Snowflake stages — internal or external file-storage. ``catalog``
         # arg is unused (Snowflake stages are schema-scoped).
         sql = f"SHOW STAGES IN SCHEMA {self.quote_identifier(schema)}"
@@ -291,14 +284,19 @@ class SnowflakeAdapter(DatabaseAdapter):
         # SHOW SHARES is account-level. Listing both inbound and
         # outbound shares; the ``kind`` column distinguishes.
         return self._show_to_dicts(
-            engine, "SHOW SHARES", "share", name_keys=("name", "NAME"),
+            engine,
+            "SHOW SHARES",
+            "share",
+            name_keys=("name", "NAME"),
             extra_keys=("kind", "owner_account", "to_accounts", "listing_global_name"),
         )
 
     def list_external_tables(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         sql = f"SHOW EXTERNAL TABLES IN SCHEMA {self.quote_identifier(schema)}"
         return self._show_to_dicts(
-            engine, sql, "external_table",
+            engine,
+            sql,
+            "external_table",
             extra_keys=("location", "file_format_name", "auto_refresh"),
         )
 

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -370,6 +370,83 @@ class DatabaseConnector:
             return []
         return self._adapter.list_materialized_views(self.engine, schema)
 
+    # ── Extended object types ─────────────────────────────────────────────
+    #
+    # Each accessor is gated by the matching ``BackendCapabilities`` flag
+    # so unsupported backends short-circuit without firing a query.
+    # Adapter exceptions degrade to ``[]`` with a debug-level log entry,
+    # mirroring the ``list_databases`` resilience pattern — a single
+    # permission failure should never tank a wider listing operation.
+
+    def _list_extended(
+        self,
+        flag_name: str,
+        method_name: str,
+        *args: Any,
+    ) -> list[dict[str, Any]]:
+        if not getattr(self.capabilities, flag_name, False):
+            return []
+        try:
+            return list(getattr(self._adapter, method_name)(self.engine, *args))
+        except Exception as exc:
+            log.debug("%s failed: %s", method_name, exc)
+            return []
+
+    def list_stored_procedures(self, schema: str) -> list[dict[str, Any]]:
+        return self._list_extended("stored_procedures", "list_stored_procedures", schema)
+
+    def list_functions(self, schema: str) -> list[dict[str, Any]]:
+        return self._list_extended("functions", "list_functions", schema)
+
+    def list_sequences(self, schema: str) -> list[dict[str, Any]]:
+        return self._list_extended("sequences", "list_sequences", schema)
+
+    def list_triggers(
+        self, schema: str, table: str | None = None
+    ) -> list[dict[str, Any]]:
+        return self._list_extended("triggers", "list_triggers", schema, table)
+
+    def list_events(self, schema: str) -> list[dict[str, Any]]:
+        return self._list_extended("events", "list_events", schema)
+
+    def list_packages(self, schema: str) -> list[dict[str, Any]]:
+        return self._list_extended("packages", "list_packages", schema)
+
+    def list_synonyms(self, schema: str) -> list[dict[str, Any]]:
+        return self._list_extended("synonyms", "list_synonyms", schema)
+
+    def list_user_defined_types(self, schema: str) -> list[dict[str, Any]]:
+        return self._list_extended("user_defined_types", "list_user_defined_types", schema)
+
+    def list_dictionaries(self, database: str | None = None) -> list[dict[str, Any]]:
+        # ClickHouse exposes dictionaries by *database* — defaults to the
+        # connection's current database when not passed.
+        db = database if database is not None else getattr(self.cfg, "database", "") or ""
+        return self._list_extended("dictionaries", "list_dictionaries", db)
+
+    def list_macros(self, schema: str) -> list[dict[str, Any]]:
+        return self._list_extended("macros", "list_macros", schema)
+
+    def list_volumes(
+        self, schema: str, catalog: str | None = None
+    ) -> list[dict[str, Any]]:
+        cat = catalog if catalog is not None else getattr(self.cfg, "catalog", "") or ""
+        return self._list_extended("volumes", "list_volumes", cat, schema)
+
+    def list_datashares(self) -> list[dict[str, Any]]:
+        # No schema / catalog argument — datashares live at the cluster /
+        # account level on every backend that supports them.
+        if not self.capabilities.datashares:
+            return []
+        try:
+            return list(self._adapter.list_datashares(self.engine))
+        except Exception as exc:
+            log.debug("list_datashares failed: %s", exc)
+            return []
+
+    def list_external_tables(self, schema: str) -> list[dict[str, Any]]:
+        return self._list_extended("external_tables", "list_external_tables", schema)
+
     def list_assets(self, schema: str) -> list[tuple[str, AssetKind]]:
         """All analyzable assets (tables, views, materialized views) in a schema."""
         assets: list[tuple[str, AssetKind]] = []

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -401,9 +401,7 @@ class DatabaseConnector:
     def list_sequences(self, schema: str) -> list[dict[str, Any]]:
         return self._list_extended("sequences", "list_sequences", schema)
 
-    def list_triggers(
-        self, schema: str, table: str | None = None
-    ) -> list[dict[str, Any]]:
+    def list_triggers(self, schema: str, table: str | None = None) -> list[dict[str, Any]]:
         return self._list_extended("triggers", "list_triggers", schema, table)
 
     def list_events(self, schema: str) -> list[dict[str, Any]]:
@@ -427,9 +425,7 @@ class DatabaseConnector:
     def list_macros(self, schema: str) -> list[dict[str, Any]]:
         return self._list_extended("macros", "list_macros", schema)
 
-    def list_volumes(
-        self, schema: str, catalog: str | None = None
-    ) -> list[dict[str, Any]]:
+    def list_volumes(self, schema: str, catalog: str | None = None) -> list[dict[str, Any]]:
         cat = catalog if catalog is not None else getattr(self.cfg, "catalog", "") or ""
         return self._list_extended("volumes", "list_volumes", cat, schema)
 

--- a/docs/design/multi-db-plan.md
+++ b/docs/design/multi-db-plan.md
@@ -408,3 +408,65 @@ Each phase is its own PR, merged into the umbrella branch
    detects the historical default value, emit a single-line warn
    in `/db-profiles` and the startup summary suggesting the user
    run `/edit` to clear it. We never touch their YAML.
+
+---
+
+## 9. Phase 2 — six new backends + extended object model (2026-05)
+
+After 0.11 stabilised the 4-backend matrix, Phase 2 added MySQL, Oracle,
+SQL Server, Redshift, ClickHouse, and DuckDB **and** extended the adapter
+contract to model object types beyond tables/views.
+
+### 9.1 Per-backend object inventory
+
+What each backend exposes that AMX consumes. ✓ = supported, ★ = backend-distinctive.
+
+| Object              | PG | SF | DBX | BQ | MySQL | Oracle | MSSQL | Redshift | ClickHouse | DuckDB |
+|---------------------|----|----|-----|----|-------|--------|-------|----------|------------|--------|
+| Tables              | ✓  | ✓  | ✓   | ✓  | ✓     | ✓      | ✓     | ✓        | ✓          | ✓      |
+| Views               | ✓  | ✓  | ✓   | ✓  | ✓     | ✓      | ✓     | ✓        | ✓          | ✓      |
+| Materialized views  | ✓  | ✓  | –   | ✓  | –     | ✓      | –     | ✓        | ✓          | –      |
+| External tables     | –  | ✓  | ✓   | ✓  | –     | –      | –     | ✓ (Spectrum) ★ | – | ✓ (Parquet/S3) |
+| Stored procedures   | ✓  | ✓  | –   | ✓  | ✓     | ✓      | ✓     | ✓        | –          | –      |
+| Functions / UDFs    | ✓  | ✓  | ✓   | ✓  | ✓     | ✓      | ✓     | ✓        | ✓          | ✓      |
+| Sequences           | ✓  | ✓  | –   | –  | –     | ✓      | ✓     | –        | –          | ✓      |
+| Triggers            | ✓  | –  | –   | –  | ✓     | ✓      | ✓     | –        | –          | –      |
+| Events / scheduled  | –  | ✓ (tasks) | – | –  | ✓ ★ (events) | – | – | – | – | – |
+| Packages            | –  | –  | –   | –  | –     | ✓ ★    | –     | –        | –          | –      |
+| Synonyms            | –  | –  | –   | –  | –     | ✓      | ✓     | –        | –          | –      |
+| User-defined types  | ✓  | –  | –   | –  | –     | ✓      | –     | –        | –          | –      |
+| Dictionaries        | –  | –  | –   | –  | –     | –      | –     | –        | ✓ ★        | –      |
+| Macros              | –  | –  | –   | –  | –     | –      | –     | –        | –          | ✓ ★    |
+| Volumes / stages    | –  | ✓ (stages) | ✓ ★ | – | – | – | – | – | – | – |
+| Datashares          | –  | ✓  | –   | –  | –     | –      | –     | ✓        | –          | –      |
+| Dist/Sort keys      | –  | –  | –   | –  | –     | –      | –     | ✓ ★      | –          | –      |
+| Storage engine      | –  | –  | –   | –  | ✓ ★ (InnoDB/MyISAM) | – | – | – | ✓ ★ (MergeTree) | – |
+
+### 9.2 Contract extension
+
+* `BackendCapabilities` gained 13 new flags (`stored_procedures`, `functions`,
+  `sequences`, `triggers`, `events`, `packages`, `synonyms`,
+  `user_defined_types`, `dictionaries`, `macros`, `volumes`, `datashares`,
+  `external_tables`).
+* `DatabaseAdapter` gained matching `list_<object>()` methods. Each defaults
+  to `[]` so existing adapters stay untouched until they opt in.
+* Each method returns a list of dicts shaped
+  `{name, type, definition, comment, metadata}` — uniform enough that
+  search/index can treat them generically, loose enough that backend-specific
+  fields (Snowflake task schedule, ClickHouse dictionary layout, Oracle
+  package members) fit in `metadata`.
+* `DatabaseConnector` exposes capability-gated wrappers for each method.
+  Adapter exceptions degrade to `[]` with a debug-level log entry, mirroring
+  the `list_databases` resilience pattern.
+
+### 9.3 Driver packaging
+
+Database driver dependencies migrated from `[project.dependencies]` to
+`[project.optional-dependencies]` extras — one extra per backend, plus an
+`all` extra for "give me everything" (~100MB+ of drivers). `get_adapter()`
+catches the first-use `ImportError` and raises `MissingDriverError` with
+the concrete `pip install amx[<extra>]` hint.
+
+This is a breaking install-time change; existing users must reinstall with
+the relevant extras. The migration is documented in CHANGELOG and surfaces
+on first use of an unconfigured backend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "rich>=13.0",
     "prompt_toolkit>=3.0.40",
     "sqlalchemy>=2.0",
-    "psycopg2-binary>=2.9",
     "pandas>=2.0",
     "chromadb>=0.5",
     "langchain>=0.3",
@@ -68,12 +67,6 @@ dependencies = [
     "google-api-python-client>=2.0",
     "google-auth>=2.0",
     "msal>=1.24",
-    "snowflake-sqlalchemy>=1.6",
-    "snowflake-connector-python>=3.6",
-    "databricks-sqlalchemy>=1.0",
-    "databricks-sql-connector>=3.0",
-    "sqlalchemy-bigquery>=1.9",
-    "google-cloud-bigquery>=3.13",
     "keyring>=24.0",
 ]
 
@@ -89,6 +82,53 @@ code-intel = [
 ]
 local-embeddings = [
     "sentence-transformers>=3.0",
+]
+# ── Database backend extras ───────────────────────────────────────────────
+# Each backend's drivers live in their own extra so the default install
+# stays lean. Pick what you use:
+#   pip install amx[postgresql]      # one backend
+#   pip install amx[postgresql,mysql,duckdb]  # several
+#   pip install amx[all]             # every backend (~100MB+ of drivers)
+postgresql = ["psycopg2-binary>=2.9"]
+snowflake = [
+    "snowflake-sqlalchemy>=1.6",
+    "snowflake-connector-python>=3.6",
+]
+databricks = [
+    "databricks-sqlalchemy>=1.0",
+    "databricks-sql-connector>=3.0",
+]
+bigquery = [
+    "sqlalchemy-bigquery>=1.9",
+    "google-cloud-bigquery>=3.13",
+]
+mysql = ["pymysql>=1.1", "cryptography>=42.0"]
+oracle = ["oracledb>=2.0"]
+mssql = ["pyodbc>=5.0"]
+redshift = ["redshift_connector>=2.1", "sqlalchemy-redshift>=0.8"]
+clickhouse = [
+    "clickhouse-connect>=0.7",
+    "clickhouse-sqlalchemy>=0.3",
+]
+duckdb = ["duckdb-engine>=0.13", "duckdb>=1.0"]
+all = [
+    "psycopg2-binary>=2.9",
+    "snowflake-sqlalchemy>=1.6",
+    "snowflake-connector-python>=3.6",
+    "databricks-sqlalchemy>=1.0",
+    "databricks-sql-connector>=3.0",
+    "sqlalchemy-bigquery>=1.9",
+    "google-cloud-bigquery>=3.13",
+    "pymysql>=1.1",
+    "cryptography>=42.0",
+    "oracledb>=2.0",
+    "pyodbc>=5.0",
+    "redshift_connector>=2.1",
+    "sqlalchemy-redshift>=0.8",
+    "clickhouse-connect>=0.7",
+    "clickhouse-sqlalchemy>=0.3",
+    "duckdb-engine>=0.13",
+    "duckdb>=1.0",
 ]
 dev = [
     "pytest>=8.0",

--- a/tests/test_db_multi_backend_expansion.py
+++ b/tests/test_db_multi_backend_expansion.py
@@ -25,21 +25,26 @@ from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
 def _fixture(backend: str) -> dict[str, object]:
     """Minimal DBConfig kwargs that satisfy is_connection_configured for *backend*."""
     return {
-        "postgresql": dict(host="db.example.com", user="alice"),
-        "snowflake": dict(account="acc.example", user="alice"),
-        "databricks": dict(host="adb.example.com", access_token="tok"),
-        "bigquery": dict(project="my-project"),
-        "mysql": dict(host="mysql.example.com", user="alice", password="x"),
-        "oracle": dict(host="ora.example.com", user="APP", password="x", service_name="XEPDB1"),
-        "mssql": dict(host="mssql.example.com", user="sa", password="x"),
-        "redshift": dict(
-            host="cluster.xyz.eu-west-1.redshift.amazonaws.com",
-            user="admin",
-            password="x",
-            database="dev",
-        ),
-        "clickhouse": dict(host="ch.example.com", user="default"),
-        "duckdb": dict(database="/tmp/x.duckdb"),
+        "postgresql": {"host": "db.example.com", "user": "alice"},
+        "snowflake": {"account": "acc.example", "user": "alice"},
+        "databricks": {"host": "adb.example.com", "access_token": "tok"},
+        "bigquery": {"project": "my-project"},
+        "mysql": {"host": "mysql.example.com", "user": "alice", "password": "x"},
+        "oracle": {
+            "host": "ora.example.com",
+            "user": "APP",
+            "password": "x",
+            "service_name": "XEPDB1",
+        },
+        "mssql": {"host": "mssql.example.com", "user": "sa", "password": "x"},
+        "redshift": {
+            "host": "cluster.xyz.eu-west-1.redshift.amazonaws.com",
+            "user": "admin",
+            "password": "x",
+            "database": "dev",
+        },
+        "clickhouse": {"host": "ch.example.com", "user": "default"},
+        "duckdb": {"database": "/tmp/x.duckdb"},
     }[backend]
 
 

--- a/tests/test_db_multi_backend_expansion.py
+++ b/tests/test_db_multi_backend_expansion.py
@@ -1,0 +1,283 @@
+"""Multi-backend expansion (Phase 2): MySQL, Oracle, SQL Server, Redshift,
+ClickHouse, DuckDB.
+
+These tests pin:
+
+* Every name in ``SUPPORTED_BACKENDS`` resolves to an adapter class.
+* Each adapter declares a coherent ``BackendCapabilities`` (no abstract
+  method left unimplemented; ``name`` is set).
+* Each new backend's ``DBConfig.url`` builds a sensible SQLAlchemy URL
+  with the canonical port substituted when the user didn't pick one.
+* ``is_connection_configured`` and ``is_database_pinned`` return the
+  expected booleans for each new backend.
+* ``_db_to_mapping`` / ``_db_from_mapping`` round-trip the new fields.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amx.config import DBConfig, _db_from_mapping, _db_to_mapping
+from amx.db.adapters import SUPPORTED_BACKENDS, get_adapter
+from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
+
+
+def _fixture(backend: str) -> dict[str, object]:
+    """Minimal DBConfig kwargs that satisfy is_connection_configured for *backend*."""
+    return {
+        "postgresql": dict(host="db.example.com", user="alice"),
+        "snowflake": dict(account="acc.example", user="alice"),
+        "databricks": dict(host="adb.example.com", access_token="tok"),
+        "bigquery": dict(project="my-project"),
+        "mysql": dict(host="mysql.example.com", user="alice", password="x"),
+        "oracle": dict(host="ora.example.com", user="APP", password="x", service_name="XEPDB1"),
+        "mssql": dict(host="mssql.example.com", user="sa", password="x"),
+        "redshift": dict(
+            host="cluster.xyz.eu-west-1.redshift.amazonaws.com",
+            user="admin",
+            password="x",
+            database="dev",
+        ),
+        "clickhouse": dict(host="ch.example.com", user="default"),
+        "duckdb": dict(database="/tmp/x.duckdb"),
+    }[backend]
+
+
+# ── Registry ──────────────────────────────────────────────────────────────
+
+
+def test_all_backends_resolve_through_get_adapter():
+    """Every supported backend instantiates without a live connection."""
+    for backend in SUPPORTED_BACKENDS:
+        cfg = DBConfig(backend=backend, **_fixture(backend))
+        adapter = get_adapter(cfg)
+        assert isinstance(adapter, DatabaseAdapter)
+        assert adapter.name == backend
+
+
+def test_unknown_backend_raises_valueerror():
+    cfg = DBConfig(backend="cassandra", host="x", user="y")
+    with pytest.raises(ValueError, match="Unknown database backend"):
+        get_adapter(cfg)
+
+
+# ── Per-adapter contract ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("backend", SUPPORTED_BACKENDS)
+def test_adapter_declares_capabilities(backend: str):
+    """Adapter must expose a BackendCapabilities instance."""
+    cfg = DBConfig(backend=backend, **_fixture(backend))
+    adapter = get_adapter(cfg)
+    assert isinstance(adapter.capabilities, BackendCapabilities)
+
+
+@pytest.mark.parametrize("backend", SUPPORTED_BACKENDS)
+def test_adapter_implements_required_dml_templates(backend: str):
+    """Each adapter's set_*_comment_sql must return either a SQL string
+    or raise UnsupportedDatabaseOperation — never NotImplementedError
+    from the base class."""
+    cfg = DBConfig(backend=backend, **_fixture(backend))
+    adapter = get_adapter(cfg)
+
+    from amx.db.adapters.base import UnsupportedDatabaseOperation
+
+    # Try each comment-write template and accept either a string or the
+    # adapter's "I don't support this" sentinel.
+    for fn, args in [
+        (adapter.set_table_comment_sql, ("schema", "table", "TABLE")),
+        (adapter.set_column_comment_sql, ("schema", "table", "col")),
+        (adapter.set_schema_comment_sql, ("schema",)),
+        (adapter.set_database_comment_sql, ()),
+    ]:
+        try:
+            sql = fn(*args)
+        except UnsupportedDatabaseOperation:
+            continue  # explicit opt-out is fine
+        assert isinstance(sql, str) and sql.strip(), f"{fn.__name__} returned empty SQL"
+
+
+@pytest.mark.parametrize("backend", SUPPORTED_BACKENDS)
+def test_adapter_implements_required_profiling_templates(backend: str):
+    cfg = DBConfig(backend=backend, **_fixture(backend))
+    adapter = get_adapter(cfg)
+    fqn = adapter.fully_qualified_name("schema", "table")
+    quoted = adapter.quote_identifier("col")
+    assert isinstance(adapter.column_stats_sql(fqn, quoted), str)
+    assert isinstance(adapter.column_sample_sql(fqn, quoted), str)
+
+
+# ── New-backend URL building ─────────────────────────────────────────────
+
+
+def test_mysql_url_builds_with_canonical_port():
+    db = DBConfig(backend="mysql", host="db.example.com", user="alice", password="pw")
+    assert db.url.startswith("mysql+pymysql://alice:pw@db.example.com:3306")
+
+
+def test_mysql_url_includes_database_when_pinned():
+    db = DBConfig(
+        backend="mysql", host="db.example.com", user="alice", password="pw", database="warehouse"
+    )
+    assert db.url.endswith("/warehouse")
+
+
+def test_oracle_url_prefers_service_name():
+    db = DBConfig(
+        backend="oracle",
+        host="ora.example.com",
+        user="APP",
+        password="pw",
+        service_name="XEPDB1",
+    )
+    assert "service_name=XEPDB1" in db.url
+    assert db.url.startswith("oracle+oracledb://APP:pw@ora.example.com:1521")
+
+
+def test_oracle_url_falls_back_to_database_as_sid():
+    db = DBConfig(
+        backend="oracle",
+        host="ora.example.com",
+        user="APP",
+        password="pw",
+        database="XE",
+    )
+    assert "service_name" not in db.url
+    assert db.url.endswith("/XE")
+
+
+def test_mssql_url_defaults_driver_and_encrypts():
+    db = DBConfig(
+        backend="mssql",
+        host="mssql.example.com",
+        user="sa",
+        password="pw",
+        database="analytics",
+    )
+    assert db.url.startswith("mssql+pyodbc://sa:pw@mssql.example.com:1433/analytics")
+    assert "driver=ODBC+Driver+18+for+SQL+Server" in db.url
+    assert "Encrypt=yes" in db.url
+
+
+def test_mssql_url_can_disable_encrypt():
+    db = DBConfig(
+        backend="mssql",
+        host="mssql.example.com",
+        user="sa",
+        password="pw",
+        encrypt=False,
+        trust_server_certificate=True,
+    )
+    assert "Encrypt=no" in db.url
+    assert "TrustServerCertificate=yes" in db.url
+
+
+def test_redshift_url_uses_canonical_port():
+    db = DBConfig(
+        backend="redshift",
+        host="cluster.xxx.redshift.amazonaws.com",
+        user="admin",
+        password="pw",
+        database="dev",
+    )
+    assert db.url.startswith(
+        "redshift+redshift_connector://admin:pw@cluster.xxx.redshift.amazonaws.com:5439/dev"
+    )
+
+
+def test_clickhouse_url_secure_picks_https_and_8443():
+    db = DBConfig(
+        backend="clickhouse",
+        host="ch.example.com",
+        user="default",
+        password="",
+        database="analytics",
+        secure=True,
+    )
+    assert db.url.startswith("clickhouse+https://default:@ch.example.com:8443/analytics")
+
+
+def test_clickhouse_url_insecure_picks_http_and_8123():
+    db = DBConfig(backend="clickhouse", host="ch.example.com", user="default")
+    assert db.url.startswith("clickhouse+http://default:@ch.example.com:8123")
+
+
+def test_duckdb_url_uses_path():
+    db = DBConfig(backend="duckdb", database="/tmp/warehouse.duckdb")
+    assert db.url == "duckdb:////tmp/warehouse.duckdb"
+
+
+def test_duckdb_url_in_memory_when_blank():
+    db = DBConfig(backend="duckdb", database="")
+    assert db.url == "duckdb:///:memory:"
+
+
+# ── is_connection_configured / is_database_pinned ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ("mysql", "oracle", "mssql", "redshift", "clickhouse", "duckdb"),
+)
+def test_new_backend_minimum_fields_pass_connection_configured(backend: str):
+    db = DBConfig(backend=backend, **_fixture(backend))
+    assert db.is_connection_configured() is True
+
+
+def test_oracle_unpinned_when_neither_service_name_nor_database():
+    db = DBConfig(backend="oracle", host="ora", user="APP", password="x")
+    assert db.is_connection_configured() is False  # service_name OR database required
+    assert db.is_database_pinned() is False
+
+
+def test_duckdb_in_memory_counts_as_pinned():
+    """DuckDB has no separate "pick a DB later" flow — :memory: or a
+    file path are both legitimate active choices."""
+    db = DBConfig(backend="duckdb", database="")
+    assert db.is_database_pinned() is True
+
+
+# ── (De)serialize round-trip ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ("mysql", "oracle", "mssql", "redshift", "clickhouse", "duckdb"),
+)
+def test_new_backend_roundtrips_through_mapping(backend: str):
+    original = DBConfig(backend=backend, **_fixture(backend))
+    restored = _db_from_mapping(_db_to_mapping(original))
+    assert restored.backend == original.backend
+    assert restored.url == original.url
+    assert restored.display_summary == original.display_summary
+
+
+# ── MissingDriverError ───────────────────────────────────────────────────
+
+
+def test_missing_driver_error_class_exists():
+    """The MissingDriverError class is part of the public adapters API
+    so callers can catch it specifically and surface install hints."""
+    from amx.db.adapters import MissingDriverError
+
+    assert issubclass(MissingDriverError, ImportError)
+
+
+# ── Connector list_* gating ──────────────────────────────────────────────
+
+
+def test_connector_extended_listings_short_circuit_on_unsupported_capabilities():
+    """When a backend has a capability flag set to False, the matching
+    connector accessor must return [] without ever touching the engine
+    (so adapters without the upstream support don't blow up)."""
+    from amx.db.connector import DatabaseConnector
+
+    # DuckDB has stored_procedures=False, dictionaries=False, datashares=False.
+    cfg = DBConfig(backend="duckdb", database=":memory:")
+    conn = DatabaseConnector(cfg)
+    # These should hit the capability gate, never the engine.
+    assert conn.list_stored_procedures("main") == []
+    assert conn.list_dictionaries() == []
+    assert conn.list_datashares() == []
+    assert conn.list_packages("main") == []
+    assert conn.list_synonyms("main") == []


### PR DESCRIPTION
## Summary

* Adds 6 new database adapters (MySQL, Oracle, SQL Server, Redshift, ClickHouse, DuckDB), bringing supported backends from 4 to 10.
* Extends the adapter contract: `BackendCapabilities` grew 13 new flags and `DatabaseAdapter` gained matching `list_<object>()` methods so adapters can expose stored procedures, functions, sequences, triggers, events, packages, synonyms, UDTs, dictionaries, macros, volumes, datashares, and external tables — not just tables and views.
* Back-fills the existing 4 adapters (PG, Snowflake, Databricks, BigQuery) with the same extended object types where applicable. Highlights: PG gains procedures/functions/sequences/triggers/UDTs; Snowflake gains tasks/stages/shares/external tables; Databricks gains user functions and **volumes** (Unity Catalog file storage); BigQuery gains routines and external tables.
* Migrates DB drivers from `[project.dependencies]` to `[project.optional-dependencies]` extras (one per backend, plus `all`). `MissingDriverError` raises with the exact `pip install amx[<extra>]` hint when a backend is selected without its driver. **Breaking install change** — existing users must reinstall with extras.
* Adds the 6 new backends to the `/add-db-profile` wizard and `/inspect` display, with per-backend prompts (Oracle service_name vs SID, MSSQL ODBC driver/encrypt/trust-server-cert, ClickHouse HTTPS toggle, DuckDB file vs `:memory:`).
* New 59-test parametrized suite (`tests/test_db_multi_backend_expansion.py`) pins adapter registration, capability declarations, comment-write SQL templates, URL building, port substitution, and (de)serialize round-trip for all 10 backends.

Per-backend object inventory (★ = backend-distinctive):

| Backend | Headline new types |
|---------|--------------------|
| DuckDB | sequences, functions, **macros** ★ |
| MySQL | procedures, functions, triggers, **events** ★ |
| Oracle | mat-views, procedures, functions, **packages** ★, triggers, sequences, synonyms, UDTs |
| SQL Server | procedures, functions (FN/TF/IF), triggers, sequences, synonyms |
| Redshift | mat-views, procedures, UDFs, **datashares** ★, **external tables** (Spectrum) |
| ClickHouse | mat-views, UDFs, **dictionaries** ★, skipping indices |

Comment write-back works on every backend whose dialect supports it — including SQL Server's `sp_addextendedproperty` / `sp_updateextendedproperty` (handled with a single `IF EXISTS` block that switches between insert and update) and ClickHouse's `ALTER … MODIFY COMMENT` (21.x+).

Full test suite: 503 passed, 0 regressions.

## Test plan

- [x] All 503 existing tests pass (`pytest tests/`)
- [x] 59 new contract tests pass for the 10 backends (registration, capabilities, comment SQL, profiling SQL, URL building, port defaults, round-trip)
- [x] Live PG (docker container) end-to-end: schemas, tables, views, **stored procedures, functions, sequences, triggers, UDTs** all extracted via the new `list_*` accessors
- [x] Live DuckDB end-to-end: schema/table/view/sequence/macro extraction + `COMMENT ON` write-back
- [x] Pre-push credential scan: no real hostnames or secrets in the diff
- [ ] Live MySQL/MSSQL/Oracle/Redshift/ClickHouse end-to-end — needs containers / accounts (docker-compose extension is a follow-up)
- [ ] `/add-db-profile` wizard walked end-to-end for each new backend (needs interactive session)
- [ ] `pip install amx` (no extras) → `/add-db-profile` → pick MySQL → confirm `MissingDriverError` surfaces the `pip install amx[mysql]` hint
