### PR TITLE
feat(llm): user-settable sampling temperature (wizard prompt + /temperature)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added — `/temperature` slash command and wizard prompt
+
+The LLM sampling temperature is now user-configurable from the interactive
+CLI instead of being locked at the `0.2` default. The `/add-llm-profile`
+wizard prompts for it alongside the existing generation settings, and a
+new `/temperature` slash command shows or sets the value on the active
+profile (e.g. `/temperature 0.7`). Values are clamped to `[0.0, 2.0]` and
+persist to `~/.amx/config.yml` so every downstream call — both
+`chat_completions` and OpenAI Batch — picks up the new value automatically.
+The default stays `0.2`; existing profiles are unaffected.
+
 ### Added — six new database backends + extended object model
 
 AMX now ships adapters for **MySQL, Oracle, SQL Server, Redshift, ClickHouse,

--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -100,6 +100,12 @@ def interactive_llm_block(defaults: LLMConfig | None = None) -> LLMConfig:
     info("Generation settings:")
     n_alt = ask("  Alternatives (1-5)", default=str(getattr(defaults, "n_alternatives", 3)))
     batch = ask("  Column batch size", default=str(getattr(defaults, "column_batch_size", 10)))
+    temp_raw = ask("  Temperature (0.0-2.0)", default=str(getattr(defaults, "temperature", 0.2)))
+    try:
+        temperature = float(temp_raw)
+    except ValueError:
+        temperature = defaults.temperature
+    temperature = max(0.0, min(2.0, temperature))
 
     info("Confidence thresholds (token probability 0.0-1.0):")
     high = ask("  High threshold", default=str(getattr(defaults, "logprob_high", 0.85)))
@@ -110,7 +116,7 @@ def interactive_llm_block(defaults: LLMConfig | None = None) -> LLMConfig:
         model=normalize_llm_model(provider, model),
         api_key=api_key,
         api_base=api_base,
-        temperature=defaults.temperature,
+        temperature=temperature,
         max_tokens=defaults.max_tokens,
         n_alternatives=int(n_alt),
         column_batch_size=int(batch),
@@ -155,6 +161,33 @@ def cmd_logprob_thresholds(cfg: AMXConfig, rest: list[str]) -> None:
     success(
         f"Logprob thresholds saved for LLM profile '{cfg.active_llm_profile}': "
         f"HIGH >= {high:.2f}, MEDIUM >= {medium:.2f}"
+    )
+
+
+def cmd_temperature(cfg: AMXConfig, rest: list[str]) -> None:
+    """Show or set the LLM sampling temperature for the active profile."""
+    if not rest:
+        current = getattr(cfg.llm, "temperature", 0.2)
+        info(f"Current LLM temperature: [bold]{current:.2f}[/]")
+        info("Run [cyan]/temperature <value>[/cyan] to change (e.g. 0.7). Range: 0.0-2.0.")
+        return
+
+    try:
+        value = float(rest[0])
+    except ValueError:
+        error(f"Expected a numeric value, got: {rest[0]}")
+        return
+
+    clamped = max(0.0, min(2.0, value))
+    if clamped != value:
+        warn(f"Temperature {value} clamped to {clamped:.2f} (allowed range 0.0-2.0).")
+
+    cfg.llm.temperature = clamped
+    if cfg.active_llm_profile and cfg.active_llm_profile in cfg.llm_profiles:
+        cfg.llm_profiles[cfg.active_llm_profile].temperature = clamped
+    cfg.save()
+    success(
+        f"Temperature saved for LLM profile '{cfg.active_llm_profile}': {clamped:.2f}"
     )
 
 

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -74,6 +74,9 @@ from amx.cli_support.commands.profiles import (
     cmd_prompt_detail as _cmd_prompt_detail,
 )
 from amx.cli_support.commands.profiles import (
+    cmd_temperature as _cmd_temperature,
+)
+from amx.cli_support.commands.profiles import (
     cmd_remove_code_profile as _cmd_remove_code_profile,
 )
 from amx.cli_support.commands.profiles import (
@@ -686,6 +689,11 @@ def _handle_session_builtin(
         if not _require_namespace(head, namespace, "llm", "logprob-thresholds"):
             return True
         _cmd_logprob_thresholds(cfg, parts[1:])
+        return True
+    if head == "temperature":
+        if not _require_namespace(head, namespace, "llm", "temperature"):
+            return True
+        _cmd_temperature(cfg, parts[1:])
         return True
     if head == "doc-profiles":
         if not _require_namespace(head, namespace, "docs", "doc-profiles"):

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -187,6 +187,11 @@ _LLM_COMMANDS: tuple[SlashCommand, ...] = (
         "llm",
         "Show/set confidence thresholds (/logprob-thresholds [high] [med])",
     ),
+    SlashCommand(
+        "/temperature",
+        "llm",
+        "Show/set LLM sampling temperature (/temperature [0.0-2.0])",
+    ),
 )
 
 _CODE_COMMANDS: tuple[SlashCommand, ...] = (


### PR DESCRIPTION
## Summary
- Add a temperature prompt to the LLM wizard (`/add-llm-profile`) and a new `/temperature` slash command for the active profile, closing the only LLM knob that wasn't reachable from the CLI.
- Values are clamped to `[0.0, 2.0]` and persist to `~/.amx/config.yml`; the default stays `0.2` so existing profiles are untouched.
- No downstream plumbing changes — `LLMProvider.chat` and every `BatchRequest` caller already read `cfg.llm.temperature`.

## Test plan
- [x] `pytest -q` (503 passed, 19 deselected)
- [x] Direct `cmd_temperature` exercise: show, set, clamp high, clamp low, invalid input, YAML round-trip
- [x] Wizard `interactive_llm_block` exercise: happy path, ValueError fallback, out-of-range clamp
- [ ] Manual REPL run (`amx interactive` → `/add-llm-profile`, `/temperature 0.7`) on a real profile
