### PR TITLE
fix(llm): raise max_tokens floor for OpenRouter reasoning routes in CHAT mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — reasoning models on OpenRouter no longer truncate in CHAT mode
+
+Non-streamed calls to OpenRouter reasoning routes (kimi-k2-thinking,
+deepseek-reasoner, claude-sonnet-4 / opus-4 / 3.7-sonnet, and any
+o-series / gpt-5 route) kept the regular `max_tokens=4096` budget, so
+agents in CHAT mode (Profile, Code, RAG) routinely failed with
+`finish_reason=length` and "0 visible characters" — the model burned
+the whole budget on internal thinking. The auto-raise floor at the
+bottom of `LLMProvider.chat` previously fired only for OpenAI direct;
+it now applies whenever `_supports_thinking()` is true, so every
+provider/model the streaming path already recognises as a reasoning
+route gets the same `AMX_LLM_MIN_MAX_TOKENS` floor (default 16384).
+The OpenAI-shaped `reasoning_effort` kwarg stays gated to
+`provider == "openai"` to avoid leaking it into routes that use a
+different parameter shape.
+
 ### Added — `/temperature` slash command and wizard prompt
 
 The LLM sampling temperature is now user-configurable from the interactive

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -1006,7 +1006,12 @@ class LLMProvider:
                 extra.setdefault("num_probs", 5)
 
         # Reasoning models: raise floor so visible content can appear after thinking tokens.
-        if self.cfg.provider == "openai" and _is_openai_reasoning_style_model(model):
+        # Applies to every provider/model the streaming path treats as a reasoning route
+        # (OpenRouter's kimi-k2-thinking, Anthropic extended-thinking, deepseek-reasoner,
+        # OpenAI o-series / gpt-5). Without this, non-streamed callers (profile / code /
+        # rag agents in CHAT mode) keep the regular 4096 budget and routinely truncate
+        # with finish_reason=length once the model has spent it on internal thinking.
+        if _supports_thinking(self.cfg.provider, model):
             floor = int(os.getenv("AMX_LLM_MIN_MAX_TOKENS", str(_DEFAULT_REASONING_FLOOR)))
             if mt < floor:
                 log.debug(
@@ -1016,9 +1021,14 @@ class LLMProvider:
                     model,
                 )
                 mt = floor
-            effort = os.getenv("AMX_REASONING_EFFORT", "low").strip().lower()
-            if effort in ("none", "minimal", "low", "medium", "high"):
-                extra.setdefault("reasoning_effort", effort)
+            # ``reasoning_effort`` is OpenAI's parameter shape; OpenRouter uses
+            # ``reasoning: {effort: ...}`` (set in the streaming branch above).
+            # Other providers manage it via their own thinking budgets, so only
+            # forward this kwarg for OpenAI direct.
+            if self.cfg.provider == "openai":
+                effort = os.getenv("AMX_REASONING_EFFORT", "low").strip().lower()
+                if effort in ("none", "minimal", "low", "medium", "high"):
+                    extra.setdefault("reasoning_effort", effort)
 
         log.debug("LLM call → model=%s, max_tokens=%d", model, mt)
         call_api_base = (


### PR DESCRIPTION
## Summary
- Profile/Code/RAG agents using OpenRouter reasoning models (kimi-k2-thinking, deepseek-reasoner, Claude extended-thinking, OpenAI o-series via OpenRouter) were truncating with `finish_reason=length` because the auto-raise floor was guarded by `provider == "openai"`.
- Broaden the condition to `_supports_thinking()` so non-streamed callers get the same `AMX_LLM_MIN_MAX_TOKENS` floor (default 16384) on every reasoning route the streaming path already recognises.
- Keep the OpenAI-shaped `reasoning_effort` kwarg gated to `provider == "openai"` so the OpenRouter / Anthropic routes don't get a wrong-shape parameter.

## Test plan
- [x] `pytest -q` (503 passed, 19 deselected)
- [x] Mock `_litellm().completion` and verify:
  - OpenRouter `moonshotai/kimi-k2-thinking` → `max_tokens` lifted from 4096 to 16384, `reasoning_effort` NOT in kwargs.
  - OpenAI `o4-mini` → `max_tokens` lifted to 16384, `reasoning_effort=low` still set.
  - OpenAI `gpt-4o` → `max_tokens` stays 4096 (non-reasoning, untouched).
- [ ] Manual: rerun the failing `Profile Agent` on `sap_s6p.adr6` with `openrouter/moonshotai/kimi-k2-thinking` and confirm metadata suggestions are produced.
