### PR TITLE
fix(cli): typo'd slash commands in /search no longer become search-agent questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — typo'd slash commands in /search no longer silently feed the search agent
+
+Inside the `/search` namespace, any unknown slash command was rewritten to
+`["search", "ask", <head>]` and dispatched to the search agent as a
+question — so `/asl` (a typo of `/ask`) silently became a 30-second LLM
+call about the literal string "asl". Bare-text questions are already
+auto-prefixed with `/ask` upstream, so anything still landing in the
+unknown-command branch was an explicit slash command from the user.
+Return `None` so the dispatcher prints `Unknown command: /asl. Type
+/help.` instead of swallowing typos. Real `/search` subcommands,
+shortcut-map entries (`/run`, `/scan`, `/doctor`, …), and namespace
+switches all keep working unchanged.
+
 ### Fixed — reasoning models on OpenRouter no longer truncate in CHAT mode
 
 Non-streamed calls to OpenRouter reasoning routes (kimi-k2-thinking,

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -904,7 +904,14 @@ def session_to_click_args(namespace: str, parts: list[str]) -> list[str] | None:
             if head == "manual":
                 return ["metadata"] + parts[1:]
             return parts
-        return ["search", "ask"] + parts
+        # Unknown slash command typed inside /search. Bare-text questions are
+        # already rewritten to ``/ask <text>`` upstream (see the input loop's
+        # ``not raw.startswith("/")`` branch), so anything still landing here
+        # has an explicit leading slash from the user — i.e. they meant a
+        # command, not a question. Return ``None`` so the caller surfaces
+        # "Unknown command: /<x>" instead of silently routing the typo into
+        # the search agent (e.g. ``/asl`` → ``search ask asl``).
+        return None
     if head in {
         "db",
         "metadata",


### PR DESCRIPTION
## Summary
- Repro: from `/search`, type `/asl` → spends ~30s asking the LLM "what is asl?" instead of erroring as unknown command.
- Root cause: `session_to_click_args()` had a fall-through that rewrote any unknown head in `/search` to `["search", "ask", <head>]`. Bare-text questions are already auto-prefixed with `/ask` upstream, so anything still in the fall-through path was an explicit slash command from the user.
- Fix: return `None` from that branch so the caller prints `Unknown command: /<x>. Type /help.`.

## Test plan
- [x] `pytest -q` (503 passed, 19 deselected)
- [x] Targeted dispatch tests:
  - `/asl`, `/asls`, `/xyz foo` from `/search` → `None` (unknown).
  - `/ask <q>`, `/status`, `/sync`, `/find-columns` from `/search` → unchanged.
  - `/run`, `/scan`, `/doctor` cross-namespace shortcuts from `/search` → unchanged.
  - `/db schemas`, `/llm` namespace switches from `/search` → unchanged.
  - `/search <bare-text>` from `/db` still becomes an ask (intentional shorthand from other namespaces).
- [ ] Manual: from `/search`, type `/asl` and confirm the dispatcher prints `Unknown command: /asl. Type /help.` instead of firing the search agent.
