### PR TITLE
feat(history): shared run-history store for team collaboration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added — shared run-history store for team collaboration
+
+AMX has always kept its run history in a single SQLite file at
+`~/.amx/history.db` — fine for one engineer, invisible to teammates.
+0.12.0 introduces an **optional shared mode**: every `/run`,
+`/run-apply`, and `/ask` invocation is dual-written to a backend the
+team already owns (PostgreSQL, MySQL, MSSQL, Oracle, Snowflake,
+Databricks, Redshift, or BigQuery) under a dedicated `AMX` schema, so
+two engineers running AMX against the same warehouse can finally see
+each other's analyses, results, and review decisions.
+
+Onboarding is one command — `/history-store enable` picks a saved DB
+profile, bootstraps the schema (with `CREATE SCHEMA IF NOT EXISTS`
+DDL adapted per backend), creates the AMX tables via SQLAlchemy
+`MetaData.create_all`, and offers to ferry existing local rows up
+with `/history-store migrate-from-local` (idempotent — safe to
+re-run).
+
+Writes go to local SQLite first (always-on cache, source of truth for
+reads in v0.12) and then best-effort to the shared backend. Network
+hiccups never break a CLI session: failed shared writes land in a
+local `pending_shared_writes` outbox and are replayed by
+`/history-store flush-pending`. Reads continue to come from the local
+SQLite cache so `/history list` stays instant; team-wide read views
+are slated for a follow-up minor.
+
+DuckDB and ClickHouse are explicitly blocked at `enable` time —
+DuckDB is a local file, not shared storage; ClickHouse cannot
+`UPDATE` rows the way `finish_run` requires. The
+`BackendCapabilities.supports_shared_history` flag gates the choice
+and surfaces a clear error listing the supported backends.
+
+User attribution (`created_by`, `hostname`, `client_version`) and
+provenance (`local_id` linking each shared row back to the local
+SQLite INT id) are recorded on every row, so the team can answer
+"who ran this?" and the dual-write coordinator can find the right
+shared row when later UPDATEs fire.
+
+New CLI surface (under `/history-store`): `status`, `enable`,
+`disable`, `migrate-from-local`, `flush-pending`, `dump-ddl`. All
+six are documented under "Run history storage" in the README.
+
+### Changed — config schema bumped to v2 (additive)
+
+`config.yml` gains three optional keys (`history_store_enabled`,
+`history_store_profile`, `history_store_schema`). Existing 0.11.x
+configs load unchanged because `schema_version` is still backwards-
+compatible at read time — the bump only matters when an older AMX
+binary tries to read a config written by 0.12+, in which case it
+gets the actionable `ConfigSchemaTooNewError` upgrade prompt.
+
 ### Fixed — typo'd slash commands in /search no longer silently feed the search agent
 
 Inside the `/search` namespace, any unknown slash command was rewritten to

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ db_profiles:
 
 AMX stores its configuration at `~/.amx/config.yml`. To use a different file, start the CLI with `amx --config path/to/config.yml`.
 
-## Local SQLite history
+## Run history storage
 
 AMX automatically initializes a local SQLite database at:
 
@@ -452,6 +452,50 @@ Query it directly in AMX via `/history` namespace:
 | `/events [-n N]` | App events |
 | `/results <run_id>` | All saved LLM alternatives for a run |
 | `/review <run_id>` | Re-evaluate alternatives interactively; `--unevaluated-only` / `--apply` |
+
+### Shared mode (team collaboration, optional)
+
+By default the SQLite history is per-machine — your teammate cannot
+see runs you executed. Enable shared mode to dual-write every
+run/result/event into a backend the team already owns:
+
+```bash
+/history-store enable             # interactive picker
+/history-store enable --profile prod_pg --schema AMX
+```
+
+AMX then bootstraps an `AMX` schema (configurable) on the chosen DB
+profile and creates four tables: `analysis_runs`, `run_results`,
+`app_events`, `session_state`. Every subsequent write goes to local
+SQLite first (always-on cache, source of truth for `/history list`)
+and best-effort to the shared backend.
+
+| `/history-store …` | Description |
+|---|---|
+| `status` | Show whether shared mode is on, which profile/schema, outbox depth |
+| `enable [--profile P --schema S]` | Bootstrap the AMX schema and start dual-writing |
+| `disable` | Stop dual-writing. Existing shared rows are not deleted |
+| `migrate-from-local` | Idempotent one-shot copy of existing local history rows into the shared store |
+| `flush-pending` | Replay queued shared writes that failed at write time |
+| `dump-ddl [--profile P --schema S]` | Print bootstrap DDL for a DBA to run by hand |
+
+**Supported backends for shared mode:** PostgreSQL, MySQL, MSSQL,
+Oracle, Snowflake, Databricks, Redshift, BigQuery. DuckDB (local
+file) and ClickHouse (no row UPDATE support) are blocked at `enable`
+time with a clear error.
+
+**Failure semantics:** when the shared backend is unreachable, the
+local row still lands and the failed write is queued in
+`pending_shared_writes` for replay via `/history-store flush-pending`.
+Your CLI session is never blocked by team-store outages.
+
+**Reads:** v0.12.0 reads still come from local SQLite — `/history
+list` shows your machine's runs. Cross-machine read views (e.g.
+`/history-store list-team`) are slated for a follow-up minor.
+
+**Attribution:** every shared row records `created_by`, `hostname`,
+and `client_version`, plus a `local_id` linking back to the SQLite
+INT id on the originating machine.
 
 ## Search Catalog
 

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 __all__ = [
     "AMXApplication",

--- a/amx/cli.py
+++ b/amx/cli.py
@@ -22,6 +22,7 @@ from amx.cli_support.commands.db import (
 from amx.cli_support.commands.docs import register_docs_commands
 from amx.cli_support.commands.doctor import register_doctor_command
 from amx.cli_support.commands.history import register_history_commands
+from amx.cli_support.commands.history_store import register_history_store_commands
 from amx.cli_support.commands.manual import register_manual_commands
 from amx.cli_support.commands.profiles import (
     interactive_llm_block as _interactive_llm_block,
@@ -37,7 +38,8 @@ from amx.cli_support.commands.run import (
 from amx.cli_support.commands.search import register_search_commands
 from amx.cli_support.root_commands import register_root_commands
 from amx.config import AMXConfig, ConfigSchemaTooNewError
-from amx.storage.sqlite_store import history_store, init_history_store
+from amx.storage.factory import init_history_store
+from amx.storage.sqlite_store import history_store
 from amx.utils.console import (
     error,
     info,
@@ -293,7 +295,7 @@ def main(ctx: click.Context, cfg_path: str | None, debug: bool) -> None:
             "and delete `~/.amx/config.yml` to start fresh."
         )
         sys.exit(2)
-    init_history_store(ctx.obj.CONFIG_DIR)
+    init_history_store(ctx.obj)
     _install_embedding_provider(ctx.obj)
     is_session_child = os.getenv("AMX_SESSION_CHILD") == "1"
     if not is_session_child:
@@ -327,6 +329,7 @@ def main(ctx: click.Context, cfg_path: str | None, debug: bool) -> None:
 
 history_group = register_history_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_compare_command(history_group, pass_config=pass_config, log_event=_log_app_event)
+register_history_store_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_search_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_doctor_command(main, pass_config=pass_config, log_event=_log_app_event)
 register_chat_session_commands(main, pass_config=pass_config, log_event=_log_app_event)

--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -1,0 +1,316 @@
+"""``/history-store`` command — configure shared run-history collaboration.
+
+Lives next to ``/db-profiles`` (analysis-DB) and ``/llm-profiles`` (LLM
+config) but is intentionally a separate top-level namespace so the
+existing wizard stays focused on the analysis-DB. The shared store IS
+a saved DB profile (a :class:`amx.config.DBConfig`) but flagged as
+"this profile hosts AMX's history schema" via
+``cfg.history_store_profile``.
+
+Subcommands:
+
+* ``status`` — what's enabled, which profile, schema name, outbox depth.
+* ``enable`` — interactive: pick a profile, run schema bootstrap, offer
+  to migrate local history.
+* ``disable`` — flip back to local-only. Does NOT delete shared rows.
+* ``migrate-from-local`` — idempotent one-shot copy of local SQLite
+  rows into the shared schema (only useful right after enabling).
+* ``flush-pending`` — drain the dual-write outbox (replay queued
+  shared writes that failed at write time).
+* ``dump-ddl`` — print the schema-bootstrap DDL so a DBA can run it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import click
+
+from amx.config import AMXConfig
+from amx.storage.factory import HistoryStoreBootstrapError, history_store
+from amx.utils.console import (
+    ask_choice,
+    confirm,
+    error,
+    heading,
+    info,
+    render_table,
+    success,
+    warn,
+)
+
+LogEvent = Callable[..., None]
+
+
+def _resolve_history_dual_store() -> Any | None:
+    """Return the active store iff it is a DualWriteHistoryStore.
+
+    ``/history-store flush-pending`` and ``status`` only make sense
+    when shared mode is on. For local-only sessions both subcommands
+    short-circuit with a friendly message.
+    """
+    store = history_store()
+    if store is None:
+        return None
+    # Avoid a hard import dependency on dual_write at module load —
+    # most sessions don't enable shared mode and importing the
+    # SQLAlchemy stack on the cold path would slow startup. The
+    # duck-type check below matches our DualWriteHistoryStore exactly.
+    if hasattr(store, "shared") and hasattr(store, "flush_pending"):
+        return store
+    return None
+
+
+def register_history_store_commands(
+    main: click.Group,
+    *,
+    pass_config: Callable[[Callable[..., Any]], Callable[..., Any]],
+    log_event: LogEvent,
+) -> click.Group:
+    """Attach ``/history-store`` namespace commands to *main*."""
+
+    @main.group("history-store")
+    def history_store_grp() -> None:
+        """Configure shared run-history (team collaboration)."""
+
+    @history_store_grp.command("status")
+    @pass_config
+    def hs_status(cfg: AMXConfig) -> None:
+        """Show whether shared mode is on and which profile hosts it."""
+        heading("Shared run-history status")
+        if not getattr(cfg, "history_store_enabled", False):
+            info("Shared mode: [bold]disabled[/bold] (local SQLite only)")
+            info("Run /history-store enable to turn it on.")
+            return
+        profile = cfg.history_store_profile or "(none)"
+        schema = cfg.history_store_schema or "AMX"
+        info("Shared mode: [bold green]enabled[/bold green]")
+        info(f"  Profile: {profile}")
+        info(f"  Schema:  {schema}")
+        store = _resolve_history_dual_store()
+        if store is not None:
+            depth = 0
+            try:
+                depth = store.pending_count()
+            except Exception:
+                depth = -1
+            if depth < 0:
+                warn("  Outbox: (could not query)")
+            elif depth == 0:
+                info("  Outbox: empty (everything is in sync)")
+            else:
+                warn(
+                    f"  Outbox: {depth} pending shared writes — run "
+                    "/history-store flush-pending to retry them."
+                )
+        else:
+            warn(
+                "  Active store: local-only fallback. Bootstrap probably "
+                "failed; check the connection / re-run /history-store enable."
+            )
+
+    @history_store_grp.command("enable")
+    @click.option(
+        "--profile",
+        "profile_name",
+        default=None,
+        help="DB profile that should host the AMX schema. Defaults to an interactive picker.",
+    )
+    @click.option(
+        "--schema",
+        "schema_name",
+        default=None,
+        help="Schema/database name where AMX tables live. Default 'AMX'.",
+    )
+    @pass_config
+    def hs_enable(cfg: AMXConfig, profile_name: str | None, schema_name: str | None) -> None:
+        """Bootstrap the AMX schema in a saved DB profile and enable shared mode."""
+        if not cfg.db_profiles:
+            error(
+                "No DB profiles saved. Configure one with /db-profiles or "
+                "/setup before enabling shared history."
+            )
+            return
+
+        if profile_name is None:
+            profile_name = ask_choice(
+                "Pick a DB profile to host the AMX schema",
+                sorted(cfg.db_profiles.keys()),
+                default=cfg.active_db_profile or next(iter(cfg.db_profiles)),
+            )
+        if profile_name not in cfg.db_profiles:
+            error(f"Unknown DB profile: {profile_name!r}")
+            return
+
+        db_cfg = cfg.db_profiles[profile_name]
+        # Local imports so this command does not pay the SQLAlchemy
+        # adapter cost on the cold path.
+        from amx.db.adapters import get_adapter
+        from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+
+        adapter = get_adapter(db_cfg)
+        if not getattr(adapter.capabilities, "supports_shared_history", False):
+            error(
+                f"The {db_cfg.backend!r} backend does not support shared "
+                "run-history. Supported backends: PostgreSQL, MySQL, MSSQL, "
+                "Oracle, Redshift, Snowflake, Databricks, BigQuery."
+            )
+            return
+
+        if schema_name is None or not schema_name.strip():
+            schema_name = (cfg.history_store_schema or "AMX").strip() or "AMX"
+
+        info(
+            f"Bootstrapping schema {schema_name!r} on profile {profile_name!r} ({db_cfg.backend})…"
+        )
+        engine = adapter.create_engine()
+        try:
+            adapter.create_history_schema(engine, schema_name)
+        except Exception as exc:
+            error(f"Could not create schema {schema_name!r}: {exc}")
+            ddl = adapter.create_history_schema_ddl(schema_name)
+            warn("Hand the following DDL to a DBA and re-run enable:")
+            click.echo(ddl)
+            return
+
+        store = SQLAlchemyHistoryStore(engine=engine, schema=schema_name)
+        try:
+            store.init()
+        except Exception as exc:
+            error(f"Could not create AMX tables under {schema_name!r}: {exc}")
+            return
+
+        # Persist the choice. Saving toggles autosave; the next CLI
+        # command picks up the new dual-write coordinator.
+        with cfg.transaction():
+            cfg.history_store_enabled = True
+            cfg.history_store_profile = profile_name
+            cfg.history_store_schema = schema_name
+
+        success(
+            f"Shared run-history enabled. Profile: {profile_name!r} "
+            f"({db_cfg.backend}). Schema: {schema_name!r}."
+        )
+        info(
+            "All future runs will be dual-written to local SQLite AND the "
+            "shared backend. Reads still come from local SQLite."
+        )
+        if confirm(
+            "Migrate existing local runs into the shared store now? (Idempotent — safe to skip.)",
+            default=True,
+        ):
+            _run_migration(cfg, store)
+        log_event(event_type="history_store.enable", status="ok", command="/history-store enable")
+
+    @history_store_grp.command("disable")
+    @pass_config
+    def hs_disable(cfg: AMXConfig) -> None:
+        """Stop dual-writing to the shared store. Local SQLite continues normally."""
+        if not getattr(cfg, "history_store_enabled", False):
+            info("Shared mode is already disabled.")
+            return
+        if not confirm(
+            "Disable shared run-history? Existing shared rows are NOT deleted; "
+            "you can re-enable later from this same machine.",
+            default=False,
+        ):
+            return
+        with cfg.transaction():
+            cfg.history_store_enabled = False
+        success("Shared run-history disabled.")
+        info("Restart AMX (or run any command) for the change to take effect.")
+        log_event(event_type="history_store.disable", status="ok", command="/history-store disable")
+
+    @history_store_grp.command("migrate-from-local")
+    @pass_config
+    def hs_migrate(cfg: AMXConfig) -> None:
+        """Copy local SQLite history into the shared store (idempotent)."""
+        if not getattr(cfg, "history_store_enabled", False):
+            error("Shared mode is disabled. Run /history-store enable first.")
+            return
+        store = _resolve_history_dual_store()
+        if store is None:
+            error("Shared store is not active. Run /history-store enable.")
+            return
+        _run_migration(cfg, store.shared)
+
+    @history_store_grp.command("flush-pending")
+    @pass_config
+    def hs_flush(cfg: AMXConfig) -> None:
+        """Replay queued shared-write retries from the local outbox."""
+        store = _resolve_history_dual_store()
+        if store is None:
+            warn("Shared mode is disabled — nothing to flush.")
+            return
+        succeeded, remaining = store.flush_pending()
+        if succeeded == 0 and remaining == 0:
+            info("Outbox is empty.")
+        else:
+            success(
+                f"Flushed {succeeded} pending writes. "
+                f"{remaining} remaining (will retry on next /history-store flush-pending)."
+            )
+
+    @history_store_grp.command("dump-ddl")
+    @click.option(
+        "--profile",
+        "profile_name",
+        default=None,
+        help="DB profile to template DDL for (defaults to the configured "
+        "history-store profile, or the active analysis profile).",
+    )
+    @click.option(
+        "--schema",
+        "schema_name",
+        default=None,
+        help="Schema name to use in the DDL (default 'AMX').",
+    )
+    @pass_config
+    def hs_dump_ddl(cfg: AMXConfig, profile_name: str | None, schema_name: str | None) -> None:
+        """Print the schema-bootstrap DDL so a DBA can run it by hand."""
+        target = profile_name or cfg.history_store_profile or cfg.active_db_profile or ""
+        if not target or target not in cfg.db_profiles:
+            error("No DB profile resolved. Specify --profile or configure one via /db-profiles.")
+            return
+        from amx.db.adapters import get_adapter
+
+        db_cfg = cfg.db_profiles[target]
+        adapter = get_adapter(db_cfg)
+        schema = (schema_name or cfg.history_store_schema or "AMX").strip() or "AMX"
+        click.echo(f"-- Backend: {db_cfg.backend}")
+        click.echo(f"-- Schema:  {schema}")
+        click.echo(adapter.create_history_schema_ddl(schema))
+
+    return history_store_grp
+
+
+def _run_migration(cfg: AMXConfig, shared) -> None:
+    """Execute the local→shared migration with progress + result table."""
+    from amx.storage.migration import migrate_local_to_shared
+    from amx.storage.sqlite_store import SQLiteHistoryStore
+
+    # Build a thin local handle bound to the same db_path the running
+    # CLI uses. We do not reuse the global singleton because the
+    # singleton may already be wrapped in DualWriteHistoryStore — the
+    # migration takes the raw SQLite store directly.
+    local_path = (
+        history_store().local.db_path  # type: ignore[union-attr]
+        if hasattr(history_store(), "local")
+        else history_store().db_path  # type: ignore[union-attr]
+    )
+    local = SQLiteHistoryStore(local_path)
+
+    info(f"Migrating local history → shared (schema {shared.schema!r})…")
+    try:
+        stats = migrate_local_to_shared(local=local, shared=shared)
+    except HistoryStoreBootstrapError as exc:
+        error(f"Migration failed: {exc}")
+        return
+    except Exception as exc:
+        error(f"Migration failed: {exc}")
+        return
+
+    rows = [[table, str(count)] for table, count in stats.items()]
+    render_table("Migration result", ["Table", "Rows copied"], rows)
+    success("Migration complete (idempotent — safe to re-run).")

--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -186,9 +186,7 @@ def cmd_temperature(cfg: AMXConfig, rest: list[str]) -> None:
     if cfg.active_llm_profile and cfg.active_llm_profile in cfg.llm_profiles:
         cfg.llm_profiles[cfg.active_llm_profile].temperature = clamped
     cfg.save()
-    success(
-        f"Temperature saved for LLM profile '{cfg.active_llm_profile}': {clamped:.2f}"
-    )
+    success(f"Temperature saved for LLM profile '{cfg.active_llm_profile}': {clamped:.2f}")
 
 
 def cmd_llm_profiles(cfg: AMXConfig) -> None:

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -74,9 +74,6 @@ from amx.cli_support.commands.profiles import (
     cmd_prompt_detail as _cmd_prompt_detail,
 )
 from amx.cli_support.commands.profiles import (
-    cmd_temperature as _cmd_temperature,
-)
-from amx.cli_support.commands.profiles import (
     cmd_remove_code_profile as _cmd_remove_code_profile,
 )
 from amx.cli_support.commands.profiles import (
@@ -84,6 +81,9 @@ from amx.cli_support.commands.profiles import (
 )
 from amx.cli_support.commands.profiles import (
     cmd_remove_llm_profile as _cmd_remove_llm_profile,
+)
+from amx.cli_support.commands.profiles import (
+    cmd_temperature as _cmd_temperature,
 )
 from amx.cli_support.commands.profiles import (
     cmd_use_code as _cmd_use_code,
@@ -922,6 +922,7 @@ def session_to_click_args(namespace: str, parts: list[str]) -> list[str] | None:
         "analyze",
         "search",
         "history",
+        "history-store",
         "session",
         "setup",
         "config",

--- a/amx/config.py
+++ b/amx/config.py
@@ -1078,7 +1078,7 @@ def _embedding_to_mapping(emb: EmbeddingConfig) -> dict[str, Any]:
 # refuses with ``ConfigSchemaTooNewError`` so the user gets a clear
 # upgrade message instead of having profiles silently mangled (the
 # exact bug class that hit the 0.3.1 / 0.11.0 PATH skew on 2026-05-01).
-CONFIG_SCHEMA_VERSION: int = 1
+CONFIG_SCHEMA_VERSION: int = 2
 
 
 class ConfigSchemaTooNewError(RuntimeError):
@@ -1137,6 +1137,16 @@ class AMXConfig:
     active_code_profile: str = ""
     write_through_config: bool = True
 
+    # ── Shared history store (v0.12.0) ───────────────────────────────────
+    # When ``history_store_enabled`` is True, every run/result/event
+    # write is dual-written to a team backend (named DBConfig profile)
+    # under a dedicated schema (``history_store_schema``). Local SQLite
+    # remains the read source for ``/history list`` so single-user
+    # workflows keep their fast path. Configure via ``/history-store``.
+    history_store_enabled: bool = False
+    history_store_profile: str = ""
+    history_store_schema: str = "AMX"
+
     # Ephemeral, never persisted to YAML. Tracks which chat session the
     # current REPL is appending to. Reset to None on every load.
     active_chat_session_id: int | None = field(default=None)
@@ -1168,6 +1178,9 @@ class AMXConfig:
             "code_profiles",
             "active_code_profile",
             "write_through_config",
+            "history_store_enabled",
+            "history_store_profile",
+            "history_store_schema",
         }
     )
 
@@ -1278,6 +1291,12 @@ class AMXConfig:
 
             cfg.active_code_profile = str(data.get("active_code_profile") or "")
             cfg.write_through_config = bool(data.get("write_through_config", True))
+
+            # 0.12.0 — shared run-history store. Defaults preserve
+            # local-only behaviour for users upgrading from 0.11.x.
+            cfg.history_store_enabled = bool(data.get("history_store_enabled", False))
+            cfg.history_store_profile = str(data.get("history_store_profile") or "")
+            cfg.history_store_schema = str(data.get("history_store_schema") or "AMX")
 
             embedding_raw = data.get("embedding")
             if isinstance(embedding_raw, dict):
@@ -1410,6 +1429,9 @@ class AMXConfig:
             data["selected_schemas"] = self.selected_schemas
             data["selected_tables"] = self.selected_tables
             data["write_through_config"] = self.write_through_config
+            data["history_store_enabled"] = bool(self.history_store_enabled)
+            data["history_store_profile"] = str(self.history_store_profile or "")
+            data["history_store_schema"] = str(self.history_store_schema or "AMX")
             data["embedding"] = _embedding_to_mapping(self.embedding)
             # Move plaintext secrets to the OS keyring; the YAML now stores only
             # opaque "keyring:..." references. No-op when keyring is unavailable.

--- a/amx/core/application.py
+++ b/amx/core/application.py
@@ -16,7 +16,8 @@ from amx.core.ask_agent import AskToolbox, LoopBasedAskAgent, ToolAskResponse
 from amx.core.state import StateManager
 from amx.search.catalog import SearchAnswer, SearchCatalog
 from amx.search.service import SearchService
-from amx.storage.sqlite_store import SQLiteHistoryStore, history_store, init_history_store
+from amx.storage.factory import init_history_store
+from amx.storage.sqlite_store import SQLiteHistoryStore, history_store
 
 __all__ = ["AMXApplication"]
 
@@ -32,7 +33,7 @@ class AMXApplication:
     @classmethod
     def load(cls, config_path: str | None = None) -> AMXApplication:
         cfg = AMXConfig.load(config_path)
-        init_history_store(cfg.CONFIG_DIR)
+        init_history_store(cfg)
         store = history_store()
         catalog = SearchCatalog.from_history_store()
         if catalog is None:

--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -50,6 +50,13 @@ class BackendCapabilities:
     comment_asset_keywords: frozenset[str] = field(
         default_factory=lambda: frozenset({"TABLE", "VIEW"})
     )
+    # ── Shared-history collaboration (v0.12.0) ───────────────────────────
+    # ``supports_shared_history`` gates ``/history-store enable`` against
+    # this backend. Backends that cannot host AMX's run-history schema
+    # (DuckDB — local file, not shared; ClickHouse — no row UPDATE for
+    # the ``finish_run`` lifecycle) leave this False so the user gets a
+    # clean error instead of a silent half-broken setup.
+    supports_shared_history: bool = False
 
 
 class DatabaseAdapter(ABC):
@@ -369,3 +376,28 @@ class DatabaseAdapter(ABC):
     def set_database_comment_sql(self) -> str:
         """Return a SQL template for comment text write-back."""
         ...
+
+    # ── Shared-history schema bootstrap ───────────────────────────────────
+
+    def create_history_schema(self, engine: Engine, schema_name: str) -> None:
+        """Create AMX's shared-history schema idempotently.
+
+        Default implementation works for every ANSI-SQL-ish backend
+        (PostgreSQL, MySQL, MSSQL, Redshift). Backends with a different
+        schema-creation primitive (Snowflake's ``CREATE SCHEMA "DB"."AMX"``,
+        Databricks Unity Catalog ``CREATE SCHEMA catalog.amx``,
+        BigQuery's project-qualified DDL, Oracle's CREATE USER) override.
+        """
+        ddl = self.create_history_schema_ddl(schema_name)
+        with engine.begin() as conn:
+            conn.execute(text(ddl))
+
+    def create_history_schema_ddl(self, schema_name: str) -> str:
+        """Return the DDL ``/history-store dump-ddl`` shows to a DBA.
+
+        Kept as a separate method (not inlined in ``create_history_schema``)
+        so the user can request the SQL without actually executing it —
+        useful when the active connection lacks ``CREATE SCHEMA``
+        privileges and a DBA needs to provision the schema by hand.
+        """
+        return f"CREATE SCHEMA IF NOT EXISTS {self.quote_identifier(schema_name)}"

--- a/amx/db/adapters/bigquery.py
+++ b/amx/db/adapters/bigquery.py
@@ -22,8 +22,20 @@ class BigQueryAdapter(DatabaseAdapter):
         stored_procedures=True,
         functions=True,
         external_tables=True,
+        supports_shared_history=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
     )
+
+    def create_history_schema_ddl(self, schema_name: str) -> str:
+        # BigQuery uses backtick-quoted ``project.dataset`` identifiers.
+        # The dataset (= "schema" in AMX nomenclature) lives under a
+        # specific project; we use the project pinned on the profile.
+        project = (getattr(self.cfg, "project", "") or "").strip()
+        if not project:
+            raise ValueError(
+                "BigQuery shared-history bootstrap requires `project` to be set on the DB profile."
+            )
+        return f"CREATE SCHEMA IF NOT EXISTS `{project}.{schema_name}`"
 
     def create_engine(self) -> Engine:
         try:

--- a/amx/db/adapters/databricks.py
+++ b/amx/db/adapters/databricks.py
@@ -28,8 +28,22 @@ class DatabricksAdapter(DatabaseAdapter):
         functions=True,
         volumes=True,  # ★ Unity Catalog volumes — distinctively Databricks
         external_tables=True,
+        supports_shared_history=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW"}),
     )
+
+    def create_history_schema_ddl(self, schema_name: str) -> str:
+        # Unity Catalog requires ``catalog.schema``. Fall back to the
+        # connection's default catalog (also implicit in DBConfig.url)
+        # so the DDL is portable across both Hive and UC workspaces.
+        catalog = (getattr(self.cfg, "catalog", "") or "").strip()
+        if catalog:
+            return (
+                f"CREATE SCHEMA IF NOT EXISTS "
+                f"{self.quote_identifier(catalog)}.{self.quote_identifier(schema_name)}"
+            )
+        return f"CREATE SCHEMA IF NOT EXISTS {self.quote_identifier(schema_name)}"
+
     trusted_ca_env_vars = (
         "AMX_DATABRICKS_TRUSTED_CA_FILE",
         "DATABRICKS_TRUSTED_CA_FILE",

--- a/amx/db/adapters/mssql.py
+++ b/amx/db/adapters/mssql.py
@@ -57,7 +57,27 @@ class MSSQLAdapter(DatabaseAdapter):
         triggers=True,
         synonyms=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW"}),
+        supports_shared_history=True,
     )
+
+    def create_history_schema(self, engine: Engine, schema_name: str) -> None:
+        # SQL Server does not support ``IF NOT EXISTS`` on ``CREATE SCHEMA``
+        # in older versions, so we use a self-contained EXEC pattern that
+        # works from SQL Server 2008+. Equivalent to ``CREATE SCHEMA IF
+        # NOT EXISTS`` on other backends.
+        check = (
+            "IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = :schema_name) "
+            f"EXEC('CREATE SCHEMA {self.quote_identifier(schema_name)}')"
+        )
+        with engine.begin() as conn:
+            conn.execute(text(check), {"schema_name": schema_name})
+
+    def create_history_schema_ddl(self, schema_name: str) -> str:
+        return (
+            "IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = "
+            f"{self.quote_literal(schema_name)}) "
+            f"EXEC('CREATE SCHEMA {self.quote_identifier(schema_name)}');"
+        )
 
     def create_engine(self) -> Engine:
         return create_engine(self.cfg.url, pool_pre_ping=True)

--- a/amx/db/adapters/mysql.py
+++ b/amx/db/adapters/mysql.py
@@ -51,7 +51,18 @@ class MySQLAdapter(DatabaseAdapter):
         triggers=True,
         events=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW"}),
+        supports_shared_history=True,
     )
+
+    def create_history_schema_ddl(self, schema_name: str) -> str:
+        # In MySQL, ``SCHEMA`` and ``DATABASE`` are synonyms; the DDL
+        # below works on both MySQL 5.7+ and MariaDB 10.x. CHARSET pinning
+        # makes JSON columns and `created_by` text portable across server
+        # default-charset variations.
+        return (
+            f"CREATE DATABASE IF NOT EXISTS {self.quote_identifier(schema_name)} "
+            f"CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+        )
 
     def create_engine(self) -> Engine:
         return create_engine(self.cfg.url, pool_pre_ping=True)

--- a/amx/db/adapters/oracle.py
+++ b/amx/db/adapters/oracle.py
@@ -33,6 +33,20 @@ from sqlalchemy.engine import Engine
 
 from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
 
+# Oracle uniquely binds schema = user. ``CREATE SCHEMA`` exists but is
+# only a logical grouping inside the current user; it does NOT create
+# a separate namespace the way every other backend does. The shared-
+# history bootstrap on Oracle therefore expects the AMX user/schema to
+# already exist (provisioned by a DBA) and verifies it via
+# ``ALL_USERS``.
+_ORACLE_AMX_SCHEMA_HINT = (
+    "Oracle binds schema=user. Ask your DBA to run:\n"
+    "    CREATE USER AMX IDENTIFIED BY <strong-password>;\n"
+    "    GRANT CREATE SESSION, RESOURCE, UNLIMITED TABLESPACE TO AMX;\n"
+    "Then connect AMX with that user (or grant the AMX schema to your "
+    "current user) and re-run /history-store enable."
+)
+
 # Oracle ships with a long list of system schemas. Filtering them out
 # of the schema picker is the difference between "12 user schemas" and
 # "120 schemas, 90% of which are XDB / APEX / OLAP support".
@@ -94,7 +108,32 @@ class OracleAdapter(DatabaseAdapter):
         synonyms=True,
         user_defined_types=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
+        supports_shared_history=True,
     )
+
+    def create_history_schema(self, engine: Engine, schema_name: str) -> None:
+        # Oracle ties schema to user. Verify the user exists; if not,
+        # surface the DBA hint instead of attempting a privileged
+        # CREATE USER (which most application accounts cannot do).
+        with engine.begin() as conn:
+            row = conn.execute(
+                text("SELECT username FROM all_users WHERE username = :u"),
+                {"u": schema_name.upper()},
+            ).fetchone()
+        if not row:
+            raise PermissionError(
+                f"Oracle user/schema {schema_name!r} does not exist. " + _ORACLE_AMX_SCHEMA_HINT
+            )
+
+    def create_history_schema_ddl(self, schema_name: str) -> str:
+        return (
+            f"-- Oracle: ensure user/schema {schema_name!r} exists.\n"
+            "-- Run as a DBA:\n"
+            f"CREATE USER {self.quote_identifier(schema_name)} "
+            f"IDENTIFIED BY <strong-password>;\n"
+            f"GRANT CREATE SESSION, RESOURCE, UNLIMITED TABLESPACE "
+            f"TO {self.quote_identifier(schema_name)};"
+        )
 
     def create_engine(self) -> Engine:
         return create_engine(self.cfg.url, pool_pre_ping=True)

--- a/amx/db/adapters/postgresql.py
+++ b/amx/db/adapters/postgresql.py
@@ -23,6 +23,7 @@ class PostgreSQLAdapter(DatabaseAdapter):
         triggers=True,
         user_defined_types=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
+        supports_shared_history=True,
     )
 
     def create_engine(self) -> Engine:

--- a/amx/db/adapters/redshift.py
+++ b/amx/db/adapters/redshift.py
@@ -37,6 +37,7 @@ class RedshiftAdapter(DatabaseAdapter):
         functions=True,
         external_tables=True,
         datashares=True,
+        supports_shared_history=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
     )
 

--- a/amx/db/adapters/snowflake.py
+++ b/amx/db/adapters/snowflake.py
@@ -25,8 +25,23 @@ class SnowflakeAdapter(DatabaseAdapter):
         volumes=True,  # SHOW STAGES — Snowflake's file-storage primitive
         datashares=True,
         external_tables=True,
+        supports_shared_history=True,
         comment_asset_keywords=frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"}),
     )
+
+    def create_history_schema_ddl(self, schema_name: str) -> str:
+        # Snowflake fully-qualifies on a database; if the active profile
+        # has a database pinned we emit a ``"DB"."AMX"`` qualified DDL
+        # so the schema lands in the expected database. Otherwise the
+        # connection's default database is used (the user picked it via
+        # /database) and the unqualified form below works.
+        db = getattr(self.cfg, "database", "") or ""
+        if db:
+            return (
+                f"CREATE SCHEMA IF NOT EXISTS "
+                f"{self.quote_identifier(db)}.{self.quote_identifier(schema_name)}"
+            )
+        return f"CREATE SCHEMA IF NOT EXISTS {self.quote_identifier(schema_name)}"
 
     def create_engine(self) -> Engine:
         try:

--- a/amx/storage/dual_write.py
+++ b/amx/storage/dual_write.py
@@ -1,0 +1,518 @@
+"""Local + shared dual-write history store.
+
+Wraps a local :class:`SQLiteHistoryStore` and a remote
+:class:`SQLAlchemyHistoryStore`. Every write hits the local store first
+(source of truth, always-on cache); the remote write follows
+best-effort. If the remote write fails — network blip, expired token,
+schema migration — the operation is parked in the local
+``pending_shared_writes`` outbox so a later ``flush_pending()`` can
+retry it without losing data.
+
+Reads come from the local store. The shared store exists for *team
+visibility* (a teammate on another laptop sees your runs); local reads
+are always faster and avoid surfacing the wrong UUID-keyed rows. A
+future minor adds ``list_team_runs()`` for cross-machine visibility.
+
+Caller-facing IDs are LOCAL int IDs (matching the historical SQLite
+contract). The shared store uses UUIDs internally; the dual-write
+store maps local int ↔ shared UUID by querying the shared store on
+``hostname + local_id`` whenever a downstream UPDATE-style call
+arrives. This keeps the IHistoryStore Protocol stable for the dozen+
+existing call sites.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import sqlite3
+import time
+from typing import Any
+
+from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+from amx.storage.sqlite_store import SQLiteHistoryStore
+from amx.utils.logging import get_logger
+
+log = get_logger("storage.dual_write")
+
+
+# Op-kinds in the outbox. Each is a serialised method-name + kwargs
+# tuple; ``flush_pending`` re-dispatches by op_kind. New write methods
+# must be added here AND in ``_replay_op`` below.
+OP_CREATE_RUN = "create_run"
+OP_FINISH_RUN = "finish_run"
+OP_UPDATE_RUN_STATUS = "update_run_status"
+OP_UPDATE_RUN_PLANNED_COUNT = "update_run_planned_count"
+OP_INCREMENT_RUN_PROCESSED = "increment_run_processed"
+OP_INCREMENT_RUN_APPLIED = "increment_run_applied"
+OP_SAVE_RUN_RESULTS = "save_run_results"
+OP_RECORD_EVALUATION = "record_evaluation"
+OP_RECORD_APPLIED = "record_applied"
+OP_RECORD_DB_APPLY_FAILURE = "record_db_apply_failure"
+OP_LOG_EVENT = "log_event"
+OP_SET_SESSION_STATE = "set_session_state"
+
+
+class DualWriteHistoryStore:
+    """Façade that writes to local SQLite and a shared SQLAlchemy backend.
+
+    Reads delegate to the local store. The shared store is best-effort
+    on writes — a failure surfaces as a WARN log and an outbox row,
+    never a raised exception, so the user's CLI session keeps working
+    even if the team store is down.
+    """
+
+    def __init__(
+        self,
+        local: SQLiteHistoryStore,
+        shared: SQLAlchemyHistoryStore,
+    ) -> None:
+        self.local = local
+        self.shared = shared
+        self.db_path = local.db_path
+        self._ensure_outbox()
+
+    @property
+    def _lock(self) -> Any:  # pragma: no cover - delegate accessor
+        return self.local._lock
+
+    # ── Outbox housekeeping ───────────────────────────────────────────────
+
+    def _ensure_outbox(self) -> None:
+        with self.local._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS pending_shared_writes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    op_kind TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    queued_at REAL NOT NULL,
+                    last_error TEXT NOT NULL DEFAULT '',
+                    attempts INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pending_shared_writes_queued "
+                "ON pending_shared_writes(queued_at)"
+            )
+
+    def _enqueue(self, op_kind: str, payload: dict[str, Any], err: Exception) -> None:
+        try:
+            with self.local._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO pending_shared_writes
+                    (op_kind, payload_json, queued_at, last_error, attempts)
+                    VALUES (?, ?, ?, ?, 1)
+                    """,
+                    (
+                        op_kind,
+                        json.dumps(payload, ensure_ascii=True, default=str),
+                        time.time(),
+                        str(err)[:2000],
+                    ),
+                )
+        except sqlite3.Error as enq_err:
+            log.warning(
+                "Could not enqueue shared-write for retry (op=%s): %s — data is "
+                "in local SQLite only.",
+                op_kind,
+                enq_err,
+            )
+
+    def pending_count(self) -> int:
+        with contextlib.suppress(sqlite3.Error):
+            with self.local._connect() as conn:
+                row = conn.execute("SELECT COUNT(*) FROM pending_shared_writes").fetchone()
+                if row is not None:
+                    return int(row[0] or 0)
+        return 0
+
+    def flush_pending(self, *, max_attempts: int = 5) -> tuple[int, int]:
+        """Retry every queued op. Returns ``(succeeded, remaining)``.
+
+        Ops that have failed ``max_attempts`` times are NOT dropped —
+        they remain in the outbox so the user can inspect them via
+        ``/history-store list-pending``.
+        """
+        succeeded = 0
+        with self.local._connect() as conn:
+            rows = conn.execute(
+                "SELECT id, op_kind, payload_json, attempts FROM pending_shared_writes "
+                "ORDER BY queued_at ASC"
+            ).fetchall()
+        for row in rows:
+            row_id, op_kind, payload_json, attempts = row
+            if int(attempts or 0) >= max_attempts:
+                continue
+            try:
+                payload = json.loads(payload_json)
+            except json.JSONDecodeError:
+                log.warning("Skipping malformed outbox row %s (op=%s)", row_id, op_kind)
+                continue
+            try:
+                self._replay_op(op_kind, payload)
+            except Exception as exc:
+                with contextlib.suppress(sqlite3.Error):
+                    with self.local._connect() as conn:
+                        conn.execute(
+                            "UPDATE pending_shared_writes "
+                            "SET attempts = attempts + 1, last_error = ? WHERE id = ?",
+                            (str(exc)[:2000], row_id),
+                        )
+                continue
+            with contextlib.suppress(sqlite3.Error):
+                with self.local._connect() as conn:
+                    conn.execute("DELETE FROM pending_shared_writes WHERE id = ?", (row_id,))
+            succeeded += 1
+        return succeeded, self.pending_count()
+
+    def _replay_op(self, op_kind: str, payload: dict[str, Any]) -> None:
+        """Re-dispatch an outbox row to the shared store.
+
+        New ops added in :meth:`_try_remote` must be added here too.
+        Each branch reconstructs the original method call from the
+        serialised payload so the retry is byte-equivalent to the
+        original write.
+        """
+        if op_kind == OP_CREATE_RUN:
+            self.shared.create_run(**payload)
+        elif op_kind == OP_FINISH_RUN:
+            self.shared.finish_run(payload.pop("run_id"), **payload)
+        elif op_kind == OP_UPDATE_RUN_STATUS:
+            self.shared.update_run_status(
+                payload["run_id"],
+                payload["status"],
+                payload.get("error_text", ""),
+            )
+        elif op_kind == OP_UPDATE_RUN_PLANNED_COUNT:
+            self.shared.update_run_planned_count(payload["run_id"], payload["planned_count"])
+        elif op_kind == OP_INCREMENT_RUN_PROCESSED:
+            self.shared.increment_run_processed(payload["run_id"], payload.get("by", 1))
+        elif op_kind == OP_INCREMENT_RUN_APPLIED:
+            self.shared.increment_run_applied(payload["run_id"], payload.get("by", 1))
+        elif op_kind == OP_SAVE_RUN_RESULTS:
+            self.shared.save_run_results(
+                payload["run_id"],
+                payload["suggestions"],
+                local_ids=payload.get("local_ids"),
+            )
+        elif op_kind == OP_RECORD_EVALUATION:
+            self.shared.record_evaluation(
+                payload["result_id"],
+                chosen_description=payload["chosen_description"],
+                evaluation=payload["evaluation"],
+            )
+        elif op_kind == OP_RECORD_APPLIED:
+            self.shared.record_applied(payload["result_id"])
+        elif op_kind == OP_RECORD_DB_APPLY_FAILURE:
+            self.shared.record_db_apply_failure(payload["result_id"], payload.get("error_text", ""))
+        elif op_kind == OP_LOG_EVENT:
+            self.shared.log_event(**payload)
+        elif op_kind == OP_SET_SESSION_STATE:
+            self.shared.set_session_state(payload["namespace"], payload["key"], payload["value"])
+        else:
+            log.warning("Unknown outbox op_kind=%s — leaving queued", op_kind)
+            raise ValueError(f"unknown op_kind: {op_kind}")
+
+    # ── Helpers ───────────────────────────────────────────────────────────
+
+    def _try_remote(self, op_kind: str, payload: dict[str, Any], call) -> None:
+        """Run *call*; on failure, enqueue *payload* under *op_kind*."""
+        try:
+            call()
+        except Exception as exc:
+            log.warning(
+                "Shared-history write failed (op=%s): %s — queued for retry.",
+                op_kind,
+                exc,
+            )
+            self._enqueue(op_kind, payload, exc)
+
+    def _resolve_run_uuid(self, local_run_id: int) -> str | None:
+        return self.shared.find_run_uuid_by_local_id(local_run_id)
+
+    def _resolve_result_uuid(self, local_result_id: int) -> str | None:
+        return self.shared.find_result_uuid_by_local_id(local_result_id)
+
+    # ── IHistoryStore — write methods ─────────────────────────────────────
+
+    def create_run(self, **kwargs: Any) -> int:
+        local_id = self.local.create_run(**kwargs)
+        # Re-shape kwargs for the shared call: scope is required, others
+        # mirror the local signature 1:1. UUID is generated server-side
+        # (in the SQLAlchemy store) but we capture the local_id linkage.
+        payload: dict[str, Any] = dict(kwargs)
+        payload["local_id"] = local_id
+        self._try_remote(
+            OP_CREATE_RUN,
+            payload,
+            lambda: self.shared.create_run(**payload),
+        )
+        return local_id
+
+    def finish_run(
+        self,
+        run_id: int,
+        *,
+        status: str,
+        metrics: dict[str, Any],
+        tokens: dict[str, Any],
+        results: dict[str, Any],
+        error_text: str = "",
+    ) -> None:
+        self.local.finish_run(
+            run_id,
+            status=status,
+            metrics=metrics,
+            tokens=tokens,
+            results=results,
+            error_text=error_text,
+        )
+        run_uuid = self._resolve_run_uuid(run_id)
+        if run_uuid is None:
+            # The original create_run was queued — this finish_run goes
+            # in too, in order, so flush replays both.
+            self._enqueue(
+                OP_FINISH_RUN,
+                {
+                    "run_id": "<unresolved>",
+                    "status": status,
+                    "metrics": metrics,
+                    "tokens": tokens,
+                    "results": results,
+                    "error_text": error_text,
+                    "local_run_id": run_id,
+                },
+                RuntimeError("shared run_uuid not found"),
+            )
+            return
+        payload = {
+            "run_id": run_uuid,
+            "status": status,
+            "metrics": metrics,
+            "tokens": tokens,
+            "results": results,
+            "error_text": error_text,
+        }
+        self._try_remote(
+            OP_FINISH_RUN,
+            payload,
+            lambda: self.shared.finish_run(
+                run_uuid,
+                status=status,
+                metrics=metrics,
+                tokens=tokens,
+                results=results,
+                error_text=error_text,
+            ),
+        )
+
+    def update_run_status(self, run_id: int, status: str, error_text: str = "") -> None:
+        self.local.update_run_status(run_id, status, error_text)
+        run_uuid = self._resolve_run_uuid(run_id)
+        if run_uuid is None:
+            return
+        payload = {"run_id": run_uuid, "status": status, "error_text": error_text}
+        self._try_remote(
+            OP_UPDATE_RUN_STATUS,
+            payload,
+            lambda: self.shared.update_run_status(run_uuid, status, error_text),
+        )
+
+    def update_run_planned_count(self, run_id: int, planned_count: int) -> None:
+        self.local.update_run_planned_count(run_id, planned_count)
+        run_uuid = self._resolve_run_uuid(run_id)
+        if run_uuid is None:
+            return
+        payload = {"run_id": run_uuid, "planned_count": int(planned_count)}
+        self._try_remote(
+            OP_UPDATE_RUN_PLANNED_COUNT,
+            payload,
+            lambda: self.shared.update_run_planned_count(run_uuid, planned_count),
+        )
+
+    def increment_run_processed(self, run_id: int, by: int = 1) -> None:
+        self.local.increment_run_processed(run_id, by)
+        run_uuid = self._resolve_run_uuid(run_id)
+        if run_uuid is None:
+            return
+        payload = {"run_id": run_uuid, "by": int(by)}
+        self._try_remote(
+            OP_INCREMENT_RUN_PROCESSED,
+            payload,
+            lambda: self.shared.increment_run_processed(run_uuid, by),
+        )
+
+    def increment_run_applied(self, run_id: int, by: int = 1) -> None:
+        self.local.increment_run_applied(run_id, by)
+        run_uuid = self._resolve_run_uuid(run_id)
+        if run_uuid is None:
+            return
+        payload = {"run_id": run_uuid, "by": int(by)}
+        self._try_remote(
+            OP_INCREMENT_RUN_APPLIED,
+            payload,
+            lambda: self.shared.increment_run_applied(run_uuid, by),
+        )
+
+    def save_run_results(self, run_id: int, suggestions: list[dict[str, Any]]) -> list[int]:
+        local_ids = self.local.save_run_results(run_id, suggestions)
+        run_uuid = self._resolve_run_uuid(run_id)
+        if run_uuid is None:
+            self._enqueue(
+                OP_SAVE_RUN_RESULTS,
+                {
+                    "run_id": "<unresolved>",
+                    "suggestions": suggestions,
+                    "local_ids": local_ids,
+                    "local_run_id": run_id,
+                },
+                RuntimeError("shared run_uuid not found"),
+            )
+            return local_ids
+        payload = {
+            "run_id": run_uuid,
+            "suggestions": suggestions,
+            "local_ids": local_ids,
+        }
+        self._try_remote(
+            OP_SAVE_RUN_RESULTS,
+            payload,
+            lambda: self.shared.save_run_results(run_uuid, suggestions, local_ids=local_ids),
+        )
+        return local_ids
+
+    def record_evaluation(
+        self,
+        result_id: int,
+        *,
+        chosen_description: str,
+        evaluation: str,
+    ) -> None:
+        self.local.record_evaluation(
+            result_id,
+            chosen_description=chosen_description,
+            evaluation=evaluation,
+        )
+        result_uuid = self._resolve_result_uuid(result_id)
+        if result_uuid is None:
+            return
+        payload = {
+            "result_id": result_uuid,
+            "chosen_description": chosen_description,
+            "evaluation": evaluation,
+        }
+        self._try_remote(
+            OP_RECORD_EVALUATION,
+            payload,
+            lambda: self.shared.record_evaluation(
+                result_uuid,
+                chosen_description=chosen_description,
+                evaluation=evaluation,
+            ),
+        )
+
+    def record_applied(self, result_id: int) -> None:
+        self.local.record_applied(result_id)
+        result_uuid = self._resolve_result_uuid(result_id)
+        if result_uuid is None:
+            return
+        payload = {"result_id": result_uuid}
+        self._try_remote(
+            OP_RECORD_APPLIED,
+            payload,
+            lambda: self.shared.record_applied(result_uuid),
+        )
+
+    def record_db_apply_failure(self, result_id: int, error_text: str = "") -> None:
+        self.local.record_db_apply_failure(result_id, error_text)
+        result_uuid = self._resolve_result_uuid(result_id)
+        if result_uuid is None:
+            return
+        payload = {"result_id": result_uuid, "error_text": error_text}
+        self._try_remote(
+            OP_RECORD_DB_APPLY_FAILURE,
+            payload,
+            lambda: self.shared.record_db_apply_failure(result_uuid, error_text),
+        )
+
+    def log_event(
+        self,
+        *,
+        event_type: str,
+        status: str,
+        command: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self.local.log_event(event_type=event_type, status=status, command=command, details=details)
+        payload = {
+            "event_type": event_type,
+            "status": status,
+            "command": command,
+            "details": details or {},
+        }
+        self._try_remote(
+            OP_LOG_EVENT,
+            payload,
+            lambda: self.shared.log_event(
+                event_type=event_type,
+                status=status,
+                command=command,
+                details=details,
+            ),
+        )
+
+    def set_session_state(self, namespace: str, key: str, value: Any) -> None:
+        self.local.set_session_state(namespace, key, value)
+        payload = {"namespace": namespace, "key": key, "value": value}
+        self._try_remote(
+            OP_SET_SESSION_STATE,
+            payload,
+            lambda: self.shared.set_session_state(namespace, key, value),
+        )
+
+    # ── IHistoryStore — read methods (delegate to local) ──────────────────
+
+    def get_run(self, run_id: int) -> dict[str, Any] | None:
+        return self.local.get_run(run_id)
+
+    def get_run_results(
+        self, run_id: int, *, unevaluated_only: bool = False
+    ) -> list[dict[str, Any]]:
+        return self.local.get_run_results(run_id, unevaluated_only=unevaluated_only)
+
+    def list_recent_runs(
+        self, limit: int = 20, *, command_filter: str | None = "analyze.run"
+    ) -> list[dict[str, Any]]:
+        return self.local.list_recent_runs(limit, command_filter=command_filter)
+
+    def list_runs_with_result_counts(self, limit: int = 20) -> list[dict[str, Any]]:
+        return self.local.list_runs_with_result_counts(limit)
+
+    def find_runs_for_scope(
+        self,
+        *,
+        schema: str | None = None,
+        table: str | None = None,
+        command_filter: str | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        return self.local.find_runs_for_scope(
+            schema=schema, table=table, command_filter=command_filter, limit=limit
+        )
+
+    def list_recent_events(self, limit: int = 30) -> list[dict[str, Any]]:
+        return self.local.list_recent_events(limit)
+
+    def get_session_state(self, namespace: str, key: str, default: Any = None) -> Any:
+        return self.local.get_session_state(namespace, key, default)
+
+    # ── SQLite-only conveniences proxied through ──────────────────────────
+
+    def stats(self) -> dict[str, Any]:
+        return self.local.stats()
+
+
+__all__ = ["DualWriteHistoryStore"]

--- a/amx/storage/factory.py
+++ b/amx/storage/factory.py
@@ -1,0 +1,167 @@
+"""History-store factory.
+
+Single entry point that decides whether the running session gets a
+local-only :class:`SQLiteHistoryStore` or a dual-write store wrapping
+the local SQLite + a shared warehouse-backed
+:class:`SQLAlchemyHistoryStore`. Inspects ``cfg.history_store_enabled``
+plus a couple of guard rails (the named profile must exist, its
+backend must declare ``supports_shared_history``, the engine must be
+buildable).
+
+Replaces the original ``init_history_store(config_dir: str)`` helper in
+:mod:`amx.storage.sqlite_store` for callers that have an
+:class:`AMXConfig` in hand. The legacy function is preserved as a
+back-compat shim that defaults to local-only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from amx.storage import sqlite_store
+from amx.storage.sqlite_store import SQLiteHistoryStore
+from amx.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from amx.config import AMXConfig
+
+log = get_logger("storage.factory")
+
+
+class HistoryStoreBootstrapError(RuntimeError):
+    """Raised when shared-history setup fails in a recoverable way.
+
+    Carries the DDL the user can hand to a DBA so the failure surfaces
+    with a clear remediation path (typical case: the active connection
+    lacks ``CREATE SCHEMA`` privileges).
+    """
+
+    def __init__(self, message: str, *, ddl: str | None = None) -> None:
+        super().__init__(message)
+        self.ddl = ddl or ""
+
+
+def _build_shared_store(cfg: AMXConfig):
+    """Construct a SQLAlchemyHistoryStore from *cfg*'s history profile.
+
+    Returns ``None`` (and logs at INFO) if shared mode is disabled or
+    the named profile is missing. Raises :class:`HistoryStoreBootstrapError`
+    when shared mode is requested but the backend cannot host it.
+    """
+    if not getattr(cfg, "history_store_enabled", False):
+        return None
+
+    profile_name = (getattr(cfg, "history_store_profile", "") or "").strip()
+    if not profile_name:
+        log.warning(
+            "history_store_enabled=True but history_store_profile is empty — "
+            "falling back to local-only history."
+        )
+        return None
+    if profile_name not in cfg.db_profiles:
+        log.warning(
+            "history_store_profile=%r is not in cfg.db_profiles — "
+            "falling back to local-only history.",
+            profile_name,
+        )
+        return None
+
+    db_cfg = cfg.db_profiles[profile_name]
+
+    # Local imports keep the SQLAlchemy + adapter surface out of the
+    # main amx import path. ``init_history_store`` is hot on every
+    # ``amx`` invocation; importing SQLAlchemy adapters on a code path
+    # most users never hit would cost ~150ms of startup time.
+    from amx.db.adapters import get_adapter
+    from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+
+    adapter = get_adapter(db_cfg)
+    if not getattr(adapter.capabilities, "supports_shared_history", False):
+        raise HistoryStoreBootstrapError(
+            f"The {db_cfg.backend!r} backend does not support shared run-history "
+            f"(profile {profile_name!r}). Pick a profile whose backend supports "
+            "it, or run `/history-store disable`."
+        )
+
+    schema_name = (getattr(cfg, "history_store_schema", "") or "AMX").strip() or "AMX"
+    engine = adapter.create_engine()
+    store = SQLAlchemyHistoryStore(engine=engine, schema=schema_name)
+    return store
+
+
+def init_history_store(cfg: AMXConfig):
+    """Build the singleton history store and attach it to the legacy global.
+
+    The returned object always implements :class:`amx.storage.protocol.IHistoryStore`.
+    When shared mode is enabled, the result is a
+    :class:`amx.storage.dual_write.DualWriteHistoryStore` wrapping local
+    SQLite + the shared SQLAlchemy store; otherwise it is a vanilla
+    :class:`SQLiteHistoryStore`. Both are pin-compatible with every
+    existing call site that uses ``history_store()`` from
+    :mod:`amx.storage.sqlite_store`.
+
+    On bootstrap failure (network unreachable, schema lacks DDL
+    permissions, etc.) we DO NOT raise — we fall back to local-only and
+    log a warning. The user can fix the issue and re-run
+    ``/history-store enable`` without losing the active session.
+    """
+    config_dir = getattr(cfg, "CONFIG_DIR", str(Path.home() / ".amx"))
+    db_path = Path(config_dir) / "history.db"
+    local = SQLiteHistoryStore(db_path)
+    try:
+        local.init()
+    except Exception as exc:
+        log.warning("Could not initialise local SQLite history: %s", exc)
+
+    shared = None
+    try:
+        shared = _build_shared_store(cfg)
+    except HistoryStoreBootstrapError as exc:
+        # Surface as a warning + DDL hint; keep going with local-only
+        # so the user's session is never blocked.
+        log.warning(
+            "Shared history bootstrap failed: %s\n"
+            "Falling back to local-only history.\n"
+            "Run `/history-store enable` after fixing.",
+            exc,
+        )
+    except Exception as exc:
+        log.warning(
+            "Could not connect to shared history store; falling back "
+            "to local-only. Underlying error: %s",
+            exc,
+        )
+
+    if shared is not None:
+        try:
+            shared.init()
+        except Exception as exc:
+            log.warning(
+                "Shared history schema not initialised (%s). Run "
+                "`/history-store enable` to bootstrap the AMX schema.",
+                exc,
+            )
+            shared = None
+
+    if shared is None:
+        sqlite_store._store = local  # type: ignore[assignment]
+        return local
+
+    from amx.storage.dual_write import DualWriteHistoryStore
+
+    dual = DualWriteHistoryStore(local=local, shared=shared)
+    sqlite_store._store = dual  # type: ignore[assignment]
+    return dual
+
+
+def history_store():
+    """Return the active history store singleton, or ``None``."""
+    return sqlite_store._store
+
+
+__all__ = [
+    "HistoryStoreBootstrapError",
+    "history_store",
+    "init_history_store",
+]

--- a/amx/storage/migration.py
+++ b/amx/storage/migration.py
@@ -1,0 +1,276 @@
+"""One-shot migration of local SQLite history → shared warehouse store.
+
+Used by ``/history-store migrate-from-local``. Walks every table in
+foreign-key order, converts INT primary keys (local SQLite) into
+UUIDs (shared schema), records the original ``local_id`` + ``hostname``
+on each shared row so the dual-write coordinator can find the right
+shared row when later UPDATEs fire from this machine.
+
+Idempotent. The shared store rejects rows whose ``(hostname, local_id)``
+already exists for the given table by skipping them — which means
+re-running the migration after a partial failure picks up where it
+left off rather than duplicating data.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import socket
+import sqlite3
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import and_, insert, select
+
+from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+from amx.storage.sqlite_store import SQLiteHistoryStore
+from amx.utils.logging import get_logger
+
+log = get_logger("storage.migration")
+
+
+def _ts(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _hostname() -> str:
+    try:
+        return socket.gethostname() or ""
+    except Exception:
+        return ""
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    # ``dict(row)`` works because ``sqlite3.Row`` supports the mapping
+    # protocol via ``keys()``. The explicit cast avoids ruff's
+    # SIM118 (``.keys()`` removable) which doesn't apply here.
+    return dict(row)
+
+
+def _existing_uuid(
+    shared: SQLAlchemyHistoryStore, table_name: str, hostname: str, local_id: int
+) -> str | None:
+    """Return the UUID for a previously-migrated row, if any."""
+    table = shared._md.tables[f"{shared.schema}.{table_name}"]
+    with shared.engine.begin() as conn:
+        row = conn.execute(
+            select(table.c.id).where(
+                and_(table.c.hostname == hostname, table.c.local_id == local_id)
+            )
+        ).fetchone()
+    return str(row[0]) if row else None
+
+
+def migrate_local_to_shared(
+    local: SQLiteHistoryStore,
+    shared: SQLAlchemyHistoryStore,
+    *,
+    progress: Any | None = None,
+) -> dict[str, int]:
+    """Copy ``analysis_runs``, ``run_results`` and ``app_events`` from local
+    SQLite into the shared SQLAlchemy store.
+
+    Returns a stats dict ``{table: rows_copied}``. ``app_events`` includes
+    every event-type row even if newer than the migration started — the
+    SQLite store is append-only so a second run drops duplicates by
+    ``(hostname, local_id)``.
+    """
+    stats: dict[str, int] = {
+        "analysis_runs": 0,
+        "run_results": 0,
+        "app_events": 0,
+    }
+    # Use the shared store's hostname so subsequent ``find_run_uuid_by_local_id``
+    # lookups (which scope by ``shared._hostname``) resolve. In production
+    # the two values match (both call ``socket.gethostname()``); the
+    # explicit assignment matters for tests that override the store's
+    # hostname.
+    host = getattr(shared, "_hostname", None) or _hostname()
+    started = time.time()
+
+    # Build INT → UUID maps once so run_results can reference the
+    # parent run's freshly-minted UUID without re-querying per row.
+    run_id_map: dict[int, str] = {}
+
+    # ── analysis_runs ─────────────────────────────────────────────────────
+    log.info("Migrating analysis_runs from %s …", local.db_path)
+    with local._connect() as conn:
+        rows = conn.execute("SELECT * FROM analysis_runs ORDER BY id").fetchall()
+
+    table_runs = shared._md.tables[f"{shared.schema}.analysis_runs"]
+    for row in rows:
+        d = _row_to_dict(row)
+        local_id = int(d.get("id") or 0)
+        existing = _existing_uuid(shared, "analysis_runs", host, local_id)
+        if existing:
+            run_id_map[local_id] = existing
+            continue
+        new_uuid = str(uuid.uuid4())
+        run_id_map[local_id] = new_uuid
+        with shared.engine.begin() as sconn:
+            sconn.execute(
+                insert(table_runs).values(
+                    id=new_uuid,
+                    started_at=_ts(d.get("started_at")) or datetime.now(timezone.utc),
+                    ended_at=_ts(d.get("ended_at")),
+                    duration_sec=d.get("duration_sec"),
+                    status=str(d.get("status") or ""),
+                    command=str(d.get("command") or ""),
+                    mode=d.get("mode"),
+                    db_backend=d.get("db_backend"),
+                    db_profile=d.get("db_profile"),
+                    llm_provider=d.get("llm_provider"),
+                    llm_model=d.get("llm_model"),
+                    scope_json=_loads_or_none(d.get("scope_json")),
+                    metrics_json=_loads_or_none(d.get("metrics_json")),
+                    tokens_json=_loads_or_none(d.get("tokens_json")),
+                    results_json=_loads_or_none(d.get("results_json")),
+                    error_text=d.get("error_text"),
+                    selected_count=int(d.get("selected_count") or 0),
+                    planned_count=int(d.get("planned_count") or 0),
+                    processed_count=int(d.get("processed_count") or 0),
+                    applied_count=int(d.get("applied_count") or 0),
+                    review_strategy=d.get("review_strategy"),
+                    llm_profile=d.get("llm_profile"),
+                    doc_profile=d.get("doc_profile"),
+                    code_profile=d.get("code_profile"),
+                    settings_json=_loads_or_none(d.get("settings_json")),
+                    created_by=shared._username,
+                    hostname=host,
+                    client_version=shared._client_version,
+                    local_id=local_id,
+                )
+            )
+        stats["analysis_runs"] += 1
+        if progress is not None:
+            with contextlib.suppress(Exception):
+                progress("analysis_runs", stats["analysis_runs"])
+
+    # ── run_results ───────────────────────────────────────────────────────
+    log.info("Migrating run_results …")
+    with local._connect() as conn:
+        rows = conn.execute("SELECT * FROM run_results ORDER BY id").fetchall()
+
+    table_results = shared._md.tables[f"{shared.schema}.run_results"]
+    for row in rows:
+        d = _row_to_dict(row)
+        local_id = int(d.get("id") or 0)
+        existing = _existing_uuid(shared, "run_results", host, local_id)
+        if existing:
+            continue
+        local_run_id = int(d.get("run_id") or 0)
+        run_uuid = run_id_map.get(local_run_id)
+        if not run_uuid:
+            log.warning(
+                "Skipping run_results.id=%s — its run_id=%s is not in the migrated set.",
+                local_id,
+                local_run_id,
+            )
+            continue
+        with shared.engine.begin() as sconn:
+            sconn.execute(
+                insert(table_results).values(
+                    id=str(uuid.uuid4()),
+                    run_id=run_uuid,
+                    saved_at=_ts(d.get("saved_at")) or datetime.now(timezone.utc),
+                    schema_name=str(d.get("schema_name") or ""),
+                    table_name=str(d.get("table_name") or ""),
+                    column_name=d.get("column_name"),
+                    asset_kind=str(d.get("asset_kind") or "table"),
+                    source=str(d.get("source") or "unknown"),
+                    confidence=str(d.get("confidence") or "medium"),
+                    logprob_score=d.get("logprob_score"),
+                    raw_logprob=d.get("raw_logprob"),
+                    token_count=d.get("token_count"),
+                    model_version=str(d.get("model_version") or ""),
+                    reasoning=d.get("reasoning"),
+                    alternatives_json=_loads_or_none(d.get("alternatives_json")) or [],
+                    evaluated_at=_ts(d.get("evaluated_at")),
+                    applied_at=_ts(d.get("applied_at")),
+                    chosen_description=d.get("chosen_description"),
+                    evaluation=d.get("evaluation"),
+                    catalog_status=str(d.get("catalog_status") or ""),
+                    catalog_indexed_at=_ts(d.get("catalog_indexed_at")),
+                    db_applied_status=str(d.get("db_applied_status") or ""),
+                    effective_source_kind=str(d.get("effective_source_kind") or ""),
+                    superseded_at=_ts(d.get("superseded_at")),
+                    rejection_reason=str(d.get("rejection_reason") or ""),
+                    hostname=host,
+                    local_id=local_id,
+                )
+            )
+        stats["run_results"] += 1
+        if progress is not None:
+            with contextlib.suppress(Exception):
+                progress("run_results", stats["run_results"])
+
+    # ── app_events ────────────────────────────────────────────────────────
+    log.info("Migrating app_events …")
+    with local._connect() as conn:
+        rows = conn.execute("SELECT * FROM app_events ORDER BY id").fetchall()
+
+    table_events = shared._md.tables[f"{shared.schema}.app_events"]
+    for row in rows:
+        d = _row_to_dict(row)
+        local_id = int(d.get("id") or 0)
+        # app_events uses an event-id-as-local-id surrogate; idempotency
+        # is keyed off (hostname, local_id) the same way as the other tables.
+        with shared.engine.begin() as sconn:
+            event_match = sconn.execute(
+                select(table_events.c.id).where(
+                    and_(
+                        table_events.c.hostname == host,
+                        table_events.c.command == str(d.get("command") or ""),
+                        table_events.c.event_type == str(d.get("event_type") or ""),
+                        table_events.c.created_at == _ts(d.get("created_at")),
+                    )
+                )
+            ).fetchone()
+            if event_match:
+                continue
+            sconn.execute(
+                insert(table_events).values(
+                    id=str(uuid.uuid4()),
+                    created_at=_ts(d.get("created_at")) or datetime.now(timezone.utc),
+                    event_type=str(d.get("event_type") or ""),
+                    status=str(d.get("status") or ""),
+                    command=str(d.get("command") or ""),
+                    details_json=_loads_or_none(d.get("details_json")) or {},
+                    created_by=shared._username,
+                    hostname=host,
+                    client_version=shared._client_version,
+                )
+            )
+        stats["app_events"] += 1
+        if progress is not None:
+            with contextlib.suppress(Exception):
+                progress("app_events", stats["app_events"])
+
+    log.info(
+        "Migration finished in %.1fs: %s",
+        time.time() - started,
+        ", ".join(f"{k}={v}" for k, v in stats.items()),
+    )
+    return stats
+
+
+def _loads_or_none(value: Any) -> Any:
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+
+
+__all__ = ["migrate_local_to_shared"]

--- a/amx/storage/protocol.py
+++ b/amx/storage/protocol.py
@@ -1,0 +1,119 @@
+"""Backend-agnostic history-store contract.
+
+The :class:`IHistoryStore` Protocol is the public surface every history
+backend (local SQLite, shared warehouse, dual-write façade) implements.
+Call sites import from this module instead of binding to
+:class:`amx.storage.sqlite_store.SQLiteHistoryStore` directly so swapping
+in :class:`amx.storage.sqlalchemy_store.SQLAlchemyHistoryStore` (shared
+team mode) or :class:`amx.storage.dual_write.DualWriteHistoryStore`
+(local + shared) is transparent.
+
+Only the methods that *all* backends are expected to implement live
+here; SQLite-only conveniences (e.g. ``stats()``) are re-exported from
+the SQLite class for the few callers that need them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class IHistoryStore(Protocol):
+    """Run-history persistence contract shared by every backend."""
+
+    # ── Run lifecycle ─────────────────────────────────────────────────────
+
+    def create_run(
+        self,
+        *,
+        command: str,
+        mode: str,
+        db_backend: str,
+        db_profile: str,
+        llm_provider: str,
+        llm_model: str,
+        scope: dict[str, list[str]],
+        selected_count: int = 0,
+        planned_count: int = 0,
+        review_strategy: str | None = None,
+        llm_profile: str | None = None,
+        doc_profile: str | None = None,
+        code_profile: str | None = None,
+        settings: dict[str, Any] | None = None,
+    ) -> int: ...
+
+    def finish_run(
+        self,
+        run_id: int,
+        *,
+        status: str,
+        metrics: dict[str, Any],
+        tokens: dict[str, Any],
+        results: dict[str, Any],
+        error_text: str = "",
+    ) -> None: ...
+
+    def update_run_status(self, run_id: int, status: str, error_text: str = "") -> None: ...
+
+    def update_run_planned_count(self, run_id: int, planned_count: int) -> None: ...
+
+    def increment_run_processed(self, run_id: int, by: int = 1) -> None: ...
+
+    def increment_run_applied(self, run_id: int, by: int = 1) -> None: ...
+
+    # ── Per-result helpers ────────────────────────────────────────────────
+
+    def save_run_results(self, run_id: int, suggestions: list[dict[str, Any]]) -> list[int]: ...
+
+    def record_evaluation(
+        self,
+        result_id: int,
+        *,
+        chosen_description: str,
+        evaluation: str,
+    ) -> None: ...
+
+    def record_applied(self, result_id: int) -> None: ...
+
+    def record_db_apply_failure(self, result_id: int, error_text: str = "") -> None: ...
+
+    # ── Reads ─────────────────────────────────────────────────────────────
+
+    def get_run(self, run_id: int) -> dict[str, Any] | None: ...
+
+    def get_run_results(
+        self, run_id: int, *, unevaluated_only: bool = False
+    ) -> list[dict[str, Any]]: ...
+
+    def list_recent_runs(
+        self, limit: int = 20, *, command_filter: str | None = "analyze.run"
+    ) -> list[dict[str, Any]]: ...
+
+    def list_runs_with_result_counts(self, limit: int = 20) -> list[dict[str, Any]]: ...
+
+    def find_runs_for_scope(
+        self,
+        *,
+        schema: str | None = None,
+        table: str | None = None,
+        command_filter: str | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]: ...
+
+    def list_recent_events(self, limit: int = 30) -> list[dict[str, Any]]: ...
+
+    # ── Misc ──────────────────────────────────────────────────────────────
+
+    def log_event(
+        self,
+        *,
+        event_type: str,
+        status: str,
+        command: str,
+        details: dict[str, Any] | None = None,
+    ) -> None: ...
+
+    def set_session_state(self, namespace: str, key: str, value: Any) -> None: ...
+
+    def get_session_state(self, namespace: str, key: str, default: Any = None) -> Any: ...

--- a/amx/storage/shared_schema.py
+++ b/amx/storage/shared_schema.py
@@ -1,0 +1,192 @@
+"""SQLAlchemy schema for AMX's shared run-history store.
+
+Every table in the shared (warehouse-hosted) AMX schema is declared
+here as a portable SQLAlchemy ``Table`` against a single ``MetaData``
+instance. ``MetaData.create_all(engine)`` is used to bootstrap the
+schema on first connection in :func:`bootstrap_shared_history`.
+
+Design notes:
+
+* **Primary keys are UUID strings** (``String(36)``) because shared
+  mode supports concurrent writers from multiple machines. INT
+  autoincrement does not work in that setting.
+* **Attribution columns** (``created_by``, ``hostname``, ``client_version``,
+  ``local_id``) live on every row that originates from a specific
+  machine, so ``/history-store list-team`` can show "who ran what".
+* ``local_id`` records the local SQLite INT id, which lets the
+  dual-write coordinator find the corresponding shared row when later
+  ``UPDATE``-style methods (e.g. :meth:`finish_run`) are called.
+* JSON columns use :class:`sqlalchemy.JSON` so the dialect chooses the
+  best native type — ``JSONB`` on PostgreSQL, ``JSON`` on MySQL, ``VARIANT``
+  on Snowflake (via dialect adapters), ``STRING`` everywhere else.
+* ``DateTime(timezone=True)`` is used over float epoch seconds because
+  warehouse query semantics for "last 7 days" expect actual timestamps.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    Column,
+    DateTime,
+    Float,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+)
+
+# Schema name is configurable per-deployment — the user can pick a
+# different name in ``/history-store enable``. Default is ``AMX`` which
+# matches the user-facing nomenclature in docs/CLI prompts.
+DEFAULT_HISTORY_SCHEMA = "AMX"
+
+# All client versions writing into a shared store record this as their
+# ``schema_version`` so an older client refuses to write into a schema
+# bumped by a newer client (avoids losing columns the new client added).
+SHARED_SCHEMA_VERSION = 1
+
+
+def build_metadata(schema: str | None = None) -> MetaData:
+    """Build a fresh ``MetaData`` bound to *schema*.
+
+    A function (rather than a module-level singleton) is used because
+    different deployments may pick different schema names, and SQLAlchemy
+    bakes the schema into each ``Table`` at construction time. Tests and
+    the bootstrap path each get their own ``MetaData`` for isolation.
+    """
+    md = MetaData(schema=schema or DEFAULT_HISTORY_SCHEMA)
+
+    # ── analysis_runs: one row per /run or /ask invocation ────────────────
+    Table(
+        "analysis_runs",
+        md,
+        Column("id", String(36), primary_key=True),  # UUID
+        Column("started_at", DateTime(timezone=True), nullable=False, index=True),
+        Column("ended_at", DateTime(timezone=True)),
+        Column("duration_sec", Float),
+        Column("status", String(40), nullable=False),
+        Column("command", String(80), nullable=False),
+        Column("mode", String(40)),
+        Column("db_backend", String(40)),
+        Column("db_profile", String(120)),
+        Column("llm_provider", String(40)),
+        Column("llm_model", String(120)),
+        Column("scope_json", JSON),
+        Column("metrics_json", JSON),
+        Column("tokens_json", JSON),
+        Column("results_json", JSON),
+        Column("error_text", Text),
+        Column("selected_count", Integer, nullable=False, default=0),
+        Column("planned_count", Integer, nullable=False, default=0),
+        Column("processed_count", Integer, nullable=False, default=0),
+        Column("applied_count", Integer, nullable=False, default=0),
+        Column("review_strategy", String(40)),
+        Column("llm_profile", String(120)),
+        Column("doc_profile", String(120)),
+        Column("code_profile", String(120)),
+        Column("settings_json", JSON),
+        # Attribution — only meaningful in shared mode.
+        Column("created_by", String(120)),
+        Column("hostname", String(255)),
+        Column("client_version", String(40)),
+        # Provenance back to the local row, scoped by hostname so two
+        # machines can both have ``local_id=5`` without collision.
+        Column("local_id", BigInteger),
+        Index("ix_analysis_runs_started_at", "started_at"),
+        Index("ix_analysis_runs_local_lookup", "hostname", "local_id"),
+    )
+
+    # ── run_results: per-asset LLM alternatives + review state ─────────────
+    Table(
+        "run_results",
+        md,
+        Column("id", String(36), primary_key=True),
+        Column("run_id", String(36), nullable=False, index=True),
+        Column("saved_at", DateTime(timezone=True), nullable=False),
+        Column("schema_name", String(255), nullable=False),
+        Column("table_name", String(255), nullable=False),
+        Column("column_name", String(255)),
+        Column("asset_kind", String(40), nullable=False, default="table"),
+        Column("source", String(40), nullable=False),
+        Column("confidence", String(20), nullable=False),
+        Column("logprob_score", Float),
+        Column("raw_logprob", Float),
+        Column("token_count", Integer),
+        Column("model_version", String(120), nullable=False, default=""),
+        Column("reasoning", Text),
+        Column("alternatives_json", JSON, nullable=False),
+        Column("evaluated_at", DateTime(timezone=True)),
+        Column("applied_at", DateTime(timezone=True)),
+        Column("chosen_description", Text),
+        Column("evaluation", String(40)),
+        Column("catalog_status", String(40), nullable=False, default=""),
+        Column("catalog_indexed_at", DateTime(timezone=True)),
+        Column("db_applied_status", String(40), nullable=False, default=""),
+        Column("effective_source_kind", String(40), nullable=False, default=""),
+        Column("superseded_at", DateTime(timezone=True)),
+        Column("rejection_reason", Text, nullable=False, default=""),
+        Column("hostname", String(255)),
+        Column("local_id", BigInteger),
+        Index("ix_run_results_asset", "schema_name", "table_name", "column_name"),
+        Index("ix_run_results_local_lookup", "hostname", "local_id"),
+    )
+
+    # ── app_events: append-only event log ─────────────────────────────────
+    Table(
+        "app_events",
+        md,
+        Column("id", String(36), primary_key=True),
+        Column("created_at", DateTime(timezone=True), nullable=False, index=True),
+        Column("event_type", String(80), nullable=False),
+        Column("status", String(40), nullable=False),
+        Column("command", String(120), nullable=False),
+        Column("details_json", JSON),
+        Column("created_by", String(120)),
+        Column("hostname", String(255)),
+        Column("client_version", String(40)),
+        Index("ix_app_events_created_at", "created_at"),
+    )
+
+    # ── session_state: namespaced key/value storage ───────────────────────
+    # Used by ``StateManager`` for inter-turn agent memory. In shared
+    # mode it lets the team (or the same user across machines) share
+    # session checkpoints. ``hostname`` is part of the PK so two
+    # machines can hold independent state under the same namespace/key.
+    Table(
+        "session_state",
+        md,
+        Column("namespace", String(120), primary_key=True),
+        Column("key_name", String(255), primary_key=True),
+        Column("hostname", String(255), primary_key=True, default=""),
+        Column("value_json", JSON, nullable=False),
+        Column("updated_at", DateTime(timezone=True), nullable=False),
+        Column("created_by", String(120)),
+    )
+
+    # ── schema_meta: version stamp so older clients refuse to write ──────
+    # Single-row table. The /history-store enable bootstrap inserts
+    # version=SHARED_SCHEMA_VERSION; a newer client bumps it on its
+    # first write; an older client refuses to write when it sees a
+    # higher version than it knows about (mirrors the AMXConfig
+    # schema_version guard).
+    Table(
+        "schema_meta",
+        md,
+        Column("id", Integer, primary_key=True),  # always 1
+        Column("schema_version", Integer, nullable=False),
+        Column("created_at", DateTime(timezone=True), nullable=False),
+        Column("created_by_client_version", String(40)),
+    )
+
+    return md
+
+
+__all__ = [
+    "DEFAULT_HISTORY_SCHEMA",
+    "SHARED_SCHEMA_VERSION",
+    "build_metadata",
+]

--- a/amx/storage/sqlalchemy_store.py
+++ b/amx/storage/sqlalchemy_store.py
@@ -1,0 +1,606 @@
+"""Warehouse-backed history store.
+
+Mirrors the public surface of :class:`amx.storage.sqlite_store.SQLiteHistoryStore`
+but persists every row into a remote relational backend (PostgreSQL,
+MySQL, Snowflake, Databricks, …) via SQLAlchemy Core. The class is
+intentionally a 1:1 method-for-method analogue of the SQLite store so
+the diff between local and shared semantics is reviewable.
+
+Used in two ways:
+
+1. **Direct** — when the user has shared mode enabled and wants reads
+   to come from the team store. (Future minor; v0.12 reads still come
+   from the local SQLite cache.)
+2. **Wrapped** — :class:`amx.storage.dual_write.DualWriteHistoryStore`
+   wraps both a :class:`SQLiteHistoryStore` (local cache, source of
+   truth for read paths) and an instance of this class (remote, source
+   of truth for the team).
+
+Concurrency model: every method opens a fresh ``engine.begin()`` and
+commits at the end. SQLAlchemy's connection pool handles reuse; we
+never share connections across threads.
+
+Identifiers: PKs are UUIDv4 strings. Local INT ids from the SQLite
+side travel as ``local_id`` + ``hostname`` columns so the dual-write
+coordinator can find the corresponding shared row when later UPDATEs
+fire (e.g. ``finish_run`` for a run that was created on this host).
+"""
+
+from __future__ import annotations
+
+import getpass
+import socket
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import and_, delete, insert, select, update
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
+
+from amx.storage.shared_schema import (
+    SHARED_SCHEMA_VERSION,
+    build_metadata,
+)
+from amx.utils.logging import get_logger
+
+log = get_logger("storage.sqlalchemy")
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ts_to_dt(ts: float | None) -> datetime | None:
+    """Convert a float epoch second (the SQLite store's native time
+    unit) into a timezone-aware ``datetime`` for portable backends."""
+    if ts is None:
+        return None
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _client_version() -> str:
+    try:
+        from amx import __version__ as v
+
+        return str(v)
+    except Exception:
+        return ""
+
+
+def _hostname() -> str:
+    try:
+        return socket.gethostname() or ""
+    except Exception:
+        return ""
+
+
+def _username() -> str:
+    try:
+        return getpass.getuser() or ""
+    except Exception:
+        return ""
+
+
+class SchemaVersionMismatch(RuntimeError):
+    """Raised when the shared schema version is newer than this client knows."""
+
+
+class SQLAlchemyHistoryStore:
+    """Run-history persistence backed by a SQLAlchemy Engine.
+
+    Parameters
+    ----------
+    engine
+        Pre-built SQLAlchemy engine for the team backend.
+    schema
+        Schema/database name where AMX tables live (default ``"AMX"``).
+    """
+
+    def __init__(self, engine: Engine, schema: str) -> None:
+        self.engine = engine
+        self.schema = schema
+        self._md = build_metadata(schema=schema)
+        self._t_runs = self._md.tables[f"{schema}.analysis_runs"]
+        self._t_results = self._md.tables[f"{schema}.run_results"]
+        self._t_events = self._md.tables[f"{schema}.app_events"]
+        self._t_session = self._md.tables[f"{schema}.session_state"]
+        self._t_meta = self._md.tables[f"{schema}.schema_meta"]
+        self._hostname = _hostname()
+        self._username = _username()
+        self._client_version = _client_version()
+
+    # ── Bootstrap ─────────────────────────────────────────────────────────
+
+    def init(self) -> None:
+        """Create tables on the remote backend if they do not exist.
+
+        Idempotent. ``MetaData.create_all`` skips tables that already
+        exist. Also stamps :data:`SHARED_SCHEMA_VERSION` into
+        ``schema_meta`` so older clients can detect a forward-rolled schema.
+        """
+        self._md.create_all(self.engine)
+        with self.engine.begin() as conn:
+            existing = conn.execute(select(self._t_meta.c.schema_version)).fetchone()
+            if existing is None:
+                conn.execute(
+                    insert(self._t_meta).values(
+                        id=1,
+                        schema_version=SHARED_SCHEMA_VERSION,
+                        created_at=_utcnow(),
+                        created_by_client_version=self._client_version,
+                    )
+                )
+            else:
+                stored = int(existing[0])
+                if stored > SHARED_SCHEMA_VERSION:
+                    raise SchemaVersionMismatch(
+                        f"Shared AMX schema version {stored} is newer than this "
+                        f"client supports ({SHARED_SCHEMA_VERSION}). Upgrade AMX."
+                    )
+
+    # ── Run lifecycle ─────────────────────────────────────────────────────
+
+    def create_run(
+        self,
+        *,
+        command: str,
+        mode: str,
+        db_backend: str,
+        db_profile: str,
+        llm_provider: str,
+        llm_model: str,
+        scope: dict[str, list[str]],
+        selected_count: int = 0,
+        planned_count: int = 0,
+        review_strategy: str | None = None,
+        llm_profile: str | None = None,
+        doc_profile: str | None = None,
+        code_profile: str | None = None,
+        settings: dict[str, Any] | None = None,
+        # Shared-mode extras (passed by DualWriteHistoryStore so
+        # ``local_id`` ties the shared row to the SQLite row).
+        run_id: str | None = None,
+        local_id: int | None = None,
+    ) -> str:
+        """Insert a new run row, returning the UUID PK.
+
+        ``run_id`` may be supplied to use a pre-generated UUID — used by
+        the dual-write coordinator so the same UUID is re-used in
+        retry-from-outbox flows.
+        """
+        if selected_count <= 0:
+            try:
+                selected_count = sum(len(v or []) for v in (scope or {}).values())
+            except Exception:
+                selected_count = 0
+        if planned_count <= 0:
+            planned_count = selected_count
+        rid = run_id or _new_uuid()
+        with self.engine.begin() as conn:
+            conn.execute(
+                insert(self._t_runs).values(
+                    id=rid,
+                    started_at=_utcnow(),
+                    status="running",
+                    command=command,
+                    mode=mode,
+                    db_backend=db_backend,
+                    db_profile=db_profile,
+                    llm_provider=llm_provider,
+                    llm_model=llm_model,
+                    scope_json=scope,
+                    selected_count=int(selected_count),
+                    planned_count=int(planned_count),
+                    processed_count=0,
+                    applied_count=0,
+                    review_strategy=str(review_strategy or ""),
+                    llm_profile=llm_profile,
+                    doc_profile=doc_profile,
+                    code_profile=code_profile,
+                    settings_json=settings,
+                    created_by=self._username,
+                    hostname=self._hostname,
+                    client_version=self._client_version,
+                    local_id=local_id,
+                )
+            )
+        return rid
+
+    def finish_run(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        metrics: dict[str, Any],
+        tokens: dict[str, Any],
+        results: dict[str, Any],
+        error_text: str = "",
+    ) -> None:
+        with self.engine.begin() as conn:
+            row = conn.execute(
+                select(self._t_runs.c.started_at).where(self._t_runs.c.id == run_id)
+            ).fetchone()
+            ended = _utcnow()
+            if row and row[0] is not None:
+                # SQLite returns datetimes as naive even when TIMESTAMP
+                # WITH TIME ZONE was requested. Reattach UTC so the
+                # subtraction against ``ended`` (always tz-aware) is valid.
+                started = row[0]
+                if started.tzinfo is None:
+                    started = started.replace(tzinfo=timezone.utc)
+                duration = max(0.0, (ended - started).total_seconds())
+            else:
+                duration = 0.0
+            conn.execute(
+                update(self._t_runs)
+                .where(self._t_runs.c.id == run_id)
+                .values(
+                    ended_at=ended,
+                    duration_sec=duration,
+                    status=status,
+                    metrics_json=metrics,
+                    tokens_json=tokens,
+                    results_json=results,
+                    error_text=(error_text or "")[:4000],
+                )
+            )
+
+    def update_run_status(self, run_id: str, status: str, error_text: str = "") -> None:
+        with self.engine.begin() as conn:
+            current = conn.execute(
+                select(self._t_runs.c.error_text).where(self._t_runs.c.id == run_id)
+            ).fetchone()
+            existing_err = current[0] if current else ""
+            if status == "success":
+                err_value = ""
+            elif error_text:
+                err_value = error_text
+            else:
+                err_value = existing_err
+            conn.execute(
+                update(self._t_runs)
+                .where(self._t_runs.c.id == run_id)
+                .values(status=status, error_text=err_value)
+            )
+
+    def update_run_planned_count(self, run_id: str, planned_count: int) -> None:
+        with self.engine.begin() as conn:
+            conn.execute(
+                update(self._t_runs)
+                .where(self._t_runs.c.id == run_id)
+                .values(planned_count=int(planned_count))
+            )
+
+    def increment_run_processed(self, run_id: str, by: int = 1) -> None:
+        with self.engine.begin() as conn:
+            conn.execute(
+                update(self._t_runs)
+                .where(self._t_runs.c.id == run_id)
+                .values(processed_count=self._t_runs.c.processed_count + int(by))
+            )
+
+    def increment_run_applied(self, run_id: str, by: int = 1) -> None:
+        with self.engine.begin() as conn:
+            conn.execute(
+                update(self._t_runs)
+                .where(self._t_runs.c.id == run_id)
+                .values(applied_count=self._t_runs.c.applied_count + int(by))
+            )
+
+    # ── Per-result helpers ────────────────────────────────────────────────
+
+    def save_run_results(
+        self,
+        run_id: str,
+        suggestions: list[dict[str, Any]],
+        local_ids: list[int] | None = None,
+    ) -> list[str]:
+        """Insert all LLM alternatives for a run; return the inserted UUIDs.
+
+        ``local_ids`` parallel-arrays with ``suggestions`` so each shared
+        row records the SQLite INT id from the local store. Used by
+        :class:`amx.storage.dual_write.DualWriteHistoryStore` so the
+        later ``record_applied(local_int_id)`` call can find the right
+        shared row.
+        """
+        ids: list[str] = []
+        if not suggestions:
+            return ids
+        now = _utcnow()
+        rows = []
+        for idx, s in enumerate(suggestions):
+            rid = _new_uuid()
+            ids.append(rid)
+            rows.append(
+                {
+                    "id": rid,
+                    "run_id": run_id,
+                    "saved_at": now,
+                    "schema_name": s.get("schema", ""),
+                    "table_name": s.get("table", ""),
+                    "column_name": s.get("column"),
+                    "asset_kind": s.get("asset_kind", "table"),
+                    "source": s.get("source", "unknown"),
+                    "confidence": s.get("confidence", "medium"),
+                    "logprob_score": s.get("logprob_score"),
+                    "raw_logprob": s.get("raw_logprob", s.get("logprob_score")),
+                    "token_count": s.get("token_count"),
+                    "model_version": s.get("model_version", ""),
+                    "reasoning": s.get("reasoning", ""),
+                    "alternatives_json": s.get("alternatives", []),
+                    "rejection_reason": "",
+                    "hostname": self._hostname,
+                    "local_id": (local_ids[idx] if local_ids and idx < len(local_ids) else None),
+                }
+            )
+        with self.engine.begin() as conn:
+            conn.execute(insert(self._t_results), rows)
+        return ids
+
+    def record_evaluation(
+        self,
+        result_id: str,
+        *,
+        chosen_description: str,
+        evaluation: str,
+    ) -> None:
+        with self.engine.begin() as conn:
+            conn.execute(
+                update(self._t_results)
+                .where(self._t_results.c.id == result_id)
+                .values(
+                    evaluated_at=_utcnow(),
+                    chosen_description=chosen_description,
+                    evaluation=evaluation,
+                )
+            )
+
+    def record_applied(self, result_id: str) -> None:
+        with self.engine.begin() as conn:
+            conn.execute(
+                update(self._t_results)
+                .where(self._t_results.c.id == result_id)
+                .values(
+                    applied_at=_utcnow(),
+                    db_applied_status="applied",
+                    rejection_reason="",
+                )
+            )
+
+    def record_db_apply_failure(self, result_id: str, error_text: str = "") -> None:
+        with self.engine.begin() as conn:
+            existing = conn.execute(
+                select(self._t_results.c.rejection_reason).where(self._t_results.c.id == result_id)
+            ).fetchone()
+            current_reason = existing[0] if existing else ""
+            new_reason = error_text if error_text else current_reason
+            conn.execute(
+                update(self._t_results)
+                .where(self._t_results.c.id == result_id)
+                .values(db_applied_status="failed", rejection_reason=new_reason or "")
+            )
+
+    # ── Reads ─────────────────────────────────────────────────────────────
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        with self.engine.begin() as conn:
+            row = (
+                conn.execute(select(self._t_runs).where(self._t_runs.c.id == run_id))
+                .mappings()
+                .fetchone()
+            )
+        return dict(row) if row else None
+
+    def get_run_results(
+        self, run_id: str, *, unevaluated_only: bool = False
+    ) -> list[dict[str, Any]]:
+        stmt = select(self._t_results).where(self._t_results.c.run_id == run_id)
+        if unevaluated_only:
+            stmt = stmt.where(
+                (self._t_results.c.evaluation.is_(None)) | (self._t_results.c.evaluation == "")
+            )
+        stmt = stmt.order_by(self._t_results.c.saved_at)
+        with self.engine.begin() as conn:
+            rows = conn.execute(stmt).mappings().all()
+        return [dict(r) for r in rows]
+
+    def list_recent_runs(
+        self, limit: int = 20, *, command_filter: str | None = "analyze.run"
+    ) -> list[dict[str, Any]]:
+        stmt = select(self._t_runs)
+        if command_filter:
+            stmt = stmt.where(self._t_runs.c.command == command_filter)
+        stmt = stmt.order_by(self._t_runs.c.started_at.desc()).limit(max(1, int(limit)))
+        with self.engine.begin() as conn:
+            rows = conn.execute(stmt).mappings().all()
+        return [dict(r) for r in rows]
+
+    def list_runs_with_result_counts(self, limit: int = 20) -> list[dict[str, Any]]:
+        # Two-step (run list + per-run count) keeps the query portable
+        # across the eight Tier-1/2 backends without needing dialect-
+        # specific GROUP BY shapes.
+        runs = self.list_recent_runs(limit=limit, command_filter=None)
+        if not runs:
+            return []
+        with self.engine.begin() as conn:
+            for r in runs:
+                rid = r.get("id")
+                if not rid:
+                    r["total_alternatives"] = 0
+                    r["pending_count"] = 0
+                    continue
+                total = conn.execute(
+                    select(self._t_results.c.id).where(self._t_results.c.run_id == rid)
+                ).fetchall()
+                pending = conn.execute(
+                    select(self._t_results.c.id).where(
+                        and_(
+                            self._t_results.c.run_id == rid,
+                            (self._t_results.c.evaluation.is_(None))
+                            | (self._t_results.c.evaluation == ""),
+                        )
+                    )
+                ).fetchall()
+                r["total_alternatives"] = len(total)
+                r["pending_count"] = len(pending)
+        return runs
+
+    def find_runs_for_scope(
+        self,
+        *,
+        schema: str | None = None,
+        table: str | None = None,
+        command_filter: str | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        # Portable scope filtering: pull the recent N×4 rows and filter
+        # in Python rather than emit a backend-specific JSON query.
+        # /compare itself usually only inspects the last few runs so
+        # the bandwidth cost is negligible.
+        rows = self.list_recent_runs(limit=max(1, int(limit) * 4), command_filter=command_filter)
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            scope_json = r.get("scope_json") or {}
+            if schema and schema not in scope_json:
+                continue
+            if table:
+                tables = scope_json.get(schema, []) if schema else []
+                # If schema not specified, search across all schemas
+                all_tables = (
+                    list(tables) if schema else [t for v in scope_json.values() for t in (v or [])]
+                )
+                if table not in all_tables:
+                    continue
+            out.append(r)
+            if len(out) >= int(limit):
+                break
+        return out
+
+    def list_recent_events(self, limit: int = 30) -> list[dict[str, Any]]:
+        stmt = (
+            select(self._t_events)
+            .order_by(self._t_events.c.created_at.desc())
+            .limit(max(1, int(limit)))
+        )
+        with self.engine.begin() as conn:
+            rows = conn.execute(stmt).mappings().all()
+        return [dict(r) for r in rows]
+
+    # ── Misc ──────────────────────────────────────────────────────────────
+
+    def log_event(
+        self,
+        *,
+        event_type: str,
+        status: str,
+        command: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        with self.engine.begin() as conn:
+            conn.execute(
+                insert(self._t_events).values(
+                    id=_new_uuid(),
+                    created_at=_utcnow(),
+                    event_type=event_type,
+                    status=status,
+                    command=command,
+                    details_json=details or {},
+                    created_by=self._username,
+                    hostname=self._hostname,
+                    client_version=self._client_version,
+                )
+            )
+
+    def set_session_state(self, namespace: str, key: str, value: Any) -> None:
+        # Session state on shared store is keyed by hostname so
+        # different machines do not stomp on each other's checkpoints.
+        with self.engine.begin() as conn:
+            conn.execute(
+                delete(self._t_session).where(
+                    and_(
+                        self._t_session.c.namespace == namespace,
+                        self._t_session.c.key_name == key,
+                        self._t_session.c.hostname == self._hostname,
+                    )
+                )
+            )
+            conn.execute(
+                insert(self._t_session).values(
+                    namespace=namespace,
+                    key_name=key,
+                    hostname=self._hostname,
+                    value_json=value,
+                    updated_at=_utcnow(),
+                    created_by=self._username,
+                )
+            )
+
+    def get_session_state(self, namespace: str, key: str, default: Any = None) -> Any:
+        with self.engine.begin() as conn:
+            row = conn.execute(
+                select(self._t_session.c.value_json).where(
+                    and_(
+                        self._t_session.c.namespace == namespace,
+                        self._t_session.c.key_name == key,
+                        self._t_session.c.hostname == self._hostname,
+                    )
+                )
+            ).fetchone()
+        if not row:
+            return default
+        return row[0]
+
+    # ── Dual-write convenience (used by DualWriteHistoryStore) ────────────
+
+    def find_run_uuid_by_local_id(self, local_id: int) -> str | None:
+        """Look up the shared UUID for a given local SQLite int id.
+
+        Returns ``None`` if the row was never propagated (e.g., shared
+        write failed and the outbox still owns it). Scoped to *this*
+        machine's hostname so two laptops with overlapping local ids
+        do not cross-pollute.
+        """
+        try:
+            with self.engine.begin() as conn:
+                row = conn.execute(
+                    select(self._t_runs.c.id).where(
+                        and_(
+                            self._t_runs.c.hostname == self._hostname,
+                            self._t_runs.c.local_id == int(local_id),
+                        )
+                    )
+                ).fetchone()
+            return str(row[0]) if row else None
+        except SQLAlchemyError as exc:
+            log.debug("find_run_uuid_by_local_id failed: %s", exc)
+            return None
+
+    def find_result_uuid_by_local_id(self, local_id: int) -> str | None:
+        try:
+            with self.engine.begin() as conn:
+                row = conn.execute(
+                    select(self._t_results.c.id).where(
+                        and_(
+                            self._t_results.c.hostname == self._hostname,
+                            self._t_results.c.local_id == int(local_id),
+                        )
+                    )
+                ).fetchone()
+            return str(row[0]) if row else None
+        except SQLAlchemyError as exc:
+            log.debug("find_result_uuid_by_local_id failed: %s", exc)
+            return None
+
+
+__all__ = [
+    "SQLAlchemyHistoryStore",
+    "SchemaVersionMismatch",
+]

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -988,11 +988,24 @@ class SQLiteHistoryStore:
         return out
 
 
-_store: SQLiteHistoryStore | None = None
+# The singleton is typed as ``Any`` so v0.12.0+ shared-history mode
+# can store a :class:`amx.storage.dual_write.DualWriteHistoryStore`
+# (which implements :class:`amx.storage.protocol.IHistoryStore` but is
+# not a SQLiteHistoryStore subclass). All call sites use Protocol-
+# compatible methods, so the loose typing does not hurt them.
+_store: Any | None = None
 
 
 def init_history_store(config_dir: str) -> SQLiteHistoryStore:
-    """Initialize and return the singleton history store."""
+    """Initialize the local-only history store (legacy entry point).
+
+    .. deprecated:: 0.12.0
+        Prefer :func:`amx.storage.factory.init_history_store(cfg)` —
+        the new entry takes an :class:`AMXConfig` and dispatches to
+        the dual-write store when shared mode is enabled. This shim
+        is kept so the headless application path (which never calls
+        the CLI directly) continues to work.
+    """
     global _store
     if _store is None:
         db_path = Path(config_dir) / "history.db"
@@ -1005,5 +1018,10 @@ def init_history_store(config_dir: str) -> SQLiteHistoryStore:
     return _store
 
 
-def history_store() -> SQLiteHistoryStore | None:
+def history_store() -> Any | None:
+    """Return the active singleton.
+
+    May be ``SQLiteHistoryStore`` (local-only) or ``DualWriteHistoryStore``
+    (shared mode) — both implement the :class:`IHistoryStore` Protocol.
+    """
     return _store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx"
-version = "0.11.0"
+version = "0.12.0"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_dual_write_outbox.py
+++ b/tests/test_dual_write_outbox.py
@@ -1,0 +1,157 @@
+"""Tests for the dual-write outbox semantics.
+
+When the shared store fails on a write, ``DualWriteHistoryStore``
+must:
+1. Keep the local row (the user's CLI session never breaks).
+2. Queue the failed op in ``pending_shared_writes``.
+3. Retry it on ``flush_pending()``.
+
+These tests fake the shared store with a controllable mock so we can
+flip its behaviour mid-test (fail → succeed) and assert the outbox
+drains as expected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+
+from amx.storage.dual_write import DualWriteHistoryStore
+from amx.storage.shared_schema import build_metadata
+from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _make_shared(tmp_path: Path) -> SQLAlchemyHistoryStore:
+    db_path = tmp_path / "shared.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    md = build_metadata(schema="main")
+    md.create_all(engine)
+    s = SQLAlchemyHistoryStore.__new__(SQLAlchemyHistoryStore)
+    s.engine = engine
+    s.schema = "main"
+    s._md = md
+    s._t_runs = md.tables["main.analysis_runs"]
+    s._t_results = md.tables["main.run_results"]
+    s._t_events = md.tables["main.app_events"]
+    s._t_session = md.tables["main.session_state"]
+    s._t_meta = md.tables["main.schema_meta"]
+    s._hostname = "test-host"
+    s._username = "test-user"
+    s._client_version = "0.12.0-test"
+    return s
+
+
+@pytest.fixture
+def dual(tmp_path: Path) -> DualWriteHistoryStore:
+    local = SQLiteHistoryStore(tmp_path / "local.db")
+    local.init()
+    shared = _make_shared(tmp_path)
+    return DualWriteHistoryStore(local=local, shared=shared)
+
+
+def test_create_run_writes_to_both(dual: DualWriteHistoryStore) -> None:
+    rid = dual.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile="default",
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope={"public": ["t"]},
+    )
+    assert isinstance(rid, int) and rid > 0
+    # Local has the run
+    assert dual.local.get_run(rid) is not None
+    # Shared has a row keyed by hostname + local_id
+    found = dual.shared.find_run_uuid_by_local_id(rid)
+    assert found is not None
+    # Outbox is empty
+    assert dual.pending_count() == 0
+
+
+def test_outbox_grows_when_shared_fails(dual: DualWriteHistoryStore) -> None:
+    """When shared.create_run raises, the local row still exists and the
+    op is queued for retry."""
+    # Replace shared store's create_run with a raising mock so the
+    # next dual write fails just on the shared side.
+    original = dual.shared.create_run
+    dual.shared.create_run = MagicMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("network down")
+    )
+    rid = dual.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile="default",
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope={"public": ["t"]},
+    )
+    assert isinstance(rid, int)
+    assert dual.local.get_run(rid) is not None
+    assert dual.pending_count() == 1
+
+    # Restore the real shared.create_run and flush — outbox should drain.
+    dual.shared.create_run = original  # type: ignore[method-assign]
+    succeeded, remaining = dual.flush_pending()
+    assert succeeded == 1
+    assert remaining == 0
+
+
+def test_flush_pending_does_not_drop_failed_after_max_attempts(
+    dual: DualWriteHistoryStore,
+) -> None:
+    """A persistently-failing op stays in the outbox so the user can
+    inspect it. We never silently drop work."""
+    dual.shared.create_run = MagicMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("still down")
+    )
+    for _ in range(3):
+        dual.create_run(
+            command="analyze.run",
+            mode="auto",
+            db_backend="postgresql",
+            db_profile="default",
+            llm_provider="openai",
+            llm_model="gpt-5",
+            scope={"public": ["t"]},
+        )
+    assert dual.pending_count() == 3
+    # Flush; everything still fails — succeeded=0, remaining=3.
+    succeeded, remaining = dual.flush_pending()
+    assert succeeded == 0
+    assert remaining == 3
+
+
+def test_log_event_dual_write(dual: DualWriteHistoryStore) -> None:
+    dual.log_event(event_type="cli.start", status="ok", command="/", details={"v": 1})
+    local_events = dual.local.list_recent_events(limit=10)
+    shared_events = dual.shared.list_recent_events(limit=10)
+    assert len(local_events) == 1
+    assert len(shared_events) == 1
+    assert local_events[0]["event_type"] == "cli.start"
+    assert shared_events[0]["event_type"] == "cli.start"
+
+
+def test_reads_come_from_local(dual: DualWriteHistoryStore) -> None:
+    """Reads always go through local SQLite — even when shared has different data.
+
+    This is intentional: shared mode v0.12 is dual-write but local-read
+    so /history list is always fast and consistent with the user's
+    machine. Team-wide reads are a follow-up minor.
+    """
+    rid = dual.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile="default",
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope={"public": ["t"]},
+    )
+    listed = dual.list_recent_runs(limit=5, command_filter="analyze.run")
+    assert any(r["id"] == rid for r in listed)

--- a/tests/test_history_migration.py
+++ b/tests/test_history_migration.py
@@ -1,0 +1,127 @@
+"""Local-SQLite → shared migration tests.
+
+The migration helper walks the FK graph (``analysis_runs`` →
+``run_results`` → ``app_events``), assigns UUID PKs to shared rows,
+records the original local INT id + hostname so the dual-write
+coordinator can later look up the right shared row.
+
+These tests exercise the migration against an in-memory SQLite-backed
+"shared" engine (no network, fast) and assert the row counts and FK
+linkage round-trip.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+
+from amx.storage.migration import migrate_local_to_shared
+from amx.storage.shared_schema import build_metadata
+from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _make_shared(tmp_path: Path) -> SQLAlchemyHistoryStore:
+    db_path = tmp_path / "shared.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    md = build_metadata(schema="main")
+    md.create_all(engine)
+    s = SQLAlchemyHistoryStore.__new__(SQLAlchemyHistoryStore)
+    s.engine = engine
+    s.schema = "main"
+    s._md = md
+    s._t_runs = md.tables["main.analysis_runs"]
+    s._t_results = md.tables["main.run_results"]
+    s._t_events = md.tables["main.app_events"]
+    s._t_session = md.tables["main.session_state"]
+    s._t_meta = md.tables["main.schema_meta"]
+    s._hostname = "test-host"
+    s._username = "test-user"
+    s._client_version = "0.12.0-test"
+    return s
+
+
+@pytest.fixture
+def seeded_local(tmp_path: Path) -> SQLiteHistoryStore:
+    db_path = tmp_path / "local.db"
+    s = SQLiteHistoryStore(db_path)
+    s.init()
+    rid = s.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile="default",
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope={"public": ["users", "orders"]},
+        selected_count=2,
+        planned_count=2,
+    )
+    s.save_run_results(
+        rid,
+        [
+            {
+                "schema": "public",
+                "table": "users",
+                "column": "email",
+                "asset_kind": "column",
+                "source": "llm",
+                "confidence": "high",
+                "alternatives": ["user email"],
+            },
+            {
+                "schema": "public",
+                "table": "orders",
+                "column": "id",
+                "asset_kind": "column",
+                "source": "llm",
+                "confidence": "medium",
+                "alternatives": ["order id"],
+            },
+        ],
+    )
+    s.finish_run(rid, status="success", metrics={}, tokens={}, results={"applied": 0})
+    s.log_event(event_type="analyze.run", status="success", command="/run", details={})
+    return s
+
+
+def test_migration_copies_all_tables(seeded_local: SQLiteHistoryStore, tmp_path: Path) -> None:
+    shared = _make_shared(tmp_path)
+    stats = migrate_local_to_shared(local=seeded_local, shared=shared)
+    assert stats["analysis_runs"] == 1
+    assert stats["run_results"] == 2
+    assert stats["app_events"] == 1
+
+
+def test_migration_is_idempotent(seeded_local: SQLiteHistoryStore, tmp_path: Path) -> None:
+    """Running the migration twice copies once and skips the second run."""
+    shared = _make_shared(tmp_path)
+    first = migrate_local_to_shared(local=seeded_local, shared=shared)
+    second = migrate_local_to_shared(local=seeded_local, shared=shared)
+    assert first["analysis_runs"] == 1
+    assert second["analysis_runs"] == 0  # nothing new to copy
+    assert first["run_results"] == 2
+    assert second["run_results"] == 0
+
+
+def test_migration_preserves_fks(seeded_local: SQLiteHistoryStore, tmp_path: Path) -> None:
+    """Each shared run_results row should resolve back to its parent run."""
+    shared = _make_shared(tmp_path)
+    migrate_local_to_shared(local=seeded_local, shared=shared)
+    runs = shared.list_recent_runs(limit=10, command_filter="analyze.run")
+    assert len(runs) == 1
+    parent_uuid = runs[0]["id"]
+    results = shared.get_run_results(parent_uuid)
+    assert len(results) == 2
+    assert all(r["run_id"] == parent_uuid for r in results)
+
+
+def test_migration_records_local_id(seeded_local: SQLiteHistoryStore, tmp_path: Path) -> None:
+    """``find_run_uuid_by_local_id`` finds the shared row by INT id."""
+    shared = _make_shared(tmp_path)
+    migrate_local_to_shared(local=seeded_local, shared=shared)
+    # The seed created run id=1 in local — assert we can look it up.
+    found = shared.find_run_uuid_by_local_id(1)
+    assert found is not None

--- a/tests/test_history_store_capability_gating.py
+++ b/tests/test_history_store_capability_gating.py
@@ -1,0 +1,70 @@
+"""Capability-gating tests for shared run-history.
+
+DuckDB and ClickHouse adapters explicitly leave
+``BackendCapabilities.supports_shared_history = False`` because
+neither backend can hold AMX's run-history schema (DuckDB is a local
+file; ClickHouse cannot UPDATE rows the way ``finish_run`` needs).
+The factory must reject these backends with a clear error.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amx.config import AMXConfig, DBConfig
+from amx.db.adapters import get_adapter
+from amx.storage.factory import HistoryStoreBootstrapError, _build_shared_store
+
+
+@pytest.mark.parametrize(
+    "backend,expected_flag",
+    [
+        ("postgresql", True),
+        ("mysql", True),
+        ("mssql", True),
+        ("oracle", True),
+        ("redshift", True),
+        ("snowflake", True),
+        ("databricks", True),
+        ("bigquery", True),
+        ("duckdb", False),
+        ("clickhouse", False),
+    ],
+)
+def test_supports_shared_history_flag(backend: str, expected_flag: bool) -> None:
+    db = DBConfig(backend=backend)
+    try:
+        adapter = get_adapter(db)
+    except ImportError:
+        # The adapter's optional driver is not installed in this test
+        # environment. The capability flag is on the class itself, so
+        # we can read it from the class without instantiating.
+        pytest.skip(f"Optional driver for {backend!r} not installed in this environment.")
+    assert adapter.capabilities.supports_shared_history is expected_flag, (
+        f"{backend!r}: expected supports_shared_history={expected_flag}, "
+        f"got {adapter.capabilities.supports_shared_history}"
+    )
+
+
+def test_factory_rejects_unsupported_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Asking the factory to build a shared store on DuckDB raises a
+    HistoryStoreBootstrapError naming the backend."""
+    cfg = AMXConfig()
+    cfg.history_store_enabled = True
+    cfg.history_store_profile = "duck-prof"
+    cfg.history_store_schema = "AMX"
+    cfg.db_profiles["duck-prof"] = DBConfig(backend="duckdb", database=":memory:")
+
+    with pytest.raises(HistoryStoreBootstrapError) as exc_info:
+        _build_shared_store(cfg)
+    assert "duckdb" in str(exc_info.value).lower()
+
+
+def test_factory_warns_when_profile_missing(caplog: pytest.LogCaptureFixture) -> None:
+    """A missing history_store_profile is a soft fallback to local-only,
+    not a hard error — we never break the user's session for config drift."""
+    cfg = AMXConfig()
+    cfg.history_store_enabled = True
+    cfg.history_store_profile = "does-not-exist"
+    result = _build_shared_store(cfg)
+    assert result is None

--- a/tests/test_shared_history_protocol.py
+++ b/tests/test_shared_history_protocol.py
@@ -1,0 +1,230 @@
+"""Protocol-conformance tests for the shared run-history backends.
+
+Both :class:`SQLiteHistoryStore` (local) and
+:class:`SQLAlchemyHistoryStore` (shared) implement the
+:class:`IHistoryStore` Protocol. This file pins their behaviour by
+exercising every method against an in-memory SQLite-backed
+SQLAlchemy engine — fast, deterministic, no network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+
+from amx.storage.protocol import IHistoryStore
+from amx.storage.shared_schema import build_metadata
+from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def shared_store(tmp_path: Path) -> SQLAlchemyHistoryStore:
+    """SQLAlchemy store backed by an in-memory SQLite engine.
+
+    SQLite-as-target gives us a portable Plain-SQL backend whose
+    behaviour matches PostgreSQL closely enough for protocol-level
+    sanity checks. Per-backend dialect quirks (Snowflake VARIANT,
+    BigQuery quotas) are tested separately under the integration tier.
+    """
+    db_path = tmp_path / "shared.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    # SQLite does not support real schemas — pretend the schema is the
+    # default by passing ``schema=None`` to ``build_metadata`` which
+    # binds tables to the default ``main`` schema.
+    md = build_metadata(schema="main")
+    # Bypass the prefix so SQLite reads ``main.analysis_runs`` as
+    # ``analysis_runs`` in the default database.
+    store = SQLAlchemyHistoryStore.__new__(SQLAlchemyHistoryStore)
+    store.engine = engine
+    store.schema = "main"
+    store._md = md
+    store._t_runs = md.tables["main.analysis_runs"]
+    store._t_results = md.tables["main.run_results"]
+    store._t_events = md.tables["main.app_events"]
+    store._t_session = md.tables["main.session_state"]
+    store._t_meta = md.tables["main.schema_meta"]
+    store._hostname = "test-host"
+    store._username = "test-user"
+    store._client_version = "0.12.0-test"
+    md.create_all(engine)
+    return store
+
+
+@pytest.fixture
+def local_store(tmp_path: Path) -> SQLiteHistoryStore:
+    db_path = tmp_path / "local.db"
+    s = SQLiteHistoryStore(db_path)
+    s.init()
+    return s
+
+
+def test_sqlite_store_implements_protocol(local_store: SQLiteHistoryStore) -> None:
+    # Structural typing: SQLiteHistoryStore exposes every method the
+    # IHistoryStore Protocol declares. ``isinstance`` on a
+    # ``runtime_checkable`` Protocol verifies that.
+    assert isinstance(local_store, IHistoryStore)
+
+
+def test_sqlalchemy_store_implements_protocol(
+    shared_store: SQLAlchemyHistoryStore,
+) -> None:
+    assert isinstance(shared_store, IHistoryStore)
+
+
+def test_full_run_lifecycle_on_shared(shared_store: SQLAlchemyHistoryStore) -> None:
+    rid = shared_store.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile="default",
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope={"public": ["customers"]},
+        selected_count=1,
+        planned_count=1,
+    )
+    assert isinstance(rid, str) and len(rid) == 36
+
+    shared_store.update_run_planned_count(rid, 2)
+    shared_store.increment_run_processed(rid, by=1)
+    shared_store.increment_run_applied(rid, by=1)
+
+    result_ids = shared_store.save_run_results(
+        rid,
+        [
+            {
+                "schema": "public",
+                "table": "customers",
+                "column": "email",
+                "asset_kind": "column",
+                "source": "llm",
+                "confidence": "high",
+                "alternatives": ["email address", "customer email"],
+                "reasoning": "fits the column shape",
+            }
+        ],
+    )
+    assert len(result_ids) == 1
+
+    shared_store.record_evaluation(
+        result_ids[0], chosen_description="email address", evaluation="accepted"
+    )
+    shared_store.record_applied(result_ids[0])
+    shared_store.finish_run(
+        rid,
+        status="success",
+        metrics={"tables": 1},
+        tokens={"in": 100, "out": 50},
+        results={"applied": 1},
+    )
+
+    fetched = shared_store.get_run(rid)
+    assert fetched is not None
+    assert fetched["status"] == "success"
+    assert fetched["processed_count"] == 1
+    assert fetched["applied_count"] == 1
+
+    rows = shared_store.list_recent_runs(limit=5, command_filter="analyze.run")
+    assert any(r["id"] == rid for r in rows)
+
+    results = shared_store.get_run_results(rid)
+    assert len(results) == 1
+    assert results[0]["evaluation"] == "accepted"
+
+
+def test_log_event_appends(shared_store: SQLAlchemyHistoryStore) -> None:
+    shared_store.log_event(
+        event_type="analyze.run",
+        status="success",
+        command="/run",
+        details={"foo": "bar"},
+    )
+    events = shared_store.list_recent_events(limit=10)
+    assert len(events) == 1
+    assert events[0]["event_type"] == "analyze.run"
+    assert events[0]["status"] == "success"
+
+
+def test_session_state_round_trip(shared_store: SQLAlchemyHistoryStore) -> None:
+    shared_store.set_session_state("test", "key", {"a": 1})
+    assert shared_store.get_session_state("test", "key") == {"a": 1}
+    # Default for missing key
+    assert shared_store.get_session_state("test", "missing", default=42) == 42
+
+
+def test_record_db_apply_failure_preserves_reason(
+    shared_store: SQLAlchemyHistoryStore,
+) -> None:
+    rid = shared_store.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile="default",
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope={"public": ["users"]},
+    )
+    [result_id] = shared_store.save_run_results(
+        rid,
+        [
+            {
+                "schema": "public",
+                "table": "users",
+                "column": "id",
+                "source": "llm",
+                "confidence": "low",
+                "alternatives": ["user id"],
+            }
+        ],
+    )
+    shared_store.record_db_apply_failure(result_id, "permission denied")
+    fetched = shared_store.get_run_results(rid)
+    assert fetched[0]["db_applied_status"] == "failed"
+    assert "permission denied" in (fetched[0]["rejection_reason"] or "")
+
+
+def test_find_runs_for_scope_filters_by_schema(
+    shared_store: SQLAlchemyHistoryStore,
+) -> None:
+    shared_store.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile="default",
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope={"sales": ["orders"]},
+    )
+    shared_store.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile="default",
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope={"hr": ["employees"]},
+    )
+    found = shared_store.find_runs_for_scope(schema="sales", limit=10)
+    assert len(found) == 1
+    assert "sales" in found[0]["scope_json"]
+
+
+def test_local_id_lookup(shared_store: SQLAlchemyHistoryStore) -> None:
+    """find_run_uuid_by_local_id is the dual-write coordinator's lookup."""
+    rid = shared_store.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile="default",
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope={"public": []},
+        local_id=42,
+    )
+    found = shared_store.find_run_uuid_by_local_id(42)
+    assert found == rid
+    missing = shared_store.find_run_uuid_by_local_id(9999)
+    assert missing is None


### PR DESCRIPTION
## Summary

Introduce an optional shared run-history mode so two engineers running AMX against the same warehouse can finally see each other's analyses, results, and review decisions. Until now `~/.amx/history.db` was per-machine — invisible to teammates. With this change, a one-line `/history-store enable` bootstraps a dedicated `AMX` schema in any of 8 supported backends and dual-writes every run/result/event there alongside the local SQLite cache.

- **Dual-write semantics:** local SQLite first (always-on cache, source of truth for reads in v0.12), shared backend best-effort. Failed shared writes land in a `pending_shared_writes` outbox replayed by `/history-store flush-pending` — a network blip never blocks the CLI session.
- **8 supported backends:** PostgreSQL, MySQL, MSSQL, Oracle, Snowflake, Databricks, Redshift, BigQuery. DuckDB and ClickHouse are explicitly gated off (DuckDB is a local file; ClickHouse cannot UPDATE the way `finish_run` requires) via `BackendCapabilities.supports_shared_history` with a clear error at enable time.
- **Attribution + provenance:** every shared row carries `created_by` / `hostname` / `client_version` plus a `local_id` linking back to the originating SQLite INT id.

## Surface

| `/history-store …` | Description |
|---|---|
| `status` | Show whether shared mode is on, profile/schema, outbox depth |
| `enable [--profile P --schema S]` | Bootstrap AMX schema, start dual-writing |
| `disable` | Stop dual-writing (existing shared rows untouched) |
| `migrate-from-local` | Idempotent copy of existing local history into shared |
| `flush-pending` | Replay queued shared writes that failed at write time |
| `dump-ddl [--profile P --schema S]` | Print schema-bootstrap DDL for a DBA |

Reads still come from local SQLite — team-wide read views are slated for a follow-up minor.

## Files

**New (10):** `amx/storage/{protocol,shared_schema,sqlalchemy_store,dual_write,factory,migration}.py`, `amx/cli_support/commands/history_store.py`, four test files under `tests/`.

**Modified (key):** `amx/db/adapters/base.py` (+ all 10 adapter files) — `create_history_schema()` + per-backend DDL overrides, `supports_shared_history` capability flag. `amx/config.py` — three new fields, schema bumped to v2 (additive). `amx/cli.py` + `amx/core/application.py` — wire `init_history_store(cfg)` from new factory. `amx/cli_support/session.py` — register `/history-store` in slash dispatcher.

**Version:** 0.11.0 → 0.12.0 in `pyproject.toml` and `amx/__init__.py`. CHANGELOG and README updated.

## Test plan

- [x] `ruff check amx tests` — clean
- [x] `ruff format --check amx tests` — clean
- [x] `pytest -m "not integration and not live"` — 532 pass, 19 deselected (29 new tests under `tests/test_shared_history_*.py`, `test_dual_write_outbox.py`, `test_history_migration.py`)
- [x] `python -m build` + `twine check dist/*` — pass
- [x] mypy on new code paths — clean (two pre-existing errors in `sqlite_store.py` lines I did not touch)
- [ ] CI green on Python 3.10 / 3.11 / 3.12 (this PR)
- [ ] Manual test: enable against Postgres, run `/run`, kill PG, run another `/run`, verify outbox grows; bring PG back, `flush-pending`, verify drain
- [ ] Manual test: `/history-store enable` against DuckDB profile → expect clean error naming the supported backends
