### PR TITLE
feat(history): move /history-store under /db tab with interactive picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,24 +17,28 @@ Databricks, Redshift, or BigQuery) under a dedicated `AMX` schema, so
 two engineers running AMX against the same warehouse can finally see
 each other's analyses, results, and review decisions.
 
-Onboarding is one command — `/history-store enable` picks a saved DB
-profile, bootstraps the schema (with `CREATE SCHEMA IF NOT EXISTS`
-DDL adapted per backend), creates the AMX tables via SQLAlchemy
-`MetaData.create_all`, and offers to ferry existing local rows up
-with `/history-store migrate-from-local` (idempotent — safe to
-re-run).
+Onboarding is one command — `/history-store` (under the `/db` tab)
+opens an interactive picker that prints the current shared-mode
+status first, then shows a numbered menu (Enable / Disable / Migrate
+from local / Flush pending / Dump DDL) tailored to whether shared
+mode is already on. Picking Enable bootstraps the schema (with
+`CREATE SCHEMA IF NOT EXISTS` DDL adapted per backend), creates the
+AMX tables via SQLAlchemy `MetaData.create_all`, and offers to ferry
+existing local rows up (idempotent — safe to re-run). Power users
+can still invoke any action directly, e.g. `amx db history-store
+status` or `amx db history-store enable --profile prod_pg --schema AMX`.
 
 Writes go to local SQLite first (always-on cache, source of truth for
 reads in v0.12) and then best-effort to the shared backend. Network
 hiccups never break a CLI session: failed shared writes land in a
-local `pending_shared_writes` outbox and are replayed by
-`/history-store flush-pending`. Reads continue to come from the local
+local `pending_shared_writes` outbox and are replayed by the
+"Flush pending" picker action. Reads continue to come from the local
 SQLite cache so `/history list` stays instant; team-wide read views
 are slated for a follow-up minor.
 
-DuckDB and ClickHouse are explicitly blocked at `enable` time —
-DuckDB is a local file, not shared storage; ClickHouse cannot
-`UPDATE` rows the way `finish_run` requires. The
+DuckDB and ClickHouse are explicitly blocked at Enable time — DuckDB
+is a local file, not shared storage; ClickHouse cannot `UPDATE` rows
+the way `finish_run` requires. The
 `BackendCapabilities.supports_shared_history` flag gates the choice
 and surfaces a clear error listing the supported backends.
 
@@ -44,9 +48,12 @@ SQLite INT id) are recorded on every row, so the team can answer
 "who ran this?" and the dual-write coordinator can find the right
 shared row when later UPDATEs fire.
 
-New CLI surface (under `/history-store`): `status`, `enable`,
-`disable`, `migrate-from-local`, `flush-pending`, `dump-ddl`. All
-six are documented under "Run history storage" in the README.
+New CLI surface lives under `/db history-store` (visual `/db` tab).
+Bare command opens the picker; six explicit Click subcommands —
+`status`, `enable`, `disable`, `migrate-from-local`, `flush-pending`,
+`dump-ddl` — back the picker entries and are also available
+directly for scripting. Documented under "Run history storage" in
+the README.
 
 ### Changed — config schema bumped to v2 (additive)
 

--- a/README.md
+++ b/README.md
@@ -457,41 +457,60 @@ Query it directly in AMX via `/history` namespace:
 
 By default the SQLite history is per-machine — your teammate cannot
 see runs you executed. Enable shared mode to dual-write every
-run/result/event into a backend the team already owns:
+run/result/event into a backend the team already owns.
 
-```bash
-/history-store enable             # interactive picker
-/history-store enable --profile prod_pg --schema AMX
+`/history-store` lives under the `/db` namespace. Type the bare
+command to open an interactive picker — Status comes first, followed
+by context-aware actions (Enable / Disable / Migrate / Flush) based
+on whether shared mode is already on:
+
+```
+/db
+/history-store
 ```
 
-AMX then bootstraps an `AMX` schema (configurable) on the chosen DB
-profile and creates four tables: `analysis_runs`, `run_results`,
+The picker prints the current shared-mode status and then shows a
+numbered menu (Enter accepts the highlighted default, "Status"):
+
+```
+1. Status — show shared-mode state and outbox depth   (default)
+2. Enable — bootstrap an AMX schema on a saved DB profile
+3. Dump DDL — print bootstrap SQL for a DBA to run by hand
+4. Cancel — exit without doing anything
+```
+
+Once shared mode is enabled, the menu shifts to Status / Disable /
+Migrate from local / Flush pending / Dump DDL / Cancel. AMX
+bootstraps an `AMX` schema (configurable) on the chosen DB profile
+and creates four tables: `analysis_runs`, `run_results`,
 `app_events`, `session_state`. Every subsequent write goes to local
 SQLite first (always-on cache, source of truth for `/history list`)
 and best-effort to the shared backend.
 
-| `/history-store …` | Description |
-|---|---|
-| `status` | Show whether shared mode is on, which profile/schema, outbox depth |
-| `enable [--profile P --schema S]` | Bootstrap the AMX schema and start dual-writing |
-| `disable` | Stop dual-writing. Existing shared rows are not deleted |
-| `migrate-from-local` | Idempotent one-shot copy of existing local history rows into the shared store |
-| `flush-pending` | Replay queued shared writes that failed at write time |
-| `dump-ddl [--profile P --schema S]` | Print bootstrap DDL for a DBA to run by hand |
+Power users / scripts can invoke each action directly:
+
+| Picker option | Click subcommand | Description |
+|---|---|---|
+| Status | `amx db history-store status` | Show shared mode state, profile, schema, outbox depth |
+| Enable | `amx db history-store enable [--profile P --schema S]` | Bootstrap the AMX schema and start dual-writing |
+| Disable | `amx db history-store disable` | Stop dual-writing. Existing shared rows are not deleted |
+| Migrate from local | `amx db history-store migrate-from-local` | Idempotent one-shot copy of existing local history rows into the shared store |
+| Flush pending | `amx db history-store flush-pending` | Replay queued shared writes that failed at write time |
+| Dump DDL | `amx db history-store dump-ddl [--profile P --schema S]` | Print bootstrap DDL for a DBA to run by hand |
 
 **Supported backends for shared mode:** PostgreSQL, MySQL, MSSQL,
 Oracle, Snowflake, Databricks, Redshift, BigQuery. DuckDB (local
-file) and ClickHouse (no row UPDATE support) are blocked at `enable`
+file) and ClickHouse (no row UPDATE support) are blocked at Enable
 time with a clear error.
 
 **Failure semantics:** when the shared backend is unreachable, the
 local row still lands and the failed write is queued in
-`pending_shared_writes` for replay via `/history-store flush-pending`.
+`pending_shared_writes` for replay via the Flush pending action.
 Your CLI session is never blocked by team-store outages.
 
 **Reads:** v0.12.0 reads still come from local SQLite — `/history
-list` shows your machine's runs. Cross-machine read views (e.g.
-`/history-store list-team`) are slated for a follow-up minor.
+list` shows your machine's runs. Cross-machine read views are slated
+for a follow-up minor.
 
 **Attribution:** every shared row records `created_by`, `hostname`,
 and `client_version`, plus a `local_id` linking back to the SQLite

--- a/amx/cli.py
+++ b/amx/cli.py
@@ -329,7 +329,6 @@ def main(ctx: click.Context, cfg_path: str | None, debug: bool) -> None:
 
 history_group = register_history_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_compare_command(history_group, pass_config=pass_config, log_event=_log_app_event)
-register_history_store_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_search_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_doctor_command(main, pass_config=pass_config, log_event=_log_app_event)
 register_chat_session_commands(main, pass_config=pass_config, log_event=_log_app_event)
@@ -351,6 +350,15 @@ register_root_commands(
     main,
     interactive_db_block=_interactive_db_block,
     interactive_llm_block=_interactive_llm_block,
+)
+# Attach /history-store under the /db group so it appears in the visual
+# /db tab next to /db-profiles, /use-db, /add-db-profile, etc. The
+# group object is cached on register_root_commands by name; pulling it
+# here keeps the wiring obvious.
+register_history_store_commands(
+    register_root_commands._db_group,  # type: ignore[attr-defined]
+    pass_config=pass_config,
+    log_event=_log_app_event,
 )
 
 

--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -1,13 +1,15 @@
 """``/history-store`` command — configure shared run-history collaboration.
 
-Lives next to ``/db-profiles`` (analysis-DB) and ``/llm-profiles`` (LLM
-config) but is intentionally a separate top-level namespace so the
-existing wizard stays focused on the analysis-DB. The shared store IS
-a saved DB profile (a :class:`amx.config.DBConfig`) but flagged as
-"this profile hosts AMX's history schema" via
-``cfg.history_store_profile``.
+Lives under the ``/db`` namespace (next to ``/db-profiles`` and
+``/use-db``) because it manages a database resource. Bare
+``/history-store`` opens an interactive picker — Status first, then
+the actions you might want next based on whether shared mode is on.
+Each menu entry maps to a Click subcommand so power users / scripts
+can still invoke them directly (``amx db history-store status``,
+``amx db history-store enable``, etc.).
 
-Subcommands:
+Subcommands (also available individually, but the picker is the
+primary user-facing surface):
 
 * ``status`` — what's enabled, which profile, schema name, outbox depth.
 * ``enable`` — interactive: pick a profile, run schema bootstrap, offer
@@ -43,72 +45,294 @@ from amx.utils.console import (
 LogEvent = Callable[..., None]
 
 
-def _resolve_history_dual_store() -> Any | None:
-    """Return the active store iff it is a DualWriteHistoryStore.
+# ── Action labels (also the picker entries) ───────────────────────────────
+# Status comes first per UX request — the user almost always wants to
+# know "what's currently configured?" before deciding the next action.
+ACTION_STATUS = "Status — show shared-mode state and outbox depth"
+ACTION_ENABLE = "Enable — bootstrap an AMX schema on a saved DB profile"
+ACTION_DISABLE = "Disable — stop dual-writing (existing shared rows are kept)"
+ACTION_MIGRATE = "Migrate from local — copy local SQLite history into the shared store"
+ACTION_FLUSH = "Flush pending — retry queued shared writes that failed at write time"
+ACTION_DUMP_DDL = "Dump DDL — print bootstrap SQL for a DBA to run by hand"
+ACTION_CANCEL = "Cancel — exit without doing anything"
 
-    ``/history-store flush-pending`` and ``status`` only make sense
-    when shared mode is on. For local-only sessions both subcommands
-    short-circuit with a friendly message.
-    """
+
+def _resolve_history_dual_store() -> Any | None:
+    """Return the active store iff it is a DualWriteHistoryStore."""
     store = history_store()
     if store is None:
         return None
-    # Avoid a hard import dependency on dual_write at module load —
-    # most sessions don't enable shared mode and importing the
-    # SQLAlchemy stack on the cold path would slow startup. The
-    # duck-type check below matches our DualWriteHistoryStore exactly.
+    # Avoid a hard import on dual_write at module load — most sessions
+    # don't enable shared mode and importing the SQLAlchemy stack on
+    # the cold path would slow startup. The duck-type check below
+    # matches DualWriteHistoryStore exactly.
     if hasattr(store, "shared") and hasattr(store, "flush_pending"):
         return store
     return None
 
 
+# ── Action implementations (shared between picker and subcommands) ────────
+
+
+def _action_status(cfg: AMXConfig) -> None:
+    heading("Shared run-history status")
+    if not getattr(cfg, "history_store_enabled", False):
+        info("Shared mode: [bold]disabled[/bold] (local SQLite only)")
+        info("Run /history-store and pick Enable to turn it on.")
+        return
+    profile = cfg.history_store_profile or "(none)"
+    schema = cfg.history_store_schema or "AMX"
+    info("Shared mode: [bold green]enabled[/bold green]")
+    info(f"  Profile: {profile}")
+    info(f"  Schema:  {schema}")
+    store = _resolve_history_dual_store()
+    if store is not None:
+        try:
+            depth = store.pending_count()
+        except Exception:
+            depth = -1
+        if depth < 0:
+            warn("  Outbox: (could not query)")
+        elif depth == 0:
+            info("  Outbox: empty (everything is in sync)")
+        else:
+            warn(f"  Outbox: {depth} pending shared writes — pick 'Flush pending' to retry them.")
+    else:
+        warn(
+            "  Active store: local-only fallback. Bootstrap probably "
+            "failed; check the connection / re-run Enable."
+        )
+
+
+def _action_enable(
+    cfg: AMXConfig,
+    *,
+    log_event: LogEvent,
+    profile_name: str | None = None,
+    schema_name: str | None = None,
+) -> None:
+    if not cfg.db_profiles:
+        error(
+            "No DB profiles saved. Configure one with /db-profiles or "
+            "/setup before enabling shared history."
+        )
+        return
+
+    if profile_name is None:
+        profile_name = ask_choice(
+            "Pick a DB profile to host the AMX schema",
+            sorted(cfg.db_profiles.keys()),
+            default=cfg.active_db_profile or next(iter(cfg.db_profiles)),
+        )
+    if profile_name not in cfg.db_profiles:
+        error(f"Unknown DB profile: {profile_name!r}")
+        return
+
+    db_cfg = cfg.db_profiles[profile_name]
+    # Local imports so this command does not pay the SQLAlchemy adapter
+    # cost on the cold path.
+    from amx.db.adapters import get_adapter
+    from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+
+    adapter = get_adapter(db_cfg)
+    if not getattr(adapter.capabilities, "supports_shared_history", False):
+        error(
+            f"The {db_cfg.backend!r} backend does not support shared "
+            "run-history. Supported backends: PostgreSQL, MySQL, MSSQL, "
+            "Oracle, Redshift, Snowflake, Databricks, BigQuery."
+        )
+        return
+
+    if schema_name is None or not schema_name.strip():
+        schema_name = (cfg.history_store_schema or "AMX").strip() or "AMX"
+
+    info(f"Bootstrapping schema {schema_name!r} on profile {profile_name!r} ({db_cfg.backend})…")
+    engine = adapter.create_engine()
+    try:
+        adapter.create_history_schema(engine, schema_name)
+    except Exception as exc:
+        error(f"Could not create schema {schema_name!r}: {exc}")
+        ddl = adapter.create_history_schema_ddl(schema_name)
+        warn("Hand the following DDL to a DBA and re-run Enable:")
+        click.echo(ddl)
+        return
+
+    store = SQLAlchemyHistoryStore(engine=engine, schema=schema_name)
+    try:
+        store.init()
+    except Exception as exc:
+        error(f"Could not create AMX tables under {schema_name!r}: {exc}")
+        return
+
+    with cfg.transaction():
+        cfg.history_store_enabled = True
+        cfg.history_store_profile = profile_name
+        cfg.history_store_schema = schema_name
+
+    success(
+        f"Shared run-history enabled. Profile: {profile_name!r} "
+        f"({db_cfg.backend}). Schema: {schema_name!r}."
+    )
+    info(
+        "All future runs will be dual-written to local SQLite AND the "
+        "shared backend. Reads still come from local SQLite."
+    )
+    if confirm(
+        "Migrate existing local runs into the shared store now? (Idempotent — safe to skip.)",
+        default=True,
+    ):
+        _run_migration(cfg, store)
+    log_event(event_type="history_store.enable", status="ok", command="/history-store enable")
+
+
+def _action_disable(cfg: AMXConfig, *, log_event: LogEvent) -> None:
+    if not getattr(cfg, "history_store_enabled", False):
+        info("Shared mode is already disabled.")
+        return
+    if not confirm(
+        "Disable shared run-history? Existing shared rows are NOT deleted; "
+        "you can re-enable later from this same machine.",
+        default=False,
+    ):
+        return
+    with cfg.transaction():
+        cfg.history_store_enabled = False
+    success("Shared run-history disabled.")
+    info("Restart AMX (or run any command) for the change to take effect.")
+    log_event(event_type="history_store.disable", status="ok", command="/history-store disable")
+
+
+def _action_migrate(cfg: AMXConfig) -> None:
+    if not getattr(cfg, "history_store_enabled", False):
+        error("Shared mode is disabled. Pick Enable first.")
+        return
+    store = _resolve_history_dual_store()
+    if store is None:
+        error("Shared store is not active. Pick Enable first.")
+        return
+    _run_migration(cfg, store.shared)
+
+
+def _action_flush(cfg: AMXConfig) -> None:
+    store = _resolve_history_dual_store()
+    if store is None:
+        warn("Shared mode is disabled — nothing to flush.")
+        return
+    succeeded, remaining = store.flush_pending()
+    if succeeded == 0 and remaining == 0:
+        info("Outbox is empty.")
+    else:
+        success(
+            f"Flushed {succeeded} pending writes. "
+            f"{remaining} remaining (will retry next time you pick Flush pending)."
+        )
+
+
+def _action_dump_ddl(
+    cfg: AMXConfig,
+    *,
+    profile_name: str | None = None,
+    schema_name: str | None = None,
+) -> None:
+    target = profile_name or cfg.history_store_profile or cfg.active_db_profile or ""
+    if not target or target not in cfg.db_profiles:
+        error("No DB profile resolved. Specify --profile or configure one via /db-profiles.")
+        return
+    from amx.db.adapters import get_adapter
+
+    db_cfg = cfg.db_profiles[target]
+    adapter = get_adapter(db_cfg)
+    schema = (schema_name or cfg.history_store_schema or "AMX").strip() or "AMX"
+    click.echo(f"-- Backend: {db_cfg.backend}")
+    click.echo(f"-- Schema:  {schema}")
+    click.echo(adapter.create_history_schema_ddl(schema))
+
+
+# ── Picker (the main user-facing surface) ─────────────────────────────────
+
+
+def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> None:
+    """Print current status + show a numbered menu of next actions.
+
+    The menu is short on purpose — six actions plus Cancel. Status is
+    listed first so picking it (or pressing Enter on the default) is
+    the safe answer when the user doesn't know what they want.
+    Disable / Migrate / Flush only show when shared mode is on; Enable
+    only shows when it's off — so the picker never offers an option
+    that would error.
+    """
+    enabled = bool(getattr(cfg, "history_store_enabled", False))
+    options: list[str] = [ACTION_STATUS]
+    if enabled:
+        options.append(ACTION_DISABLE)
+        options.append(ACTION_MIGRATE)
+        options.append(ACTION_FLUSH)
+    else:
+        options.append(ACTION_ENABLE)
+    options.append(ACTION_DUMP_DDL)
+    options.append(ACTION_CANCEL)
+
+    # Always show status before the menu so the user has context.
+    _action_status(cfg)
+
+    picked = ask_choice(
+        "What would you like to do?",
+        options,
+        default=ACTION_STATUS,
+    )
+    if picked == ACTION_STATUS:
+        # The picker already printed status above; nothing more to do.
+        return
+    if picked == ACTION_ENABLE:
+        _action_enable(cfg, log_event=log_event)
+        return
+    if picked == ACTION_DISABLE:
+        _action_disable(cfg, log_event=log_event)
+        return
+    if picked == ACTION_MIGRATE:
+        _action_migrate(cfg)
+        return
+    if picked == ACTION_FLUSH:
+        _action_flush(cfg)
+        return
+    if picked == ACTION_DUMP_DDL:
+        _action_dump_ddl(cfg)
+        return
+    # ACTION_CANCEL or anything else — exit silently.
+
+
+# ── Click registration ────────────────────────────────────────────────────
+
+
 def register_history_store_commands(
-    main: click.Group,
+    parent: click.Group,
     *,
     pass_config: Callable[[Callable[..., Any]], Callable[..., Any]],
     log_event: LogEvent,
 ) -> click.Group:
-    """Attach ``/history-store`` namespace commands to *main*."""
+    """Attach ``/history-store`` to a parent Click group.
 
-    @main.group("history-store")
-    def history_store_grp() -> None:
+    Pass the ``/db`` group so the command lives at
+    ``amx db history-store …`` and shows under the visual ``/db`` tab.
+    """
+
+    @parent.group("history-store", invoke_without_command=True)
+    @click.pass_context
+    def history_store_grp(ctx: click.Context) -> None:
         """Configure shared run-history (team collaboration)."""
+        if ctx.invoked_subcommand is not None:
+            return
+        cfg = ctx.find_object(AMXConfig)
+        if cfg is None:
+            error("Config not loaded — run /setup or restart AMX.")
+            return
+        _run_picker(ctx, cfg, log_event=log_event)
 
     @history_store_grp.command("status")
     @pass_config
     def hs_status(cfg: AMXConfig) -> None:
         """Show whether shared mode is on and which profile hosts it."""
-        heading("Shared run-history status")
-        if not getattr(cfg, "history_store_enabled", False):
-            info("Shared mode: [bold]disabled[/bold] (local SQLite only)")
-            info("Run /history-store enable to turn it on.")
-            return
-        profile = cfg.history_store_profile or "(none)"
-        schema = cfg.history_store_schema or "AMX"
-        info("Shared mode: [bold green]enabled[/bold green]")
-        info(f"  Profile: {profile}")
-        info(f"  Schema:  {schema}")
-        store = _resolve_history_dual_store()
-        if store is not None:
-            depth = 0
-            try:
-                depth = store.pending_count()
-            except Exception:
-                depth = -1
-            if depth < 0:
-                warn("  Outbox: (could not query)")
-            elif depth == 0:
-                info("  Outbox: empty (everything is in sync)")
-            else:
-                warn(
-                    f"  Outbox: {depth} pending shared writes — run "
-                    "/history-store flush-pending to retry them."
-                )
-        else:
-            warn(
-                "  Active store: local-only fallback. Bootstrap probably "
-                "failed; check the connection / re-run /history-store enable."
-            )
+        _action_status(cfg)
 
     @history_store_grp.command("enable")
     @click.option(
@@ -126,131 +350,30 @@ def register_history_store_commands(
     @pass_config
     def hs_enable(cfg: AMXConfig, profile_name: str | None, schema_name: str | None) -> None:
         """Bootstrap the AMX schema in a saved DB profile and enable shared mode."""
-        if not cfg.db_profiles:
-            error(
-                "No DB profiles saved. Configure one with /db-profiles or "
-                "/setup before enabling shared history."
-            )
-            return
-
-        if profile_name is None:
-            profile_name = ask_choice(
-                "Pick a DB profile to host the AMX schema",
-                sorted(cfg.db_profiles.keys()),
-                default=cfg.active_db_profile or next(iter(cfg.db_profiles)),
-            )
-        if profile_name not in cfg.db_profiles:
-            error(f"Unknown DB profile: {profile_name!r}")
-            return
-
-        db_cfg = cfg.db_profiles[profile_name]
-        # Local imports so this command does not pay the SQLAlchemy
-        # adapter cost on the cold path.
-        from amx.db.adapters import get_adapter
-        from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
-
-        adapter = get_adapter(db_cfg)
-        if not getattr(adapter.capabilities, "supports_shared_history", False):
-            error(
-                f"The {db_cfg.backend!r} backend does not support shared "
-                "run-history. Supported backends: PostgreSQL, MySQL, MSSQL, "
-                "Oracle, Redshift, Snowflake, Databricks, BigQuery."
-            )
-            return
-
-        if schema_name is None or not schema_name.strip():
-            schema_name = (cfg.history_store_schema or "AMX").strip() or "AMX"
-
-        info(
-            f"Bootstrapping schema {schema_name!r} on profile {profile_name!r} ({db_cfg.backend})…"
+        _action_enable(
+            cfg,
+            log_event=log_event,
+            profile_name=profile_name,
+            schema_name=schema_name,
         )
-        engine = adapter.create_engine()
-        try:
-            adapter.create_history_schema(engine, schema_name)
-        except Exception as exc:
-            error(f"Could not create schema {schema_name!r}: {exc}")
-            ddl = adapter.create_history_schema_ddl(schema_name)
-            warn("Hand the following DDL to a DBA and re-run enable:")
-            click.echo(ddl)
-            return
-
-        store = SQLAlchemyHistoryStore(engine=engine, schema=schema_name)
-        try:
-            store.init()
-        except Exception as exc:
-            error(f"Could not create AMX tables under {schema_name!r}: {exc}")
-            return
-
-        # Persist the choice. Saving toggles autosave; the next CLI
-        # command picks up the new dual-write coordinator.
-        with cfg.transaction():
-            cfg.history_store_enabled = True
-            cfg.history_store_profile = profile_name
-            cfg.history_store_schema = schema_name
-
-        success(
-            f"Shared run-history enabled. Profile: {profile_name!r} "
-            f"({db_cfg.backend}). Schema: {schema_name!r}."
-        )
-        info(
-            "All future runs will be dual-written to local SQLite AND the "
-            "shared backend. Reads still come from local SQLite."
-        )
-        if confirm(
-            "Migrate existing local runs into the shared store now? (Idempotent — safe to skip.)",
-            default=True,
-        ):
-            _run_migration(cfg, store)
-        log_event(event_type="history_store.enable", status="ok", command="/history-store enable")
 
     @history_store_grp.command("disable")
     @pass_config
     def hs_disable(cfg: AMXConfig) -> None:
         """Stop dual-writing to the shared store. Local SQLite continues normally."""
-        if not getattr(cfg, "history_store_enabled", False):
-            info("Shared mode is already disabled.")
-            return
-        if not confirm(
-            "Disable shared run-history? Existing shared rows are NOT deleted; "
-            "you can re-enable later from this same machine.",
-            default=False,
-        ):
-            return
-        with cfg.transaction():
-            cfg.history_store_enabled = False
-        success("Shared run-history disabled.")
-        info("Restart AMX (or run any command) for the change to take effect.")
-        log_event(event_type="history_store.disable", status="ok", command="/history-store disable")
+        _action_disable(cfg, log_event=log_event)
 
     @history_store_grp.command("migrate-from-local")
     @pass_config
     def hs_migrate(cfg: AMXConfig) -> None:
         """Copy local SQLite history into the shared store (idempotent)."""
-        if not getattr(cfg, "history_store_enabled", False):
-            error("Shared mode is disabled. Run /history-store enable first.")
-            return
-        store = _resolve_history_dual_store()
-        if store is None:
-            error("Shared store is not active. Run /history-store enable.")
-            return
-        _run_migration(cfg, store.shared)
+        _action_migrate(cfg)
 
     @history_store_grp.command("flush-pending")
     @pass_config
     def hs_flush(cfg: AMXConfig) -> None:
         """Replay queued shared-write retries from the local outbox."""
-        store = _resolve_history_dual_store()
-        if store is None:
-            warn("Shared mode is disabled — nothing to flush.")
-            return
-        succeeded, remaining = store.flush_pending()
-        if succeeded == 0 and remaining == 0:
-            info("Outbox is empty.")
-        else:
-            success(
-                f"Flushed {succeeded} pending writes. "
-                f"{remaining} remaining (will retry on next /history-store flush-pending)."
-            )
+        _action_flush(cfg)
 
     @history_store_grp.command("dump-ddl")
     @click.option(
@@ -269,18 +392,7 @@ def register_history_store_commands(
     @pass_config
     def hs_dump_ddl(cfg: AMXConfig, profile_name: str | None, schema_name: str | None) -> None:
         """Print the schema-bootstrap DDL so a DBA can run it by hand."""
-        target = profile_name or cfg.history_store_profile or cfg.active_db_profile or ""
-        if not target or target not in cfg.db_profiles:
-            error("No DB profile resolved. Specify --profile or configure one via /db-profiles.")
-            return
-        from amx.db.adapters import get_adapter
-
-        db_cfg = cfg.db_profiles[target]
-        adapter = get_adapter(db_cfg)
-        schema = (schema_name or cfg.history_store_schema or "AMX").strip() or "AMX"
-        click.echo(f"-- Backend: {db_cfg.backend}")
-        click.echo(f"-- Schema:  {schema}")
-        click.echo(adapter.create_history_schema_ddl(schema))
+        _action_dump_ddl(cfg, profile_name=profile_name, schema_name=schema_name)
 
     return history_store_grp
 

--- a/amx/cli_support/root_commands.py
+++ b/amx/cli_support/root_commands.py
@@ -133,7 +133,11 @@ def register_root_commands(
 
     @main.group()
     def db() -> None:
-        """Database inspection and profiling commands."""
+        """Database inspection, profiling, and shared run-history commands."""
+
+    # Cached on the wrapper so the caller in cli.py can attach more
+    # subcommands (like /history-store) under the same /db group.
+    register_root_commands._db_group = db  # type: ignore[attr-defined]
 
     @db.command("connect")
     @click.pass_obj

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -240,6 +240,11 @@ Commands (in order):
                                   review manually.") from the live DB. Use this once when
                                   upgrading from pre-0.6.3 — newer versions never write
                                   these in the first place.
+ 17) /history-store               Configure shared run-history (team collaboration).
+                                  Bare command opens an interactive picker — Status,
+                                  Enable, Disable, Migrate from local, Flush pending,
+                                  Dump DDL. Power-user shortcuts also accept a
+                                  subcommand directly (e.g. /history-store status).
 
 Navigation:
   Esc (empty line)                 Go back to root namespace
@@ -467,7 +472,7 @@ Getting started (in order):
  10) /history                      Local SQLite history (/list, /show, /stats, /events)
 
 Inside namespaces (examples):
-  [bright_white]/db[/bright_white]   → /db-profiles, /schema, /table, /connect, …
+  [bright_white]/db[/bright_white]   → /db-profiles, /schema, /table, /connect, /history-store, …
   [bright_white]/docs[/bright_white] → /doc-profiles, /add-doc-profile, /ingest, …
   [bright_white]/metadata[/bright_white] → /inspect, /edit, /monitor
   [bright_white]/llm[/bright_white]   → /llm-profiles, /add-llm-profile, …
@@ -873,6 +878,12 @@ def session_to_click_args(namespace: str, parts: list[str]) -> list[str] | None:
         # an unknown subcommand. The shortcut maps it to the correct
         # namespace from anywhere.
         "compare": ["history", "compare"],
+        # /history-store lives under /db (it manages a database
+        # resource — a saved DB profile that hosts the AMX schema).
+        # When typed from outside /db this shortcut routes it; when
+        # typed from inside /db the namespace+head fallthrough below
+        # already produces ["db", "history-store", ...].
+        "history-store": ["db", "history-store"],
     }
     if head == "search" and len(parts) > 1:
         if parts[1] in {
@@ -922,7 +933,6 @@ def session_to_click_args(namespace: str, parts: list[str]) -> list[str] | None:
         "analyze",
         "search",
         "history",
-        "history-store",
         "session",
         "setup",
         "config",


### PR DESCRIPTION
## Summary

Two UX adjustments after 0.12.0 (PR #73), driven by direct user feedback:

1. **Move `/history-store` under the `/db` tab.** It was a top-level slash with no visual home — now it's a Click subgroup of `/db`, listed in the `/db` namespace help, and routed via `shortcut_map["history-store"] = ["db", "history-store"]` so typing it from any tab still works. `register_history_store_commands(parent)` now takes the `/db` group (exposed as `register_root_commands._db_group`) instead of `main`.

2. **Replace subcommand-style invocation with an interactive picker.** Bare `/history-store` (no subcommand) prints the current status, then shows a numbered menu tailored to current state:
    - Disabled: `Status` / `Enable` / `Dump DDL` / `Cancel`
    - Enabled:  `Status` / `Disable` / `Migrate from local` / `Flush pending` / `Dump DDL` / `Cancel`

   Status is the default — pressing Enter is the safe answer. Each picker entry maps to one of the existing Click subcommands, which stay registered so `amx db history-store enable --profile prod_pg --schema AMX` still works for scripting and CI.

## Files

- `amx/cli_support/commands/history_store.py` — refactored: action bodies extracted into `_action_*` helpers shared between picker and Click subcommands; new `_run_picker(ctx, cfg, log_event)`.
- `amx/cli_support/root_commands.py` — expose the `/db` group via `register_root_commands._db_group` for downstream attachment.
- `amx/cli.py` — register `/history-store` under that `/db` group.
- `amx/cli_support/session.py` — drop top-level `history-store` head, add `shortcut_map["history-store"] = ["db", "history-store"]`, document `/history-store` as item 17 in `/db` namespace help.
- `README.md`, `CHANGELOG.md` — updated to describe the picker UX and `/db history-store` Click paths.

## Test plan

- [x] `ruff check amx tests` — clean
- [x] `ruff format --check amx tests` — clean
- [x] `pytest -m "not integration and not live"` — 532 pass (no test changes needed; the action helpers are exercised through the existing `test_dual_write_outbox.py` and `test_history_migration.py` flows)
- [x] Click smoke test: `AMX_SESSION_CHILD=1 amx db history-store --help` lists six subcommands; bare `amx db history-store` prints status + numbered picker.
- [ ] CI green on Python 3.10 / 3.11 / 3.12 (this PR)
