### PR TITLE
fix(cli): register /history-store in the slash registry so it surfaces under /db

### DIFF
--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -130,6 +130,19 @@ _DB_COMMANDS: tuple[SlashCommand, ...] = (
         "db",
         "Remove auto-inference placeholder comments from live DB (/cleanup-placeholders [schema])",
     ),
+    SlashCommand(
+        "/history-store",
+        "db",
+        "Configure shared run-history (/history-store opens picker; /history-store status|enable|disable|migrate-from-local|flush-pending|dump-ddl)",
+        long_desc=(
+            "Configure shared run-history for team collaboration. Bare "
+            "/history-store opens an interactive picker that prints the "
+            "current shared-mode status and offers Status / Enable / "
+            "Disable / Migrate from local / Flush pending / Dump DDL "
+            "based on whether shared mode is on. Power-user shortcuts "
+            "accept a subcommand directly."
+        ),
+    ),
 )
 
 _METADATA_COMMANDS: tuple[SlashCommand, ...] = (


### PR DESCRIPTION
## Summary

PR #74 attached `/history-store` to the `/db` Click group, but didn't update the single-source-of-truth slash registry at `amx/cli_support/slash_commands.py`. As a result the command worked when typed (the dispatcher routes via `shortcut_map`), but it was **invisible** to:

- the autocomplete dropdown,
- the `/db` tab `/help` listing,
- the `cmd_heads_for_namespace("db")` set the dispatch chain checks.

So users browsing the `/db` tab saw 14 commands and assumed `/history-store` hadn't landed.

This PR adds the missing `_DB_COMMANDS` entry. `cmd_heads_for_namespace("db")` now lists `history-store` alongside `db-profiles`, `use-db`, `connect`, etc.

## Test plan

- [x] `cmd_heads_for_namespace("db")` includes `history-store` (verified via Python repl)
- [x] `ruff check amx tests` clean
- [x] `pytest -m "not integration and not live"` — 532 pass
