### PR TITLE
feat(history): three collaboration safety guards on top of shared mode

### DIFF
--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -35,6 +35,81 @@ ResolveCodebaseForRun = Callable[
 LogEvent = Callable[..., None]
 
 
+def _confirm_proceed_when_others_analyzed_scope(
+    shared_store: object,
+    db_profile: str,
+    scope: dict[str, list[str]],
+) -> bool:
+    """In shared mode, surface prior runs by other users with overlapping scope.
+
+    Queries ``AMX.analysis_runs`` on the team backend for runs against
+    the same ``db_profile`` that touched any of the assets the user is
+    about to analyze. If found, prints a compact table (who / when /
+    what) and asks the user whether to proceed. Returns True when the
+    user accepts (or no overlap was found); False to abort.
+
+    Best-effort: if the shared lookup fails (network blip,
+    schema-version mismatch) we log a warn and let the run continue —
+    we never block /run on a flaky team-store query.
+    """
+    import socket
+    from datetime import datetime, timezone
+
+    try:
+        prior = shared_store.find_prior_runs_by_others(  # type: ignore[attr-defined]
+            db_profile=db_profile,
+            scope=scope,
+            exclude_hostname=socket.gethostname(),
+            limit=10,
+        )
+    except Exception as exc:
+        log.debug("Prior-run check skipped (shared lookup failed): %s", exc)
+        return True
+    if not prior:
+        return True
+
+    info("")
+    warn("Other team members have already analyzed assets in this scope:")
+    rows: list[list[str]] = []
+    for r in prior:
+        who = r.get("created_by") or "?"
+        host = r.get("hostname") or "?"
+        started = r.get("started_at")
+        when = "?"
+        if started is not None:
+            try:
+                ts = started
+                if isinstance(ts, datetime) and ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                when = ts.astimezone().strftime("%Y-%m-%d %H:%M")  # type: ignore[union-attr]
+            except Exception:
+                when = str(started)
+        overlap = r.get("overlap_assets") or []
+        # overlap is list[(schema, table)]; render compactly.
+        if len(overlap) > 4:
+            overlap_str = (
+                ", ".join(f"{s}.{t}" for s, t in overlap[:4]) + f" (+{len(overlap) - 4} more)"
+            )
+        else:
+            overlap_str = ", ".join(f"{s}.{t}" for s, t in overlap)
+        status = r.get("status") or "?"
+        rows.append([who, host, when, status, overlap_str])
+    render_table(
+        "Prior team runs in this scope",
+        ["User", "Host", "Started", "Status", "Overlapping assets"],
+        rows,
+    )
+    info(
+        f"You are about to analyze profile [bold]{db_profile}[/bold] with the same scope. "
+        "Comment write-back is last-writer-wins on the warehouse, so a fresh run will "
+        "overwrite descriptions a teammate just published unless you skip /run-apply."
+    )
+    return confirm(
+        "Proceed anyway?",
+        default=False,
+    )
+
+
 def _require_llm_connection(llm: object, *, profile_label: str | None = None) -> None:
     label = f" using profile '{profile_label}'" if profile_label else ""
     cfg = getattr(llm, "cfg", None)
@@ -628,6 +703,18 @@ def execute_analyze_run(
                     )
 
             hs = history_store()
+            # Shared-mode collaboration check: if another user has
+            # already analyzed any of the assets in this scope, surface
+            # who/when before we create a duplicate run. Skip silently
+            # when shared mode is off (hs is a plain SQLiteHistoryStore
+            # without ``shared``) or when the warning has already been
+            # acknowledged for this REPL session via the env var.
+            if hs is not None and hasattr(hs, "shared"):
+                if not _confirm_proceed_when_others_analyzed_scope(
+                    hs.shared, cfg.active_db_profile, scope
+                ):
+                    info("/run cancelled.")
+                    return
             if hs is not None:
                 try:
                     # ``selected_count`` records what the user originally

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -826,6 +826,36 @@ def cmd_remove_profile(cfg: AMXConfig, rest: list[str]) -> None:
         error("Usage: /remove-db-profile <name>")
         return
     name = rest[0]
+    # Guard: removing the profile that hosts the shared run-history
+    # schema would orphan the connection on the next AMX startup
+    # (factory falls back to local-only with a warning, but the user
+    # would not necessarily notice). Make the consequence explicit
+    # before dropping the profile.
+    if (
+        getattr(cfg, "history_store_enabled", False)
+        and getattr(cfg, "history_store_profile", "") == name
+    ):
+        schema = cfg.history_store_schema or "AMX"
+        warn(
+            f"Profile {name!r} is the host for shared run-history "
+            f"(schema {schema!r}). Removing it will:\n"
+            "  • Disable shared mode on this machine.\n"
+            "  • Leave the shared schema on the remote untouched (your\n"
+            "    teammates' rows are safe).\n"
+            "  • Strand any pending shared writes still in the local outbox."
+        )
+        if not confirm(
+            f"Remove profile {name!r} AND disable shared run-history?",
+            default=False,
+        ):
+            info("Profile removal cancelled.")
+            return
+        # Auto-disable shared mode so the next session does not try
+        # to bootstrap against the now-deleted profile and surface a
+        # confusing "profile not found" warning at startup.
+        with cfg.transaction():
+            cfg.history_store_enabled = False
+            cfg.history_store_profile = ""
     try:
         cfg.remove_db_profile(name)
         cfg.save()

--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -189,16 +189,49 @@ def _action_disable(cfg: AMXConfig, *, log_event: LogEvent) -> None:
     if not getattr(cfg, "history_store_enabled", False):
         info("Shared mode is already disabled.")
         return
+    profile = cfg.history_store_profile or "(unknown)"
+    schema = cfg.history_store_schema or "AMX"
+    # Block disable when the outbox is non-empty so the user does not
+    # silently strand work. Local rows already exist; the queued ops
+    # are *shared* writes that haven't reached the team backend yet.
+    store = _resolve_history_dual_store()
+    if store is not None:
+        try:
+            depth = store.pending_count()
+        except Exception:
+            depth = 0
+        if depth > 0:
+            warn(
+                f"Outbox has {depth} pending shared write(s) that have NOT "
+                "reached the team backend yet."
+            )
+            if not confirm(
+                "Disable anyway? The pending writes stay queued locally; you "
+                "can re-enable and run 'Flush pending' later to deliver them.",
+                default=False,
+            ):
+                info("Disable cancelled. Pick 'Flush pending' to drain first.")
+                return
+    info(
+        "Disconnecting only flips this machine to local-only mode. The "
+        f"shared schema {schema!r} on profile {profile!r} stays untouched — "
+        "every existing shared row remains visible to your teammates, and "
+        "you can re-enable from this same machine later."
+    )
     if not confirm(
-        "Disable shared run-history? Existing shared rows are NOT deleted; "
-        "you can re-enable later from this same machine.",
+        f"Disable shared run-history (profile {profile!r}, schema {schema!r})? "
+        "Existing shared rows will NOT be deleted.",
         default=False,
     ):
         return
     with cfg.transaction():
         cfg.history_store_enabled = False
-    success("Shared run-history disabled.")
-    info("Restart AMX (or run any command) for the change to take effect.")
+    success("Shared run-history disabled (local-only on this machine).")
+    info(
+        "Shared rows untouched. To wipe the shared schema permanently you must "
+        f"DROP SCHEMA {schema} on profile {profile!r} yourself — AMX never "
+        "drops a team-shared schema automatically."
+    )
     log_event(event_type="history_store.disable", status="ok", command="/history-store disable")
 
 

--- a/amx/storage/sqlalchemy_store.py
+++ b/amx/storage/sqlalchemy_store.py
@@ -558,6 +558,74 @@ class SQLAlchemyHistoryStore:
             return default
         return row[0]
 
+    # ── Collaboration helpers ─────────────────────────────────────────────
+
+    def find_prior_runs_by_others(
+        self,
+        *,
+        db_profile: str,
+        scope: dict[str, list[str]],
+        exclude_hostname: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Return prior shared runs that touched any asset in *scope*.
+
+        Used by ``/run`` and ``/run-apply`` to warn a user that a
+        teammate already analyzed the same scope. ``exclude_hostname``
+        is normally the current machine's hostname so the user only
+        sees OTHER users' work, not their own re-runs.
+
+        Filtering is done in Python after a portable backend query
+        (recent ``analysis_runs`` rows for the same ``db_profile``)
+        because JSON containment syntax differs across PostgreSQL,
+        Snowflake, BigQuery, MSSQL etc. The set is small in practice —
+        we look at the most recent N×6 rows and stop when the limit
+        of overlap matches is reached.
+        """
+        if not scope:
+            return []
+        target_assets: set[tuple[str, str]] = set()
+        for schema, tables in scope.items():
+            for tbl in tables or []:
+                target_assets.add((str(schema), str(tbl)))
+        if not target_assets:
+            return []
+
+        # Pull a generous slice; ``analysis_runs`` is small enough that
+        # this stays cheap, and limiting on the SQL side avoids a
+        # full-table scan on backends with billions of rows over time.
+        stmt = (
+            select(self._t_runs)
+            .where(self._t_runs.c.db_profile == db_profile)
+            .where(self._t_runs.c.command.in_(["analyze.run", "search.ask"]))
+            .order_by(self._t_runs.c.started_at.desc())
+            .limit(max(50, int(limit) * 6))
+        )
+        with self.engine.begin() as conn:
+            rows = conn.execute(stmt).mappings().all()
+
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            host = row.get("hostname") or ""
+            if exclude_hostname and host == exclude_hostname:
+                continue
+            row_scope = row.get("scope_json") or {}
+            if not isinstance(row_scope, dict):
+                continue
+            row_assets: set[tuple[str, str]] = set()
+            for schema, tables in row_scope.items():
+                for tbl in tables or []:
+                    row_assets.add((str(schema), str(tbl)))
+            overlap = target_assets & row_assets
+            if not overlap:
+                continue
+            d = dict(row)
+            d["overlap_assets"] = sorted(overlap)
+            out.append(d)
+            if len(out) >= int(limit):
+                break
+        return out
+
     # ── Dual-write convenience (used by DualWriteHistoryStore) ────────────
 
     def find_run_uuid_by_local_id(self, local_id: int) -> str | None:

--- a/tests/test_history_store_collaboration.py
+++ b/tests/test_history_store_collaboration.py
@@ -1,0 +1,186 @@
+"""Collaboration-guard tests.
+
+Cover the two new safety behaviours added on top of the v0.12.0
+shared-history feature:
+
+* ``find_prior_runs_by_others`` — the query that powers the pre-run
+  "this scope was already analysed by X" warning. Verifies overlap
+  detection (any common (schema, table) tuple matches) and the
+  hostname-exclusion that hides the user's own prior runs from the
+  warning list.
+* ``_action_disable`` outbox guard — bouncing the disable when the
+  outbox is non-empty so queued shared writes are never silently
+  stranded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+
+from amx.storage.shared_schema import build_metadata
+from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+
+
+def _make_shared(tmp_path: Path, *, hostname: str = "test-host") -> SQLAlchemyHistoryStore:
+    db_path = tmp_path / f"shared-{hostname}.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    md = build_metadata(schema="main")
+    md.create_all(engine)
+    s = SQLAlchemyHistoryStore.__new__(SQLAlchemyHistoryStore)
+    s.engine = engine
+    s.schema = "main"
+    s._md = md
+    s._t_runs = md.tables["main.analysis_runs"]
+    s._t_results = md.tables["main.run_results"]
+    s._t_events = md.tables["main.app_events"]
+    s._t_session = md.tables["main.session_state"]
+    s._t_meta = md.tables["main.schema_meta"]
+    s._hostname = hostname
+    s._username = f"user-{hostname}"
+    s._client_version = "0.12.0-test"
+    return s
+
+
+@pytest.fixture
+def shared(tmp_path: Path) -> SQLAlchemyHistoryStore:
+    return _make_shared(tmp_path, hostname="machine-A")
+
+
+def _seed_run(
+    store: SQLAlchemyHistoryStore,
+    *,
+    db_profile: str,
+    scope: dict[str, list[str]],
+    hostname: str | None = None,
+    created_by: str | None = None,
+) -> str:
+    # Override the per-row attribution so we can simulate "another user".
+    if hostname is not None:
+        store._hostname = hostname
+    if created_by is not None:
+        store._username = created_by
+    return store.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile=db_profile,
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope=scope,
+    )
+
+
+def test_find_prior_runs_by_others_overlap(shared: SQLAlchemyHistoryStore) -> None:
+    # Seed one run from machine-B against (sales.orders, sales.customers)
+    _seed_run(
+        shared,
+        db_profile="prod_pg",
+        scope={"sales": ["orders", "customers"]},
+        hostname="machine-B",
+        created_by="bob",
+    )
+    # Reset the store's identity back to machine-A so the query
+    # excludes machine-A's own future runs.
+    shared._hostname = "machine-A"
+    shared._username = "alice"
+
+    prior = shared.find_prior_runs_by_others(
+        db_profile="prod_pg",
+        scope={"sales": ["orders"]},  # subset of B's scope
+        exclude_hostname="machine-A",
+    )
+    assert len(prior) == 1
+    assert prior[0]["created_by"] == "bob"
+    assert prior[0]["hostname"] == "machine-B"
+    assert ("sales", "orders") in prior[0]["overlap_assets"]
+
+
+def test_find_prior_runs_excludes_own_hostname(
+    shared: SQLAlchemyHistoryStore,
+) -> None:
+    # Same machine ran once — the query must hide it from the warning.
+    _seed_run(
+        shared,
+        db_profile="prod_pg",
+        scope={"hr": ["employees"]},
+        hostname="machine-A",
+        created_by="alice",
+    )
+    prior = shared.find_prior_runs_by_others(
+        db_profile="prod_pg",
+        scope={"hr": ["employees"]},
+        exclude_hostname="machine-A",
+    )
+    assert prior == []
+
+
+def test_find_prior_runs_no_overlap(shared: SQLAlchemyHistoryStore) -> None:
+    _seed_run(
+        shared,
+        db_profile="prod_pg",
+        scope={"finance": ["ledger"]},
+        hostname="machine-B",
+        created_by="bob",
+    )
+    shared._hostname = "machine-A"
+    prior = shared.find_prior_runs_by_others(
+        db_profile="prod_pg",
+        scope={"hr": ["employees"]},  # disjoint
+        exclude_hostname="machine-A",
+    )
+    assert prior == []
+
+
+def test_find_prior_runs_filters_by_profile(shared: SQLAlchemyHistoryStore) -> None:
+    """A run on a different profile must not surface in the warning."""
+    _seed_run(
+        shared,
+        db_profile="staging_pg",
+        scope={"sales": ["orders"]},
+        hostname="machine-B",
+        created_by="bob",
+    )
+    shared._hostname = "machine-A"
+    prior = shared.find_prior_runs_by_others(
+        db_profile="prod_pg",  # different profile
+        scope={"sales": ["orders"]},
+        exclude_hostname="machine-A",
+    )
+    assert prior == []
+
+
+def test_disable_action_blocks_when_outbox_has_pending() -> None:
+    """The Disable action must not silently strand pending shared writes."""
+    from amx.cli_support.commands import history_store as hs_module
+
+    store = MagicMock()
+    store.shared = MagicMock()
+    store.flush_pending = MagicMock(return_value=(0, 0))
+    store.pending_count = MagicMock(return_value=3)
+
+    cfg = MagicMock()
+    cfg.history_store_enabled = True
+    cfg.history_store_profile = "prod_pg"
+    cfg.history_store_schema = "AMX"
+
+    log_event = MagicMock()
+    # Stub the dual-store resolver to return our mock without touching
+    # the global singleton.
+    original = hs_module._resolve_history_dual_store
+    hs_module._resolve_history_dual_store = lambda: store
+    # Stub the second confirm() prompt to deny so the action aborts.
+    original_confirm = hs_module.confirm
+    hs_module.confirm = MagicMock(return_value=False)
+    try:
+        hs_module._action_disable(cfg, log_event=log_event)
+    finally:
+        hs_module._resolve_history_dual_store = original
+        hs_module.confirm = original_confirm
+
+    # cfg.transaction must NOT have been entered — disable should have
+    # bounced because the outbox warning was declined.
+    cfg.transaction.assert_not_called()


### PR DESCRIPTION
## Summary

Three safety improvements requested after 0.12.0 shipped — all on the shared run-history surface:

### 1. Disable never deletes/drops remote rows (and surfaces the outbox)

The Disable picker now:
- **Bounces** when the outbox has pending shared writes (prevents silently stranding work). User must explicitly accept stranding before disable proceeds.
- **States the consequence** in plain language: disabling flips this machine to local-only; the shared schema stays alive; teammates' rows are untouched; you can re-enable later. To wipe the schema permanently you must \`DROP SCHEMA\` yourself in your warehouse client — AMX never drops a team-shared schema automatically.

### 2. \`/remove-db-profile\` warns when the profile hosts shared history

If the profile being removed is the one configured under \`history_store_profile\`, AMX explicitly warns:

> Profile 'prod_pg' is the host for shared run-history (schema 'AMX'). Removing it will:
> • Disable shared mode on this machine.
> • Leave the shared schema on the remote untouched (your teammates' rows are safe).
> • Strand any pending shared writes still in the local outbox.
> Remove profile 'prod_pg' AND disable shared run-history? [y/N]

Confirming auto-disables shared mode so the next session does not surface a stale \"profile not found\" warning at startup.

### 3. \`/run\` and \`/run-apply\` warn when scope overlaps a teammate's prior run

Before creating a new run in shared mode, AMX queries \`AMX.analysis_runs\` on the team backend for runs against the same \`db_profile\` that touched any of the assets in the user's scope, scoped to OTHER hostnames (so re-running your own work doesn't trigger the prompt). If matches are found, a compact table is shown and the user is asked whether to proceed:

\`\`\`
⚠ Other team members have already analyzed assets in this scope:
╭──────────── Prior team runs in this scope ────────────╮
│ User   │ Host       │ Started          │ Status   │ Overlapping assets │
│ bob    │ machine-B  │ 2026-05-03 14:21 │ success  │ sales.orders       │
╰────────────────────────────────────────────────────────╯
ℹ You are about to analyze profile 'prod_pg' with the same scope. Comment write-back is
  last-writer-wins on the warehouse, so a fresh run will overwrite descriptions a teammate
  just published unless you skip /run-apply.
  Proceed anyway? [y/N]
\`\`\`

Best-effort: a shared-lookup failure (network blip, schema mismatch) logs at DEBUG and lets the run continue — we never block \`/run\` on a flaky team-store query.

## Files

- \`amx/storage/sqlalchemy_store.py\` — new \`find_prior_runs_by_others(db_profile, scope, exclude_hostname, limit)\`. Portable across all eight Tier-1/2 backends; pulls a generous slice and filters in Python on (schema, table) tuple overlap.
- \`amx/cli_support/commands/analyze_flow.py\` — new \`_confirm_proceed_when_others_analyzed_scope\` invoked just before \`hs.create_run\` when \`hs\` is a \`DualWriteHistoryStore\`.
- \`amx/cli_support/commands/history_store.py\` — \`_action_disable\` now checks outbox depth, requires extra confirm, prints explicit "shared rows untouched" message.
- \`amx/cli_support/commands/db.py\` — \`cmd_remove_profile\` adds the history-profile guard.
- \`tests/test_history_store_collaboration.py\` — 5 new tests (overlap, hostname-exclusion, profile filter, no-overlap silence, outbox-blocked disable).

## Test plan

- [x] \`ruff check amx tests\` clean
- [x] \`ruff format --check amx tests\` clean
- [x] \`pytest -m \"not integration and not live\"\` — 537 pass (was 532, +5 collaboration tests)
- [ ] CI green on Python 3.10 / 3.11 / 3.12 (this PR)
