### PR TITLE
feat(history): /history-store enable picks the database / catalog too

### DIFF
--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -82,9 +82,21 @@ def _action_status(cfg: AMXConfig) -> None:
         return
     profile = cfg.history_store_profile or "(none)"
     schema = cfg.history_store_schema or "AMX"
+    database = cfg.history_store_database or "(profile default)"
+    # Backend for the chosen profile drives the label — "Catalog" for
+    # Databricks, "Project" for BigQuery, otherwise "Database".
+    db_cfg = cfg.db_profiles.get(profile) if profile in cfg.db_profiles else None
+    backend = getattr(db_cfg, "backend", "") if db_cfg else ""
+    if backend == "databricks":
+        target_label = "Catalog"
+    elif backend == "bigquery":
+        target_label = "Project"
+    else:
+        target_label = "Database"
     info("Shared mode: [bold green]enabled[/bold green]")
-    info(f"  Profile: {profile}")
-    info(f"  Schema:  {schema}")
+    info(f"  Profile:  {profile}")
+    info(f"  {target_label}: {database}")
+    info(f"  Schema:   {schema}")
     store = _resolve_history_dual_store()
     if store is not None:
         try:
@@ -110,6 +122,7 @@ def _action_enable(
     log_event: LogEvent,
     profile_name: str | None = None,
     schema_name: str | None = None,
+    database_name: str | None = None,
 ) -> None:
     if not cfg.db_profiles:
         error(
@@ -132,6 +145,7 @@ def _action_enable(
     # Local imports so this command does not pay the SQLAlchemy adapter
     # cost on the cold path.
     from amx.db.adapters import get_adapter
+    from amx.storage.factory import apply_history_db_override
     from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
 
     adapter = get_adapter(db_cfg)
@@ -143,11 +157,29 @@ def _action_enable(
         )
         return
 
+    # Pick the database / catalog / project that will host the AMX
+    # schema. A single profile (e.g. ``prod_pg``) often points at
+    # multiple databases — the user may want AMX in a "tools" DB
+    # rather than alongside production data. We always offer the
+    # picker for backends where it applies; the helper returns the
+    # picked override (empty string = use the profile's default).
+    if database_name is None:
+        database_name = _pick_history_database(cfg, db_cfg, adapter)
+
+    # Apply the override on a copy of the DBConfig so the user's saved
+    # profile is never mutated. The factory does the same at every
+    # session start so subsequent runs reconnect to the same DB.
+    target_cfg = apply_history_db_override(db_cfg, database_name) if database_name else db_cfg
+
     if schema_name is None or not schema_name.strip():
         schema_name = (cfg.history_store_schema or "AMX").strip() or "AMX"
 
-    info(f"Bootstrapping schema {schema_name!r} on profile {profile_name!r} ({db_cfg.backend})…")
-    engine = adapter.create_engine()
+    target_label = _format_db_target(target_cfg, database_name)
+    info(
+        f"Bootstrapping schema {schema_name!r} on profile {profile_name!r} "
+        f"({db_cfg.backend}) → {target_label}…"
+    )
+    engine = get_adapter(target_cfg).create_engine()
     try:
         adapter.create_history_schema(engine, schema_name)
     except Exception as exc:
@@ -168,10 +200,11 @@ def _action_enable(
         cfg.history_store_enabled = True
         cfg.history_store_profile = profile_name
         cfg.history_store_schema = schema_name
+        cfg.history_store_database = database_name or ""
 
     success(
         f"Shared run-history enabled. Profile: {profile_name!r} "
-        f"({db_cfg.backend}). Schema: {schema_name!r}."
+        f"({db_cfg.backend}). Target: {target_label}. Schema: {schema_name!r}."
     )
     info(
         "All future runs will be dual-written to local SQLite AND the "
@@ -183,6 +216,76 @@ def _action_enable(
     ):
         _run_migration(cfg, store)
     log_event(event_type="history_store.enable", status="ok", command="/history-store enable")
+
+
+def _pick_history_database(cfg: AMXConfig, db_cfg, adapter) -> str:
+    """Ask the user which database / catalog should host the AMX schema.
+
+    The picker semantics differ per backend:
+
+    * Databricks Unity Catalog → catalogs (``catalog.schema.table``).
+      Listed via ``adapter.list_catalogs(engine)``.
+    * BigQuery → projects. The project is already pinned on the
+      profile (it has to be set before the engine works), so the
+      picker is skipped and the empty string is returned (which means
+      "use whatever is on the profile").
+    * MySQL → schemas == databases. The schema name itself IS the
+      database, so a separate database picker would be redundant.
+      Skipped.
+    * PostgreSQL / MSSQL / Oracle / Redshift / Snowflake → databases
+      listed via ``adapter.list_databases(engine)``.
+
+    Returns the picked override as a string (empty string to mean
+    "no override"). On any discovery error we surface a warning and
+    let the user proceed with the profile's default — never block.
+    """
+    backend = db_cfg.backend
+    if backend in {"bigquery", "mysql"}:
+        return ""
+
+    is_databricks = backend == "databricks"
+    label_kind = "catalog" if is_databricks else "database"
+    current = (
+        getattr(db_cfg, "catalog", "") if is_databricks else getattr(db_cfg, "database", "")
+    ) or ""
+
+    info(f"Discovering available {label_kind}s on profile (read-only)…")
+    try:
+        engine = adapter.create_engine()
+        choices = adapter.list_catalogs(engine) if is_databricks else adapter.list_databases(engine)
+    except Exception as exc:
+        warn(
+            f"Could not list {label_kind}s ({exc}). Using the profile's "
+            f"current {label_kind}: {current or '(none)'}."
+        )
+        return current
+
+    choices = sorted({str(c) for c in (choices or []) if c})
+    if not choices:
+        warn(
+            f"No {label_kind}s reported by the server. Using the profile's "
+            f"current {label_kind}: {current or '(none)'}."
+        )
+        return current
+
+    default = current if current in choices else choices[0]
+    picked = ask_choice(
+        f"Where should the AMX schema live? Pick a {label_kind}",
+        choices,
+        default=default,
+    )
+    return picked or default
+
+
+def _format_db_target(target_cfg, database_name: str) -> str:
+    """Render the user-facing label for the chosen database/catalog."""
+    if not database_name:
+        if target_cfg.backend == "databricks":
+            return target_cfg.catalog or "(profile default)"
+        if target_cfg.backend == "bigquery":
+            return target_cfg.project or "(profile default)"
+        return target_cfg.database or "(profile default)"
+    return database_name
 
 
 def _action_disable(cfg: AMXConfig, *, log_event: LogEvent) -> None:
@@ -381,14 +484,32 @@ def register_history_store_commands(
         default=None,
         help="Schema/database name where AMX tables live. Default 'AMX'.",
     )
+    @click.option(
+        "--database",
+        "database_name",
+        default=None,
+        help=(
+            "Override which database/catalog inside the profile hosts the "
+            "AMX schema. Defaults to an interactive picker for backends "
+            "that support multi-database listing (PG, MSSQL, Oracle, "
+            "Redshift, Snowflake, Databricks). Skipped on MySQL "
+            "(schema == database) and BigQuery (project pinned on profile)."
+        ),
+    )
     @pass_config
-    def hs_enable(cfg: AMXConfig, profile_name: str | None, schema_name: str | None) -> None:
+    def hs_enable(
+        cfg: AMXConfig,
+        profile_name: str | None,
+        schema_name: str | None,
+        database_name: str | None,
+    ) -> None:
         """Bootstrap the AMX schema in a saved DB profile and enable shared mode."""
         _action_enable(
             cfg,
             log_event=log_event,
             profile_name=profile_name,
             schema_name=schema_name,
+            database_name=database_name,
         )
 
     @history_store_grp.command("disable")

--- a/amx/config.py
+++ b/amx/config.py
@@ -1146,6 +1146,15 @@ class AMXConfig:
     history_store_enabled: bool = False
     history_store_profile: str = ""
     history_store_schema: str = "AMX"
+    # Overrides the profile's pinned database/catalog when building the
+    # shared-history engine. A single DB profile (e.g. ``prod_pg``)
+    # often points at multiple databases; the user picks where the AMX
+    # schema lives at /history-store enable time. Interpreted per-backend
+    # by ``apply_history_db_override`` — database for PG/MySQL/MSSQL/
+    # Oracle/Redshift/Snowflake, catalog for Databricks, project for
+    # BigQuery. Empty string means "use whatever the profile already
+    # has pinned".
+    history_store_database: str = ""
 
     # Ephemeral, never persisted to YAML. Tracks which chat session the
     # current REPL is appending to. Reset to None on every load.
@@ -1181,6 +1190,7 @@ class AMXConfig:
             "history_store_enabled",
             "history_store_profile",
             "history_store_schema",
+            "history_store_database",
         }
     )
 
@@ -1297,6 +1307,7 @@ class AMXConfig:
             cfg.history_store_enabled = bool(data.get("history_store_enabled", False))
             cfg.history_store_profile = str(data.get("history_store_profile") or "")
             cfg.history_store_schema = str(data.get("history_store_schema") or "AMX")
+            cfg.history_store_database = str(data.get("history_store_database") or "")
 
             embedding_raw = data.get("embedding")
             if isinstance(embedding_raw, dict):
@@ -1432,6 +1443,7 @@ class AMXConfig:
             data["history_store_enabled"] = bool(self.history_store_enabled)
             data["history_store_profile"] = str(self.history_store_profile or "")
             data["history_store_schema"] = str(self.history_store_schema or "AMX")
+            data["history_store_database"] = str(self.history_store_database or "")
             data["embedding"] = _embedding_to_mapping(self.embedding)
             # Move plaintext secrets to the OS keyring; the YAML now stores only
             # opaque "keyring:..." references. No-op when keyring is unavailable.

--- a/amx/storage/factory.py
+++ b/amx/storage/factory.py
@@ -16,6 +16,7 @@ back-compat shim that defaults to local-only.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -24,9 +25,33 @@ from amx.storage.sqlite_store import SQLiteHistoryStore
 from amx.utils.logging import get_logger
 
 if TYPE_CHECKING:
-    from amx.config import AMXConfig
+    from amx.config import AMXConfig, DBConfig
 
 log = get_logger("storage.factory")
+
+
+def apply_history_db_override(db_cfg: DBConfig, override: str) -> DBConfig:
+    """Return a copy of *db_cfg* with *override* applied to the right field.
+
+    Different backends use different fields to identify the container
+    that holds the AMX schema:
+
+    * Databricks Unity Catalog → ``catalog`` (the FQN is
+      ``catalog.schema.table``).
+    * BigQuery → ``project`` (datasets are scoped to a project).
+    * Everything else (PG, MySQL, MSSQL, Oracle, Redshift, Snowflake) →
+      ``database``.
+
+    Empty *override* is a no-op — the profile keeps whatever it had
+    pinned originally.
+    """
+    if not override:
+        return db_cfg
+    if db_cfg.backend == "databricks":
+        return replace(db_cfg, catalog=override)
+    if db_cfg.backend == "bigquery":
+        return replace(db_cfg, project=override)
+    return replace(db_cfg, database=override)
 
 
 class HistoryStoreBootstrapError(RuntimeError):
@@ -68,6 +93,16 @@ def _build_shared_store(cfg: AMXConfig):
         return None
 
     db_cfg = cfg.db_profiles[profile_name]
+
+    # Apply the user's "where do you want the AMX schema?" choice
+    # (set during /history-store enable). For PG/MySQL/MSSQL/Oracle/
+    # Redshift/Snowflake this overrides ``database``; for Databricks
+    # ``catalog``; for BigQuery ``project``. ``replace`` returns a
+    # copy so the user's saved profile in ``cfg.db_profiles`` is
+    # untouched.
+    override = (getattr(cfg, "history_store_database", "") or "").strip()
+    if override:
+        db_cfg = apply_history_db_override(db_cfg, override)
 
     # Local imports keep the SQLAlchemy + adapter surface out of the
     # main amx import path. ``init_history_store`` is hot on every
@@ -162,6 +197,7 @@ def history_store():
 
 __all__ = [
     "HistoryStoreBootstrapError",
+    "apply_history_db_override",
     "history_store",
     "init_history_store",
 ]

--- a/tests/test_history_store_collaboration.py
+++ b/tests/test_history_store_collaboration.py
@@ -153,6 +153,72 @@ def test_find_prior_runs_filters_by_profile(shared: SQLAlchemyHistoryStore) -> N
     assert prior == []
 
 
+def test_apply_history_db_override_postgres() -> None:
+    """PG-style backends route the override to ``database``."""
+    from amx.config import DBConfig
+    from amx.storage.factory import apply_history_db_override
+
+    pg = DBConfig(backend="postgresql", database="prod_db")
+    overridden = apply_history_db_override(pg, "tools_db")
+    assert overridden.database == "tools_db"
+    # Original untouched (we returned a copy, not mutated)
+    assert pg.database == "prod_db"
+
+
+def test_apply_history_db_override_databricks() -> None:
+    """Databricks routes to ``catalog`` (Unity Catalog FQN prefix)."""
+    from amx.config import DBConfig
+    from amx.storage.factory import apply_history_db_override
+
+    db = DBConfig(backend="databricks", catalog="prod_catalog", database="default")
+    overridden = apply_history_db_override(db, "ops_catalog")
+    assert overridden.catalog == "ops_catalog"
+    assert overridden.database == "default"  # database untouched
+    assert db.catalog == "prod_catalog"  # original untouched
+
+
+def test_apply_history_db_override_bigquery() -> None:
+    """BigQuery routes to ``project`` (datasets are scoped to projects)."""
+    from amx.config import DBConfig
+    from amx.storage.factory import apply_history_db_override
+
+    bq = DBConfig(backend="bigquery", project="prod-proj", dataset="warehouse")
+    overridden = apply_history_db_override(bq, "ops-proj")
+    assert overridden.project == "ops-proj"
+    assert overridden.dataset == "warehouse"
+    assert bq.project == "prod-proj"
+
+
+def test_apply_history_db_override_empty_is_noop() -> None:
+    from amx.config import DBConfig
+    from amx.storage.factory import apply_history_db_override
+
+    pg = DBConfig(backend="postgresql", database="prod_db")
+    assert apply_history_db_override(pg, "") is pg
+
+
+def test_history_store_database_round_trips_through_yaml(
+    tmp_path: Path,
+) -> None:
+    """The new field persists across save+load — same shape as the rest of
+    the history-store config."""
+    from amx.config import AMXConfig
+
+    cfg_path = tmp_path / "config.yml"
+    cfg = AMXConfig()
+    cfg._config_path = str(cfg_path)
+    cfg.history_store_enabled = True
+    cfg.history_store_profile = "prod_pg"
+    cfg.history_store_schema = "AMX"
+    cfg.history_store_database = "tools_db"
+    cfg.save(str(cfg_path))
+
+    reloaded = AMXConfig.load(str(cfg_path))
+    assert reloaded.history_store_enabled is True
+    assert reloaded.history_store_profile == "prod_pg"
+    assert reloaded.history_store_database == "tools_db"
+
+
 def test_disable_action_blocks_when_outbox_has_pending() -> None:
     """The Disable action must not silently strand pending shared writes."""
     from amx.cli_support.commands import history_store as hs_module


### PR DESCRIPTION
## Summary

A single DB profile (e.g. `prod_pg`) often points at multiple databases, and the right place to put the AMX schema isn't always the same database the user does analysis in. They might want a dedicated `tools_db` or `metadata_db` so AMX rows live next to other tooling, not alongside production data. Until now `/history-store enable` silently used whichever database the profile had pinned.

This PR adds an interactive **database / catalog picker** to `enable`, persists the choice in config, and applies it on every session reconnect.

### Behavior

When you pick a profile, AMX:

1. Connects read-only and lists available databases via `adapter.list_databases(engine)` (or `list_catalogs(engine)` on Databricks).
2. Shows a numbered picker — default is whatever the profile already had pinned.
3. Saves your choice to `cfg.history_store_database`. Subsequent sessions auto-rebuild the engine with this database pinned, no re-prompt.
4. Skipped for **MySQL** (schema == database, redundant) and **BigQuery** (project is pinned on the profile, no separate concept).
5. On a discovery error (no `list_databases` permission, network blip), AMX warns and falls back to the profile default — never blocks.

The status panel labels the field correctly per backend: `Database` for PG/MySQL/MSSQL/Oracle/Redshift/Snowflake, `Catalog` for Databricks, `Project` for BigQuery.

### Files

- `amx/config.py` — new `AMXConfig.history_store_database` field with YAML round-trip; included in `_PERSISTED_FIELDS`.
- `amx/storage/factory.py` — new `apply_history_db_override(db_cfg, override)` helper. Single function that knows which `DBConfig` field each backend uses for container semantics (database / catalog / project). The factory applies it before building the engine in every session.
- `amx/cli_support/commands/history_store.py` — new `_pick_history_database` and `_format_db_target` helpers. `_action_enable` calls the picker and saves the result. New `--database` Click flag on the `enable` subcommand for scripting. Status panel renders the per-backend label.
- `tests/test_history_store_collaboration.py` — five new tests covering the override helper per backend (PG, Databricks, BigQuery, empty-noop) and the YAML round-trip.

### Test plan

- [x] `ruff check amx tests` clean
- [x] `ruff format --check amx tests` clean
- [x] `pytest -m \"not integration and not live\"` — 542 pass (was 537, +5 picker / override tests)
- [ ] CI green on Python 3.10 / 3.11 / 3.12 (this PR)
