### PR TITLE
feat(history): pull teammates' runs from shared store on connect

### DIFF
--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -41,6 +41,9 @@ from amx.utils.console import (
     success,
     warn,
 )
+from amx.utils.logging import get_logger
+
+log = get_logger("cli.history_store")
 
 LogEvent = Callable[..., None]
 
@@ -52,6 +55,7 @@ ACTION_STATUS = "Status — show shared-mode state and outbox depth"
 ACTION_ENABLE = "Enable — bootstrap an AMX schema on a saved DB profile"
 ACTION_DISABLE = "Disable — stop dual-writing (existing shared rows are kept)"
 ACTION_MIGRATE = "Migrate from local — copy local SQLite history into the shared store"
+ACTION_PULL = "Pull from shared — sync teammates' runs into your local SQLite cache"
 ACTION_FLUSH = "Flush pending — retry queued shared writes that failed at write time"
 ACTION_DUMP_DDL = "Dump DDL — print bootstrap SQL for a DBA to run by hand"
 ACTION_CANCEL = "Cancel — exit without doing anything"
@@ -210,12 +214,96 @@ def _action_enable(
         "All future runs will be dual-written to local SQLite AND the "
         "shared backend. Reads still come from local SQLite."
     )
+
+    # Detection: did a teammate already populate this shared store?
+    # When yes, surface a compact summary of who wrote what and offer
+    # to pull those runs down into the local cache so /history list
+    # immediately shows team activity, not just this machine's.
+    _maybe_offer_pull_on_enable(store)
+
     if confirm(
-        "Migrate existing local runs into the shared store now? (Idempotent — safe to skip.)",
+        "Migrate existing local runs UP into the shared store now? (Idempotent — safe to skip.)",
         default=True,
     ):
         _run_migration(cfg, store)
     log_event(event_type="history_store.enable", status="ok", command="/history-store enable")
+
+
+def _maybe_offer_pull_on_enable(shared_store) -> None:
+    """If the shared store already has rows from other hosts, prompt
+    the user to pull them into local SQLite.
+
+    Best-effort: any error walking the shared store is logged and the
+    enable flow continues — we never block the user on this nicety.
+    """
+    import socket
+
+    try:
+        summary = shared_store.count_runs_by_other_hosts(exclude_hostname=socket.gethostname())
+    except Exception as exc:
+        log.debug("count_runs_by_other_hosts failed in enable detection: %s", exc)
+        return
+    if not summary:
+        return
+
+    info("")
+    warn("This shared store already has runs from other team members:")
+    rows: list[list[str]] = []
+    for host, bucket in sorted(summary.items(), key=lambda kv: -kv[1]["count"]):
+        users = ", ".join(bucket["users"]) if bucket["users"] else "?"
+        last = bucket["last_run"]
+        last_str = "?"
+        if last is not None:
+            try:
+                ts = last
+                if hasattr(ts, "tzinfo") and ts.tzinfo is None:
+                    from datetime import timezone
+
+                    ts = ts.replace(tzinfo=timezone.utc)
+                last_str = ts.astimezone().strftime("%Y-%m-%d %H:%M")  # type: ignore[union-attr]
+            except Exception:
+                last_str = str(last)
+        rows.append([host, users, str(bucket["count"]), last_str])
+    render_table(
+        "Existing runs in shared store",
+        ["Host", "Users", "Runs", "Last activity"],
+        rows,
+    )
+    if confirm(
+        "Pull these runs into your local SQLite cache so /history list shows "
+        "team activity? (Idempotent — safe to skip and re-run later.)",
+        default=True,
+    ):
+        _run_pull_from_shared(shared_store)
+
+
+def _run_pull_from_shared(shared_store) -> None:
+    """Execute pull_shared_to_local with progress + result table."""
+    from amx.storage.migration import pull_shared_to_local
+    from amx.storage.sqlite_store import SQLiteHistoryStore
+
+    store = history_store()
+    if store is None:
+        error("History store not initialised — cannot pull.")
+        return
+    local_path = (
+        store.local.db_path  # type: ignore[union-attr]
+        if hasattr(store, "local")
+        else store.db_path  # type: ignore[union-attr]
+    )
+    local = SQLiteHistoryStore(local_path)
+    info("Pulling teammates' runs into local SQLite cache…")
+    try:
+        stats = pull_shared_to_local(local=local, shared=shared_store)
+    except Exception as exc:
+        error(f"Pull failed: {exc}")
+        return
+    rows = [[table, str(count)] for table, count in stats.items()]
+    render_table("Pull result", ["Table", "Rows pulled"], rows)
+    if any(stats.values()):
+        success("Pull complete. /history list will now include teammates' runs alongside your own.")
+    else:
+        info("Nothing new to pull (already in sync).")
 
 
 def _pick_history_database(cfg: AMXConfig, db_cfg, adapter) -> str:
@@ -349,6 +437,24 @@ def _action_migrate(cfg: AMXConfig) -> None:
     _run_migration(cfg, store.shared)
 
 
+def _action_pull(cfg: AMXConfig) -> None:
+    """Pull teammates' runs from the shared store into local SQLite.
+
+    The mirror of _action_migrate (which pushes UP). Reads come from
+    local SQLite in v0.12, so pulling is what makes ``/history list``
+    surface team activity. Idempotent — re-running only inserts rows
+    whose ``shared_uuid`` is not already present locally.
+    """
+    if not getattr(cfg, "history_store_enabled", False):
+        error("Shared mode is disabled. Pick Enable first.")
+        return
+    store = _resolve_history_dual_store()
+    if store is None:
+        error("Shared store is not active. Pick Enable first.")
+        return
+    _run_pull_from_shared(store.shared)
+
+
 def _action_flush(cfg: AMXConfig) -> None:
     store = _resolve_history_dual_store()
     if store is None:
@@ -405,6 +511,7 @@ def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> N
     options: list[str] = [ACTION_STATUS]
     if enabled:
         options.append(ACTION_DISABLE)
+        options.append(ACTION_PULL)
         options.append(ACTION_MIGRATE)
         options.append(ACTION_FLUSH)
     else:
@@ -425,6 +532,9 @@ def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> N
         return
     if picked == ACTION_DISABLE:
         _action_disable(cfg, log_event=log_event)
+        return
+    if picked == ACTION_PULL:
+        _action_pull(cfg)
         return
     if picked == ACTION_MIGRATE:
         _action_migrate(cfg)
@@ -523,6 +633,12 @@ def register_history_store_commands(
     def hs_migrate(cfg: AMXConfig) -> None:
         """Copy local SQLite history into the shared store (idempotent)."""
         _action_migrate(cfg)
+
+    @history_store_grp.command("pull-from-shared")
+    @pass_config
+    def hs_pull(cfg: AMXConfig) -> None:
+        """Pull teammates' runs from the shared store into local SQLite (idempotent)."""
+        _action_pull(cfg)
 
     @history_store_grp.command("flush-pending")
     @pass_config

--- a/amx/storage/migration.py
+++ b/amx/storage/migration.py
@@ -1,15 +1,23 @@
-"""One-shot migration of local SQLite history → shared warehouse store.
+"""Bidirectional migration between local SQLite and the shared store.
 
-Used by ``/history-store migrate-from-local``. Walks every table in
-foreign-key order, converts INT primary keys (local SQLite) into
-UUIDs (shared schema), records the original ``local_id`` + ``hostname``
-on each shared row so the dual-write coordinator can find the right
-shared row when later UPDATEs fire from this machine.
+Two migrations live here, both idempotent:
 
-Idempotent. The shared store rejects rows whose ``(hostname, local_id)``
-already exists for the given table by skipping them — which means
-re-running the migration after a partial failure picks up where it
-left off rather than duplicating data.
+* ``migrate_local_to_shared`` — push: copy this machine's local
+  SQLite rows up to the team's shared warehouse. Used by
+  ``/history-store migrate-from-local`` (and offered automatically
+  the first time a user enables shared mode if they have a local
+  history). UUIDs are minted on the shared side; ``hostname +
+  local_id`` is recorded so future UPDATEs from this machine can
+  find the right shared row.
+
+* ``pull_shared_to_local`` — pull: copy teammates' rows DOWN from
+  the shared warehouse into local SQLite so ``/history list``
+  surfaces team activity, not just this machine's. Triggered by
+  ``/history-store enable`` when bootstrap finds pre-existing rows
+  on the team store, and exposed as a picker action so users can
+  re-sync at any time. Idempotency is keyed on the local
+  ``shared_uuid`` column — re-running the pull only inserts
+  rows whose UUID is not already present locally.
 """
 
 from __future__ import annotations
@@ -273,4 +281,218 @@ def _loads_or_none(value: Any) -> Any:
         return value
 
 
-__all__ = ["migrate_local_to_shared"]
+def pull_shared_to_local(
+    local: SQLiteHistoryStore,
+    shared: SQLAlchemyHistoryStore,
+    *,
+    progress: Any | None = None,
+) -> dict[str, int]:
+    """Pull rows from the shared store down into local SQLite.
+
+    Reverse of :func:`migrate_local_to_shared`. Filters on hostname so
+    only OTHER machines' rows are copied (this machine's runs already
+    exist locally). Idempotent: each pulled row records the source
+    ``shared_uuid`` on the new local row, and re-running skips any
+    UUID already present.
+
+    Returns ``{table: rows_inserted}``. Tables in pull order:
+
+    1. ``analysis_runs`` — assigns a fresh local INT id, records
+       ``shared_uuid`` for dedupe, preserves ``created_by``,
+       ``hostname``, ``client_version`` so ``/history list`` can
+       render team attribution.
+    2. ``run_results`` — looks up the parent run's *new* local INT
+       id from a UUID→INT map built in step 1 and writes results
+       under that.
+    3. ``app_events`` — append-only; dedupes on
+       ``(hostname, command, event_type, created_at)`` because
+       events have no UUID locally.
+    """
+    stats: dict[str, int] = {
+        "analysis_runs": 0,
+        "run_results": 0,
+        "app_events": 0,
+    }
+    host = getattr(shared, "_hostname", None) or _hostname()
+    started = time.time()
+
+    log.info("Pulling shared analysis_runs (excluding host=%r)…", host)
+    runs = shared.iter_runs_by_other_hosts(exclude_hostname=host)
+    if not runs:
+        log.info("No other-host runs found in shared store.")
+        return stats
+
+    # Map shared UUID -> new local INT id for FK rewriting on results.
+    uuid_to_local: dict[str, int] = {}
+
+    with local._lock:
+        for r in runs:
+            shared_uuid = str(r.get("id") or "")
+            if not shared_uuid:
+                continue
+            with local._connect() as conn:
+                # Idempotency: skip rows we've already pulled.
+                existing = conn.execute(
+                    "SELECT id FROM analysis_runs WHERE shared_uuid = ?",
+                    (shared_uuid,),
+                ).fetchone()
+                if existing is not None:
+                    uuid_to_local[shared_uuid] = int(existing[0])
+                    continue
+                started_at = r.get("started_at")
+                started_ts = _dt_to_ts(started_at) or time.time()
+                ended_at = _dt_to_ts(r.get("ended_at"))
+                cur = conn.execute(
+                    """
+                    INSERT INTO analysis_runs (
+                        started_at, ended_at, duration_sec, status, command, mode,
+                        db_backend, db_profile, llm_provider, llm_model,
+                        scope_json, metrics_json, tokens_json, results_json,
+                        error_text, selected_count, planned_count,
+                        processed_count, applied_count, review_strategy,
+                        llm_profile, doc_profile, code_profile, settings_json,
+                        created_by, hostname, client_version, shared_uuid
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        started_ts,
+                        ended_at,
+                        r.get("duration_sec"),
+                        str(r.get("status") or ""),
+                        str(r.get("command") or ""),
+                        r.get("mode"),
+                        r.get("db_backend"),
+                        r.get("db_profile"),
+                        r.get("llm_provider"),
+                        r.get("llm_model"),
+                        _dump_or_none(r.get("scope_json")),
+                        _dump_or_none(r.get("metrics_json")),
+                        _dump_or_none(r.get("tokens_json")),
+                        _dump_or_none(r.get("results_json")),
+                        r.get("error_text"),
+                        int(r.get("selected_count") or 0),
+                        int(r.get("planned_count") or 0),
+                        int(r.get("processed_count") or 0),
+                        int(r.get("applied_count") or 0),
+                        r.get("review_strategy"),
+                        r.get("llm_profile"),
+                        r.get("doc_profile"),
+                        r.get("code_profile"),
+                        _dump_or_none(r.get("settings_json")),
+                        r.get("created_by"),
+                        r.get("hostname"),
+                        r.get("client_version"),
+                        shared_uuid,
+                    ),
+                )
+                local_id = int(cur.lastrowid)
+            uuid_to_local[shared_uuid] = local_id
+            stats["analysis_runs"] += 1
+            if progress is not None:
+                with contextlib.suppress(Exception):
+                    progress("analysis_runs", stats["analysis_runs"])
+
+    if not uuid_to_local:
+        log.info("Pull finished (no new analysis_runs to insert).")
+        return stats
+
+    log.info("Pulling shared run_results for %d run(s)…", len(uuid_to_local))
+    results = shared.get_results_for_runs(list(uuid_to_local.keys()))
+    with local._lock:
+        for rr in results:
+            shared_uuid = str(rr.get("id") or "")
+            if not shared_uuid:
+                continue
+            parent_uuid = str(rr.get("run_id") or "")
+            local_run_id = uuid_to_local.get(parent_uuid)
+            if local_run_id is None:
+                continue
+            with local._connect() as conn:
+                existing = conn.execute(
+                    "SELECT id FROM run_results WHERE shared_uuid = ?",
+                    (shared_uuid,),
+                ).fetchone()
+                if existing is not None:
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO run_results (
+                        run_id, saved_at, schema_name, table_name, column_name,
+                        asset_kind, source, confidence, logprob_score, raw_logprob,
+                        token_count, model_version, reasoning, alternatives_json,
+                        evaluated_at, applied_at, chosen_description, evaluation,
+                        catalog_status, catalog_indexed_at, db_applied_status,
+                        effective_source_kind, superseded_at, rejection_reason,
+                        created_by, hostname, shared_uuid
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        local_run_id,
+                        _dt_to_ts(rr.get("saved_at")) or time.time(),
+                        str(rr.get("schema_name") or ""),
+                        str(rr.get("table_name") or ""),
+                        rr.get("column_name"),
+                        str(rr.get("asset_kind") or "table"),
+                        str(rr.get("source") or "unknown"),
+                        str(rr.get("confidence") or "medium"),
+                        rr.get("logprob_score"),
+                        rr.get("raw_logprob"),
+                        rr.get("token_count"),
+                        str(rr.get("model_version") or ""),
+                        rr.get("reasoning"),
+                        _dump_or_none(rr.get("alternatives_json")) or "[]",
+                        _dt_to_ts(rr.get("evaluated_at")),
+                        _dt_to_ts(rr.get("applied_at")),
+                        rr.get("chosen_description"),
+                        rr.get("evaluation"),
+                        str(rr.get("catalog_status") or ""),
+                        _dt_to_ts(rr.get("catalog_indexed_at")),
+                        str(rr.get("db_applied_status") or ""),
+                        str(rr.get("effective_source_kind") or ""),
+                        _dt_to_ts(rr.get("superseded_at")),
+                        str(rr.get("rejection_reason") or ""),
+                        rr.get("created_by"),
+                        rr.get("hostname"),
+                        shared_uuid,
+                    ),
+                )
+            stats["run_results"] += 1
+            if progress is not None:
+                with contextlib.suppress(Exception):
+                    progress("run_results", stats["run_results"])
+
+    log.info(
+        "Pull finished in %.1fs: %s",
+        time.time() - started,
+        ", ".join(f"{k}={v}" for k, v in stats.items()),
+    )
+    return stats
+
+
+def _dt_to_ts(value: Any) -> float | None:
+    """Convert a tz-aware datetime (the shared store's native time
+    unit) into a float epoch second the local SQLite store expects."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.timestamp()
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _dump_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=True, default=str)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = ["migrate_local_to_shared", "pull_shared_to_local"]

--- a/amx/storage/sqlalchemy_store.py
+++ b/amx/storage/sqlalchemy_store.py
@@ -560,6 +560,100 @@ class SQLAlchemyHistoryStore:
 
     # ── Collaboration helpers ─────────────────────────────────────────────
 
+    def count_runs_by_other_hosts(
+        self,
+        *,
+        exclude_hostname: str | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        """Summarise how many runs each other-machine has written.
+
+        Powers the "this shared store already has 42 runs from
+        alice@laptop-A and 17 from bob@laptop-B — pull them?" prompt
+        triggered by ``/history-store enable`` when the bootstrap
+        finds pre-existing rows.
+
+        Returns ``{hostname: {"count": int, "users": [str], "last_run": datetime|None}}``.
+        Empty dict when no other-host rows exist.
+        """
+        out: dict[str, dict[str, Any]] = {}
+        try:
+            stmt = select(
+                self._t_runs.c.hostname,
+                self._t_runs.c.created_by,
+                self._t_runs.c.started_at,
+            ).order_by(self._t_runs.c.started_at.desc())
+            with self.engine.begin() as conn:
+                rows = conn.execute(stmt).fetchall()
+        except SQLAlchemyError as exc:
+            log.debug("count_runs_by_other_hosts failed: %s", exc)
+            return {}
+        for host, user, started in rows:
+            host = str(host or "")
+            if not host:
+                continue
+            if exclude_hostname and host == exclude_hostname:
+                continue
+            bucket = out.setdefault(
+                host,
+                {"count": 0, "users": [], "last_run": None},
+            )
+            bucket["count"] += 1
+            user_str = str(user or "?")
+            if user_str and user_str not in bucket["users"]:
+                bucket["users"].append(user_str)
+            if started is not None and bucket["last_run"] is None:
+                # Rows are ordered DESC, so the first one we see per
+                # host is the most-recent timestamp.
+                bucket["last_run"] = started
+        return out
+
+    def iter_runs_by_other_hosts(
+        self,
+        *,
+        exclude_hostname: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return every shared run authored on a host other than *exclude_hostname*.
+
+        Used by the pull-from-shared migration. The list is small in
+        practice — bounded by how many runs the team has done — so a
+        single query + Python filter is fine across every backend.
+        """
+        try:
+            with self.engine.begin() as conn:
+                rows = (
+                    conn.execute(select(self._t_runs).order_by(self._t_runs.c.started_at))
+                    .mappings()
+                    .all()
+                )
+        except SQLAlchemyError as exc:
+            log.debug("iter_runs_by_other_hosts failed: %s", exc)
+            return []
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            host = row.get("hostname") or ""
+            if exclude_hostname and host == exclude_hostname:
+                continue
+            out.append(dict(row))
+        return out
+
+    def get_results_for_runs(self, run_ids: list[str]) -> list[dict[str, Any]]:
+        """Return all run_results rows for *run_ids* (UUID list)."""
+        if not run_ids:
+            return []
+        try:
+            with self.engine.begin() as conn:
+                rows = (
+                    conn.execute(
+                        select(self._t_results).where(self._t_results.c.run_id.in_(run_ids))
+                    )
+                    .mappings()
+                    .all()
+                )
+        except SQLAlchemyError as exc:
+            log.debug("get_results_for_runs failed: %s", exc)
+            return []
+        return [dict(r) for r in rows]
+
     def find_prior_runs_by_others(
         self,
         *,

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -159,9 +159,22 @@ class SQLiteHistoryStore:
                 "ALTER TABLE run_results ADD COLUMN effective_source_kind TEXT NOT NULL DEFAULT ''",
                 "ALTER TABLE run_results ADD COLUMN superseded_at REAL",
                 "ALTER TABLE run_results ADD COLUMN rejection_reason TEXT NOT NULL DEFAULT ''",
+                # 0.12.x — attribution + shared-store provenance on
+                # run_results so a row pulled down from the shared
+                # store via /history-store pull-from-shared can carry
+                # the originating user/host through to /history show
+                # and dedupe on re-pull via shared_uuid.
+                "ALTER TABLE run_results ADD COLUMN created_by TEXT",
+                "ALTER TABLE run_results ADD COLUMN hostname TEXT",
+                "ALTER TABLE run_results ADD COLUMN shared_uuid TEXT",
             ):
                 with contextlib.suppress(sqlite3.OperationalError):
                     conn.execute(stmt)
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_run_results_shared_uuid "
+                    "ON run_results(shared_uuid)"
+                )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_run_results_run_id ON run_results(run_id)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_run_results_asset "
@@ -389,6 +402,18 @@ class SQLiteHistoryStore:
             # another schema migration. /history compare surfaces these
             # so users can see exactly which knobs varied between runs.
             ("settings_json", "TEXT"),
+            # 0.12.x — attribution + shared-store provenance. Populated
+            # for runs created on this machine (so /history list can
+            # render "by alice@laptop-A" once shared mode is on) AND
+            # for runs pulled down from the team's shared store via
+            # /history-store pull-from-shared. ``shared_uuid`` is NULL
+            # for runs created locally; for pulled rows it's the UUID
+            # PK of the corresponding shared row, so re-running pull
+            # is idempotent (we look up by shared_uuid before inserting).
+            ("created_by", "TEXT"),
+            ("hostname", "TEXT"),
+            ("client_version", "TEXT"),
+            ("shared_uuid", "TEXT"),
         ):
             if col_name in existing_cols:
                 continue
@@ -406,6 +431,14 @@ class SQLiteHistoryStore:
                     col_name,
                     exc,
                 )
+        # Index for the dedup lookup on pull-from-shared. SQLite skips
+        # creation when it already exists. (run_results indexes live
+        # next to its CREATE TABLE in init().)
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_analysis_runs_shared_uuid "
+                "ON analysis_runs(shared_uuid)"
+            )
 
     def create_run(
         self,
@@ -826,7 +859,8 @@ class SQLiteHistoryStore:
                 SELECT id, started_at, ended_at, duration_sec, status, command, mode,
                        db_backend, db_profile, llm_provider, llm_model,
                        llm_profile, doc_profile, code_profile,
-                       scope_json, metrics_json
+                       scope_json, metrics_json,
+                       created_by, hostname, client_version, shared_uuid
                 FROM analysis_runs
                 {where_sql}
                 ORDER BY started_at DESC

--- a/tests/test_history_store_pull.py
+++ b/tests/test_history_store_pull.py
@@ -1,0 +1,180 @@
+"""Pull-from-shared tests.
+
+Cover the v0.12.x reverse migration that surfaces a teammate's runs in
+the local user's ``/history list`` after they connect to a shared
+store another team member already populated.
+
+Two sets of behaviour:
+
+1. ``count_runs_by_other_hosts`` — the query that powers the
+   "this shared store already has runs from <X>" detection prompt
+   triggered by ``/history-store enable`` after bootstrap. Verifies
+   per-host bucketing, hostname-exclusion, and an empty result when
+   only the current machine has runs.
+2. ``pull_shared_to_local`` — the reverse migration that ferries
+   teammates' runs DOWN into local SQLite. Verifies idempotency
+   (re-pull copies zero), FK rewiring (run_results land under the
+   correct local INT id), and attribution preservation (created_by /
+   hostname / shared_uuid populated locally).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+
+from amx.storage.migration import pull_shared_to_local
+from amx.storage.shared_schema import build_metadata
+from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _make_shared(tmp_path: Path, *, hostname: str = "test-host") -> SQLAlchemyHistoryStore:
+    db_path = tmp_path / f"shared-{hostname}.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    md = build_metadata(schema="main")
+    md.create_all(engine)
+    s = SQLAlchemyHistoryStore.__new__(SQLAlchemyHistoryStore)
+    s.engine = engine
+    s.schema = "main"
+    s._md = md
+    s._t_runs = md.tables["main.analysis_runs"]
+    s._t_results = md.tables["main.run_results"]
+    s._t_events = md.tables["main.app_events"]
+    s._t_session = md.tables["main.session_state"]
+    s._t_meta = md.tables["main.schema_meta"]
+    s._hostname = hostname
+    s._username = f"user-{hostname}"
+    s._client_version = "0.12.0-test"
+    return s
+
+
+@pytest.fixture
+def shared(tmp_path: Path) -> SQLAlchemyHistoryStore:
+    return _make_shared(tmp_path, hostname="machine-A")
+
+
+@pytest.fixture
+def local(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "local.db")
+    s.init()
+    return s
+
+
+def _seed(
+    store: SQLAlchemyHistoryStore,
+    *,
+    hostname: str,
+    user: str,
+    scope: dict[str, list[str]],
+    db_profile: str = "prod_pg",
+) -> str:
+    store._hostname = hostname
+    store._username = user
+    rid = store.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="postgresql",
+        db_profile=db_profile,
+        llm_provider="openai",
+        llm_model="gpt-5",
+        scope=scope,
+    )
+    store.save_run_results(
+        rid,
+        [
+            {
+                "schema": list(scope.keys())[0],
+                "table": list(scope.values())[0][0],
+                "column": "id",
+                "asset_kind": "column",
+                "source": "llm",
+                "confidence": "high",
+                "alternatives": ["row id"],
+            }
+        ],
+    )
+    store.finish_run(rid, status="success", metrics={}, tokens={}, results={"applied": 0})
+    return rid
+
+
+def test_count_runs_by_other_hosts_buckets_per_host(
+    shared: SQLAlchemyHistoryStore,
+) -> None:
+    _seed(shared, hostname="machine-B", user="bob", scope={"sales": ["orders"]})
+    _seed(shared, hostname="machine-B", user="bob", scope={"sales": ["customers"]})
+    _seed(shared, hostname="machine-C", user="carol", scope={"hr": ["employees"]})
+    summary = shared.count_runs_by_other_hosts(exclude_hostname="machine-A")
+    assert set(summary.keys()) == {"machine-B", "machine-C"}
+    assert summary["machine-B"]["count"] == 2
+    assert "bob" in summary["machine-B"]["users"]
+    assert summary["machine-C"]["count"] == 1
+    assert summary["machine-C"]["users"] == ["carol"]
+
+
+def test_count_runs_by_other_hosts_excludes_self(
+    shared: SQLAlchemyHistoryStore,
+) -> None:
+    _seed(shared, hostname="machine-A", user="alice", scope={"x": ["y"]})
+    summary = shared.count_runs_by_other_hosts(exclude_hostname="machine-A")
+    assert summary == {}
+
+
+def test_pull_copies_other_hosts_runs(
+    shared: SQLAlchemyHistoryStore, local: SQLiteHistoryStore
+) -> None:
+    _seed(shared, hostname="machine-B", user="bob", scope={"sales": ["orders"]})
+    _seed(shared, hostname="machine-C", user="carol", scope={"hr": ["employees"]})
+    # The pull uses the shared store's ``_hostname`` to filter, so set
+    # it to this machine (machine-A) — the seeded runs were on B and C.
+    shared._hostname = "machine-A"
+    stats = pull_shared_to_local(local=local, shared=shared)
+    assert stats["analysis_runs"] == 2
+    assert stats["run_results"] == 2
+
+    # Local rows now exist with their attribution preserved.
+    rows = local.list_recent_runs(limit=10)
+    creators = {r.get("created_by") for r in rows}
+    assert {"bob", "carol"}.issubset(creators)
+    hosts = {r.get("hostname") for r in rows}
+    assert {"machine-B", "machine-C"}.issubset(hosts)
+
+
+def test_pull_is_idempotent(shared: SQLAlchemyHistoryStore, local: SQLiteHistoryStore) -> None:
+    _seed(shared, hostname="machine-B", user="bob", scope={"sales": ["orders"]})
+    shared._hostname = "machine-A"
+    first = pull_shared_to_local(local=local, shared=shared)
+    second = pull_shared_to_local(local=local, shared=shared)
+    assert first["analysis_runs"] == 1
+    assert first["run_results"] == 1
+    assert second["analysis_runs"] == 0  # nothing new to copy
+    assert second["run_results"] == 0
+
+
+def test_pull_skips_own_hostname(shared: SQLAlchemyHistoryStore, local: SQLiteHistoryStore) -> None:
+    """A run we wrote ourselves on this machine must not be pulled
+    back down — local already has the canonical row."""
+    _seed(shared, hostname="machine-A", user="alice", scope={"x": ["y"]})
+    shared._hostname = "machine-A"
+    stats = pull_shared_to_local(local=local, shared=shared)
+    assert stats["analysis_runs"] == 0
+
+
+def test_pull_preserves_fk_link(shared: SQLAlchemyHistoryStore, local: SQLiteHistoryStore) -> None:
+    """run_results pulled down must reference the parent run's NEW
+    local INT id (not the shared UUID)."""
+    _seed(shared, hostname="machine-B", user="bob", scope={"sales": ["orders"]})
+    shared._hostname = "machine-A"
+    pull_shared_to_local(local=local, shared=shared)
+
+    runs = local.list_recent_runs(limit=10)
+    assert len(runs) == 1
+    parent_local_id = int(runs[0]["id"])  # local INT id
+
+    results = local.get_run_results(parent_local_id)
+    assert len(results) == 1
+    # FK is by INT id locally, not by shared UUID
+    assert results[0]["run_id"] == parent_local_id
+    assert results[0]["shared_uuid"] is not None


### PR DESCRIPTION
## Summary

Reported by user: when a teammate connects to a shared store another team member has already populated, they expect to see those runs in `/history list` — not a blank slate that ignores existing team activity. This PR adds the reverse migration ("pull from shared") plus an automatic detection prompt at `/history-store enable` time.

### User flow on `/history-store enable` (additions in **bold**)

1. Pick profile / database / schema (unchanged).
2. Bootstrap schema + tables (unchanged).
3. **NEW:** `count_runs_by_other_hosts` queries the shared store for runs from other machines. If found, AMX prints a compact table and asks the user whether to pull:

```
⚠ This shared store already has runs from other team members:
╭──────────── Existing runs in shared store ────────────╮
│ Host       │ Users         │ Runs │ Last activity    │
│ machine-B  │ bob           │ 17   │ 2026-05-03 14:21 │
│ machine-C  │ carol         │ 5    │ 2026-05-02 09:14 │
╰────────────────────────────────────────────────────────╯
  Pull these runs into your local SQLite cache so /history list shows team activity?
  (Idempotent — safe to skip and re-run later.) [Y/n]
```

4. **NEW:** If yes, `pull_shared_to_local` walks the shared store, copies down every analysis_run + run_results row authored by other hosts, mints fresh local INT ids, rewrites FKs via a UUID→INT map.
5. The existing "migrate from local UP" prompt fires next so a fresh user contributes their own runs in the same flow.

### New picker action

`/db` → `/history-store` → **Pull from shared** (visible only when shared mode is on). Re-syncs any time. Also exposed as `amx db history-store pull-from-shared` for scripts.

### Implementation

- `amx/storage/sqlalchemy_store.py` — three new helpers:
  - `count_runs_by_other_hosts(exclude_hostname)` → `{host: {count, users, last_run}}`
  - `iter_runs_by_other_hosts(exclude_hostname)` → list of run dicts, drives the walk
  - `get_results_for_runs(uuid_list)` → results for those runs
- `amx/storage/migration.py` — new `pull_shared_to_local(local, shared)`. Reverse of `migrate_local_to_shared`. Idempotent via local `shared_uuid` column.
- `amx/storage/sqlite_store.py` — four new columns on `analysis_runs` (`created_by`, `hostname`, `client_version`, `shared_uuid`) + three on `run_results` (`created_by`, `hostname`, `shared_uuid`). All added via `contextlib.suppress` idempotent ALTERs in `init()` so older `history.db` files migrate cleanly. `list_recent_runs` SELECTs the new attribution columns for display.
- `amx/cli_support/commands/history_store.py` — new `_action_pull`, `_run_pull_from_shared`, `_maybe_offer_pull_on_enable`, plus `ACTION_PULL` picker entry and `pull-from-shared` Click subcommand.
- `tests/test_history_store_pull.py` — 6 new tests.

## Test plan

- [x] `ruff check amx tests` clean
- [x] `ruff format --check amx tests` clean
- [x] `pytest -m \"not integration and not live\"` — 548 pass (was 542, +6 pull tests)
- [ ] CI green on Python 3.10 / 3.11 / 3.12 (this PR)
