### PR TITLE
chore(history): reorder /db tab help and /history-store picker

### DIFF
--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -508,15 +508,27 @@ def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> N
     status panel) so picking a number never feels like a no-op.
     """
     enabled = bool(getattr(cfg, "history_store_enabled", False))
+    # Picker ordering follows user-task frequency, with destructive
+    # actions placed late so they're not adjacent to the default:
+    #   1. Status (default — most-used, informational)
+    #   2. Pull / Migrate / Flush (sync — the daily team workflow)
+    #   3. Dump DDL (DBA helper — infrequent but read-only)
+    #   4. Disable (administrative — moved away from #2 so it cannot
+    #      be fat-fingered)
+    #   5. Cancel
+    # When shared mode is OFF the only meaningful next step is Enable
+    # (also placed first after Status because the user opened the
+    # picker to do exactly that).
     options: list[str] = [ACTION_STATUS]
     if enabled:
-        options.append(ACTION_DISABLE)
         options.append(ACTION_PULL)
         options.append(ACTION_MIGRATE)
         options.append(ACTION_FLUSH)
+        options.append(ACTION_DUMP_DDL)
+        options.append(ACTION_DISABLE)
     else:
         options.append(ACTION_ENABLE)
-    options.append(ACTION_DUMP_DDL)
+        options.append(ACTION_DUMP_DDL)
     options.append(ACTION_CANCEL)
 
     picked = ask_choice(

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -219,32 +219,40 @@ Context:
 
 Commands (in order):
   1) /back                         Return to root namespace
+
+  Profile management:
   2) /db-profiles                  List DB profiles (Backend + connection summary)
   3) /use-db [name]                Switch profile (interactive list shows [engine] per profile)
   4) /add-db-profile [name]        Create/update profile — pick PostgreSQL, Snowflake, Databricks, or BigQuery
   5) /remove-db-profile <name>     Remove a DB profile (cannot remove last)
   6) /profiling [mode] [max] [N]   Show/set profiling guardrails
   7) /tls [on|off] [ca|clear]      Show/set Databricks TLS settings
-  8) /save                         Persist config to disk (~/.amx/config.yml)
-  9) /schema <name>                Set current schema context (used by /tables)
- 10) /table <name>                 Set current table context (used by /profile)
- 11) /connect                      Test DB connectivity
- 12) /schemas                      List schemas
- 13) /tables [schema]             List tables (defaults to current schema)
- 14) /profile [schema] [table]    Profile a table (defaults to current context)
- 15) /inspect [profile]           Diagnose a profile: backend, capabilities, connection
+  8) /history-store                Configure shared run-history (team collaboration).
+                                   Bare command opens an interactive picker — Status,
+                                   Pull from shared, Migrate from local, Flush pending,
+                                   Dump DDL, Disable. Power-user shortcuts also accept
+                                   a subcommand directly (e.g. /history-store status).
+  9) /save                         Persist config to disk (~/.amx/config.yml)
+
+  Active context:
+ 10) /schema <name>                Set current schema context (used by /tables)
+ 11) /table <name>                 Set current table context (used by /profile)
+
+  Connection & inspection:
+ 12) /connect                      Test DB connectivity
+ 13) /schemas                      List schemas
+ 14) /tables [schema]              List tables (defaults to current schema)
+ 15) /profile [schema] [table]     Profile a table (defaults to current context)
+ 16) /inspect [profile]            Diagnose a profile: backend, capabilities, connection
                                    test, visible schemas, table counts. Read-only.
- 16) /cleanup-placeholders [schema]
-                                  Remove auto-inference fallback placeholder strings
-                                  ("Auto-inference missed a reliable description; please
-                                  review manually.") from the live DB. Use this once when
-                                  upgrading from pre-0.6.3 — newer versions never write
-                                  these in the first place.
- 17) /history-store               Configure shared run-history (team collaboration).
-                                  Bare command opens an interactive picker — Status,
-                                  Enable, Disable, Migrate from local, Flush pending,
-                                  Dump DDL. Power-user shortcuts also accept a
-                                  subcommand directly (e.g. /history-store status).
+
+  Maintenance:
+ 17) /cleanup-placeholders [schema]
+                                   Remove auto-inference fallback placeholder strings
+                                   ("Auto-inference missed a reliable description; please
+                                   review manually.") from the live DB. Use this once when
+                                   upgrading from pre-0.6.3 — newer versions never write
+                                   these in the first place.
 
 Navigation:
   Esc (empty line)                 Go back to root namespace


### PR DESCRIPTION
## Summary

Two reordering changes after user feedback that the layout wasn't intuitive:

### 1. `/db` tab help block

\`/history-store\` was the last entry (item 17), buried after \`/cleanup-placeholders\` (a legacy maintenance command). Move it up to item 8, alongside the other profile-management commands — it manages a profile-related resource and belongs next to \`/db-profiles\`, \`/use-db\`, etc. Also added group headers so the rest of the \`/db\` commands are easier to scan:

- **Profile management:** /db-profiles, /use-db, /add-db-profile, /remove-db-profile, /profiling, /tls, **/history-store**, /save
- **Active context:** /schema, /table
- **Connection & inspection:** /connect, /schemas, /tables, /profile, /inspect
- **Maintenance:** /cleanup-placeholders

### 2. `/history-store` picker

Disable was option #2 — too close to the Status default and easy to fat-finger. New order groups by user-task frequency, with destructive actions late:

- **Enabled:** Status (default) → Pull from shared → Migrate from local → Flush pending → Dump DDL → **Disable** → Cancel
- **Disabled:** Status (default) → Enable → Dump DDL → Cancel

(When shared mode is off, Enable comes second — that's why the user opened the picker.)

## Test plan

No code semantics changed — only option ordering and help-text layout.

- [x] \`ruff check amx tests\` clean
- [x] \`ruff format --check amx tests\` clean
- [x] \`pytest -m \"not integration and not live\"\` — 548 pass
