### PR TITLE
chore(cli): regroup /db tab into 6 purpose buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,30 @@ namespaces, no routing changes — autocomplete just lists the tabs in
 the new order. The `/history-store` (under `/db`) vs. local
 `/history` (its own tab) split is intentional and unchanged.
 
+### Changed — /db tab regrouped (split overloaded "Profile management" group)
+
+The `/db` tab help got group headers in 0.12 (commit 9bf5b78), but the
+"Profile management" bucket ended up holding eight items mixing four
+unrelated concerns: profile lifecycle (`/db-profiles`, `/use-db`,
+`/add-db-profile`, `/remove-db-profile`), per-profile settings
+(`/profiling`, `/tls`), a team-collaboration feature (`/history-store`),
+and the global `/save` command. This pass splits them into purpose-
+focused subheaders:
+
+- **Profile management**: `/db-profiles`, `/use-db`, `/add-db-profile`, `/remove-db-profile`
+- **Profile settings**: `/profiling`, `/tls`
+- **Active context**: `/schema`, `/table`
+- **Connection & inspection**: `/connect`, `/schemas`, `/tables`, `/profile`, `/inspect`
+- **Team collaboration**: `/history-store`
+- **Maintenance**: `/cleanup-placeholders`
+
+`/save` is removed from the per-tab numbered list (it's a global,
+already shown under "Global shortcuts"). `_DB_COMMANDS` reordered to
+match — `/history-store` now sits before `/cleanup-placeholders`
+instead of last. `/inspect` is added to `_DB_COMMANDS` so autocomplete
+in `/db` shows it (was dispatcher-only — registered as a `/db` command
+distinct from the `/metadata /inspect` of the same name).
+
 ### Changed — every tab's command list grouped by purpose
 
 The same per-section grouping treatment that `/db` got in 0.12 is now

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -225,29 +225,33 @@ Commands (in order):
   3) /use-db [name]                Switch profile (interactive list shows [engine] per profile)
   4) /add-db-profile [name]        Create/update profile — pick PostgreSQL, Snowflake, Databricks, or BigQuery
   5) /remove-db-profile <name>     Remove a DB profile (cannot remove last)
+
+  Profile settings:
   6) /profiling [mode] [max] [N]   Show/set profiling guardrails
   7) /tls [on|off] [ca|clear]      Show/set Databricks TLS settings
-  8) /history-store                Configure shared run-history (team collaboration).
-                                   Bare command opens an interactive picker — Status,
-                                   Pull from shared, Migrate from local, Flush pending,
-                                   Dump DDL, Disable. Power-user shortcuts also accept
-                                   a subcommand directly (e.g. /history-store status).
-  9) /save                         Persist config to disk (~/.amx/config.yml)
 
   Active context:
- 10) /schema <name>                Set current schema context (used by /tables)
- 11) /table <name>                 Set current table context (used by /profile)
+  8) /schema <name>                Set current schema context (used by /tables)
+  9) /table <name>                 Set current table context (used by /profile)
 
   Connection & inspection:
- 12) /connect                      Test DB connectivity
- 13) /schemas                      List schemas
- 14) /tables [schema]              List tables (defaults to current schema)
- 15) /profile [schema] [table]     Profile a table (defaults to current context)
- 16) /inspect [profile]            Diagnose a profile: backend, capabilities, connection
+ 10) /connect                      Test DB connectivity
+ 11) /schemas                      List schemas
+ 12) /tables [schema]              List tables (defaults to current schema)
+ 13) /profile [schema] [table]     Profile a table (defaults to current context)
+ 14) /inspect [profile]            Diagnose a profile: backend, capabilities, connection
                                    test, visible schemas, table counts. Read-only.
 
+  Team collaboration:
+ 15) /history-store                Configure shared run-history. Bare command opens an
+                                   interactive picker — Status, Enable, Disable,
+                                   Migrate from local, Flush pending, Dump DDL — based
+                                   on whether shared mode is on. Power-user shortcuts
+                                   also accept a subcommand directly (e.g.
+                                   /history-store status).
+
   Maintenance:
- 17) /cleanup-placeholders [schema]
+ 16) /cleanup-placeholders [schema]
                                    Remove auto-inference fallback placeholder strings
                                    ("Auto-inference missed a reliable description; please
                                    review manually.") from the live DB. Use this once when

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -105,6 +105,7 @@ _ROOT_ENTRYPOINTS: tuple[SlashCommand, ...] = (
 )
 
 _DB_COMMANDS: tuple[SlashCommand, ...] = (
+    # Profile management
     SlashCommand("/db-profiles", "db", "List DB profiles"),
     SlashCommand(
         "/use-db",
@@ -113,23 +114,27 @@ _DB_COMMANDS: tuple[SlashCommand, ...] = (
     ),
     SlashCommand("/add-db-profile", "db", "Add profile — choose engine then connection details"),
     SlashCommand("/remove-db-profile", "db", "Remove DB profile (/remove-db-profile <name>)"),
+    # Profile settings
     SlashCommand(
         "/profiling",
         "db",
         "Show/set profiling guardrails (/profiling [full|sampled|metadata] [max_rows|off] [sample_size])",
     ),
     SlashCommand("/tls", "db", "Show/set Databricks TLS settings (/tls [on|off] [ca_path|clear])"),
+    # Active context
     SlashCommand("/schema", "db", "Set current schema (/schema <name>)"),
     SlashCommand("/table", "db", "Set current table (/table <name>)"),
+    # Connection & inspection
     SlashCommand("/connect", "db", "Test DB connectivity"),
     SlashCommand("/schemas", "db", "List schemas"),
     SlashCommand("/tables", "db", "List tables (/tables [schema])"),
     SlashCommand("/profile", "db", "Profile table (/profile [schema] [table])"),
     SlashCommand(
-        "/cleanup-placeholders",
+        "/inspect",
         "db",
-        "Remove auto-inference placeholder comments from live DB (/cleanup-placeholders [schema])",
+        "Diagnose a DB profile — backend, capabilities, connection test, visible schemas, table counts (/inspect [profile])",
     ),
+    # Team collaboration
     SlashCommand(
         "/history-store",
         "db",
@@ -142,6 +147,12 @@ _DB_COMMANDS: tuple[SlashCommand, ...] = (
             "based on whether shared mode is on. Power-user shortcuts "
             "accept a subcommand directly."
         ),
+    ),
+    # Maintenance
+    SlashCommand(
+        "/cleanup-placeholders",
+        "db",
+        "Remove auto-inference placeholder comments from live DB (/cleanup-placeholders [schema])",
     ),
 )
 


### PR DESCRIPTION
## Summary

Follow-up to #82 and #83. `/db` was the only tab left with rough groupings — its "Profile management" header got 8 items in 9bf5b78 because everything that touched a DB profile got dumped together. This PR splits that overloaded group into purpose-focused subheaders matching the cleaner pattern from #83:

- **Profile management**: `/db-profiles`, `/use-db`, `/add-db-profile`, `/remove-db-profile`
- **Profile settings**: `/profiling`, `/tls`
- **Active context**: `/schema`, `/table`
- **Connection & inspection**: `/connect`, `/schemas`, `/tables`, `/profile`, `/inspect`
- **Team collaboration**: `/history-store`
- **Maintenance**: `/cleanup-placeholders`

Also:
- Drops `/save` from the per-tab numbered list (it's a global, already shown under "Global shortcuts").
- Reorders `_DB_COMMANDS` so `/history-store` sits before `/cleanup-placeholders` instead of last.
- Adds `/inspect` to `_DB_COMMANDS` so autocomplete in `/db` shows it (was dispatcher-only at session.py:843). The `/db /inspect` (profile diagnose) and `/metadata /inspect` (column comments) are different commands sharing a name; both are now registered with their respective namespaces.

## Test plan

- [x] `pytest -q` — 554 passed, 19 deselected
- [x] `commands_for_namespace('db')` returns the new order
- [x] `find_command('/inspect')` resolves to the `/db` namespace (since `_DB_COMMANDS` splices first); `find_command` is exported but has no callers, so no downstream impact
- [ ] Launch `amx`, `/db`, `/help` — confirm 6 group headers render with continuous numbering 1–16
- [ ] In `/db`, type `/in` + Tab — confirm `/inspect` autocompletes (regression check for the registry addition)
