### PR TITLE
fix(history-store): dogfood AMX — annotate every table/column with comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — AMX shared-history tables now ship with column comments (dogfooding)
+
+AMX is a metadata-generation tool whose product thesis is "every
+database table and column should have a quality `COMMENT ON ...`
+description." Embarrassingly, when AMX itself bootstrapped its `AMX`
+schema in a user's warehouse via `/history-store enable`, the five
+tables (`analysis_runs`, `run_results`, `app_events`, `session_state`,
+`schema_meta`) and all 75 columns shipped with **no comments** — AMX
+was violating its own thesis on the artifacts it created.
+
+`amx/storage/shared_schema.py` now carries a `comment="..."`
+annotation on every Table and every Column. SQLAlchemy's
+`MetaData.create_all` emits `COMMENT ON TABLE` and `COMMENT ON COLUMN`
+automatically after `CREATE TABLE` on every supported backend
+(PostgreSQL, MySQL, MSSQL, Oracle, Snowflake, Databricks, Redshift,
+BigQuery), so future `/history-store enable` invocations get the
+comments for free.
+
+For users who already have an `AMX` schema bootstrapped (where
+`create_all` is a no-op), the new **`/history-store apply-comments`**
+action backfills the missing comments. It walks the annotated
+metadata and issues `COMMENT ON TABLE`/`COMMENT ON COLUMN` against
+the live shared-store DB via the same `connector.set_table_comment`/
+`set_column_comment` machinery AMX uses to write LLM-approved
+descriptions to user databases — proper dogfooding. Idempotent: re-
+running just rewrites the same comments. Available from the
+`/history-store` interactive picker (between Flush pending and Dump
+DDL) or as `amx db history-store apply-comments [--profile NAME]
+[--schema NAME]`.
+
+`/history-store dump-ddl` now renders the full annotated DDL too
+(CREATE SCHEMA + 5× CREATE TABLE with COMMENT clauses + indexes), via
+SQLAlchemy's offline DDL compiler bound to the target backend's
+dialect. Previously it emitted only `CREATE SCHEMA IF NOT EXISTS`,
+leaving DBAs to guess the rest.
+
+A new test (`tests/test_shared_schema_comments.py`) pins the
+contract: every table and every column must carry a non-empty
+`comment=`. Adding a column without a description now fails CI fast,
+preventing regression.
+
 ### Added — shared run-history store for team collaboration
 
 AMX has always kept its run history in a single SQLite file at

--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -20,6 +20,9 @@ primary user-facing surface):
 * ``flush-pending`` — drain the dual-write outbox (replay queued
   shared writes that failed at write time).
 * ``dump-ddl`` — print the schema-bootstrap DDL so a DBA can run it.
+* ``apply-comments`` — backfill table + column COMMENTs on an
+  already-bootstrapped AMX schema. Dogfooding: AMX shouldn't ship a
+  metadata-tool schema without metadata. Idempotent.
 """
 
 from __future__ import annotations
@@ -58,6 +61,7 @@ ACTION_MIGRATE = "Migrate from local — copy local SQLite history into the shar
 ACTION_PULL = "Pull from shared — sync teammates' runs into your local SQLite cache"
 ACTION_FLUSH = "Flush pending — retry queued shared writes that failed at write time"
 ACTION_DUMP_DDL = "Dump DDL — print bootstrap SQL for a DBA to run by hand"
+ACTION_APPLY_COMMENTS = "Apply comments — backfill table/column descriptions on the live AMX schema (idempotent)"
 ACTION_CANCEL = "Cancel — exit without doing anything"
 
 
@@ -492,7 +496,96 @@ def _action_dump_ddl(
     schema = (schema_name or cfg.history_store_schema or "AMX").strip() or "AMX"
     click.echo(f"-- Backend: {db_cfg.backend}")
     click.echo(f"-- Schema:  {schema}")
-    click.echo(adapter.create_history_schema_ddl(schema))
+    click.echo(adapter.create_history_schema_ddl(schema) + ";")
+    click.echo("")
+    click.echo("-- Tables (CREATE TABLE + COMMENT ON + CREATE INDEX)")
+    try:
+        click.echo(adapter.create_history_tables_ddl(schema))
+    except Exception as exc:
+        click.echo(f"-- (table DDL render failed: {exc})")
+
+
+def _action_apply_comments(
+    cfg: AMXConfig,
+    *,
+    profile_name: str | None = None,
+    schema_name: str | None = None,
+) -> None:
+    """Backfill table + column COMMENTs on an already-bootstrapped AMX schema.
+
+    AMX is a metadata-generation tool — its own warehouse artifacts must
+    meet the standard it enforces on user data. The Table/Column
+    annotations in :mod:`amx.storage.shared_schema` ride along on
+    ``MetaData.create_all`` for new installs, but existing AMX schemas
+    were created before those annotations existed. This action walks
+    every table + column in the metadata and issues
+    ``COMMENT ON TABLE``/``COMMENT ON COLUMN`` against the live shared-
+    store DB via the same connector machinery AMX uses to write LLM-
+    approved descriptions to user databases.
+
+    Idempotent: ``COMMENT ON ... IS '...'`` overwrites the existing
+    comment with no error. Safe to re-run after editing comment text in
+    ``shared_schema.py``.
+    """
+    target = profile_name or cfg.history_store_profile or cfg.active_db_profile or ""
+    if not target or target not in cfg.db_profiles:
+        error("No DB profile resolved. Specify --profile or configure one via /db-profiles.")
+        return
+
+    from amx.db.connector import DatabaseConnector
+    from amx.storage.shared_schema import build_metadata
+
+    db_cfg = cfg.db_profiles[target]
+    schema = (schema_name or cfg.history_store_schema or "AMX").strip() or "AMX"
+    md = build_metadata(schema)
+
+    connector = DatabaseConnector(db_cfg)
+    if not connector.capabilities.column_comments:
+        warn(
+            f"Backend {db_cfg.backend!r} does not support column comments — "
+            "nothing to apply. Table comments may also be unsupported."
+        )
+
+    info(f"Applying comments to {db_cfg.backend} schema [cyan]{schema}[/cyan]…")
+
+    table_writes = 0
+    column_writes = 0
+    skipped: list[str] = []
+
+    for table in md.tables.values():
+        # Strip the schema prefix that MetaData(schema=...) bakes into
+        # table.name in some SA versions. The connector takes (schema,
+        # table) separately.
+        bare_name = table.name
+        try:
+            if table.comment and connector.capabilities.table_comments:
+                connector.set_table_comment(schema, bare_name, table.comment)
+                table_writes += 1
+        except Exception as exc:
+            skipped.append(f"table {schema}.{bare_name}: {exc}")
+            continue
+
+        if not connector.capabilities.column_comments:
+            continue
+        for col in table.columns:
+            if not col.comment:
+                continue
+            try:
+                connector.set_column_comment(schema, bare_name, col.name, col.comment)
+                column_writes += 1
+            except Exception as exc:
+                skipped.append(f"column {schema}.{bare_name}.{col.name}: {exc}")
+
+    success(
+        f"Wrote {table_writes} table comment(s) and {column_writes} column comment(s) "
+        f"on {schema}. Idempotent — safe to re-run."
+    )
+    if skipped:
+        warn(f"{len(skipped)} write(s) skipped:")
+        for line in skipped[:10]:
+            warn(f"  • {line}")
+        if len(skipped) > 10:
+            warn(f"  … and {len(skipped) - 10} more.")
 
 
 # ── Picker (the main user-facing surface) ─────────────────────────────────
@@ -529,6 +622,7 @@ def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> N
         options.append(ACTION_PULL)
         options.append(ACTION_MIGRATE)
         options.append(ACTION_FLUSH)
+        options.append(ACTION_APPLY_COMMENTS)
         options.append(ACTION_DUMP_DDL)
         options.append(ACTION_DISABLE)
     else:
@@ -561,6 +655,9 @@ def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> N
         return
     if picked == ACTION_DUMP_DDL:
         _action_dump_ddl(cfg)
+        return
+    if picked == ACTION_APPLY_COMMENTS:
+        _action_apply_comments(cfg)
         return
     # ACTION_CANCEL or anything else — exit silently.
 
@@ -681,6 +778,27 @@ def register_history_store_commands(
     def hs_dump_ddl(cfg: AMXConfig, profile_name: str | None, schema_name: str | None) -> None:
         """Print the schema-bootstrap DDL so a DBA can run it by hand."""
         _action_dump_ddl(cfg, profile_name=profile_name, schema_name=schema_name)
+
+    @history_store_grp.command("apply-comments")
+    @click.option(
+        "--profile",
+        "profile_name",
+        default=None,
+        help="DB profile hosting the AMX schema (defaults to the configured "
+        "history-store profile, or the active analysis profile).",
+    )
+    @click.option(
+        "--schema",
+        "schema_name",
+        default=None,
+        help="Schema name to apply comments to (default 'AMX').",
+    )
+    @pass_config
+    def hs_apply_comments(
+        cfg: AMXConfig, profile_name: str | None, schema_name: str | None
+    ) -> None:
+        """Backfill table/column descriptions on the live AMX schema (idempotent)."""
+        _action_apply_comments(cfg, profile_name=profile_name, schema_name=schema_name)
 
     return history_store_grp
 

--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -401,3 +401,29 @@ class DatabaseAdapter(ABC):
         privileges and a DBA needs to provision the schema by hand.
         """
         return f"CREATE SCHEMA IF NOT EXISTS {self.quote_identifier(schema_name)}"
+
+    def create_history_tables_ddl(self, schema_name: str) -> str:
+        """Render full CREATE TABLE DDL for the AMX history schema.
+
+        Compiles :func:`amx.storage.shared_schema.build_metadata` against
+        a mock engine bound to this backend's dialect, so the output
+        includes dialect-correct ``CREATE TABLE``, ``COMMENT ON``, and
+        ``CREATE INDEX`` statements without needing a live connection.
+        Used by ``/history-store dump-ddl`` so a DBA can hand-provision
+        the schema in environments where AMX lacks privileges.
+        """
+        from io import StringIO
+
+        from sqlalchemy import create_mock_engine
+
+        from amx.storage.shared_schema import build_metadata
+
+        md = build_metadata(schema_name)
+        buf = StringIO()
+
+        def _dump(sql, *args, **kwargs) -> None:
+            buf.write(str(sql.compile(dialect=engine.dialect)).rstrip() + ";\n\n")
+
+        engine = create_mock_engine(f"{self.name}://", _dump)
+        md.create_all(engine, checkfirst=False)
+        return buf.getvalue().rstrip() + "\n"

--- a/amx/storage/shared_schema.py
+++ b/amx/storage/shared_schema.py
@@ -21,6 +21,12 @@ Design notes:
   on Snowflake (via dialect adapters), ``STRING`` everywhere else.
 * ``DateTime(timezone=True)`` is used over float epoch seconds because
   warehouse query semantics for "last 7 days" expect actual timestamps.
+* **Every table and column carries a ``comment=`` annotation.** AMX is
+  a metadata-generation tool — its own warehouse artifacts must meet
+  the standard it enforces on user data. ``MetaData.create_all`` emits
+  these as ``COMMENT ON`` statements after ``CREATE TABLE`` on every
+  backend that supports them; ``/history-store apply-comments``
+  backfills them onto already-bootstrapped schemas.
 """
 
 from __future__ import annotations
@@ -50,6 +56,33 @@ DEFAULT_HISTORY_SCHEMA = "AMX"
 SHARED_SCHEMA_VERSION = 1
 
 
+# ── Per-column comment text ───────────────────────────────────────────────
+# Pulled out as constants so /history-store apply-comments can also use
+# them without re-importing the Table objects, and so the same string
+# isn't duplicated between the schema declaration and any future doc
+# generation.
+
+_ATTRIBUTION_CREATED_BY = (
+    "OS username (or AMX_USER override) of the principal that wrote this row. "
+    "Populated on every shared-mode write so '/history-store list-team' can answer "
+    "'who ran what?'."
+)
+_ATTRIBUTION_HOSTNAME = (
+    "Machine that wrote this row. Part of the (hostname, local_id) provenance pair "
+    "that lets the dual-write coordinator re-find the shared row when a later UPDATE "
+    "(e.g. finish_run) fires from the same machine."
+)
+_ATTRIBUTION_CLIENT_VERSION = (
+    "AMX version string (e.g. '0.12.1') of the client that wrote this row. Used by "
+    "/doctor and post-mortems to correlate row shape changes with client upgrades."
+)
+_ATTRIBUTION_LOCAL_ID = (
+    "Corresponding INT id in the writer machine's local SQLite history.db. Scoped "
+    "by hostname so two machines can both have local_id=5 without collision; lets "
+    "the dual-write coordinator locate the shared row for in-flight UPDATEs."
+)
+
+
 def build_metadata(schema: str | None = None) -> MetaData:
     """Build a fresh ``MetaData`` bound to *schema*.
 
@@ -64,91 +97,536 @@ def build_metadata(schema: str | None = None) -> MetaData:
     Table(
         "analysis_runs",
         md,
-        Column("id", String(36), primary_key=True),  # UUID
-        Column("started_at", DateTime(timezone=True), nullable=False, index=True),
-        Column("ended_at", DateTime(timezone=True)),
-        Column("duration_sec", Float),
-        Column("status", String(40), nullable=False),
-        Column("command", String(80), nullable=False),
-        Column("mode", String(40)),
-        Column("db_backend", String(40)),
-        Column("db_profile", String(120)),
-        Column("llm_provider", String(40)),
-        Column("llm_model", String(120)),
-        Column("scope_json", JSON),
-        Column("metrics_json", JSON),
-        Column("tokens_json", JSON),
-        Column("results_json", JSON),
-        Column("error_text", Text),
-        Column("selected_count", Integer, nullable=False, default=0),
-        Column("planned_count", Integer, nullable=False, default=0),
-        Column("processed_count", Integer, nullable=False, default=0),
-        Column("applied_count", Integer, nullable=False, default=0),
-        Column("review_strategy", String(40)),
-        Column("llm_profile", String(120)),
-        Column("doc_profile", String(120)),
-        Column("code_profile", String(120)),
-        Column("settings_json", JSON),
-        # Attribution — only meaningful in shared mode.
-        Column("created_by", String(120)),
-        Column("hostname", String(255)),
-        Column("client_version", String(40)),
-        # Provenance back to the local row, scoped by hostname so two
-        # machines can both have ``local_id=5`` without collision.
-        Column("local_id", BigInteger),
+        Column(
+            "id",
+            String(36),
+            primary_key=True,
+            comment=(
+                "UUID v4 primary key. Surfaced as a short prefix in CLI output "
+                "(/list, /show, /results, /review, /compare). UUID rather than "
+                "INT autoincrement because shared mode admits concurrent writers "
+                "from multiple machines."
+            ),
+        ),
+        Column(
+            "started_at",
+            DateTime(timezone=True),
+            nullable=False,
+            index=True,
+            comment=(
+                "UTC timestamp when the agent run began. Indexed for "
+                "last-N-days filters in /list and /stats."
+            ),
+        ),
+        Column(
+            "ended_at",
+            DateTime(timezone=True),
+            comment=(
+                "UTC timestamp when the run finished. NULL while a run is in "
+                "flight; also NULL for runs killed mid-flight by Ctrl-C."
+            ),
+        ),
+        Column(
+            "duration_sec",
+            Float,
+            comment=(
+                "Wall-clock seconds between started_at and ended_at. Convenience "
+                "column so /stats does not have to recompute it on every read."
+            ),
+        ),
+        Column(
+            "status",
+            String(40),
+            nullable=False,
+            comment=(
+                "Lifecycle state of the run: running | completed | failed | "
+                "cancelled. Drives /list filters and the colored status badge."
+            ),
+        ),
+        Column(
+            "command",
+            String(80),
+            nullable=False,
+            comment=(
+                "Top-level CLI command that triggered the run: run | run-apply | "
+                "ask | doc-analyze | code-analyze. Distinguishes batch metadata "
+                "generation from one-off Q&A in /stats breakdowns."
+            ),
+        ),
+        Column(
+            "mode",
+            String(40),
+            comment=(
+                "Sub-mode chosen at the run picker: human-review | auto-apply | "
+                "confidence-threshold | dry-run."
+            ),
+        ),
+        Column(
+            "db_backend",
+            String(40),
+            comment=(
+                "Backend of the analyzed DB profile: postgresql | snowflake | "
+                "bigquery | databricks | mssql | mysql | oracle | redshift. "
+                "Enables /compare --by db_backend cross-backend audits."
+            ),
+        ),
+        Column(
+            "db_profile",
+            String(120),
+            comment=(
+                "Named DB profile used for this run (see /db-profiles). Multi-"
+                "profile runs (0.11+) record the first profile here and the "
+                "full list in scope_json.profiles."
+            ),
+        ),
+        Column(
+            "llm_provider",
+            String(40),
+            comment=(
+                "LLM vendor: openai | anthropic | gemini | openrouter | "
+                "deepseek | ollama | …. Distinct from llm_model which records "
+                "the specific model id."
+            ),
+        ),
+        Column(
+            "llm_model",
+            String(120),
+            comment=(
+                "Specific model id served by llm_provider — e.g. 'gpt-4o', "
+                "'claude-sonnet-4-20250514', 'openai/gpt-4o-mini' on OpenRouter."
+            ),
+        ),
+        Column(
+            "scope_json",
+            JSON,
+            comment=(
+                "JSON describing the analyzed scope: {schemas, tables, columns, "
+                "asset_kinds, profiles}. /compare reads this to find prior runs "
+                "of the same assets for side-by-side pivots."
+            ),
+        ),
+        Column(
+            "metrics_json",
+            JSON,
+            comment=(
+                "JSON of run metrics — counts, per-stage timings, retries, "
+                "skipped assets. Free-form so newer agents can add fields "
+                "without a schema bump."
+            ),
+        ),
+        Column(
+            "tokens_json",
+            JSON,
+            comment=(
+                "JSON of token usage broken down by phase: "
+                "{prompt, completion, cached, reasoning, total}. Drives /stats "
+                "cost reporting and /compare --by tokens."
+            ),
+        ),
+        Column(
+            "results_json",
+            JSON,
+            comment=(
+                "JSON summary of run outputs (counts, top-level rollups). "
+                "Per-asset detail lives in run_results joined on run_id."
+            ),
+        ),
+        Column(
+            "error_text",
+            Text,
+            comment=(
+                "Stack trace or error message when status='failed'. NULL on "
+                "successful runs."
+            ),
+        ),
+        Column(
+            "selected_count",
+            Integer,
+            nullable=False,
+            default=0,
+            comment=(
+                "Assets the user selected at the run picker. First step of the "
+                "selected → planned → processed → applied funnel."
+            ),
+        ),
+        Column(
+            "planned_count",
+            Integer,
+            nullable=False,
+            default=0,
+            comment=(
+                "Assets that survived post-selection filtering (already-good "
+                "comments skipped, unsupported asset kinds dropped, etc.)."
+            ),
+        ),
+        Column(
+            "processed_count",
+            Integer,
+            nullable=False,
+            default=0,
+            comment=(
+                "Assets the LLM successfully produced descriptions for. "
+                "planned_count - processed_count = LLM/network failures."
+            ),
+        ),
+        Column(
+            "applied_count",
+            Integer,
+            nullable=False,
+            default=0,
+            comment=(
+                "Assets whose chosen description was written to the live DB "
+                "via COMMENT ON. processed_count - applied_count = approved-"
+                "but-not-yet-applied (when running without --apply)."
+            ),
+        ),
+        Column(
+            "review_strategy",
+            String(40),
+            comment=(
+                "How alternatives were chosen: human | auto-best | "
+                "confidence-threshold. Affects how to read evaluated_at on "
+                "joined run_results rows."
+            ),
+        ),
+        Column(
+            "llm_profile",
+            String(120),
+            comment=(
+                "Named LLM profile used for this run (see /llm-profiles). "
+                "Captures the user-facing handle; concrete provider/model "
+                "values are mirrored in llm_provider/llm_model."
+            ),
+        ),
+        Column(
+            "doc_profile",
+            String(120),
+            comment=(
+                "Named document profile that supplied RAG evidence (see "
+                "/doc-profiles). NULL when /docs was not used in this run."
+            ),
+        ),
+        Column(
+            "code_profile",
+            String(120),
+            comment=(
+                "Named code profile that supplied code-evidence (see "
+                "/code-profiles). NULL when /code was not used in this run."
+            ),
+        ),
+        Column(
+            "settings_json",
+            JSON,
+            comment=(
+                "Snapshot of LLM settings at run time — temperature, "
+                "prompt_detail, n_alternatives, llm_batch_size, "
+                "description_verbosity, logprob_thresholds. Drives "
+                "/compare --by settings pivots so changes can be A/B-attributed."
+            ),
+        ),
+        Column("created_by", String(120), comment=_ATTRIBUTION_CREATED_BY),
+        Column("hostname", String(255), comment=_ATTRIBUTION_HOSTNAME),
+        Column("client_version", String(40), comment=_ATTRIBUTION_CLIENT_VERSION),
+        Column("local_id", BigInteger, comment=_ATTRIBUTION_LOCAL_ID),
         Index("ix_analysis_runs_started_at", "started_at"),
         Index("ix_analysis_runs_local_lookup", "hostname", "local_id"),
+        comment=(
+            "One row per AMX analysis run (/run, /run-apply, /ask, "
+            "doc-analyze, code-analyze). Captures the inputs (scope, "
+            "profiles, settings) and outputs (results, metrics, errors) of "
+            "an LLM-driven metadata generation. Joined to run_results for "
+            "per-asset alternatives. Read by /list, /show, /stats, /compare."
+        ),
     )
 
     # ── run_results: per-asset LLM alternatives + review state ─────────────
     Table(
         "run_results",
         md,
-        Column("id", String(36), primary_key=True),
-        Column("run_id", String(36), nullable=False, index=True),
-        Column("saved_at", DateTime(timezone=True), nullable=False),
-        Column("schema_name", String(255), nullable=False),
-        Column("table_name", String(255), nullable=False),
-        Column("column_name", String(255)),
-        Column("asset_kind", String(40), nullable=False, default="table"),
-        Column("source", String(40), nullable=False),
-        Column("confidence", String(20), nullable=False),
-        Column("logprob_score", Float),
-        Column("raw_logprob", Float),
-        Column("token_count", Integer),
-        Column("model_version", String(120), nullable=False, default=""),
-        Column("reasoning", Text),
-        Column("alternatives_json", JSON, nullable=False),
-        Column("evaluated_at", DateTime(timezone=True)),
-        Column("applied_at", DateTime(timezone=True)),
-        Column("chosen_description", Text),
-        Column("evaluation", String(40)),
-        Column("catalog_status", String(40), nullable=False, default=""),
-        Column("catalog_indexed_at", DateTime(timezone=True)),
-        Column("db_applied_status", String(40), nullable=False, default=""),
-        Column("effective_source_kind", String(40), nullable=False, default=""),
-        Column("superseded_at", DateTime(timezone=True)),
-        Column("rejection_reason", Text, nullable=False, default=""),
-        Column("hostname", String(255)),
-        Column("local_id", BigInteger),
+        Column(
+            "id",
+            String(36),
+            primary_key=True,
+            comment="UUID v4 primary key for this (asset, alternative) row.",
+        ),
+        Column(
+            "run_id",
+            String(36),
+            nullable=False,
+            index=True,
+            comment=(
+                "Foreign-key-by-convention to analysis_runs.id. Not a hard FK "
+                "because shared mode admits replication lag — a result row can "
+                "land before its parent run row when two writers race."
+            ),
+        ),
+        Column(
+            "saved_at",
+            DateTime(timezone=True),
+            nullable=False,
+            comment=(
+                "UTC timestamp when this alternative was persisted. Distinct "
+                "from analysis_runs.started_at when the LLM streams alternatives "
+                "across the run window."
+            ),
+        ),
+        Column(
+            "schema_name",
+            String(255),
+            nullable=False,
+            comment="Schema (or dataset/database) of the asset described.",
+        ),
+        Column(
+            "table_name",
+            String(255),
+            nullable=False,
+            comment="Table or view name of the asset described.",
+        ),
+        Column(
+            "column_name",
+            String(255),
+            comment=(
+                "Column name when asset_kind='column'. NULL when asset_kind='table' "
+                "(the alternative describes the table itself)."
+            ),
+        ),
+        Column(
+            "asset_kind",
+            String(40),
+            nullable=False,
+            default="table",
+            comment=(
+                "What this row describes: table | view | materialized_view | "
+                "column. Drives which COMMENT ON variant is emitted on apply."
+            ),
+        ),
+        Column(
+            "source",
+            String(40),
+            nullable=False,
+            comment=(
+                "Which agent produced this alternative: profile | doc | code | "
+                "combined | manual. Lets /compare and /review filter by source "
+                "of evidence."
+            ),
+        ),
+        Column(
+            "confidence",
+            String(20),
+            nullable=False,
+            comment=(
+                "Bucketed quality label derived from logprob_score against the "
+                "/logprob-thresholds settings: high | medium | low. Used by "
+                "/review filters and the human-review UI."
+            ),
+        ),
+        Column(
+            "logprob_score",
+            Float,
+            comment=(
+                "Normalized average log-probability of the description tokens "
+                "(-1..0). Higher = the LLM was more confident in the wording."
+            ),
+        ),
+        Column(
+            "raw_logprob",
+            Float,
+            comment="Sum of log-probabilities (unnormalized) backing logprob_score.",
+        ),
+        Column(
+            "token_count",
+            Integer,
+            comment="Token length of the alternative description.",
+        ),
+        Column(
+            "model_version",
+            String(120),
+            nullable=False,
+            default="",
+            comment=(
+                "Specific model id that produced this alternative (e.g. "
+                "'gpt-4o-2024-11-20'). May differ from analysis_runs.llm_model "
+                "when the user switches mid-run."
+            ),
+        ),
+        Column(
+            "reasoning",
+            Text,
+            comment=(
+                "Optional reasoning trace from a reasoning model (o-series, "
+                "claude with thinking, deepseek-reasoner). NULL for normal "
+                "chat models."
+            ),
+        ),
+        Column(
+            "alternatives_json",
+            JSON,
+            nullable=False,
+            comment=(
+                "Ordered JSON list of alternative description strings the LLM "
+                "produced for this asset. The /review picker presents these; "
+                "chosen_description records which one was selected."
+            ),
+        ),
+        Column(
+            "evaluated_at",
+            DateTime(timezone=True),
+            comment=(
+                "UTC timestamp when a human (or auto-best) picked one of the "
+                "alternatives. NULL = pending review."
+            ),
+        ),
+        Column(
+            "applied_at",
+            DateTime(timezone=True),
+            comment=(
+                "UTC timestamp when chosen_description was written to the live "
+                "DB via COMMENT ON. NULL = approved but not yet applied (or "
+                "never approved)."
+            ),
+        ),
+        Column(
+            "chosen_description",
+            Text,
+            comment=(
+                "The specific alternative selected at evaluation time. Empty "
+                "string when evaluation='rejected'."
+            ),
+        ),
+        Column(
+            "evaluation",
+            String(40),
+            comment=(
+                "Outcome of human/auto review: approved | rejected | edited. "
+                "'edited' means the user accepted an alternative but modified "
+                "the wording before apply."
+            ),
+        ),
+        Column(
+            "catalog_status",
+            String(40),
+            nullable=False,
+            default="",
+            comment=(
+                "Sync state with the /search catalog: pending | indexed | stale "
+                "| skipped. Drives /search rebuild incremental updates."
+            ),
+        ),
+        Column(
+            "catalog_indexed_at",
+            DateTime(timezone=True),
+            comment="UTC timestamp of the last /search-catalog index for this row.",
+        ),
+        Column(
+            "db_applied_status",
+            String(40),
+            nullable=False,
+            default="",
+            comment=(
+                "Result of the COMMENT ON write to the live DB: success | "
+                "skipped | failed. Empty string until apply is attempted."
+            ),
+        ),
+        Column(
+            "effective_source_kind",
+            String(40),
+            nullable=False,
+            default="",
+            comment=(
+                "What actually became the column's description after evaluation: "
+                "same labels as `source` plus 'manual-edit'. Distinct from "
+                "`source` because a user may approve a doc-sourced alternative "
+                "after a manual edit."
+            ),
+        ),
+        Column(
+            "superseded_at",
+            DateTime(timezone=True),
+            comment=(
+                "Set when a newer run produces a better description for the same "
+                "asset. Lets /history filters hide stale rows without deleting "
+                "them — full audit trail preserved."
+            ),
+        ),
+        Column(
+            "rejection_reason",
+            Text,
+            nullable=False,
+            default="",
+            comment=(
+                "Free-text reason captured at evaluation time when "
+                "evaluation='rejected'. Surfaced by /review for retrospectives."
+            ),
+        ),
+        Column("hostname", String(255), comment=_ATTRIBUTION_HOSTNAME),
+        Column("local_id", BigInteger, comment=_ATTRIBUTION_LOCAL_ID),
         Index("ix_run_results_asset", "schema_name", "table_name", "column_name"),
         Index("ix_run_results_local_lookup", "hostname", "local_id"),
+        comment=(
+            "Per-asset LLM alternatives generated during an analysis_runs "
+            "invocation. One row per (asset, alternative) — a column with "
+            "3 alternatives produces 3 rows. Captures the alternative payload, "
+            "confidence, evaluation/apply state, and a back-pointer to the run."
+        ),
     )
 
     # ── app_events: append-only event log ─────────────────────────────────
     Table(
         "app_events",
         md,
-        Column("id", String(36), primary_key=True),
-        Column("created_at", DateTime(timezone=True), nullable=False, index=True),
-        Column("event_type", String(80), nullable=False),
-        Column("status", String(40), nullable=False),
-        Column("command", String(120), nullable=False),
-        Column("details_json", JSON),
-        Column("created_by", String(120)),
-        Column("hostname", String(255)),
-        Column("client_version", String(40)),
+        Column(
+            "id",
+            String(36),
+            primary_key=True,
+            comment="UUID v4 primary key for the event.",
+        ),
+        Column(
+            "created_at",
+            DateTime(timezone=True),
+            nullable=False,
+            index=True,
+            comment="UTC timestamp the event fired. Indexed for /events recent-first ordering.",
+        ),
+        Column(
+            "event_type",
+            String(80),
+            nullable=False,
+            comment=(
+                "Coarse event family: cli | db | llm | doc | code | error | "
+                "history-store. Lets /events filter by subsystem."
+            ),
+        ),
+        Column(
+            "status",
+            String(40),
+            nullable=False,
+            comment="Severity of the event: info | warn | error.",
+        ),
+        Column(
+            "command",
+            String(120),
+            nullable=False,
+            comment="CLI command (or sub-action) that was running when the event fired.",
+        ),
+        Column(
+            "details_json",
+            JSON,
+            comment=(
+                "Free-form JSON payload — varies per event_type. Examples: "
+                "{profile, backend} for db connect, {model, latency_ms} for "
+                "llm calls, {error_class, traceback} for errors."
+            ),
+        ),
+        Column("created_by", String(120), comment=_ATTRIBUTION_CREATED_BY),
+        Column("hostname", String(255), comment=_ATTRIBUTION_HOSTNAME),
+        Column("client_version", String(40), comment=_ATTRIBUTION_CLIENT_VERSION),
         Index("ix_app_events_created_at", "created_at"),
+        comment=(
+            "Append-only structured event log surfaced by /events. Records CLI "
+            "lifecycle events (connection tests, syncs, doctor checks, errors) "
+            "for audit and debugging. Distinct from analysis_runs which logs "
+            "LLM agent invocations."
+        ),
     )
 
     # ── session_state: namespaced key/value storage ───────────────────────
@@ -159,12 +637,52 @@ def build_metadata(schema: str | None = None) -> MetaData:
     Table(
         "session_state",
         md,
-        Column("namespace", String(120), primary_key=True),
-        Column("key_name", String(255), primary_key=True),
-        Column("hostname", String(255), primary_key=True, default=""),
-        Column("value_json", JSON, nullable=False),
-        Column("updated_at", DateTime(timezone=True), nullable=False),
-        Column("created_by", String(120)),
+        Column(
+            "namespace",
+            String(120),
+            primary_key=True,
+            comment=(
+                "Logical grouping for related keys (e.g. 'ask_session_42' or "
+                "'review_state'). Lets multiple StateManager instances share a "
+                "table without colliding."
+            ),
+        ),
+        Column(
+            "key_name",
+            String(255),
+            primary_key=True,
+            comment="Key within the namespace.",
+        ),
+        Column(
+            "hostname",
+            String(255),
+            primary_key=True,
+            default="",
+            comment=(
+                "Writer machine. Part of the composite PK so a teammate's state "
+                "under the same (namespace, key_name) does not clobber yours in "
+                "shared mode. Empty string when running in single-user mode."
+            ),
+        ),
+        Column(
+            "value_json",
+            JSON,
+            nullable=False,
+            comment="JSON-serialized value associated with (namespace, key_name, hostname).",
+        ),
+        Column(
+            "updated_at",
+            DateTime(timezone=True),
+            nullable=False,
+            comment="UTC timestamp of the last write to this row.",
+        ),
+        Column("created_by", String(120), comment=_ATTRIBUTION_CREATED_BY),
+        comment=(
+            "Namespaced key/value storage used by StateManager for inter-turn "
+            "agent memory within /ask conversational sessions. Composite primary "
+            "key (namespace, key_name, hostname) so a teammate's state under "
+            "the same namespace does not clobber yours in shared mode."
+        ),
     )
 
     # ── schema_meta: version stamp so older clients refuse to write ──────
@@ -176,10 +694,43 @@ def build_metadata(schema: str | None = None) -> MetaData:
     Table(
         "schema_meta",
         md,
-        Column("id", Integer, primary_key=True),  # always 1
-        Column("schema_version", Integer, nullable=False),
-        Column("created_at", DateTime(timezone=True), nullable=False),
-        Column("created_by_client_version", String(40)),
+        Column(
+            "id",
+            Integer,
+            primary_key=True,
+            comment=(
+                "Singleton sentinel — always 1. The PK exists only because every "
+                "table needs one; this table holds at most one row."
+            ),
+        ),
+        Column(
+            "schema_version",
+            Integer,
+            nullable=False,
+            comment=(
+                "Current version of the AMX shared-store schema. Older clients "
+                "refuse to write when this is higher than what they were built "
+                "against, mirroring the AMXConfig schema_version compatibility "
+                "guard."
+            ),
+        ),
+        Column(
+            "created_at",
+            DateTime(timezone=True),
+            nullable=False,
+            comment="UTC timestamp when /history-store enable first bootstrapped this schema.",
+        ),
+        Column(
+            "created_by_client_version",
+            String(40),
+            comment="AMX version string of the client that ran the bootstrap.",
+        ),
+        comment=(
+            "Single-row version stamp written at /history-store enable bootstrap. "
+            "Newer AMX clients bump schema_version on first write; older clients "
+            "refuse to write into a schema bumped beyond what they know about, "
+            "mirroring the AMXConfig schema_version guard."
+        ),
     )
 
     return md

--- a/tests/test_shared_schema_comments.py
+++ b/tests/test_shared_schema_comments.py
@@ -1,0 +1,64 @@
+"""Dogfooding test: AMX's own shared-history schema must ship with comments.
+
+AMX's product thesis is "every database table and column should have a
+quality COMMENT ON description." This test pins that AMX's own
+warehouse artifacts (the AMX schema bootstrapped by
+``/history-store enable``) also satisfy that contract — every Table
+and every Column in :func:`amx.storage.shared_schema.build_metadata`
+carries a non-empty ``comment=`` annotation.
+
+If a future contributor adds a Column without a comment, this test
+fails fast — preventing a regression that would re-create the
+embarrassment of shipping a metadata tool that does not annotate its
+own outputs.
+"""
+
+from __future__ import annotations
+
+from amx.storage.shared_schema import build_metadata
+
+
+def test_every_table_has_comment() -> None:
+    md = build_metadata("AMX")
+    missing = [name for name, table in md.tables.items() if not (table.comment or "").strip()]
+    assert not missing, f"Tables missing COMMENT: {missing}"
+
+
+def test_every_column_has_comment() -> None:
+    md = build_metadata("AMX")
+    missing: list[str] = []
+    for table in md.tables.values():
+        for col in table.columns:
+            if not (col.comment or "").strip():
+                missing.append(f"{table.name}.{col.name}")
+    assert not missing, (
+        f"{len(missing)} columns missing COMMENT (first 10): {missing[:10]}"
+    )
+
+
+def test_create_history_tables_ddl_emits_comments_on_postgres() -> None:
+    """Verify the dump-ddl pipeline renders COMMENT ON statements.
+
+    Uses the PostgreSQL dialect because it emits ``COMMENT ON TABLE``
+    and ``COMMENT ON COLUMN`` as separate statements (vs MySQL which
+    inlines them), making the contract easiest to grep.
+    """
+    from amx.config import DBConfig
+    from amx.db.adapters.postgresql import PostgreSQLAdapter
+
+    cfg = DBConfig(
+        backend="postgresql",
+        host="localhost",
+        port=5432,
+        database="test",
+        user="test",
+        password="test",
+    )
+    ddl = PostgreSQLAdapter(cfg).create_history_tables_ddl("AMX")
+
+    assert ddl.count("CREATE TABLE") == 5, "expected 5 CREATE TABLE statements"
+    assert ddl.count("COMMENT ON TABLE") == 5, "expected 5 COMMENT ON TABLE statements"
+    # 75 columns, all annotated
+    assert ddl.count("COMMENT ON COLUMN") == 75, (
+        f"expected 75 COMMENT ON COLUMN statements, got {ddl.count('COMMENT ON COLUMN')}"
+    )


### PR DESCRIPTION
## Summary

AMX's whole product thesis is "every database table and column should have a quality `COMMENT ON ...` description." Embarrassingly, when AMX bootstrapped its own `AMX` schema in a user's warehouse via `/history-store enable`, all **5 tables** and **75 columns** shipped with **no comments at all** — AMX violating its own thesis on its own outputs.

This PR fixes that in three parts:

### 1. `shared_schema.py` — every Table and Column now has `comment=`

Every `Table(...)` and every `Column(...)` in `amx/storage/shared_schema.py` now carries a `comment="..."` annotation explaining what it represents and why it exists (in AMX house style — what the row means and why the column exists, not just the type). SQLAlchemy's `MetaData.create_all` emits these as `COMMENT ON TABLE`/`COMMENT ON COLUMN` automatically after `CREATE TABLE` on every supported backend (PostgreSQL, MySQL, MSSQL, Oracle, Snowflake, Databricks, Redshift, BigQuery), so **future** `/history-store enable` installs ship comments for free.

### 2. New `/history-store apply-comments` — backfill existing schemas

For users who already have an AMX schema bootstrapped (where `create_all` is a no-op), Part 1 alone doesn't help. The new action walks the annotated metadata and issues `COMMENT ON` against the live shared-store DB via the same `connector.set_table_comment` / `set_column_comment` machinery AMX uses to write LLM-approved descriptions to user databases. Proper dogfooding. **Idempotent** — re-runnable.

Available from the `/history-store` interactive picker (between Flush pending and Dump DDL) or as `amx db history-store apply-comments [--profile NAME] [--schema NAME]`.

### 3. `/history-store dump-ddl` now renders the full annotated DDL

Previously emitted only `CREATE SCHEMA IF NOT EXISTS`. Now renders `CREATE SCHEMA` + 5× `CREATE TABLE` with COMMENT clauses + indexes, via SQLAlchemy's offline DDL compiler bound to the target backend's dialect. DBAs no longer have to guess the rest.

### Regression guard

`tests/test_shared_schema_comments.py` pins the contract: every table and every column must carry a non-empty `comment=`. Adding a column without a description fails CI fast.

## Test plan

- [x] `pytest -q` — 557 passed (554 existing + 3 new), 19 deselected
- [x] `build_metadata('AMX')` — confirms 5 tables, 75 columns, all annotated
- [x] PostgreSQL dialect render — confirms `5× COMMENT ON TABLE`, `75× COMMENT ON COLUMN`, `5× CREATE TABLE`
- [ ] `/history-store apply-comments` against a live shared store — confirm output reports counts, then `\d+ AMX.analysis_runs` shows the comments. Re-run, confirm idempotent.
- [ ] `/history-store dump-ddl` — visually confirm CREATE TABLE + COMMENT statements appear
