### PR TITLE
fix(history-store): comment the AMX schema namespace; remove apply-comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,41 +6,40 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
-### Fixed — AMX shared-history tables now ship with column comments (dogfooding)
+### Fixed — AMX shared-history schema now ships with full comments (dogfooding)
 
 AMX is a metadata-generation tool whose product thesis is "every
-database table and column should have a quality `COMMENT ON ...`
-description." Embarrassingly, when AMX itself bootstrapped its `AMX`
-schema in a user's warehouse via `/history-store enable`, the five
-tables (`analysis_runs`, `run_results`, `app_events`, `session_state`,
-`schema_meta`) and all 75 columns shipped with **no comments** — AMX
+database schema, table, and column should have a quality
+`COMMENT ON ...` description." Embarrassingly, when AMX itself
+bootstrapped its `AMX` schema in a user's warehouse via
+`/history-store enable`, the schema namespace, the five tables
+(`analysis_runs`, `run_results`, `app_events`, `session_state`,
+`schema_meta`), and all 75 columns shipped with **no comments** — AMX
 was violating its own thesis on the artifacts it created.
 
-`amx/storage/shared_schema.py` now carries a `comment="..."`
-annotation on every Table and every Column. SQLAlchemy's
-`MetaData.create_all` emits `COMMENT ON TABLE` and `COMMENT ON COLUMN`
-automatically after `CREATE TABLE` on every supported backend
-(PostgreSQL, MySQL, MSSQL, Oracle, Snowflake, Databricks, Redshift,
-BigQuery), so future `/history-store enable` invocations get the
-comments for free.
+Three fixes:
 
-For users who already have an `AMX` schema bootstrapped (where
-`create_all` is a no-op), the new **`/history-store apply-comments`**
-action backfills the missing comments. It walks the annotated
-metadata and issues `COMMENT ON TABLE`/`COMMENT ON COLUMN` against
-the live shared-store DB via the same `connector.set_table_comment`/
-`set_column_comment` machinery AMX uses to write LLM-approved
-descriptions to user databases — proper dogfooding. Idempotent: re-
-running just rewrites the same comments. Available from the
-`/history-store` interactive picker (between Flush pending and Dump
-DDL) or as `amx db history-store apply-comments [--profile NAME]
-[--schema NAME]`.
+1. **Schema-level comment.** `DatabaseAdapter.create_history_schema`
+   now writes `DEFAULT_HISTORY_SCHEMA_COMMENT` via
+   `COMMENT ON SCHEMA` immediately after `CREATE SCHEMA`, on every
+   backend that advertises `schema_comments=True`.
+2. **Table + column comments.** `amx/storage/shared_schema.py` carries
+   a `comment="..."` annotation on every `Table(...)` and every
+   `Column(...)`. SQLAlchemy's `MetaData.create_all` emits
+   `COMMENT ON TABLE`/`COMMENT ON COLUMN` automatically after
+   `CREATE TABLE` on every supported backend (PostgreSQL, MySQL,
+   MSSQL, Oracle, Snowflake, Databricks, Redshift, BigQuery).
+3. **`/history-store dump-ddl`** now renders the full annotated DDL
+   (CREATE SCHEMA + COMMENT ON SCHEMA + 5× CREATE TABLE with
+   COMMENT clauses + indexes), via SQLAlchemy's offline DDL compiler
+   bound to the target backend's dialect. Previously it emitted only
+   `CREATE SCHEMA IF NOT EXISTS`, leaving DBAs to guess the rest.
 
-`/history-store dump-ddl` now renders the full annotated DDL too
-(CREATE SCHEMA + 5× CREATE TABLE with COMMENT clauses + indexes), via
-SQLAlchemy's offline DDL compiler bound to the target backend's
-dialect. Previously it emitted only `CREATE SCHEMA IF NOT EXISTS`,
-leaving DBAs to guess the rest.
+Future `/history-store enable` invocations get all 81 comments
+(1 schema + 5 tables + 75 columns) for free. Existing schemas were
+backfilled in-place during this release; AMX intentionally does not
+ship a maintenance subcommand for re-applying — comments are emitted
+at bootstrap and that is the only well-defined moment.
 
 A new test (`tests/test_shared_schema_comments.py`) pins the
 contract: every table and every column must carry a non-empty

--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -20,9 +20,6 @@ primary user-facing surface):
 * ``flush-pending`` — drain the dual-write outbox (replay queued
   shared writes that failed at write time).
 * ``dump-ddl`` — print the schema-bootstrap DDL so a DBA can run it.
-* ``apply-comments`` — backfill table + column COMMENTs on an
-  already-bootstrapped AMX schema. Dogfooding: AMX shouldn't ship a
-  metadata-tool schema without metadata. Idempotent.
 """
 
 from __future__ import annotations
@@ -61,7 +58,6 @@ ACTION_MIGRATE = "Migrate from local — copy local SQLite history into the shar
 ACTION_PULL = "Pull from shared — sync teammates' runs into your local SQLite cache"
 ACTION_FLUSH = "Flush pending — retry queued shared writes that failed at write time"
 ACTION_DUMP_DDL = "Dump DDL — print bootstrap SQL for a DBA to run by hand"
-ACTION_APPLY_COMMENTS = "Apply comments — backfill table/column descriptions on the live AMX schema (idempotent)"
 ACTION_CANCEL = "Cancel — exit without doing anything"
 
 
@@ -497,95 +493,15 @@ def _action_dump_ddl(
     click.echo(f"-- Backend: {db_cfg.backend}")
     click.echo(f"-- Schema:  {schema}")
     click.echo(adapter.create_history_schema_ddl(schema) + ";")
+    schema_comment_ddl = adapter.history_schema_comment_ddl(schema)
+    if schema_comment_ddl:
+        click.echo(schema_comment_ddl + ";")
     click.echo("")
     click.echo("-- Tables (CREATE TABLE + COMMENT ON + CREATE INDEX)")
     try:
         click.echo(adapter.create_history_tables_ddl(schema))
     except Exception as exc:
         click.echo(f"-- (table DDL render failed: {exc})")
-
-
-def _action_apply_comments(
-    cfg: AMXConfig,
-    *,
-    profile_name: str | None = None,
-    schema_name: str | None = None,
-) -> None:
-    """Backfill table + column COMMENTs on an already-bootstrapped AMX schema.
-
-    AMX is a metadata-generation tool — its own warehouse artifacts must
-    meet the standard it enforces on user data. The Table/Column
-    annotations in :mod:`amx.storage.shared_schema` ride along on
-    ``MetaData.create_all`` for new installs, but existing AMX schemas
-    were created before those annotations existed. This action walks
-    every table + column in the metadata and issues
-    ``COMMENT ON TABLE``/``COMMENT ON COLUMN`` against the live shared-
-    store DB via the same connector machinery AMX uses to write LLM-
-    approved descriptions to user databases.
-
-    Idempotent: ``COMMENT ON ... IS '...'`` overwrites the existing
-    comment with no error. Safe to re-run after editing comment text in
-    ``shared_schema.py``.
-    """
-    target = profile_name or cfg.history_store_profile or cfg.active_db_profile or ""
-    if not target or target not in cfg.db_profiles:
-        error("No DB profile resolved. Specify --profile or configure one via /db-profiles.")
-        return
-
-    from amx.db.connector import DatabaseConnector
-    from amx.storage.shared_schema import build_metadata
-
-    db_cfg = cfg.db_profiles[target]
-    schema = (schema_name or cfg.history_store_schema or "AMX").strip() or "AMX"
-    md = build_metadata(schema)
-
-    connector = DatabaseConnector(db_cfg)
-    if not connector.capabilities.column_comments:
-        warn(
-            f"Backend {db_cfg.backend!r} does not support column comments — "
-            "nothing to apply. Table comments may also be unsupported."
-        )
-
-    info(f"Applying comments to {db_cfg.backend} schema [cyan]{schema}[/cyan]…")
-
-    table_writes = 0
-    column_writes = 0
-    skipped: list[str] = []
-
-    for table in md.tables.values():
-        # Strip the schema prefix that MetaData(schema=...) bakes into
-        # table.name in some SA versions. The connector takes (schema,
-        # table) separately.
-        bare_name = table.name
-        try:
-            if table.comment and connector.capabilities.table_comments:
-                connector.set_table_comment(schema, bare_name, table.comment)
-                table_writes += 1
-        except Exception as exc:
-            skipped.append(f"table {schema}.{bare_name}: {exc}")
-            continue
-
-        if not connector.capabilities.column_comments:
-            continue
-        for col in table.columns:
-            if not col.comment:
-                continue
-            try:
-                connector.set_column_comment(schema, bare_name, col.name, col.comment)
-                column_writes += 1
-            except Exception as exc:
-                skipped.append(f"column {schema}.{bare_name}.{col.name}: {exc}")
-
-    success(
-        f"Wrote {table_writes} table comment(s) and {column_writes} column comment(s) "
-        f"on {schema}. Idempotent — safe to re-run."
-    )
-    if skipped:
-        warn(f"{len(skipped)} write(s) skipped:")
-        for line in skipped[:10]:
-            warn(f"  • {line}")
-        if len(skipped) > 10:
-            warn(f"  … and {len(skipped) - 10} more.")
 
 
 # ── Picker (the main user-facing surface) ─────────────────────────────────
@@ -622,7 +538,6 @@ def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> N
         options.append(ACTION_PULL)
         options.append(ACTION_MIGRATE)
         options.append(ACTION_FLUSH)
-        options.append(ACTION_APPLY_COMMENTS)
         options.append(ACTION_DUMP_DDL)
         options.append(ACTION_DISABLE)
     else:
@@ -655,9 +570,6 @@ def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> N
         return
     if picked == ACTION_DUMP_DDL:
         _action_dump_ddl(cfg)
-        return
-    if picked == ACTION_APPLY_COMMENTS:
-        _action_apply_comments(cfg)
         return
     # ACTION_CANCEL or anything else — exit silently.
 
@@ -778,27 +690,6 @@ def register_history_store_commands(
     def hs_dump_ddl(cfg: AMXConfig, profile_name: str | None, schema_name: str | None) -> None:
         """Print the schema-bootstrap DDL so a DBA can run it by hand."""
         _action_dump_ddl(cfg, profile_name=profile_name, schema_name=schema_name)
-
-    @history_store_grp.command("apply-comments")
-    @click.option(
-        "--profile",
-        "profile_name",
-        default=None,
-        help="DB profile hosting the AMX schema (defaults to the configured "
-        "history-store profile, or the active analysis profile).",
-    )
-    @click.option(
-        "--schema",
-        "schema_name",
-        default=None,
-        help="Schema name to apply comments to (default 'AMX').",
-    )
-    @pass_config
-    def hs_apply_comments(
-        cfg: AMXConfig, profile_name: str | None, schema_name: str | None
-    ) -> None:
-        """Backfill table/column descriptions on the live AMX schema (idempotent)."""
-        _action_apply_comments(cfg, profile_name=profile_name, schema_name=schema_name)
 
     return history_store_grp
 

--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -387,10 +387,20 @@ class DatabaseAdapter(ABC):
         schema-creation primitive (Snowflake's ``CREATE SCHEMA "DB"."AMX"``,
         Databricks Unity Catalog ``CREATE SCHEMA catalog.amx``,
         BigQuery's project-qualified DDL, Oracle's CREATE USER) override.
+
+        Also writes :data:`DEFAULT_HISTORY_SCHEMA_COMMENT` to the schema
+        when the backend supports it, so a freshly-created AMX schema
+        carries a description matching the metadata thesis AMX enforces
+        on user data.
         """
+        from amx.storage.shared_schema import DEFAULT_HISTORY_SCHEMA_COMMENT
+
         ddl = self.create_history_schema_ddl(schema_name)
         with engine.begin() as conn:
             conn.execute(text(ddl))
+            if self.capabilities.schema_comments:
+                stmt = self.set_schema_comment_sql(schema_name)
+                conn.execute(text(stmt), {"cmt": DEFAULT_HISTORY_SCHEMA_COMMENT})
 
     def create_history_schema_ddl(self, schema_name: str) -> str:
         """Return the DDL ``/history-store dump-ddl`` shows to a DBA.
@@ -399,8 +409,30 @@ class DatabaseAdapter(ABC):
         so the user can request the SQL without actually executing it —
         useful when the active connection lacks ``CREATE SCHEMA``
         privileges and a DBA needs to provision the schema by hand.
+
+        Single statement, no trailing ``;`` — callers append the
+        terminator. For the schema-comment statement that ships
+        alongside, see :meth:`history_schema_comment_ddl`.
         """
         return f"CREATE SCHEMA IF NOT EXISTS {self.quote_identifier(schema_name)}"
+
+    def history_schema_comment_ddl(self, schema_name: str) -> str | None:
+        """Return ``COMMENT ON SCHEMA`` DDL for the AMX schema, or None.
+
+        Returns None on backends that do not support schema comments
+        (BigQuery, MySQL pre-8.0). Caller is responsible for appending
+        the trailing ``;``. Embeds the literal comment text so the
+        output of ``/history-store dump-ddl`` is copy-pasteable into a
+        DBA's psql/Snowsight session without parameter binding.
+        """
+        if not self.capabilities.schema_comments:
+            return None
+        from amx.storage.shared_schema import DEFAULT_HISTORY_SCHEMA_COMMENT
+
+        # SQL string literal — single quotes doubled per ANSI rules.
+        comment_lit = DEFAULT_HISTORY_SCHEMA_COMMENT.replace("'", "''")
+        template = self.set_schema_comment_sql(schema_name)
+        return template.replace(":cmt", f"'{comment_lit}'")
 
     def create_history_tables_ddl(self, schema_name: str) -> str:
         """Render full CREATE TABLE DDL for the AMX history schema.

--- a/amx/storage/shared_schema.py
+++ b/amx/storage/shared_schema.py
@@ -21,12 +21,14 @@ Design notes:
   on Snowflake (via dialect adapters), ``STRING`` everywhere else.
 * ``DateTime(timezone=True)`` is used over float epoch seconds because
   warehouse query semantics for "last 7 days" expect actual timestamps.
-* **Every table and column carries a ``comment=`` annotation.** AMX is
-  a metadata-generation tool — its own warehouse artifacts must meet
-  the standard it enforces on user data. ``MetaData.create_all`` emits
-  these as ``COMMENT ON`` statements after ``CREATE TABLE`` on every
-  backend that supports them; ``/history-store apply-comments``
-  backfills them onto already-bootstrapped schemas.
+* **Every table and column carries a ``comment=`` annotation, and the
+  schema itself gets a comment via** :data:`DEFAULT_HISTORY_SCHEMA_COMMENT`.
+  AMX is a metadata-generation tool — its own warehouse artifacts must
+  meet the standard it enforces on user data. ``MetaData.create_all``
+  emits the table/column comments as ``COMMENT ON`` statements after
+  ``CREATE TABLE`` on every backend that supports them;
+  :meth:`DatabaseAdapter.create_history_schema` emits the schema
+  comment alongside ``CREATE SCHEMA`` for the same reason.
 """
 
 from __future__ import annotations
@@ -50,6 +52,19 @@ from sqlalchemy import (
 # matches the user-facing nomenclature in docs/CLI prompts.
 DEFAULT_HISTORY_SCHEMA = "AMX"
 
+# Comment text written to the schema (namespace) itself via
+# ``COMMENT ON SCHEMA``. ``MetaData`` does not carry schema-level
+# annotations natively, so :meth:`DatabaseAdapter.create_history_schema`
+# emits this explicitly after ``CREATE SCHEMA``.
+DEFAULT_HISTORY_SCHEMA_COMMENT = (
+    "AMX shared run-history schema. Created by AMX (Agentic Metadata "
+    "Extractor) via /history-store enable. Holds cross-machine analysis "
+    "history, per-asset LLM alternatives, app events, agent session "
+    "state, and a schema version stamp so multiple AMX clients can "
+    "share run history under one warehouse. See "
+    "https://github.com/omeryasirkucuk/amx for details."
+)
+
 # All client versions writing into a shared store record this as their
 # ``schema_version`` so an older client refuses to write into a schema
 # bumped by a newer client (avoids losing columns the new client added).
@@ -57,10 +72,8 @@ SHARED_SCHEMA_VERSION = 1
 
 
 # ── Per-column comment text ───────────────────────────────────────────────
-# Pulled out as constants so /history-store apply-comments can also use
-# them without re-importing the Table objects, and so the same string
-# isn't duplicated between the schema declaration and any future doc
-# generation.
+# Pulled out as constants so the same string isn't duplicated across
+# attribution columns on every table.
 
 _ATTRIBUTION_CREATED_BY = (
     "OS username (or AMX_USER override) of the principal that wrote this row. "
@@ -738,6 +751,7 @@ def build_metadata(schema: str | None = None) -> MetaData:
 
 __all__ = [
     "DEFAULT_HISTORY_SCHEMA",
+    "DEFAULT_HISTORY_SCHEMA_COMMENT",
     "SHARED_SCHEMA_VERSION",
     "build_metadata",
 ]


### PR DESCRIPTION
## Summary

Two follow-ups to PR #85 (the dogfooding fix that added comments to AMX's own shared-history tables):

### 1. The AMX schema namespace itself now gets a comment

PR #85 covered tables and columns but missed the schema namespace itself — `MetaData` has no schema-level annotation slot, so `create_all` never wrote one. A user inspecting the live AMX schema saw a populated description on every table and column but a NULL description on the schema namespace itself. Fixed by:

- New `DEFAULT_HISTORY_SCHEMA_COMMENT` constant in `amx/storage/shared_schema.py`
- `DatabaseAdapter.create_history_schema` (executor) now writes `COMMENT ON SCHEMA` immediately after `CREATE SCHEMA`, gated on `capabilities.schema_comments`
- New `history_schema_comment_ddl()` helper renders the same statement for `/history-store dump-ddl` output

Future `/history-store enable` invocations now write **1 schema + 5 table + 75 column** comments at bootstrap. The existing live AMX schema was backfilled in-place during this release window.

### 2. Removed `/history-store apply-comments` entirely

The action shipped in #85 was a one-shot migration tool, not a real feature. AMX shouldn't ship long-lived maintenance subcommands for schema patches that should happen at bootstrap. Removed:

- `ACTION_APPLY_COMMENTS` constant
- Picker wiring
- `_action_apply_comments` handler (~70 lines)
- `apply-comments` Click subcommand
- Module docstring entry

`dump-ddl` output now includes the `COMMENT ON SCHEMA` statement so a DBA hand-provisioning the schema gets the full annotated DDL.

CHANGELOG `[Unreleased]` rewritten in-place since `apply-comments` was never released.

## Test plan

- [x] `pytest -q` — 557 passed, 19 deselected
- [x] Backfill executed against live AMX schema during this release: 1 schema + 5 tables + 75 columns written successfully
- [ ] Fresh `/history-store enable` on a sandbox PG: confirm `\dn+` shows AMX schema with description
- [ ] `/history-store dump-ddl`: confirm `COMMENT ON SCHEMA` line appears between `CREATE SCHEMA` and the table DDL
