### PR TITLE
fix(history-store): drop empty 'postgres' maintenance DB from enable picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — /history-store enable no longer offers the empty `postgres` maintenance DB
+
+When bootstrapping AMX onto a PostgreSQL profile, the database picker
+(`Where should the AMX schema live?`) listed every database the server
+exposed — including the empty `postgres` maintenance DB that ships
+with every PG install. A user connected to a real data DB (e.g.
+`SAP`) could pick `postgres` thinking it meant "the postgres server"
+and end up with the AMX schema in an empty system database that's
+invisible from their main connection.
+
+`PostgreSQLAdapter.list_databases` now drops `postgres` from the
+result when other databases exist, matching the docstring intent that
+was never actually implemented. On a truly fresh server with only
+`postgres`, it remains the sole choice (otherwise bootstrap would
+have nothing to pick) and the picker labels it
+`(maintenance DB — empty by default)` so the user knows what they're
+picking.
+
+Three regression tests pin the contract:
+`test_postgres_dropped_when_other_dbs_exist`,
+`test_postgres_kept_when_it_is_the_only_db`,
+`test_user_dbs_returned_unchanged_when_postgres_absent`.
+
 ### Fixed — AMX shared-history schema now ships with full comments (dogfooding)
 
 AMX is a metadata-generation tool whose product thesis is "every

--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -362,10 +362,19 @@ def _pick_history_database(cfg: AMXConfig, db_cfg, adapter) -> str:
         return current
 
     default = current if current in choices else choices[0]
+    # Annotate well-known maintenance/system targets so a user does not
+    # accidentally pick an empty system DB on a fresh server. Today only
+    # PostgreSQL surfaces such a target (``postgres``) — its adapter
+    # already drops it when other DBs exist, so this label only fires
+    # in the fresh-install fallback.
+    descriptions: dict[str, str] = {}
+    if backend == "postgresql" and "postgres" in choices:
+        descriptions["postgres"] = "(maintenance DB — empty by default)"
     picked = ask_choice(
         f"Where should the AMX schema live? Pick a {label_kind}",
         choices,
         default=default,
+        descriptions=descriptions or None,
     )
     return picked or default
 

--- a/amx/db/adapters/postgresql.py
+++ b/amx/db/adapters/postgresql.py
@@ -69,21 +69,25 @@ class PostgreSQLAdapter(DatabaseAdapter):
         """Return user-visible databases on this PostgreSQL server.
 
         Excludes templates (``datistemplate = false``) and the system
-        ``postgres`` database itself unless the user has nothing else —
-        when a fresh server has only ``postgres``, returning an empty
-        list would be misleading. The default ordering is alphabetical
-        for stable picker UX.
+        ``postgres`` maintenance database itself unless the user has
+        nothing else — when a fresh server has only ``postgres``,
+        returning an empty list would be misleading and block AMX
+        bootstrap. The default ordering is alphabetical for stable
+        picker UX.
         """
         with engine.connect() as conn:
             rows = conn.execute(
                 text("SELECT datname FROM pg_database WHERE datistemplate = false ORDER BY datname")
             ).fetchall()
         names = [str(r[0]) for r in rows]
-        # When the only thing on the server is the system DB itself, the
-        # picker would offer just ``postgres`` (which has no user data).
-        # Surface it anyway — the picker UI will show "(system DB)" so
-        # the user knows what they're picking.
-        return names
+        # Drop the ``postgres`` maintenance DB when real user databases
+        # exist. It otherwise shows up in the /history-store enable
+        # picker as a tempting but wrong target — users connected to a
+        # data DB (e.g. SAP) sometimes pick it without realising it's
+        # the empty system database. Keep it as the sole option only
+        # when the server has nothing else (fresh install).
+        non_system = [n for n in names if n != "postgres"]
+        return non_system if non_system else names
 
     # ── Materialized views ────────────────────────────────────────────────
 

--- a/tests/test_postgresql_list_databases_filter.py
+++ b/tests/test_postgresql_list_databases_filter.py
@@ -1,0 +1,54 @@
+"""PostgreSQLAdapter.list_databases hides the maintenance ``postgres`` DB.
+
+The /history-store enable picker passes the result of
+``adapter.list_databases(engine)`` to a numbered picker. The PG
+maintenance database (``postgres``) is empty by default and offering
+it as a numbered choice next to a real user database (e.g. ``SAP``)
+has caused users to pick it by mistake — the AMX schema then lands in
+the empty system DB and is invisible from the user's main connection.
+
+This test pins the filter: when other DBs exist, ``postgres`` is
+dropped; on a fresh server with only ``postgres``, it is still
+returned (otherwise bootstrap would have nothing to pick).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from amx.config import DBConfig
+from amx.db.adapters.postgresql import PostgreSQLAdapter
+
+
+def _adapter_with_db_listing(rows: list[str]) -> PostgreSQLAdapter:
+    """Build a PostgreSQLAdapter whose engine returns *rows* from list_databases."""
+    cfg = DBConfig(
+        backend="postgresql",
+        host="localhost",
+        port=5432,
+        database="test",
+        user="test",
+        password="test",
+    )
+    adapter = PostgreSQLAdapter(cfg)
+    fake_engine = MagicMock()
+    cm = fake_engine.connect.return_value.__enter__.return_value
+    cm.execute.return_value.fetchall.return_value = [(name,) for name in rows]
+    fake_engine.connect.return_value.__exit__.return_value = False
+    return adapter, fake_engine
+
+
+def test_postgres_dropped_when_other_dbs_exist() -> None:
+    adapter, engine = _adapter_with_db_listing(["postgres", "SAP", "analytics"])
+    assert adapter.list_databases(engine) == ["SAP", "analytics"]
+
+
+def test_postgres_kept_when_it_is_the_only_db() -> None:
+    """Fresh install fallback — bootstrap can't pick from an empty list."""
+    adapter, engine = _adapter_with_db_listing(["postgres"])
+    assert adapter.list_databases(engine) == ["postgres"]
+
+
+def test_user_dbs_returned_unchanged_when_postgres_absent() -> None:
+    adapter, engine = _adapter_with_db_listing(["SAP", "analytics", "warehouse_prod"])
+    assert adapter.list_databases(engine) == ["SAP", "analytics", "warehouse_prod"]


### PR DESCRIPTION
## Summary

User report: `/history-store enable` against a PostgreSQL profile connected to the `SAP` database showed both `SAP` and `postgres` in the "Where should the AMX schema live?" picker. Picking `postgres` (the empty maintenance DB that ships with every PG install) put the AMX schema somewhere invisible from the user's main connection — a footgun.

`PostgreSQLAdapter.list_databases` now drops `postgres` when other databases exist. The function's docstring already claimed this behavior — it just wasn't implemented (the SQL only filtered template DBs, never `postgres` itself).

On a truly fresh server with **only** `postgres`, it remains the sole option — bootstrap has to pick something — and `_pick_target_database` now labels it `(maintenance DB — empty by default)` via `ask_choice`'s `descriptions` parameter so the user knows what they're agreeing to.

Three regression tests pin the contract:

- `test_postgres_dropped_when_other_dbs_exist`
- `test_postgres_kept_when_it_is_the_only_db`
- `test_user_dbs_returned_unchanged_when_postgres_absent`

## Test plan

- [x] `pytest -q` — 560 passed (557 + 3 new), 19 deselected
- [ ] `/history-store enable` against a PG profile with multiple user DBs — confirm `postgres` no longer appears in the picker
- [ ] `/history-store enable` against a fresh PG (only `postgres`) — confirm it's labeled `(maintenance DB — empty by default)`
