### PR TITLE
chore(release): publish under PyPI distribution name 'amx-cli'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: Lint & format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -35,8 +35,8 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -57,8 +57,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -77,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install build
@@ -89,7 +89,7 @@ jobs:
         run: |
           python -m pip install twine
           twine check dist/*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/amx
+      url: https://pypi.org/p/amx-cli
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install build tooling
@@ -35,7 +35,7 @@ jobs:
             echo "Tag ($tag) does not match pyproject version ($version)" >&2
             exit 1
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -50,7 +50,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -64,10 +64,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/amx-banner.png" alt="AMX — Agentic Metadata Extractor" width="760">
+  <img src="https://raw.githubusercontent.com/omeryasirkucuk/amx/main/docs/assets/amx-banner.png" alt="AMX — Agentic Metadata Extractor" width="760">
 </p>
 
 <p align="center">
@@ -16,7 +16,7 @@
   ·
   <a href="https://omeryasirkucuk.github.io/amx-docs/getting-started/quickstart/">Quickstart</a>
   ·
-  <a href="./CHANGELOG.md">Changelog</a>
+  <a href="https://github.com/omeryasirkucuk/amx/blob/main/CHANGELOG.md">Changelog</a>
   ·
   <a href="https://github.com/omeryasirkucuk/amx/issues">Issues</a>
 </p>
@@ -30,10 +30,10 @@ Five minutes from `pip install` to your first reviewed description. **Ten suppor
 ## Install
 
 ```bash
-pip install amx
+pip install amx-cli
 ```
 
-Requires Python 3.10+. See the [installation guide](https://omeryasirkucuk.github.io/amx-docs/getting-started/installation/) for prerequisites, source builds, and where AMX writes config / history / logs.
+The PyPI distribution is `amx-cli`; the import package is `amx` (`import amx`). Requires Python 3.10+. See the [installation guide](https://omeryasirkucuk.github.io/amx-docs/getting-started/installation/) for prerequisites, source builds, and where AMX writes config / history / logs.
 
 ## Quick start
 
@@ -83,14 +83,14 @@ Provider-specific guides (including OpenAI / Anthropic Batch mode and local-mode
 
 ## Documentation
 
-Full user, operator, and contributor docs live at **[omeryasirkucuk.github.io/amx-docs](https://omeryasirkucuk.github.io/amx-docs/)** — concepts, the slash-command map, configuration, data sources, collaboration, troubleshooting, and the [Python API](https://omeryasirkucuk.github.io/amx-docs/api/reference/) for headless use. Release notes are in [`CHANGELOG.md`](./CHANGELOG.md) and on the [GitHub Releases page](https://github.com/omeryasirkucuk/amx/releases).
+Full user, operator, and contributor docs live at **[omeryasirkucuk.github.io/amx-docs](https://omeryasirkucuk.github.io/amx-docs/)** — concepts, the slash-command map, configuration, data sources, collaboration, troubleshooting, and the [Python API](https://omeryasirkucuk.github.io/amx-docs/api/reference/) for headless use. Release notes are in [`CHANGELOG.md`](https://github.com/omeryasirkucuk/amx/blob/main/CHANGELOG.md) and on the [GitHub Releases page](https://github.com/omeryasirkucuk/amx/releases).
 
 ## Contributing & support
 
-- [Contributing guide](./CONTRIBUTING.md) — development setup, branching, commit format, release process
-- [Security policy](./SECURITY.md) — how to report a vulnerability
+- [Contributing guide](https://github.com/omeryasirkucuk/amx/blob/main/CONTRIBUTING.md) — development setup, branching, commit format, release process
+- [Security policy](https://github.com/omeryasirkucuk/amx/blob/main/SECURITY.md) — how to report a vulnerability
 - [Open an issue](https://github.com/omeryasirkucuk/amx/issues) — bugs, questions, feature requests
 
 ## License
 
-Apache-2.0 — see [`LICENSE`](./LICENSE).
+Apache-2.0 — see [`LICENSE`](https://github.com/omeryasirkucuk/amx/blob/main/LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "amx"
+name = "amx-cli"
 version = "0.12.0"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
@@ -72,6 +72,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/omeryasirkucuk/amx"
+Documentation = "https://omeryasirkucuk.github.io/amx-docs/"
 Repository = "https://github.com/omeryasirkucuk/amx"
 Issues = "https://github.com/omeryasirkucuk/amx/issues"
 Changelog = "https://github.com/omeryasirkucuk/amx/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

Prepare the repo for the first PyPI release. The bare `amx` name on PyPI is taken by an unrelated 0.0.0 placeholder (owner `ppak10`, last published 2026-04-03), so we publish under **`amx-cli`**. The import package stays `amx` — users do `pip install amx-cli` then `import amx`, which is standard practice when distribution name and import name diverge.

### Changes

- **`pyproject.toml`**: `name = "amx"` → `name = "amx-cli"`. Add `Documentation = "https://omeryasirkucuk.github.io/amx-docs/"` URL.
- **`.github/workflows/release.yml`**: PyPI environment URL `https://pypi.org/p/amx` → `https://pypi.org/p/amx-cli`.
- **`README.md`**:
  - `pip install amx` → `pip install amx-cli`, with a one-line note explaining the dist/import name split.
  - Banner image src and all relative repo links (`LICENSE`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`) rewritten to absolute `github.com` / `raw.githubusercontent.com` URLs so the README renders correctly on the PyPI project page (`long_description`).

### Verification

Local dry-run with `python -m build` + `twine check`:
- `amx_cli-0.12.0.tar.gz` — PASSED
- `amx_cli-0.12.0-py3-none-any.whl` — PASSED

Same checks the release workflow runs, so the README's `long_description` is confirmed PyPI-renderable.

## Out of scope (do these AFTER merging this PR)

1. Configure a **Pending Publisher** on PyPI (https://pypi.org/manage/account/publishing/) with project `amx-cli`, owner `omeryasirkucuk`, repo `amx`, workflow `release.yml`, environment `pypi`.
2. Tag and push: `git tag v0.12.0 && git push origin v0.12.0` — `release.yml` then builds, validates, publishes via OIDC, and creates the GitHub Release.
