### PR TITLE
fix(windows,databricks): cross-platform launch + tolerant Databricks host input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — Cross-platform: AMX no longer crashes on first launch on Windows
+
+`amx` crashed immediately on Windows with
+`AttributeError: module 'signal' has no attribute 'SIGWINCH'`. The
+interactive session unconditionally captured `signal.SIGWINCH` to
+defend against `prompt_toolkit` installing its own resize handler, but
+`SIGWINCH` is POSIX-only — Windows raises on attribute access. The
+save/restore is now guarded with `getattr(signal, "SIGWINCH", None)`,
+so the session starts on Linux/macOS/Windows alike. Linux/macOS
+behaviour is unchanged.
+
+### Fixed — Pasting the full Databricks workspace URL no longer crashes schema listing
+
+When a user pasted the full workspace URL into the host prompt
+(`https://dbc-xxx.cloud.databricks.com/`), the SQLAlchemy URL builder
+produced `databricks://token:xxx@host/:443`, which then failed with
+`invalid literal for int() with base 10: ''` the moment the user
+listed schemas — because the URL parser tried to read the empty string
+between `/:` and the rest as a port number.
+
+Fix is layered:
+
+1. `_normalize_db_host()` strips `https://`/`http://`, surrounding
+   whitespace, and any trailing path component down to the bare
+   hostname. Applied at the wizard prompt for immediate feedback.
+2. `DBConfig.url` for the Databricks backend re-normalises the host
+   defensively, so existing configs already on disk with a slash in
+   the host self-heal on the next run without requiring the user to
+   re-enter their workspace URL.
+
+`test_normalize_db_host_strips_scheme_and_trailing_slash` and
+`test_databricks_url_normalizes_host_with_trailing_slash` lock the
+contract.
+
 ### Fixed — /history-store enable no longer offers the empty `postgres` maintenance DB
 
 When bootstrapping AMX onto a PostgreSQL profile, the database picker

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 __all__ = [
     "AMXApplication",

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -8,7 +8,13 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from amx.config import PROFILING_MODES, SUPPORTED_BACKENDS, AMXConfig, DBConfig
+from amx.config import (
+    PROFILING_MODES,
+    SUPPORTED_BACKENDS,
+    AMXConfig,
+    DBConfig,
+    _normalize_db_host,
+)
 from amx.utils.console import (
     ask,
     ask_choice,
@@ -490,6 +496,10 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             required=True,
             allow_clear=False,
         )
+        # Accept the full workspace URL too — strip scheme + trailing
+        # slash so the SQLAlchemy URL builder doesn't choke on
+        # ``host/:443`` later.
+        host = _normalize_db_host(host)
         http_path = _ask_update_text(
             "SQL warehouse HTTP path (e.g. /sql/1.0/warehouses/abc1234567890)",
             defaults.http_path,

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -1076,7 +1076,12 @@ def run_interactive_session(
     search_cmd_heads = _registry_cmd_heads("search") | frozenset({"embeddings", "embedding"})
     history_cmd_heads = _registry_cmd_heads("history")
 
-    prev_sigwinch = signal.getsignal(signal.SIGWINCH)
+    # SIGWINCH (terminal resize) is POSIX-only — Windows raises
+    # AttributeError on signal.SIGWINCH. Guard so the interactive session
+    # starts on Windows; the save/restore is purely defensive against
+    # prompt_toolkit installing its own handler.
+    _sigwinch = getattr(signal, "SIGWINCH", None)
+    prev_sigwinch = signal.getsignal(_sigwinch) if _sigwinch is not None else None
 
     def _toolbar() -> HTML:
         ns = namespace or "root"
@@ -1314,4 +1319,5 @@ def run_interactive_session(
                 else:
                     os.environ["AMX_SESSION_CHILD"] = previous
     finally:
-        signal.signal(signal.SIGWINCH, prev_sigwinch)
+        if _sigwinch is not None and prev_sigwinch is not None:
+            signal.signal(_sigwinch, prev_sigwinch)

--- a/amx/config.py
+++ b/amx/config.py
@@ -67,6 +67,27 @@ _LEGACY_DATABASE_DEFAULTS: frozenset[tuple[str, str]] = frozenset(
 )
 
 
+def _normalize_db_host(raw: str | None) -> str:
+    """Strip URL scheme, surrounding whitespace, and trailing path/slash from a DB host.
+
+    Users routinely paste full workspace URLs like
+    ``https://dbc-xxx.cloud.databricks.com/`` into a "host" prompt. The
+    Databricks SQL connector and SQLAlchemy URL builder both want the
+    bare hostname — anything else turns ``host:443`` into ``host/:443``
+    and the SQLAlchemy URL parser then tries ``int("")`` for the port.
+    """
+    host = (raw or "").strip()
+    if not host:
+        return ""
+    for scheme in ("https://", "http://"):
+        if host.lower().startswith(scheme):
+            host = host[len(scheme) :]
+            break
+    # Drop any path component the user accidentally included.
+    host = host.split("/", 1)[0]
+    return host.strip()
+
+
 def has_legacy_database_default(db: DBConfig) -> bool:
     """Return True when *db* still carries the historical ``database='SAP'`` default.
 
@@ -514,7 +535,15 @@ class DBConfig(_ObservableConfig):
 
         if self.backend == "databricks":
             token = self.access_token or self.password
-            url = f"databricks://token:{quote_plus(token)}@{self.host}:443"
+            # Defensive normalization: users routinely paste the
+            # full workspace URL ("https://dbc-xxx.cloud.databricks.com/")
+            # — without stripping the scheme and trailing slash, the
+            # resulting "databricks://token:xxx@https://host/:443" URL
+            # makes SQLAlchemy try int("") for the port and crash with
+            # "invalid literal for int() with base 10: ''" the moment
+            # you list schemas.
+            host = _normalize_db_host(self.host)
+            url = f"databricks://token:{quote_plus(token)}@{host}:443"
             if self.database:
                 url += f"/{quote_plus(self.database)}"
             params = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx-cli"
-version = "0.12.0"
+version = "0.12.1"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_db_multi_backend_expansion.py
+++ b/tests/test_db_multi_backend_expansion.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import pytest
 
-from amx.config import DBConfig, _db_from_mapping, _db_to_mapping
+from amx.config import DBConfig, _db_from_mapping, _db_to_mapping, _normalize_db_host
 from amx.db.adapters import SUPPORTED_BACKENDS, get_adapter
 from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
 
@@ -205,6 +205,35 @@ def test_clickhouse_url_secure_picks_https_and_8443():
 def test_clickhouse_url_insecure_picks_http_and_8123():
     db = DBConfig(backend="clickhouse", host="ch.example.com", user="default")
     assert db.url.startswith("clickhouse+http://default:@ch.example.com:8123")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("dbc-xxx.cloud.databricks.com", "dbc-xxx.cloud.databricks.com"),
+        ("https://dbc-xxx.cloud.databricks.com", "dbc-xxx.cloud.databricks.com"),
+        ("https://dbc-xxx.cloud.databricks.com/", "dbc-xxx.cloud.databricks.com"),
+        ("http://dbc-xxx.cloud.databricks.com/sql/", "dbc-xxx.cloud.databricks.com"),
+        ("  dbc-xxx.cloud.databricks.com  ", "dbc-xxx.cloud.databricks.com"),
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_normalize_db_host_strips_scheme_and_trailing_slash(raw, expected):
+    assert _normalize_db_host(raw) == expected
+
+
+def test_databricks_url_normalizes_host_with_trailing_slash():
+    """Regression: pasting the full workspace URL with a trailing slash
+    used to crash schema listing with ``invalid literal for int() with
+    base 10: ''`` because ``host:443`` became ``host/:443``."""
+    db = DBConfig(
+        backend="databricks",
+        host="https://dbc-xxx.cloud.databricks.com/",
+        access_token="tok",
+    )
+    assert "@dbc-xxx.cloud.databricks.com:443" in db.url
+    assert "https://" not in db.url.split("@", 1)[1]
 
 
 def test_duckdb_url_uses_path():


### PR DESCRIPTION
## Summary
- Windows: guard `signal.SIGWINCH` (POSIX-only) so `amx` no longer crashes on first launch with `AttributeError: module 'signal' has no attribute 'SIGWINCH'`.
- Databricks: pasting the full workspace URL (`https://dbc-xxx.cloud.databricks.com/`) used to crash schema listing with `invalid literal for int() with base 10: ''`. Add `_normalize_db_host()` to strip scheme + trailing path; apply at the wizard prompt **and** inside `DBConfig.url` so on-disk configs self-heal.
- Bump to 0.12.1.

## Test plan
- [x] `pytest tests/ -q` (548 passed)
- [x] New regression tests: `test_normalize_db_host_strips_scheme_and_trailing_slash`, `test_databricks_url_normalizes_host_with_trailing_slash`
- [x] Smoke: `from amx.cli_support import session` imports clean
- [x] Smoke: `DBConfig(backend='databricks', host='https://dbc-xxx.cloud.databricks.com/', access_token='tok').url` → `databricks://token:tok@dbc-xxx.cloud.databricks.com:443`
- [x] Simulated Windows path: `getattr(signal, "SIGWINCH", None)` returns `None` cleanly
