### PR TITLE
fix(install,doctor,databricks): correct PyPI name + actionable missing-driver UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — Install hints now reference the correct PyPI distribution name (`amx-cli`)
+
+The package was renamed to `amx-cli` on PyPI in 0.12.0 (PR #93), but a
+dozen runtime hints, error messages, and docstrings still told users
+to run `pip install -U amx` or `pip install 'amx[databricks]'`.
+`pip install -U amx` resolves to a *different* package on PyPI — so
+following the hint silently did nothing for `amx-cli` users and could
+even pull a stranger's package onto their machine.
+
+Swept across `amx/cli.py`, `amx/cli_support/commands/doctor.py`,
+`amx/cli_support/commands/embeddings.py`, `amx/db/adapters/__init__.py`,
+`amx/db/adapters/databricks.py`, `amx/db/adapters/snowflake.py`,
+`amx/db/adapters/bigquery.py`, `amx/search/embeddings.py`, and
+`amx/codebase/analyzer.py`. Every install instruction now reads
+`pip install 'amx-cli[<extra>]'`.
+
+### Fixed — Wizard fails fast when an optional database driver is missing
+
+`/add-db-profile` used to let a user save a Databricks (or Snowflake,
+BigQuery, …) profile on a fresh `pip install amx-cli` install with no
+extras, then crash on first `/edit` or `/run` with the not-very-
+actionable message *"databricks-sqlalchemy is required"*. The wizard
+now probes the chosen backend's driver immediately after the user
+picks it and prints a single warning with the exact `pip install
+'amx-cli[<extra>]'` command if the driver is missing — non-fatal, so
+air-gapped users can still capture the profile and install the driver
+later.
+
+### Fixed — `amx doctor` on Windows: detect `amx.exe`, gate driver-required on the active backend
+
+Two doctor regressions surfaced together on the same Windows install:
+
+1. **`amx on PATH — (not found)`** even though the user was running
+   `amx`. The PATH walk only looked for the bare `amx` filename, so
+   Windows installs (which ship `amx.exe` / `amx.cmd`) reported a
+   false negative. The walk now considers `.exe` / `.cmd` / `.bat`
+   suffixes on Windows and falls back to `shutil.which("amx")` when
+   the manual scan misses.
+2. **`✓ Databricks driver — not installed (optional)`** when the
+   active profile was Databricks. Reporting the very driver the
+   active profile depends on as an optional info line is actively
+   misleading. `_check_optional_deps` now consults `cfg.db.backend`
+   and promotes the matching driver line to a hard `✗` failure with
+   a `pip install 'amx-cli[<extra>]'` hint.
+
+### Fixed — Databricks catalog picker surfaces missing-driver as actionable hint
+
+When the Databricks driver wasn't installed, `db.list_catalogs()` —
+which lazy-builds the SQLAlchemy engine — raised an `ImportError`
+that the connector and the catalog picker both swallowed with a bare
+`except Exception: return []`. The user then saw the misleading
+*"`SHOW CATALOGS` returned nothing — set `/db` profile's catalog
+explicitly"* warning even though their workspace had catalogs;
+they were just connecting through a workspace they'd never installed
+the driver for. `Connector.list_catalogs` now re-raises `ImportError`
+specifically; the picker catches it and shows the install hint
+instead of falling through to the legacy schema inspector path.
+
 ### Fixed — Cross-platform: AMX no longer crashes on first launch on Windows
 
 `amx` crashed immediately on Windows with

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 __all__ = [
     "AMXApplication",

--- a/amx/cli.py
+++ b/amx/cli.py
@@ -289,7 +289,7 @@ def main(ctx: click.Context, cfg_path: str | None, debug: bool) -> None:
         # silently drop on the next save (ghost-profile incident).
         error(str(exc))
         info(
-            "Run `pip install --upgrade amx` (or your install path's equivalent), "
+            "Run `pip install --upgrade amx-cli` (or your install path's equivalent), "
             "then re-run. If you must stay on this AMX, restore the previous "
             "config from `~/.amx/config.yml.bak-*` if one exists, or back up "
             "and delete `~/.amx/config.yml` to start fresh."

--- a/amx/cli_support/catalog_picker.py
+++ b/amx/cli_support/catalog_picker.py
@@ -69,6 +69,13 @@ def ensure_catalog_selected(
     try:
         with step_spinner("Listing catalogs"):
             catalogs = list(db.list_catalogs())  # type: ignore[attr-defined]
+    except ImportError as exc:
+        # Missing optional driver — surface the actionable install hint
+        # the adapter already attached to the ImportError instead of
+        # falling through to the misleading "SHOW CATALOGS returned
+        # nothing" path.
+        warn(str(exc))
+        return ""
     except Exception as exc:
         log.debug("list_catalogs failed: %s", exc)
         catalogs = []

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -39,6 +39,44 @@ class DBConnectAttempt:
     detail: str = ""
 
 
+# (label, importable module) — extras whose presence we probe up front
+# in the wizard. Keep in sync with ``[project.optional-dependencies]``
+# entries in ``pyproject.toml``.
+_BACKEND_DRIVER_PROBES: dict[str, tuple[str, str]] = {
+    "postgresql": ("postgresql", "psycopg2"),
+    "snowflake": ("snowflake", "snowflake.connector"),
+    "databricks": ("databricks", "databricks.sql"),
+    "bigquery": ("bigquery", "google.cloud.bigquery"),
+    "mysql": ("mysql", "pymysql"),
+    "oracle": ("oracle", "oracledb"),
+    "mssql": ("mssql", "pyodbc"),
+    "redshift": ("redshift", "redshift_connector"),
+    "clickhouse": ("clickhouse", "clickhouse_connect"),
+    "duckdb": ("duckdb", "duckdb"),
+}
+
+
+def _warn_if_backend_driver_missing(backend: str) -> None:
+    """Emit an actionable warning if *backend*'s optional extra is missing.
+
+    Non-fatal: the user can still complete the wizard (helpful for an
+    air-gapped environment where you want to capture the profile now
+    and install the driver later). The same hint shows up later in
+    /doctor and at engine-creation time.
+    """
+    probe = _BACKEND_DRIVER_PROBES.get(backend)
+    if not probe:
+        return
+    extra, module = probe
+    try:
+        __import__(module)
+    except ImportError:
+        warn(
+            f"The {backend!r} driver is not installed. To use this profile, run: "
+            f"pip install 'amx-cli[{extra}]'"
+        )
+
+
 def _ask_update_text(
     label: str,
     current: str = "",
@@ -366,6 +404,14 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             "duckdb": "Single-file or in-memory; no host/auth (analytical, embedded)",
         },
     )
+    # Probe for the chosen backend's optional driver up front. The
+    # wizard saving a Databricks profile on a fresh `pip install
+    # amx-cli` (no extras) used to succeed silently — the user only
+    # discovered the missing driver on first /edit, with the not-very-
+    # actionable message "databricks-sqlalchemy is required". Surfacing
+    # the install hint here means they can ^C, install the extra, and
+    # rerun before bothering to type credentials.
+    _warn_if_backend_driver_missing(backend)
 
     # Truly-blank defaults for a brand-new profile or after a cross-
     # backend reset. ``DBConfig()`` carries the dataclass-level

--- a/amx/cli_support/commands/doctor.py
+++ b/amx/cli_support/commands/doctor.py
@@ -50,19 +50,37 @@ class CheckResult:
 
 
 def _check_amx_on_path() -> CheckResult:
-    """Detect multiple ``amx`` binaries on PATH (the 0.3.1 ghost-profile bug)."""
+    """Detect multiple ``amx`` binaries on PATH (the 0.3.1 ghost-profile bug).
+
+    Cross-platform: on POSIX the file is named ``amx``; on Windows it's
+    ``amx.exe`` (and pip also drops ``amx.cmd`` / ``amx-script.py``).
+    The earlier loop only looked for the bare ``amx`` filename and
+    therefore reported "(not found)" on a perfectly healthy Windows
+    install. Use ``shutil.which`` for the canonical resolution and a
+    cross-platform PATH walk to surface duplicates.
+    """
+    primary = shutil.which("amx")
+    # Windows lookups via PATHEXT also resolve ``amx.exe``/``amx.cmd``;
+    # ``shutil.which("amx")`` already does that for us.
     path_env = os.environ.get("PATH", "")
-    seen: list[str] = []
+    candidates: list[str] = []
+    is_windows = os.name == "nt"
+    suffixes = (".exe", ".cmd", ".bat", "") if is_windows else ("",)
     for directory in path_env.split(os.pathsep):
         if not directory:
             continue
-        candidate = Path(directory) / "amx"
-        if candidate.is_file() and os.access(candidate, os.X_OK):
-            seen.append(str(candidate))
+        for suffix in suffixes:
+            candidate = Path(directory) / f"amx{suffix}"
+            if candidate.is_file():
+                # On POSIX additionally require the executable bit; on
+                # Windows file extension already gates executability.
+                if is_windows or os.access(candidate, os.X_OK):
+                    candidates.append(str(candidate))
+                    break
     # Dedup while preserving order — the first entry is what `which amx` returns.
     deduped: list[str] = []
     seen_set: set[str] = set()
-    for entry in seen:
+    for entry in candidates:
         # Resolve to absolute physical path to detect symlink shadowing.
         try:
             real = str(Path(entry).resolve())
@@ -71,13 +89,21 @@ def _check_amx_on_path() -> CheckResult:
         if real not in seen_set:
             seen_set.add(real)
             deduped.append(entry)
+    if not deduped and primary:
+        # ``shutil.which`` succeeded but our manual scan missed it
+        # (e.g. PATH entry contains an env var the loop didn't expand).
+        # Trust ``shutil.which`` over our walk so the user doesn't see
+        # a false "(not found)" while the binary they just ran works.
+        deduped = [primary]
     if len(deduped) <= 1:
         location = deduped[0] if deduped else "(not found)"
         return CheckResult(
             name="amx on PATH",
             ok=bool(deduped),
             detail=location,
-            hint="" if deduped else "Reinstall AMX (`pip install amx` or `pipx install amx`).",
+            hint=""
+            if deduped
+            else "Reinstall AMX (`pip install amx-cli` or `pipx install amx-cli`).",
         )
     return CheckResult(
         name="amx on PATH",
@@ -158,45 +184,68 @@ def _check_config_file(cfg: AMXConfig) -> CheckResult:
     )
 
 
-def _check_optional_deps() -> list[CheckResult]:
-    """Probe optional backend deps so users know what's available before they need it."""
-    backends: tuple[tuple[str, str, str], ...] = (
-        # (label, module to import, install hint)
+def _check_optional_deps(active_backend: str | None = None) -> list[CheckResult]:
+    """Probe optional backend deps so users know what's available before they need it.
+
+    When *active_backend* matches one of the database backends the check
+    is promoted from "optional info" to "required" — the active profile
+    cannot work without its driver, so reporting ``✓ not installed
+    (optional)`` for the very thing the user is trying to use is
+    actively misleading.
+    """
+    # (label, backend key, module to import, install hint)
+    backends: tuple[tuple[str, str | None, str, str], ...] = (
         (
             "BigQuery driver",
+            "bigquery",
             "google.cloud.bigquery",
-            "pip install 'amx[bigquery]' (or: pip install google-cloud-bigquery)",
+            "pip install 'amx-cli[bigquery]'",
         ),
         (
             "Snowflake driver",
+            "snowflake",
             "snowflake.connector",
-            "pip install 'amx[snowflake]' (or: pip install snowflake-connector-python)",
+            "pip install 'amx-cli[snowflake]'",
         ),
         (
             "Databricks driver",
+            "databricks",
             "databricks.sql",
-            "pip install 'amx[databricks]' (or: pip install databricks-sql-connector)",
+            "pip install 'amx-cli[databricks]'",
         ),
         (
             "OS keyring",
+            None,
             "keyring",
             "pip install keyring (secrets fall back to plaintext YAML without it)",
         ),
     )
     results: list[CheckResult] = []
-    for label, mod, hint in backends:
+    for label, backend_key, mod, hint in backends:
+        is_required = backend_key is not None and backend_key == active_backend
         try:
             __import__(mod)
-            results.append(CheckResult(name=label, ok=True, detail="installed"))
+            detail = "installed (required for active profile)" if is_required else "installed"
+            results.append(CheckResult(name=label, ok=True, detail=detail))
         except ImportError:
-            results.append(
-                CheckResult(
-                    name=label,
-                    ok=True,  # Optional — surface as info, not error.
-                    detail="not installed (optional)",
-                    hint=hint,
+            if is_required:
+                results.append(
+                    CheckResult(
+                        name=label,
+                        ok=False,
+                        detail=f"not installed — required for active '{active_backend}' profile",
+                        hint=hint,
+                    )
                 )
-            )
+            else:
+                results.append(
+                    CheckResult(
+                        name=label,
+                        ok=True,  # Optional — surface as info, not error.
+                        detail="not installed (optional)",
+                        hint=hint,
+                    )
+                )
     return results
 
 
@@ -314,7 +363,10 @@ def run_doctor(cfg: AMXConfig, *, skip_network: bool = False) -> int:
     results.append(_check_amx_on_path())
     results.append(_check_config_dir(cfg))
     results.append(_check_config_file(cfg))
-    results.extend(_check_optional_deps())
+    active_backend: str | None = None
+    if cfg.active_db_profile and cfg.db_profiles:
+        active_backend = getattr(cfg.db, "backend", None) or None
+    results.extend(_check_optional_deps(active_backend))
     if not skip_network:
         results.append(_check_active_db_profile(cfg))
         results.append(_check_active_llm_profile(cfg))

--- a/amx/cli_support/commands/embeddings.py
+++ b/amx/cli_support/commands/embeddings.py
@@ -85,7 +85,7 @@ def _print_current(cfg: AMXConfig) -> None:
     if emb.kind == "sentence_transformers":
         info("Local sentence-transformers (offline, stronger than MiniLM).")
         info(f"  Model: {emb.model or '(unset — required)'}")
-        info('Requires `pip install "amx[local-embeddings]"`.')
+        info('Requires `pip install "amx-cli[local-embeddings]"`.')
         return
     info(f"Kind: {emb.kind}")
     info(f"Model: {emb.model or '(unset)'}")
@@ -157,7 +157,7 @@ def _set_sentence_transformers(cfg: AMXConfig, rest: list[str]) -> None:
     configure_from_amx_config(cfg, on_warning=warn)
     success(f"Embeddings switched to local sentence-transformers / {model}.")
     info(
-        'Requires `pip install "amx[local-embeddings]"` if you have not '
+        'Requires `pip install "amx-cli[local-embeddings]"` if you have not '
         "already done so. The model will be downloaded on first /search use."
     )
     info("Run /rebuild (inside /search) to re-embed the catalog with the new provider.")

--- a/amx/codebase/analyzer.py
+++ b/amx/codebase/analyzer.py
@@ -171,7 +171,7 @@ def _scan_sqlglot_sql_file(
     references: dict[str, list[CodeReference]],
     external_mentions: dict[str, list[CodeReference]],
 ) -> None:
-    """Optional richer SQL table mentions when ``sqlglot`` is installed (``pip install 'amx[code-intel]'``)."""
+    """Optional richer SQL table mentions when ``sqlglot`` is installed (``pip install 'amx-cli[code-intel]'``)."""
     try:
         import sqlglot
         from sqlglot import exp

--- a/amx/db/adapters/__init__.py
+++ b/amx/db/adapters/__init__.py
@@ -44,7 +44,7 @@ _BACKEND_EXTRAS: dict[str, str] = {
 class MissingDriverError(ImportError):
     """Raised when a backend's optional driver dependency is not installed.
 
-    Surfaces the concrete `pip install amx[<extra>]` remediation so the
+    Surfaces the concrete `pip install amx-cli[<extra>]` remediation so the
     user is never left staring at a generic ``ModuleNotFoundError``.
     """
 
@@ -98,7 +98,7 @@ def _import_adapter(backend: str) -> type[DatabaseAdapter]:
         extra = _BACKEND_EXTRAS.get(backend, backend)
         raise MissingDriverError(
             f"The {backend!r} backend requires its optional driver. Install it with:\n"
-            f"    pip install amx[{extra}]\n"
+            f"    pip install 'amx-cli[{extra}]'\n"
             f"(Underlying import error: {exc})"
         ) from exc
     raise ValueError(
@@ -130,7 +130,7 @@ def get_adapter(cfg: DBConfig) -> DatabaseAdapter:
     Imports the adapter module on demand so users only pay the driver
     cost for the backends they actually use. Missing-driver errors are
     translated into :class:`MissingDriverError` with a concrete
-    ``pip install amx[<extra>]`` hint.
+    ``pip install amx-cli[<extra>]`` hint.
     """
     _ensure_registry()
     backend = getattr(cfg, "backend", "postgresql") or "postgresql"

--- a/amx/db/adapters/bigquery.py
+++ b/amx/db/adapters/bigquery.py
@@ -47,7 +47,7 @@ class BigQueryAdapter(DatabaseAdapter):
         except ImportError as exc:
             raise ImportError(
                 "sqlalchemy-bigquery is required for the BigQuery backend. "
-                "Reinstall AMX: pip install -U amx"
+                "Install the extra: pip install 'amx-cli[bigquery]'"
             ) from exc
         return create_engine(self.cfg.url, pool_pre_ping=True)
 

--- a/amx/db/adapters/databricks.py
+++ b/amx/db/adapters/databricks.py
@@ -76,7 +76,7 @@ class DatabricksAdapter(DatabaseAdapter):
         except ImportError as exc:
             raise ImportError(
                 "databricks-sqlalchemy is required for the Databricks backend. "
-                "Reinstall AMX: pip install -U amx"
+                "Install the extra: pip install 'amx-cli[databricks]'"
             ) from exc
         connect_args: dict[str, object] = {
             "user_agent_entry": "amx",
@@ -102,7 +102,7 @@ class DatabricksAdapter(DatabaseAdapter):
         except ImportError as exc:  # pragma: no cover
             raise ImportError(
                 "databricks-sql-connector is required for the Databricks backend. "
-                "Reinstall AMX: pip install -U amx"
+                "Install the extra: pip install 'amx-cli[databricks]'"
             ) from exc
 
         connect_args: dict[str, object] = {

--- a/amx/db/adapters/snowflake.py
+++ b/amx/db/adapters/snowflake.py
@@ -48,14 +48,14 @@ class SnowflakeAdapter(DatabaseAdapter):
             from sqlalchemy import create_engine
         except ImportError as exc:  # pragma: no cover
             raise ImportError(
-                "SQLAlchemy is required for Snowflake. Install with: pip install 'amx[snowflake]'"
+                "SQLAlchemy is required for Snowflake. Install with: pip install 'amx-cli[snowflake]'"
             ) from exc
         try:
             import snowflake.sqlalchemy  # noqa: F401 — registers dialect
         except ImportError as exc:
             raise ImportError(
                 "snowflake-sqlalchemy is required for the Snowflake backend. "
-                "Reinstall AMX: pip install -U amx"
+                "Install the extra: pip install 'amx-cli[snowflake]'"
             ) from exc
         return create_engine(self.cfg.url, pool_pre_ping=True)
 

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -270,9 +270,16 @@ class DatabaseConnector:
         catalog/schema/table hierarchy. Used by the manual-edit
         wizard on Databricks Unity Catalog so the user picks a
         catalog before the schema picker fires.
+
+        ``ImportError`` propagates so the missing-driver case (user
+        ran ``pip install amx-cli`` without ``[databricks]``) reaches
+        the catalog picker as an actionable hint instead of
+        masquerading as "empty workspace".
         """
         try:
             return list(self._adapter.list_catalogs(self.engine))
+        except ImportError:
+            raise
         except Exception:
             return []
 

--- a/amx/search/embeddings.py
+++ b/amx/search/embeddings.py
@@ -19,7 +19,7 @@ embedding providers wrapped as Chroma ``EmbeddingFunction`` instances:
 
 The ``sentence-transformers`` dependency is optional and only required
 for :class:`SentenceTransformerEmbedding`. Install via the
-``local-embeddings`` extra (``pip install 'amx[local-embeddings]'``).
+``local-embeddings`` extra (``pip install 'amx-cli[local-embeddings]'``).
 
 Use :func:`make_embedding_function` to build a provider from a config
 dict; it returns ``None`` for the MiniLM default so callers can pass
@@ -220,7 +220,7 @@ class SentenceTransformerEmbedding(EmbeddingFunction):
 
     Requires the ``local-embeddings`` extra::
 
-        pip install "amx[local-embeddings]"
+        pip install "amx-cli[local-embeddings]"
     """
 
     name = "sentence-transformers"
@@ -235,7 +235,7 @@ class SentenceTransformerEmbedding(EmbeddingFunction):
         except ImportError as exc:
             raise RuntimeError(
                 "sentence-transformers is not installed. "
-                'Install via `pip install "amx[local-embeddings]"`.'
+                'Install via `pip install "amx-cli[local-embeddings]"`.'
             ) from exc
         self._model_id = model
         self._st = SentenceTransformer(model)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx-cli"
-version = "0.12.1"
+version = "0.12.2"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_doctor_and_schema.py
+++ b/tests/test_doctor_and_schema.py
@@ -25,6 +25,7 @@ from amx.cli_support.commands.doctor import (
     CheckResult,
     _check_amx_on_path,
     _check_amx_version,
+    _check_optional_deps,
     _check_python_version,
     _render_results,
     run_doctor,
@@ -139,6 +140,58 @@ class DoctorPathConflictTests(unittest.TestCase):
                 result = _check_amx_on_path()
             self.assertFalse(result.ok)
             self.assertIn("Reinstall", result.hint)
+            # The hint must reference the live PyPI distribution name,
+            # not the legacy ``amx`` import name.
+            self.assertIn("amx-cli", result.hint)
+
+    def test_falls_back_to_shutil_which_when_walk_misses(self) -> None:
+        """``shutil.which`` is the canonical PATH resolver; when the
+        manual walk misses a hit (e.g. on Windows where binaries are
+        named ``amx.exe``) the result must still report success
+        instead of the false "(not found)" the pre-0.12.2 doctor
+        printed on a healthy Windows install."""
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_amx = str(Path(tmp) / "amx.exe")
+            with (
+                patch.dict(os.environ, {"PATH": tmp}, clear=True),
+                patch("amx.cli_support.commands.doctor.shutil.which", return_value=fake_amx),
+            ):
+                result = _check_amx_on_path()
+            self.assertTrue(result.ok, msg=result.detail)
+            self.assertIn("amx.exe", result.detail)
+
+
+class DoctorOptionalDepsActiveBackendGateTests(unittest.TestCase):
+    """The active DB profile's driver must be reported as REQUIRED,
+    not as a green ``optional`` line, so a fresh ``pip install
+    amx-cli`` user who set up Databricks doesn't see ``✓ Databricks
+    driver — not installed (optional)`` while the actual workflow
+    crashes the moment they try to use it."""
+
+    def test_databricks_driver_marked_required_when_active(self) -> None:
+        results = _check_optional_deps(active_backend="databricks")
+        databricks_check = next(r for r in results if r.name == "Databricks driver")
+        try:
+            import databricks.sql  # noqa: F401
+        except ImportError:
+            self.assertFalse(databricks_check.ok)
+            self.assertIn("required for active 'databricks' profile", databricks_check.detail)
+            self.assertIn("amx-cli[databricks]", databricks_check.hint)
+        else:
+            # Driver happens to be installed in the test environment —
+            # the line still gets the "required" tag instead of the
+            # plain "installed" wording.
+            self.assertTrue(databricks_check.ok)
+            self.assertIn("required", databricks_check.detail)
+
+    def test_other_backends_stay_optional(self) -> None:
+        results = _check_optional_deps(active_backend="postgresql")
+        # Postgres isn't in the optional-deps probe list (driver is
+        # plain ``psycopg2``), so the only thing we care about is that
+        # Databricks/Snowflake/BigQuery DON'T get demoted to required.
+        for r in results:
+            if r.name in {"Snowflake driver", "BigQuery driver", "Databricks driver"}:
+                self.assertNotIn("required for active", r.detail)
 
 
 class DoctorVersionAndPythonChecksTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
A fresh `pip install amx-cli` user setting up Databricks hit a wall of misleading errors. This PR fixes them comprehensively.

- **Wrong PyPI name everywhere.** Every `pip install -U amx` / `pip install 'amx[<extra>]'` hint now reads `pip install 'amx-cli[<extra>]'`. The package was renamed to `amx-cli` in 0.12.0; the old strings would silently install a *different* package on PyPI.
- **Wizard fail-fast.** `/add-db-profile` now probes the chosen backend's optional driver immediately after the user picks it and prints the exact install command if missing.
- **Doctor on Windows.** `amx on PATH — (not found)` was a false negative on Windows because the walk only matched the bare `amx` filename. Now considers `.exe`/`.cmd`/`.bat` and falls back to `shutil.which`.
- **Doctor active-backend gate.** `Databricks driver — not installed (optional)` is now a hard `✗` when the active profile is Databricks.
- **Catalog picker.** `Connector.list_catalogs` was swallowing the missing-driver `ImportError` with a bare `except`, so the user saw "SHOW CATALOGS returned nothing" instead of the actionable hint. Now `ImportError` propagates and the picker surfaces it.
- Bump to 0.12.2.

## Test plan
- [x] `pytest tests/ -q` (551 passed)
- [x] New tests: `test_falls_back_to_shutil_which_when_walk_misses`, `test_databricks_driver_marked_required_when_active`, `test_other_backends_stay_optional`
- [x] Existing PATH-conflict and renderer tests still pass
- [x] Grep across repo: no remaining `pip install -U amx` or `amx[<extra>]` strings
