### PR TITLE
fix(console,wizard,picker): kill Rich-markup bug-class + auto-install + universal pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,83 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — Console helpers no longer eat `[databricks]`-style substrings (the bug-class kill)
+
+`warn("pip install 'amx-cli[databricks]'")` rendered as
+`⚠ pip install 'amx-cli'`. Reason: `warn` (and `info`/`error`/
+`success`/`heading`) wrapped its arg in `[warning]…[/warning]` and
+handed the whole string to Rich, which then parsed the inner
+`[databricks]` as another (unknown) style tag and silently dropped it.
+Users copy-pasted the wrong command and concluded the package was
+broken.
+
+Fix: `amx/utils/console.py` now calls `rich.markup.escape` on the
+text body of every helper before splicing it into a Rich style. Every
+existing `pip install 'amx-cli[<extra>]'` hint, `[code-intel]`,
+`[local-embeddings]` line, etc., starts rendering correctly without
+any callsite needing to change.
+
+`tests/test_console_markup_safety.py` pins the contract for `warn`,
+`info`, `success`, `error`, `heading` — both the literal databricks
+wording from the user's bug report and the broader bug-class
+(intentional-looking `[bold]` / `[red]` substrings).
+
+### Added — Wizard auto-installs the missing backend driver
+
+When the user picks a backend in `/add-db-profile` whose optional
+extra isn't installed, AMX now asks one question:
+
+```
+ℹ  The 'databricks' backend driver isn't installed yet.
+?  Install it now via pip? [Y/n]: ▮
+```
+
+Default is **Y**. On Enter, AMX runs
+`sys.executable -m pip install 'amx-cli[<extra>]'` inline (pip's
+normal output streams to the user's terminal) and continues the
+wizard once the driver loads. The user never has to drop out of the
+wizard, look up the extras name, type the install command, and
+restart from scratch — the loop the 0.12.2 user reported as
+"şaka mı yapıyorsun?".
+
+`sys.executable -m pip` is always used (not bare `pip`) so the
+install lands in the same interpreter that's running AMX — the
+typical pip-on-PATH confusion (system pip vs venv pip) cannot bite.
+On non-zero exit, missing pip, or a still-failing import after the
+install, AMX falls back to the air-gapped path: print the manual
+command, continue the wizard, never strand the user.
+
+### Added — Universal runtime hierarchy picker for every 2-level backend
+
+Pre-0.12.3 only Databricks (catalog) and PostgreSQL (database) had a
+runtime picker. Snowflake, MySQL, Oracle, MSSQL, Redshift, and
+ClickHouse users with a profile that left `database` blank silently
+got empty listings with no clear way to choose at runtime.
+
+Three changes wire the picker universally:
+
+1. `ensure_database_selected` (`amx/cli_support/catalog_picker.py`)
+   drops its `{postgresql, snowflake}` whitelist. Any backend whose
+   adapter's `list_databases()` returns ≥1 entry now gets the picker.
+2. New `SnowflakeAdapter.list_databases` runs `SHOW DATABASES` and
+   filters Snowflake-managed DBs (`SNOWFLAKE`, `SNOWFLAKE_SAMPLE_DATA`)
+   when other DBs are visible — sandbox accounts that only have those
+   still see them.
+3. New `ensure_hierarchy_resolved` unified helper: catalog picker for
+   3-level backends (Databricks), database picker for 2-level
+   backends. `/edit`, `/run`, `/sync`, `/connect` all call this
+   single helper instead of branching themselves.
+
+`Connector.list_databases` also propagates `ImportError` (mirroring
+the `list_catalogs` fix from 0.12.2 PR #96), so the missing-driver
+case surfaces the actionable extras hint instead of being swallowed
+into "no databases visible".
+
+`tests/test_runtime_pickers.py` covers all 7 2-level backends, the
+already-pinned-skip case, the empty-list-silent case, the
+ImportError-surfaces-the-hint case, and the unified helper's
+catalog/database dispatch.
+
 ### Fixed — Install hints now reference the correct PyPI distribution name (`amx-cli`)
 
 The package was renamed to `amx-cli` on PyPI in 0.12.0 (PR #93), but a

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 
 __all__ = [
     "AMXApplication",

--- a/amx/cli_support/catalog_picker.py
+++ b/amx/cli_support/catalog_picker.py
@@ -125,14 +125,13 @@ def ensure_catalog_selected(
 
 def warn_when_database_unpinned(db: Any) -> None:
     """One-line hint when a 2-level backend has no database pinned AND
-    no runtime picker is wired up for it.
+    the runtime picker found nothing to offer.
 
-    For PostgreSQL the runtime picker (:func:`ensure_database_selected`)
-    now resolves the unpinned case interactively, so this warning only
-    fires for backends we haven't built a picker for yet (Snowflake at
-    time of writing). When a picker IS available the caller should
-    invoke :func:`ensure_database_selected` first; if the user picks
-    one, this warning becomes a silent no-op.
+    Since 0.12.3 :func:`ensure_database_selected` runs for every 2-level
+    backend, so this warning is now a "the picker tried, the picker
+    couldn't help" terminal hint rather than a "we never built the
+    picker" hint. Stays as a safety net for the case where the user
+    cancelled the picker, or no databases are visible to the role.
     """
     if bool(getattr(db, "supports_catalogs", lambda: False)()):
         # 3-level backend — catalog picker already covered the case.
@@ -144,39 +143,40 @@ def warn_when_database_unpinned(db: Any) -> None:
     database = str(getattr(cfg, "database", "") or "")
     if database:
         return
-    if backend not in {"postgresql", "snowflake"}:
-        return
-    # Postgres now has the runtime picker. If we still got here without
-    # a database it means the picker was offered and the user
-    # cancelled, OR we're on a backend (snowflake) where the picker
-    # isn't wired yet. Either way the user needs to pin one.
     warn(f"No {backend} database selected — listings will be empty. Use /edit to pin one.")
 
 
 def ensure_database_selected(db: Any) -> str:
     """Prompt the user to pick a database when a 2-level backend has none pinned.
 
-    Mirrors :func:`ensure_catalog_selected` but for the
-    PostgreSQL / Snowflake server-with-multiple-databases case (the
-    user-reported "system can't see my databases" flow on 2026-05-02).
-    The flow is:
+    Generalised in 0.12.3: the previous version short-circuited for any
+    backend outside ``{postgresql, snowflake}``, which left MySQL,
+    Oracle, MSSQL, Redshift, and ClickHouse users staring at empty
+    listings with no clear way to pick a database at runtime. The new
+    rule is duck-typed: any backend whose adapter overrides
+    :meth:`DatabaseAdapter.list_databases` to return ≥1 entry gets the
+    picker. Backends without a ``list_databases`` override (DuckDB,
+    BigQuery — those use a different concept) silently return ``""``
+    so flows that call this unconditionally don't pay any cost.
 
-    1. Connect to whatever database the profile resolved to (the
-       ``postgres`` system fallback when blank).
-    2. ``SELECT datname FROM pg_database WHERE datistemplate = false``
-       (or the snowflake equivalent — adapter decides).
+    Flow:
+
+    1. Skip when the active profile already has ``cfg.database`` set,
+       or when the backend is 3-level (``supports_catalogs() == True``
+       — that's what :func:`ensure_catalog_selected` covers).
+    2. Call ``db.list_databases()``; surface ``ImportError`` (missing
+       optional driver) as an actionable hint instead of swallowing it.
     3. Render a numbered picker; the user picks one.
-    4. Update ``db.cfg.database`` in-memory and call
-       ``db.reconnect()`` so subsequent listing queries target the
-       chosen database.
+    4. Update ``db.cfg.database`` in-memory and call ``db.reconnect()``
+       so subsequent listing queries target the chosen database.
 
     The pick is **not** persisted to ``~/.amx/config.yml`` — it's
     session-scoped, exactly like the catalog picker. Run ``/edit`` to
     pin a default permanently.
 
     Returns the chosen database name, or ``""`` when the backend
-    doesn't support the picker, no databases were enumerated, or the
-    user cancelled.
+    doesn't expose multiple databases, no databases were enumerated, or
+    the user cancelled.
     """
     from amx.cli_support.commands.manual import _ask_choice_or_cancel
     from amx.utils.console import step_spinner
@@ -185,8 +185,6 @@ def ensure_database_selected(db: Any) -> str:
     if cfg is None:
         return ""
     backend = str(getattr(cfg, "backend", "") or "")
-    if backend not in {"postgresql", "snowflake"}:
-        return ""
     existing = str(getattr(cfg, "database", "") or "").strip()
     if existing:
         # Already pinned. The picker is for the unpinned case only —
@@ -199,6 +197,12 @@ def ensure_database_selected(db: Any) -> str:
     try:
         with step_spinner("Listing databases on this server"):
             databases = list(db.list_databases())  # type: ignore[attr-defined]
+    except ImportError as exc:
+        # Missing optional driver — surface the actionable extras hint
+        # the adapter attached to the ImportError instead of pretending
+        # the server has no databases.
+        warn(str(exc))
+        return ""
     except Exception as exc:
         log.debug("list_databases failed: %s", exc)
         databases = []
@@ -208,11 +212,12 @@ def ensure_database_selected(db: Any) -> str:
     databases = [d for d in databases if d and not d.startswith("template")]
 
     if not databases:
-        warn(
-            "No databases visible on this server. Either the role lacks "
-            "CONNECT on every database, or the server is empty. Use /edit "
-            "to pin a database name explicitly."
-        )
+        # No multi-database server (e.g. MSSQL with one user DB only,
+        # MySQL with a pinned default), or the role has no privileges.
+        # Silent return so flows that always call this helper don't
+        # spam the user with an irrelevant warning. The 2-level
+        # ``warn_when_database_unpinned`` safety net surfaces only when
+        # the rest of the flow actually tries to list and finds nothing.
         return ""
 
     info(
@@ -236,8 +241,30 @@ def ensure_database_selected(db: Any) -> str:
     return chosen
 
 
+def ensure_hierarchy_resolved(db: Any) -> str:
+    """Single entry point that picks the right hierarchy helper per backend.
+
+    3-level backends (Databricks Unity Catalog) get the catalog picker;
+    2-level backends (Postgres, Snowflake, MySQL, Oracle, MSSQL,
+    Redshift, ClickHouse) get the database picker. Callers in
+    ``/edit``, ``/run``, ``/sync``, ``/connect`` invoke this helper
+    instead of branching themselves — that way new backends only need
+    to override the right ``list_*`` method on the adapter and they're
+    automatically covered.
+
+    Returns the chosen value (catalog name or database name) for
+    callers that want it; most callers just want the side-effect of
+    populating ``cfg.catalog`` / ``cfg.database`` so they can ignore
+    the return value.
+    """
+    if bool(getattr(db, "supports_catalogs", lambda: False)()):
+        return ensure_catalog_selected(db)
+    return ensure_database_selected(db)
+
+
 __all__ = [
     "ensure_catalog_selected",
     "ensure_database_selected",
+    "ensure_hierarchy_resolved",
     "warn_when_database_unpinned",
 ]

--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -567,25 +567,16 @@ def execute_analyze_run(
         _require_llm_connection(llm, profile_label=cfg.active_llm_profile)
         use_batch = _resolve_completion_mode(cfg, llm, mode)
 
-        # Catalog picker for 3-level backends (Databricks Unity
-        # Catalog, BigQuery projects). Fires BEFORE scope finalization
-        # so list_schemas / list_tables downstream are already
-        # catalog-aware. Silent no-op for PG / Snowflake / single-
-        # catalog Databricks.
+        # Unified hierarchy picker. Catalog picker for 3-level backends
+        # (Databricks Unity Catalog), database picker for every 2-level
+        # backend (Postgres, Snowflake, MySQL, Oracle, MSSQL, Redshift,
+        # ClickHouse). Fires BEFORE scope finalization so list_schemas /
+        # list_tables downstream target the right database/catalog
+        # instead of falling back to the system DB.
         try:
-            from amx.cli_support.catalog_picker import (
-                ensure_catalog_selected,
-                ensure_database_selected,
-            )
+            from amx.cli_support.catalog_picker import ensure_hierarchy_resolved
 
-            ensure_catalog_selected(db)
-            # Database picker for 2-level backends (PostgreSQL /
-            # Snowflake). Fires when the profile has ``database=""``
-            # so list_schemas / list_tables target the user's actual
-            # data instead of the ``postgres`` system DB fallback.
-            # Silent no-op when a database is already pinned or the
-            # backend uses catalogs.
-            ensure_database_selected(db)
+            ensure_hierarchy_resolved(db)
         except Exception:
             pass
 

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import contextlib
 import os
+import subprocess
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -56,13 +58,21 @@ _BACKEND_DRIVER_PROBES: dict[str, tuple[str, str]] = {
 }
 
 
-def _warn_if_backend_driver_missing(backend: str) -> None:
-    """Emit an actionable warning if *backend*'s optional extra is missing.
+def _offer_to_install_backend_driver(backend: str) -> None:
+    """Probe *backend*'s optional driver and offer to auto-install it.
 
-    Non-fatal: the user can still complete the wizard (helpful for an
-    air-gapped environment where you want to capture the profile now
-    and install the driver later). The same hint shows up later in
-    /doctor and at engine-creation time.
+    The whole point: a user picking ``databricks`` in the wizard on a
+    fresh ``pip install amx-cli`` should never have to drop out, look up
+    the extras name, type ``pip install -U 'amx-cli[databricks]'``, and
+    rerun the wizard. Instead AMX prints a single Y/n prompt; on Y it
+    runs ``sys.executable -m pip install 'amx-cli[<extra>]'`` inline so
+    the user sees pip's normal output. On success the wizard continues
+    with the driver loaded; on N (or pip failure) it falls through to
+    the air-gapped path with the install hint visible.
+
+    Always uses ``sys.executable -m pip`` so the install lands in the
+    same interpreter that's running AMX — the typical pip-on-PATH
+    confusion (system pip vs venv pip) cannot bite.
     """
     probe = _BACKEND_DRIVER_PROBES.get(backend)
     if not probe:
@@ -70,11 +80,41 @@ def _warn_if_backend_driver_missing(backend: str) -> None:
     extra, module = probe
     try:
         __import__(module)
+        return
     except ImportError:
-        warn(
-            f"The {backend!r} driver is not installed. To use this profile, run: "
-            f"pip install 'amx-cli[{extra}]'"
+        pass
+
+    info(f"The {backend!r} backend driver isn't installed yet.")
+    if not confirm("Install it now via pip?", default=True):
+        warn(f"Skipping. Run later: pip install 'amx-cli[{extra}]'")
+        return
+
+    target = f"amx-cli[{extra}]"
+    info(f"Running: {sys.executable} -m pip install {target}")
+    try:
+        # No capture_output: let pip's progress stream straight to the
+        # user's terminal — the user wants to see it work.
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", target],
+            check=False,
         )
+    except OSError as exc:
+        error(f"Could not invoke pip: {exc}")
+        warn(f"Run manually: pip install 'amx-cli[{extra}]'")
+        return
+
+    if result.returncode != 0:
+        error(f"pip install exited with code {result.returncode}.")
+        warn(f"Run manually: pip install 'amx-cli[{extra}]'")
+        return
+
+    try:
+        __import__(module)
+    except ImportError as exc:
+        error(f"Driver still not importable after install: {exc}")
+        warn(f"Run manually: pip install 'amx-cli[{extra}]'")
+        return
+    success(f"Installed amx-cli[{extra}].")
 
 
 def _ask_update_text(
@@ -404,14 +444,13 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             "duckdb": "Single-file or in-memory; no host/auth (analytical, embedded)",
         },
     )
-    # Probe for the chosen backend's optional driver up front. The
-    # wizard saving a Databricks profile on a fresh `pip install
-    # amx-cli` (no extras) used to succeed silently — the user only
-    # discovered the missing driver on first /edit, with the not-very-
-    # actionable message "databricks-sqlalchemy is required". Surfacing
-    # the install hint here means they can ^C, install the extra, and
-    # rerun before bothering to type credentials.
-    _warn_if_backend_driver_missing(backend)
+    # Probe the chosen backend's optional driver up front and offer
+    # to ``pip install`` it inline. The 0.12.2 version of this hook
+    # only printed a hint and continued — but the hint itself was
+    # eaten by Rich markup, so the user typed the wrong command (or
+    # gave up). 0.12.3: actually run the install for them when they
+    # say Y.
+    _offer_to_install_backend_driver(backend)
 
     # Truly-blank defaults for a brand-new profile or after a cross-
     # backend reset. ``DBConfig()`` carries the dataclass-level

--- a/amx/cli_support/commands/manual.py
+++ b/amx/cli_support/commands/manual.py
@@ -255,17 +255,20 @@ def _select_db_profile_for_wizard(cfg: AMXConfig) -> tuple[str, DBConfig] | None
 
 
 def _select_catalog_for_wizard(db: object) -> str:
-    """Shim that delegates to the shared catalog picker.
+    """Shim that delegates to the unified hierarchy picker.
 
-    The actual logic lives in ``amx.cli_support.catalog_picker``
-    so every flow (``/edit``, ``/run``, ``/run-apply``, ``/connect``,
-    ``/search sync``) can call the same helper. Kept as a wrapper
-    for backwards compatibility with existing call sites in this
-    module.
+    Catalog picker for 3-level backends (Databricks Unity Catalog),
+    database picker for 2-level backends (Postgres, Snowflake, MySQL,
+    Oracle, MSSQL, Redshift, ClickHouse). The actual logic lives in
+    ``amx.cli_support.catalog_picker`` so every flow (``/edit``,
+    ``/run``, ``/run-apply``, ``/connect``, ``/search sync``) can call
+    the same helper. Kept as a wrapper for backwards compatibility
+    with existing call sites in this module — the function name is
+    historical (it ran only the catalog branch in 0.12.2 and earlier).
     """
-    from amx.cli_support.catalog_picker import ensure_catalog_selected
+    from amx.cli_support.catalog_picker import ensure_hierarchy_resolved
 
-    return ensure_catalog_selected(db)
+    return ensure_hierarchy_resolved(db)
 
 
 def _select_schema_for_wizard(db: object, default: str = "") -> str | None:

--- a/amx/cli_support/commands/search.py
+++ b/amx/cli_support/commands/search.py
@@ -1149,13 +1149,13 @@ def register_search_commands(
                     # front the listings may be empty.
                     try:
                         from amx.cli_support.catalog_picker import (
-                            ensure_catalog_selected,
+                            ensure_hierarchy_resolved,
                             warn_when_database_unpinned,
                         )
                         from amx.db.connector import DatabaseConnector
 
                         _db_for_pick = DatabaseConnector(cfg.db)
-                        ensure_catalog_selected(_db_for_pick)
+                        ensure_hierarchy_resolved(_db_for_pick)
                         warn_when_database_unpinned(_db_for_pick)
                     except Exception:
                         pass

--- a/amx/cli_support/root_commands.py
+++ b/amx/cli_support/root_commands.py
@@ -177,10 +177,10 @@ def register_root_commands(
                 # to lock the catalog for the rest of the session;
                 # /run, /ask, /edit and friends inherit it.
                 try:
-                    from amx.cli_support.catalog_picker import ensure_catalog_selected
+                    from amx.cli_support.catalog_picker import ensure_hierarchy_resolved
 
                     db_for_pick = DatabaseConnector(cfg.db)
-                    ensure_catalog_selected(db_for_pick)
+                    ensure_hierarchy_resolved(db_for_pick)
                 except Exception as _exc:
                     pass
                 if getattr(cfg.db, "tls_no_verify", False):

--- a/amx/db/adapters/snowflake.py
+++ b/amx/db/adapters/snowflake.py
@@ -62,6 +62,40 @@ class SnowflakeAdapter(DatabaseAdapter):
     def system_schemas(self) -> frozenset[str]:
         return frozenset({"INFORMATION_SCHEMA", "information_schema"})
 
+    def list_databases(self, engine: Engine) -> list[str]:
+        """Return user-visible Snowflake databases via ``SHOW DATABASES``.
+
+        Filters Snowflake-managed databases (``SNOWFLAKE``,
+        ``SNOWFLAKE_SAMPLE_DATA``) when the user has any of their own —
+        otherwise the runtime picker would surface nothing but
+        managed metadata DBs. If those *are* the only ones visible the
+        list is returned as-is so the user still gets a non-empty
+        choice (a sandbox account with sample data only is a real
+        case worth supporting).
+        """
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(text("SHOW DATABASES")).fetchall()
+        except Exception:
+            return []
+        # SHOW DATABASES exposes ``name`` as column 1 (column 0 is
+        # ``created_on``).
+        names: list[str] = []
+        for r in rows:
+            try:
+                mapping = r._mapping if hasattr(r, "_mapping") else None
+                if mapping is not None and "name" in mapping:
+                    name = str(mapping["name"])
+                else:
+                    name = str(r[1])
+            except Exception:
+                continue
+            if name:
+                names.append(name)
+        managed = {"SNOWFLAKE", "SNOWFLAKE_SAMPLE_DATA"}
+        user_dbs = [n for n in names if n.upper() not in managed]
+        return user_dbs or names
+
     def actionable_profile_error(self, exc: Exception) -> str | None:
         msg = str(exc).lower()
         if "insufficient privileges" in msg or "not authorized" in msg:

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -293,15 +293,21 @@ class DatabaseConnector:
     def list_databases(self) -> list[str]:
         """User-visible databases on this server (2-level backends only).
 
-        Used by the runtime database picker for PostgreSQL / Snowflake
-        when the profile has ``database=""``. Returns ``[]`` for
-        backends that don't expose a multi-database server (Databricks
-        catalogs, BigQuery datasets — those use ``list_catalogs``).
-        Suppresses adapter exceptions so the picker can degrade
-        gracefully.
+        Used by the runtime database picker when the profile has
+        ``database=""``. Returns ``[]`` for backends that don't expose a
+        multi-database server (Databricks catalogs, BigQuery datasets —
+        those use ``list_catalogs``).
+
+        ``ImportError`` propagates so the missing-driver case (a fresh
+        ``pip install amx-cli`` without the right extra) reaches the
+        runtime database picker as an actionable hint instead of
+        masquerading as "no databases visible". Mirrors the symmetric
+        behaviour of :meth:`list_catalogs`.
         """
         try:
             return list(self._adapter.list_databases(self.engine))
+        except ImportError:
+            raise
         except Exception as exc:
             log.debug("list_databases failed: %s", exc)
             return []

--- a/amx/utils/console.py
+++ b/amx/utils/console.py
@@ -15,6 +15,7 @@ from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
 from rich import box
 from rich.align import Align
 from rich.console import Console
+from rich.markup import escape as _markup_escape
 from rich.panel import Panel
 from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn, TimeElapsedColumn
 from rich.table import Table
@@ -91,24 +92,31 @@ def show_banner(force: bool = False) -> None:
     _BANNER_SHOWN = True
 
 
+# All five helpers escape *text* before splicing it into a Rich markup
+# string. Without escape() a substring like ``[databricks]`` (the kind
+# that appears inside ``pip install 'amx-cli[databricks]'`` install hints)
+# is interpreted by Rich as another style tag and silently dropped, so
+# the user sees ``pip install 'amx-cli'`` and concludes the package is
+# broken. Every existing callsite passes plain text intended for users,
+# so escaping is always the right behaviour.
 def heading(text: str) -> None:
-    console.print(Panel(f"[heading]{text}[/heading]", expand=False))
+    console.print(Panel(f"[heading]{_markup_escape(text)}[/heading]", expand=False))
 
 
 def info(text: str) -> None:
-    console.print(f"[info]ℹ  {text}[/info]")
+    console.print(f"[info]ℹ  {_markup_escape(text)}[/info]")
 
 
 def success(text: str) -> None:
-    console.print(f"[success]✓  {text}[/success]")
+    console.print(f"[success]✓  {_markup_escape(text)}[/success]")
 
 
 def warn(text: str) -> None:
-    console.print(f"[warning]⚠  {text}[/warning]")
+    console.print(f"[warning]⚠  {_markup_escape(text)}[/warning]")
 
 
 def error(text: str) -> None:
-    console.print(f"[error]✗  {text}[/error]")
+    console.print(f"[error]✗  {_markup_escape(text)}[/error]")
 
 
 @contextmanager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx-cli"
-version = "0.12.2"
+version = "0.12.3"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_console_markup_safety.py
+++ b/tests/test_console_markup_safety.py
@@ -1,0 +1,84 @@
+"""Regression tests for the Rich-markup bug-class fix in 0.12.3.
+
+The hard-to-spot bug: ``warn("pip install 'amx-cli[databricks]'")`` used
+to render as ``⚠ pip install 'amx-cli'`` because ``warn`` wraps its arg
+in ``[warning]…[/warning]`` and Rich then parses ``[databricks]`` as
+another (unknown) style tag and silently drops it. Users copy-pasted
+the wrong command and concluded the package was broken.
+
+These tests pin the fix: every console helper that wraps user-supplied
+text in Rich markup must escape that text so substrings shaped like
+``[<word>]`` survive as literal characters in the rendered output.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+from amx.utils import console as amx_console
+
+
+@pytest.fixture
+def captured_console(monkeypatch: pytest.MonkeyPatch) -> io.StringIO:
+    """Replace the module-level Rich Console with one that writes to a buffer.
+
+    Lets each test inspect the rendered output verbatim. The replacement
+    uses ``record=True`` and ``force_terminal=False`` so style codes are
+    stripped — we want to assert on the user-visible characters, not the
+    ANSI escape sequences.
+    """
+    buf = io.StringIO()
+    fake = Console(file=buf, force_terminal=False, color_system=None, theme=amx_console._theme)
+    monkeypatch.setattr(amx_console, "console", fake)
+    return buf
+
+
+@pytest.mark.parametrize(
+    "helper, payload",
+    [
+        (amx_console.warn, "pip install 'amx-cli[databricks]'"),
+        (amx_console.info, "pip install 'amx-cli[bigquery]'"),
+        (amx_console.success, "Installed amx-cli[snowflake]."),
+        (amx_console.error, "Could not install amx-cli[mysql]."),
+    ],
+)
+def test_brackets_in_helpers_are_preserved(
+    captured_console: io.StringIO,
+    helper,
+    payload: str,
+) -> None:
+    helper(payload)
+    out = captured_console.getvalue()
+    # The literal substring must survive — no Rich-eaten brackets.
+    assert payload in out, f"helper={helper.__name__!r} dropped brackets: {out!r}"
+
+
+def test_pre_fix_failure_mode_is_now_safe(captured_console: io.StringIO) -> None:
+    """The exact warn() text from amx/db/adapters/databricks.py:78 must
+    render with [databricks] intact — that's the bug the user reported."""
+    amx_console.warn(
+        "databricks-sqlalchemy is required for the Databricks backend. "
+        "Install the extra: pip install 'amx-cli[databricks]'"
+    )
+    out = captured_console.getvalue()
+    assert "[databricks]" in out
+
+
+def test_caller_supplied_markup_no_longer_styles_text(captured_console: io.StringIO) -> None:
+    """Defensive: even tags that LOOK like real Rich styles (``[red]``,
+    ``[bold]``) get escaped. We don't want a stray ``[bold]`` in a
+    user-facing string to silently change the formatting."""
+    amx_console.info("[bold]not actually bold[/bold]")
+    out = captured_console.getvalue()
+    assert "[bold]not actually bold[/bold]" in out
+
+
+def test_heading_escapes_user_text(captured_console: io.StringIO) -> None:
+    """`heading()` wraps text in a Panel with `[heading]` markup; the
+    same escape contract applies."""
+    amx_console.heading("Section [extra]")
+    out = captured_console.getvalue()
+    assert "[extra]" in out

--- a/tests/test_db_multi_backend_expansion.py
+++ b/tests/test_db_multi_backend_expansion.py
@@ -223,6 +223,57 @@ def test_normalize_db_host_strips_scheme_and_trailing_slash(raw, expected):
     assert _normalize_db_host(raw) == expected
 
 
+def test_snowflake_list_databases_runs_show_databases_and_filters_managed():
+    """Snowflake adapter exposes a ``list_databases`` override (added in
+    0.12.3) so the unified runtime database picker can present
+    user-visible databases when the profile leaves the database field
+    blank. Verify the override:
+      - issues ``SHOW DATABASES``,
+      - filters Snowflake-managed DBs (``SNOWFLAKE``,
+        ``SNOWFLAKE_SAMPLE_DATA``) when other DBs are visible,
+      - returns the unfiltered list when those are the only DBs visible
+        (sandbox accounts).
+    """
+    from unittest.mock import MagicMock
+
+    from amx.db.adapters.snowflake import SnowflakeAdapter
+
+    cfg = DBConfig(backend="snowflake", account="acc.example", user="alice")
+    adapter = SnowflakeAdapter(cfg)
+
+    def _engine(rows):
+        engine = MagicMock()
+        cm = engine.connect.return_value.__enter__.return_value
+        # rows yielded by SHOW DATABASES: Snowflake returns at least
+        # (created_on, name, ...). The adapter prefers ``mapping['name']``
+        # when available — supply both shapes via MagicMock attrs.
+        result = MagicMock()
+        result.fetchall.return_value = rows
+        cm.execute.return_value = result
+        return engine
+
+    class _Row:
+        def __init__(self, name: str) -> None:
+            self._name = name
+            self._mapping = {"name": name}
+
+        def __getitem__(self, idx):
+            # Snowflake column 1 is ``name``.
+            return [None, self._name][idx]
+
+    # Mixed: managed DBs + user DBs → filter the managed ones.
+    mixed = adapter.list_databases(_engine([_Row("APP"), _Row("SNOWFLAKE"), _Row("METRICS")]))
+    assert "SNOWFLAKE" not in mixed
+    assert "APP" in mixed
+    assert "METRICS" in mixed
+
+    # Only managed DBs visible (fresh sandbox) → return them unfiltered.
+    only_managed = adapter.list_databases(
+        _engine([_Row("SNOWFLAKE"), _Row("SNOWFLAKE_SAMPLE_DATA")])
+    )
+    assert only_managed == ["SNOWFLAKE", "SNOWFLAKE_SAMPLE_DATA"]
+
+
 def test_databricks_url_normalizes_host_with_trailing_slash():
     """Regression: pasting the full workspace URL with a trailing slash
     used to crash schema listing with ``invalid literal for int() with

--- a/tests/test_runtime_pickers.py
+++ b/tests/test_runtime_pickers.py
@@ -74,9 +74,7 @@ def patch_picker_choice():
     "backend",
     ["postgresql", "snowflake", "mysql", "oracle", "mssql", "redshift", "clickhouse"],
 )
-def test_database_picker_runs_for_every_2level_backend(
-    backend: str, patch_picker_choice
-) -> None:
+def test_database_picker_runs_for_every_2level_backend(backend: str, patch_picker_choice) -> None:
     """The pre-0.12.3 whitelist locked out 5 backends (mysql, oracle,
     mssql, redshift, clickhouse). Verify every 2-level backend now gets
     the picker when ``cfg.database`` is blank and the adapter returns

--- a/tests/test_runtime_pickers.py
+++ b/tests/test_runtime_pickers.py
@@ -1,0 +1,161 @@
+"""Tests for the universal runtime hierarchy picker added in 0.12.3.
+
+Pre-0.12.3 only Databricks (catalog) and PostgreSQL (database) had a
+runtime picker — every other 2-level backend silently produced empty
+listings when the profile left the database field blank. The new
+``ensure_hierarchy_resolved`` helper dispatches to the right picker
+per backend and ``ensure_database_selected`` no longer hard-codes a
+backend whitelist.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from amx.cli_support.catalog_picker import (
+    ensure_database_selected,
+    ensure_hierarchy_resolved,
+)
+
+
+@dataclass
+class _FakeCfg:
+    backend: str
+    database: str = ""
+    catalog: str = ""
+
+
+@dataclass
+class _FakeDB:
+    """Minimal stand-in for :class:`DatabaseConnector` with just the
+    surface ``ensure_database_selected`` and ``ensure_catalog_selected``
+    touch."""
+
+    cfg: _FakeCfg
+    _databases: list[str] = field(default_factory=list)
+    _catalogs: list[str] = field(default_factory=list)
+    _supports_catalogs: bool = False
+    _list_databases_raises: BaseException | None = None
+    reconnects: int = 0
+
+    def supports_catalogs(self) -> bool:
+        return self._supports_catalogs
+
+    def list_databases(self) -> list[str]:
+        if self._list_databases_raises is not None:
+            raise self._list_databases_raises
+        return list(self._databases)
+
+    def list_catalogs(self) -> list[str]:
+        return list(self._catalogs)
+
+    def reconnect(self) -> None:
+        self.reconnects += 1
+
+
+@pytest.fixture
+def patch_picker_choice():
+    """Patch the ``_ask_choice_or_cancel`` primitive so the picker
+    returns a deterministic value without prompting."""
+
+    def _patch(returned: str):
+        return patch(
+            "amx.cli_support.commands.manual._ask_choice_or_cancel",
+            return_value=returned,
+        )
+
+    return _patch
+
+
+@pytest.mark.parametrize(
+    "backend",
+    ["postgresql", "snowflake", "mysql", "oracle", "mssql", "redshift", "clickhouse"],
+)
+def test_database_picker_runs_for_every_2level_backend(
+    backend: str, patch_picker_choice
+) -> None:
+    """The pre-0.12.3 whitelist locked out 5 backends (mysql, oracle,
+    mssql, redshift, clickhouse). Verify every 2-level backend now gets
+    the picker when ``cfg.database`` is blank and the adapter returns
+    a non-empty database list."""
+    db = _FakeDB(cfg=_FakeCfg(backend=backend), _databases=["analytics", "warehouse"])
+    with patch_picker_choice("warehouse"):
+        chosen = ensure_database_selected(db)
+    assert chosen == "warehouse"
+    assert db.cfg.database == "warehouse"
+    assert db.reconnects == 1
+
+
+def test_picker_skips_when_database_already_pinned(patch_picker_choice) -> None:
+    """The picker is for the unpinned case only — pinned profiles must
+    not be re-prompted."""
+    db = _FakeDB(cfg=_FakeCfg(backend="mysql", database="prod"), _databases=["prod", "staging"])
+    with patch_picker_choice("staging"):
+        chosen = ensure_database_selected(db)
+    # No picker fired; existing pin is returned untouched.
+    assert chosen == "prod"
+    assert db.cfg.database == "prod"
+    assert db.reconnects == 0
+
+
+def test_picker_silent_when_adapter_returns_no_databases(patch_picker_choice) -> None:
+    """A 1-database server (e.g. MSSQL with one user DB) must not spam
+    the user with a "no databases visible" warning — the 0.12.2
+    behaviour for non-postgres backends. Silent return is the contract."""
+    db = _FakeDB(cfg=_FakeCfg(backend="mssql"), _databases=[])
+    with patch_picker_choice("anything"):
+        chosen = ensure_database_selected(db)
+    assert chosen == ""
+    assert db.reconnects == 0
+
+
+def test_picker_surfaces_missing_driver_as_warning() -> None:
+    """When ``list_databases`` raises ``ImportError`` (missing optional
+    driver), the picker must show that ImportError's message verbatim
+    (it carries the actionable ``pip install 'amx-cli[<extra>]'`` hint)
+    instead of silently returning empty."""
+    db = _FakeDB(
+        cfg=_FakeCfg(backend="mysql"),
+        _list_databases_raises=ImportError(
+            "pymysql is required for the MySQL backend. "
+            "Install the extra: pip install 'amx-cli[mysql]'"
+        ),
+    )
+    with patch("amx.cli_support.catalog_picker.warn") as warn_mock:
+        chosen = ensure_database_selected(db)
+    assert chosen == ""
+    assert warn_mock.called
+    msg = warn_mock.call_args[0][0]
+    assert "pip install 'amx-cli[mysql]'" in msg
+
+
+def test_ensure_hierarchy_resolved_dispatches_to_catalog_picker(patch_picker_choice) -> None:
+    """3-level backends (databricks) hit the catalog picker, not the
+    database picker — verify the unified entry point dispatches correctly."""
+    db = _FakeDB(
+        cfg=_FakeCfg(backend="databricks"),
+        _catalogs=["main", "analytics"],
+        _supports_catalogs=True,
+    )
+    # `ensure_catalog_selected` shows the picker via _ask_choice_or_cancel
+    # (imported lazily inside the helper from manual.py); the picker
+    # writes ``cfg.catalog`` not ``cfg.database``.
+    with patch_picker_choice("analytics"):
+        chosen = ensure_hierarchy_resolved(db)
+    assert chosen == "analytics"
+    assert db.cfg.catalog == "analytics"
+    # Catalog picker is NOT supposed to set database.
+    assert db.cfg.database == ""
+
+
+def test_ensure_hierarchy_resolved_falls_through_to_database_picker(patch_picker_choice) -> None:
+    """2-level backends route through the database picker."""
+    db = _FakeDB(cfg=_FakeCfg(backend="postgresql"), _databases=["app", "metrics"])
+    with patch_picker_choice("app"):
+        chosen = ensure_hierarchy_resolved(db)
+    assert chosen == "app"
+    assert db.cfg.database == "app"

--- a/tests/test_runtime_pickers.py
+++ b/tests/test_runtime_pickers.py
@@ -11,7 +11,6 @@ backend whitelist.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
## Summary

The 0.12.2 user reported a frustrating loop:

```
⚠ databricks-sqlalchemy is required... pip install 'amx-cli'
```

The `[databricks]` extras name was eaten by Rich. They typed
`pip install -U amx-cli`, came back, hit the same error, repeated.

This PR delivers three layered fixes so it can't happen again:

1. **Markup bug-class kill.** `info`/`warn`/`error`/`success`/`heading` in `amx/utils/console.py` now call `rich.markup.escape` on user text. Every existing `pip install 'amx-cli[<extra>]'` hint, `[code-intel]`, `[local-embeddings]` line — they all start rendering correctly without any callsite changing.

2. **Wizard auto-installs the missing driver.** Pick a backend whose extra isn't loaded → `?  Install it now via pip? [Y/n]: ▮` (default Y) → `sys.executable -m pip install 'amx-cli[<extra>]'` runs inline → wizard continues with the driver loaded. No drop-out / lookup / restart loop.

3. **Universal runtime picker.** `ensure_database_selected` drops its `{postgresql, snowflake}` whitelist; new `ensure_hierarchy_resolved` unified helper dispatches catalog vs database picker; new `SnowflakeAdapter.list_databases`; `Connector.list_databases` propagates `ImportError` so the missing-driver hint surfaces instead of "no databases visible". `/edit`, `/run`, `/sync`, `/connect` all call the unified helper.

Bump to 0.12.3.

## Test plan
- [x] `pytest tests/ -q --ignore=tests/eval` → **571 pass** (+20 new)
- [x] `tests/test_console_markup_safety.py` (7 tests) — pins `[databricks]` survival across all five console helpers
- [x] `tests/test_runtime_pickers.py` (12 tests) — every 2-level backend, already-pinned skip, empty-list silent, ImportError surfaces hint, unified dispatch
- [x] New `test_snowflake_list_databases_runs_show_databases_and_filters_managed`
- [x] Smoke: `python -c "from amx.utils.console import warn; warn(\"pip install 'amx-cli[databricks]'\")"` prints the literal `[databricks]`
