### PR TITLE
fix(shared-schema): JSON columns compile on Databricks (kill the startup warning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — Shared-history bootstrap on Databricks no longer crashes the JSON columns
+
+Users with `/history-store enable` pointed at a Databricks workspace
+saw this on every `amx` startup:
+
+```
+[WARNING] amx.storage.factory — Shared history schema not initialised
+((in table 'analysis_runs', column 'scope_json'): Compiler … can't
+render element of type JSON). Run `/history-store enable` to bootstrap
+the AMX schema.
+```
+
+Root cause: `databricks-sqlalchemy` does not implement `visit_JSON`,
+so SQLAlchemy's `GenericTypeCompiler` raises the moment
+`MetaData.create_all` tries to emit the eight `JSON` columns in our
+shared schema. The bootstrap failed every time, the warning fired
+every command — but no remediation worked because `/history-store
+enable` re-ran the same broken `create_all`.
+
+Fix: new `_portable_json()` helper in `amx/storage/shared_schema.py`
+uses `JSON().with_variant(_JSONAsText(), "databricks")`. `_JSONAsText`
+is a `TypeDecorator` over `Text` that round-trips Python dicts/lists
+through `json.dumps`/`json.loads` so the read paths in
+`amx/storage/sqlalchemy_store.py` continue to receive deserialised
+Python objects regardless of which backend the row came from.
+
+Postgres still gets native `JSON`, MySQL still gets `JSON`, SQLite
+still gets `JSON` — only Databricks switches to `STRING`. Verified
+end-to-end: the same `MetaData` now compiles cleanly on the Databricks
+dialect (`scope_json STRING COMMENT '…'`) and produces identical DDL
+to before on every other dialect.
+
+`tests/test_shared_schema_comments.py` adds:
+- `test_jsonastext_round_trips_dict_through_text_storage` —
+  TypeDecorator round-trip contract.
+- `test_databricks_create_table_ddl_compiles_for_every_table` —
+  every table compiles on Databricks AND every JSON column renders as
+  `STRING`. Future JSON columns added without `_portable_json()` would
+  fail this test loudly.
+
 ### Fixed — Console helpers no longer eat `[databricks]`-style substrings (the bug-class kill)
 
 `warn("pip install 'amx-cli[databricks]'")` rendered as

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 
 __all__ = [
     "AMXApplication",

--- a/amx/storage/shared_schema.py
+++ b/amx/storage/shared_schema.py
@@ -33,6 +33,9 @@ Design notes:
 
 from __future__ import annotations
 
+import json as _json
+from typing import Any
+
 from sqlalchemy import (
     JSON,
     BigInteger,
@@ -46,6 +49,62 @@ from sqlalchemy import (
     Table,
     Text,
 )
+from sqlalchemy.types import TypeDecorator, TypeEngine
+
+
+class _JSONAsText(TypeDecorator):
+    """JSON stored as TEXT for backends without a native JSON column type.
+
+    ``databricks-sqlalchemy`` does not implement ``visit_JSON``, so the
+    SQLAlchemy generic compiler raises *"can't render element of type
+    JSON"* the moment ``MetaData.create_all`` tries to emit any JSON
+    column on Databricks. The user-visible symptom (reported on
+    2026-05-03 against 0.12.3) was a recurring warning on every
+    ``amx`` startup:
+
+        Shared history schema not initialised ((in table
+        'analysis_runs', column 'scope_json'): Compiler … can't render
+        element of type JSON). Run `/history-store enable` to bootstrap
+        the AMX schema.
+
+    This decorator stores the value as plain TEXT and round-trips it
+    through ``json.dumps`` / ``json.loads`` so callers continue to see
+    Python dicts/lists on read — no backend-aware code anywhere else.
+    """
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value: Any, dialect: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            # Already serialised — just store as-is.
+            return value
+        return _json.dumps(value, default=str)
+
+    def process_result_value(self, value: Any, dialect: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            # Some dialects/drivers might pre-deserialise; trust them.
+            return value
+        try:
+            return _json.loads(value)
+        except (TypeError, ValueError):
+            return value
+
+
+def _portable_json() -> TypeEngine:
+    """Return a JSON column type that compiles on every supported backend.
+
+    Native ``JSON`` (or ``JSONB`` / ``VARIANT``) where the dialect
+    knows how to render it; ``_JSONAsText`` on Databricks where
+    ``databricks-sqlalchemy`` lacks a ``visit_JSON`` implementation.
+    Use this everywhere in this module instead of bare ``JSON`` so a
+    new JSON column added later automatically inherits the fix.
+    """
+    return JSON().with_variant(_JSONAsText(), "databricks")
 
 # Schema name is configurable per-deployment — the user can pick a
 # different name in ``/history-store enable``. Default is ``AMX`` which
@@ -211,7 +270,7 @@ def build_metadata(schema: str | None = None) -> MetaData:
         ),
         Column(
             "scope_json",
-            JSON,
+            _portable_json(),
             comment=(
                 "JSON describing the analyzed scope: {schemas, tables, columns, "
                 "asset_kinds, profiles}. /compare reads this to find prior runs "
@@ -220,7 +279,7 @@ def build_metadata(schema: str | None = None) -> MetaData:
         ),
         Column(
             "metrics_json",
-            JSON,
+            _portable_json(),
             comment=(
                 "JSON of run metrics — counts, per-stage timings, retries, "
                 "skipped assets. Free-form so newer agents can add fields "
@@ -229,7 +288,7 @@ def build_metadata(schema: str | None = None) -> MetaData:
         ),
         Column(
             "tokens_json",
-            JSON,
+            _portable_json(),
             comment=(
                 "JSON of token usage broken down by phase: "
                 "{prompt, completion, cached, reasoning, total}. Drives /stats "
@@ -238,7 +297,7 @@ def build_metadata(schema: str | None = None) -> MetaData:
         ),
         Column(
             "results_json",
-            JSON,
+            _portable_json(),
             comment=(
                 "JSON summary of run outputs (counts, top-level rollups). "
                 "Per-asset detail lives in run_results joined on run_id."
@@ -326,7 +385,7 @@ def build_metadata(schema: str | None = None) -> MetaData:
         ),
         Column(
             "settings_json",
-            JSON,
+            _portable_json(),
             comment=(
                 "Snapshot of LLM settings at run time — temperature, "
                 "prompt_detail, n_alternatives, llm_batch_size, "
@@ -470,7 +529,7 @@ def build_metadata(schema: str | None = None) -> MetaData:
         ),
         Column(
             "alternatives_json",
-            JSON,
+            _portable_json(),
             nullable=False,
             comment=(
                 "Ordered JSON list of alternative description strings the LLM "
@@ -620,7 +679,7 @@ def build_metadata(schema: str | None = None) -> MetaData:
         ),
         Column(
             "details_json",
-            JSON,
+            _portable_json(),
             comment=(
                 "Free-form JSON payload — varies per event_type. Examples: "
                 "{profile, backend} for db connect, {model, latency_ms} for "
@@ -676,7 +735,7 @@ def build_metadata(schema: str | None = None) -> MetaData:
         ),
         Column(
             "value_json",
-            JSON,
+            _portable_json(),
             nullable=False,
             comment="JSON-serialized value associated with (namespace, key_name, hostname).",
         ),

--- a/amx/storage/shared_schema.py
+++ b/amx/storage/shared_schema.py
@@ -106,6 +106,7 @@ def _portable_json() -> TypeEngine:
     """
     return JSON().with_variant(_JSONAsText(), "databricks")
 
+
 # Schema name is configurable per-deployment — the user can pick a
 # different name in ``/history-store enable``. Default is ``AMX`` which
 # matches the user-facing nomenclature in docs/CLI prompts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx-cli"
-version = "0.12.3"
+version = "0.12.4"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_shared_schema_comments.py
+++ b/tests/test_shared_schema_comments.py
@@ -60,3 +60,92 @@ def test_create_history_tables_ddl_emits_comments_on_postgres() -> None:
     assert ddl.count("COMMENT ON COLUMN") == 75, (
         f"expected 75 COMMENT ON COLUMN statements, got {ddl.count('COMMENT ON COLUMN')}"
     )
+
+
+def test_jsonastext_round_trips_dict_through_text_storage() -> None:
+    """Verify ``_JSONAsText`` (the TypeDecorator used on Databricks)
+    serialises Python objects on write and deserialises them on read so
+    callers see Python dicts/lists regardless of which backend the row
+    came from. Without this, code in
+    ``amx/storage/sqlalchemy_store.py:471`` (``r.get("scope_json")``)
+    would receive a JSON string from Databricks and crash when it tried
+    to call ``.get(schema, [])`` on it.
+    """
+    from amx.storage.shared_schema import _JSONAsText
+
+    decorator = _JSONAsText()
+    payload = {"schemas": ["public"], "tables": {"public": ["users", "orders"]}}
+
+    stored = decorator.process_bind_param(payload, dialect=None)
+    assert isinstance(stored, str), "process_bind_param must serialise to str"
+
+    restored = decorator.process_result_value(stored, dialect=None)
+    assert restored == payload, "round-trip must preserve the original Python value"
+
+    # None passthrough on both sides — never serialise NULL as the
+    # string ``"null"``.
+    assert decorator.process_bind_param(None, dialect=None) is None
+    assert decorator.process_result_value(None, dialect=None) is None
+
+    # Already-deserialised values pass through unchanged (some drivers
+    # might do their own JSON parsing).
+    assert decorator.process_result_value({"x": 1}, dialect=None) == {"x": 1}
+
+
+def test_databricks_create_table_ddl_compiles_for_every_table() -> None:
+    """Regression: 0.12.3 and earlier raised on Databricks because the
+    JSON columns hit ``GenericTypeCompiler.process can't render element
+    of type JSON`` — ``databricks-sqlalchemy`` does not implement
+    ``visit_JSON``. The user's symptom was a recurring warning on every
+    ``amx`` startup:
+
+        Shared history schema not initialised ((in table
+        'analysis_runs', column 'scope_json'): Compiler … can't render
+        element of type JSON).
+
+    Fix in 0.12.4: ``_portable_json()`` switches to a TEXT-backed
+    TypeDecorator on the Databricks dialect. Verify every table in
+    the shared schema renders to DDL on Databricks AND the JSON
+    columns end up as ``STRING`` instead of failing.
+    """
+    pytest_skip = None
+    try:
+        import databricks.sqlalchemy  # noqa: F401 — registers dialect
+        from databricks.sqlalchemy import DatabricksDialect
+    except ImportError as exc:
+        import pytest
+
+        pytest_skip = pytest.skip(f"databricks-sqlalchemy not installed: {exc}")
+        return  # pragma: no cover
+    from sqlalchemy.schema import CreateTable
+
+    md = build_metadata("AMX")
+    dialect = DatabricksDialect()
+    json_column_names = {
+        "scope_json",
+        "metrics_json",
+        "tokens_json",
+        "results_json",
+        "settings_json",
+        "alternatives_json",
+        "details_json",
+        "value_json",
+    }
+    seen_json_columns: set[str] = set()
+    for table in md.tables.values():
+        # Compiles without raising — that's the original bug.
+        ddl = str(CreateTable(table).compile(dialect=dialect))
+        for col in table.columns:
+            if col.name in json_column_names:
+                seen_json_columns.add(col.name)
+                # Column must render as Databricks STRING, never JSON.
+                assert f"{col.name} STRING" in ddl, (
+                    f"{table.name}.{col.name} did not compile as STRING on Databricks: "
+                    f"{ddl!r}"
+                )
+    # Defence in depth: confirm we actually exercised every JSON
+    # column the schema declares — a future column added without the
+    # ``_portable_json()`` helper would slip through otherwise.
+    assert seen_json_columns == json_column_names, (
+        f"Test fixture out of sync — missed columns: {json_column_names - seen_json_columns}"
+    )

--- a/tests/test_shared_schema_comments.py
+++ b/tests/test_shared_schema_comments.py
@@ -108,15 +108,13 @@ def test_databricks_create_table_ddl_compiles_for_every_table() -> None:
     the shared schema renders to DDL on Databricks AND the JSON
     columns end up as ``STRING`` instead of failing.
     """
-    pytest_skip = None
     try:
         import databricks.sqlalchemy  # noqa: F401 — registers dialect
         from databricks.sqlalchemy import DatabricksDialect
     except ImportError as exc:
         import pytest
 
-        pytest_skip = pytest.skip(f"databricks-sqlalchemy not installed: {exc}")
-        return  # pragma: no cover
+        pytest.skip(f"databricks-sqlalchemy not installed: {exc}")
     from sqlalchemy.schema import CreateTable
 
     md = build_metadata("AMX")
@@ -140,8 +138,7 @@ def test_databricks_create_table_ddl_compiles_for_every_table() -> None:
                 seen_json_columns.add(col.name)
                 # Column must render as Databricks STRING, never JSON.
                 assert f"{col.name} STRING" in ddl, (
-                    f"{table.name}.{col.name} did not compile as STRING on Databricks: "
-                    f"{ddl!r}"
+                    f"{table.name}.{col.name} did not compile as STRING on Databricks: {ddl!r}"
                 )
     # Defence in depth: confirm we actually exercised every JSON
     # column the schema declares — a future column added without the


### PR DESCRIPTION
## Summary

User reported the recurring warning:
\`\`\`
[WARNING] amx.storage.factory — Shared history schema not initialised
((in table 'analysis_runs', column 'scope_json'): Compiler … can't
render element of type JSON). Run \`/history-store enable\` to bootstrap.
\`\`\`

Root cause: \`databricks-sqlalchemy\` does not implement \`visit_JSON\`, so SQLAlchemy's GenericTypeCompiler raises on every \`MetaData.create_all\` for the eight JSON columns in the shared schema. Bootstrap failed every command; re-running \`/history-store enable\` just hit the same wall.

Fix: new \`_portable_json()\` helper in \`amx/storage/shared_schema.py\` uses \`JSON().with_variant(_JSONAsText(), \"databricks\")\`. \`_JSONAsText\` is a \`TypeDecorator\` over \`Text\` that round-trips Python dicts/lists through \`json.dumps\`/\`json.loads\` so read paths continue to see Python objects (zero caller changes).

Postgres still gets native \`JSON\`, MySQL still gets \`JSON\`, SQLite still gets \`JSON\` — only Databricks switches to \`STRING\`. Verified: identical DDL on every other dialect.

Bump to 0.12.4.

## Test plan
- [x] \`pytest tests/ -q --ignore=tests/eval\` → **573 pass** (+2 new)
- [x] \`test_jsonastext_round_trips_dict_through_text_storage\` — TypeDecorator round-trip
- [x] \`test_databricks_create_table_ddl_compiles_for_every_table\` — every table compiles on Databricks AND every JSON column renders as \`STRING\`
- [x] DDL on Postgres/MySQL/SQLite unchanged (manual smoke)
