### PR TITLE
fix(storage): kill the 70-line shared-history warning that floods every slash command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — Shared-history bootstrap warning no longer floods the terminal with SQL
+
+User report (against 0.12.4): every slash command in an interactive
+session printed a 70-line wall of `CREATE TABLE` DDL because
+`init_history_store` re-ran on every command and the underlying
+`databricks.sql.exc.ServerOperationError` carried the full statement
+in its `str(exc)`. Sample symptom — running `/edit` printed:
+
+```
+[WARNING] Shared history schema not initialised
+((databricks.sql.exc.ServerOperationError) [SCHEMA_NOT_FOUND] …
+[SQL: CREATE TABLE `AMX`.analysis_runs (
+    id STRING NOT NULL COMMENT 'UUID v4 primary key …',
+    started_at TIMESTAMP_NTZ NOT NULL COMMENT '…',
+    -- 27 more columns —
+) USING DELTA …]
+```
+
+…repeated on every subsequent slash command.
+
+Fix:
+
+1. `_short_error()` strips multi-line SQLAlchemy bodies down to the
+   first line and drops the verbose `(Background on this error at: …)`
+   suffix. The user-visible warning is now ONE LINE.
+2. `_warn_bootstrap_failure_once()` memoises the warning by
+   `(profile, schema)` key in a process-level cache, so an
+   interactive session that re-enters `init_history_store` per slash
+   command stops spamming the same warning. Subsequent calls in the
+   same process route the full traceback to DEBUG only.
+3. The new warning text tells the user how to silence the warning
+   permanently — `run /history-store disable to silence permanently,
+   or /history-store enable to re-bootstrap` — replacing the
+   pre-0.12.5 hint that just said "Run /history-store enable", which
+   re-hit the same wall.
+
+`tests/test_history_store_warning_quiet.py` pins the contract:
+- `_short_error` strips the SQL dump and the SQLAlchemy footer.
+- `_warn_bootstrap_failure_once` fires exactly one WARNING per key,
+  even after three calls.
+- Distinct (profile, schema) keys each get their own one-shot warning.
+
 ### Fixed — Shared-history bootstrap on Databricks no longer crashes the JSON columns
 
 Users with `/history-store enable` pointed at a Databricks workspace

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.12.4"
+__version__ = "0.12.5"
 
 __all__ = [
     "AMXApplication",

--- a/amx/storage/factory.py
+++ b/amx/storage/factory.py
@@ -30,6 +30,28 @@ if TYPE_CHECKING:
 log = get_logger("storage.factory")
 
 
+# Process-level cache so the bootstrap warning fires AT MOST ONCE per
+# (profile, schema) per process. Without this, every slash command in
+# an interactive session re-enters init_history_store and re-emits a
+# multi-page warning; the user-reported regression on 2026-05-03 made
+# the terminal unusable.
+_BOOTSTRAP_FAILURE_CACHE: set[tuple[str, str]] = set()
+
+
+def _short_error(exc: BaseException) -> str:
+    """Return the first non-empty line of *exc*'s message.
+
+    SQLAlchemy errors include the offending SQL in the body — useful
+    in debug logs but a 70-line wall-of-text in user-facing warnings.
+    """
+    msg = str(exc).strip()
+    if not msg:
+        return exc.__class__.__name__
+    first = msg.split("\n", 1)[0].strip()
+    # Trim verbose SQLAlchemy boilerplate suffixes when present.
+    return first.split("(Background on this error", 1)[0].rstrip(" .")
+
+
 def apply_history_db_override(db_cfg: DBConfig, override: str) -> DBConfig:
     """Return a copy of *db_cfg* with *override* applied to the right field.
 
@@ -125,6 +147,30 @@ def _build_shared_store(cfg: AMXConfig):
     return store
 
 
+def _warn_bootstrap_failure_once(cache_key: tuple[str, str], short: str, exc: BaseException) -> None:
+    """Emit a single one-line warning per (profile, schema) per process.
+
+    The full exception (including the multi-line CREATE TABLE DDL that
+    SQLAlchemy attaches to errors) goes to the debug log only — that
+    multi-page wall-of-text was the user-reported regression on
+    2026-05-03 that turned every slash command into a screenful of SQL.
+    Subsequent calls in the same process for the same target are silent
+    so an interactive session that re-enters ``init_history_store`` per
+    slash command stops spamming the same warning.
+    """
+    if cache_key in _BOOTSTRAP_FAILURE_CACHE:
+        log.debug("Shared history bootstrap retry suppressed for %r: %s", cache_key, short)
+        return
+    _BOOTSTRAP_FAILURE_CACHE.add(cache_key)
+    log.warning(
+        "Shared run-history disabled this session: %s "
+        "(run `/history-store disable` to silence permanently, "
+        "or `/history-store enable` to re-bootstrap).",
+        short,
+    )
+    log.debug("Shared history bootstrap full traceback:", exc_info=exc)
+
+
 def init_history_store(cfg: AMXConfig):
     """Build the singleton history store and attach it to the legacy global.
 
@@ -138,8 +184,10 @@ def init_history_store(cfg: AMXConfig):
 
     On bootstrap failure (network unreachable, schema lacks DDL
     permissions, etc.) we DO NOT raise — we fall back to local-only and
-    log a warning. The user can fix the issue and re-run
-    ``/history-store enable`` without losing the active session.
+    log a single one-line warning per process. The user can fix the
+    issue and re-run ``/history-store enable`` without losing the
+    active session, or run ``/history-store disable`` to stop AMX from
+    even trying.
     """
     config_dir = getattr(cfg, "CONFIG_DIR", str(Path.home() / ".amx"))
     db_path = Path(config_dir) / "history.db"
@@ -149,34 +197,24 @@ def init_history_store(cfg: AMXConfig):
     except Exception as exc:
         log.warning("Could not initialise local SQLite history: %s", exc)
 
+    profile_key = (
+        str(getattr(cfg, "history_store_profile", "") or ""),
+        str(getattr(cfg, "history_store_schema", "") or ""),
+    )
+
     shared = None
     try:
         shared = _build_shared_store(cfg)
     except HistoryStoreBootstrapError as exc:
-        # Surface as a warning + DDL hint; keep going with local-only
-        # so the user's session is never blocked.
-        log.warning(
-            "Shared history bootstrap failed: %s\n"
-            "Falling back to local-only history.\n"
-            "Run `/history-store enable` after fixing.",
-            exc,
-        )
+        _warn_bootstrap_failure_once(profile_key, _short_error(exc), exc)
     except Exception as exc:
-        log.warning(
-            "Could not connect to shared history store; falling back "
-            "to local-only. Underlying error: %s",
-            exc,
-        )
+        _warn_bootstrap_failure_once(profile_key, _short_error(exc), exc)
 
     if shared is not None:
         try:
             shared.init()
         except Exception as exc:
-            log.warning(
-                "Shared history schema not initialised (%s). Run "
-                "`/history-store enable` to bootstrap the AMX schema.",
-                exc,
-            )
+            _warn_bootstrap_failure_once(profile_key, _short_error(exc), exc)
             shared = None
 
     if shared is None:

--- a/amx/storage/factory.py
+++ b/amx/storage/factory.py
@@ -147,7 +147,9 @@ def _build_shared_store(cfg: AMXConfig):
     return store
 
 
-def _warn_bootstrap_failure_once(cache_key: tuple[str, str], short: str, exc: BaseException) -> None:
+def _warn_bootstrap_failure_once(
+    cache_key: tuple[str, str], short: str, exc: BaseException
+) -> None:
     """Emit a single one-line warning per (profile, schema) per process.
 
     The full exception (including the multi-line CREATE TABLE DDL that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx-cli"
-version = "0.12.4"
+version = "0.12.5"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_history_store_warning_quiet.py
+++ b/tests/test_history_store_warning_quiet.py
@@ -1,0 +1,92 @@
+"""Regression: shared-history bootstrap warning must be quiet.
+
+User report (2026-05-03 against 0.12.4): every slash command in the
+interactive session re-entered ``init_history_store`` and re-emitted
+the SQLAlchemy ``ServerOperationError`` as a 70-line wall of CREATE
+TABLE DDL because the underlying exception's ``str(exc)`` carried the
+full SQL. The terminal became unusable.
+
+These tests pin the 0.12.5 contract:
+
+1. ``_short_error`` returns just the first non-empty line, with the
+   verbose SQLAlchemy "(Background on this error at: …)" suffix
+   trimmed.
+2. ``_warn_bootstrap_failure_once`` emits a single WARNING per
+   (profile, schema) per process. Subsequent calls with the same
+   key go to DEBUG only.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from amx.storage import factory
+
+
+def test_short_error_strips_sql_dump_and_background_link() -> None:
+    """The user's actual error string carried 70 lines of CREATE TABLE
+    DDL between the message and the SQLAlchemy ``Background on this
+    error`` footer. The short form must keep ONLY the first line and
+    drop the footer."""
+    raw = (
+        "(databricks.sql.exc.ServerOperationError) [SCHEMA_NOT_FOUND] "
+        "The schema `sap.amx` cannot be found.\n"
+        "[SQL: \n"
+        "CREATE TABLE `AMX`.analysis_runs (\n"
+        "    id STRING NOT NULL COMMENT 'UUID v4 …',\n"
+        "    started_at TIMESTAMP_NTZ NOT NULL COMMENT '…',\n"
+        "    -- imagine 70 more lines —\n"
+        ") USING DELTA\n"
+        "]\n"
+        "(Background on this error at: https://sqlalche.me/e/20/4xp6)"
+    )
+    short = factory._short_error(RuntimeError(raw))
+    assert "CREATE TABLE" not in short
+    assert "Background on this error" not in short
+    assert "SCHEMA_NOT_FOUND" in short
+    assert "\n" not in short
+    # Sanity: under 200 chars vs the 4 KB original.
+    assert len(short) < 200
+
+
+def test_warn_bootstrap_failure_fires_once_per_key(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The 70-line warning used to fire on every slash command in a
+    session. After 0.12.5 the second call for the same (profile,
+    schema) key is silent at WARNING level — only the first goes
+    through."""
+    # Reset the module-level cache so tests don't leak into each other.
+    monkeypatch.setattr(factory, "_BOOTSTRAP_FAILURE_CACHE", set())
+    key = ("dbr-test", "AMX")
+    exc = RuntimeError("boom")
+
+    with caplog.at_level(logging.WARNING, logger="amx.storage.factory"):
+        factory._warn_bootstrap_failure_once(key, "boom", exc)
+        factory._warn_bootstrap_failure_once(key, "boom", exc)
+        factory._warn_bootstrap_failure_once(key, "boom", exc)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1, f"expected 1 WARNING, got {len(warnings)}: {warnings}"
+    assert "Shared run-history disabled this session" in warnings[0].message
+    assert "/history-store disable" in warnings[0].message
+
+
+def test_warn_bootstrap_failure_distinguishes_keys(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Different (profile, schema) targets each get their own one-shot
+    warning. A user with two shared-history profiles configured must
+    see one warning per failing target."""
+    monkeypatch.setattr(factory, "_BOOTSTRAP_FAILURE_CACHE", set())
+    exc = RuntimeError("boom")
+
+    with caplog.at_level(logging.WARNING, logger="amx.storage.factory"):
+        factory._warn_bootstrap_failure_once(("p1", "AMX"), "boom", exc)
+        factory._warn_bootstrap_failure_once(("p2", "AMX"), "boom", exc)
+        factory._warn_bootstrap_failure_once(("p1", "AMX"), "boom", exc)  # repeat → silent
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2, f"expected 2 distinct WARNING, got {len(warnings)}"


### PR DESCRIPTION
## Summary

User report: every slash command in the interactive session was printing a 70-line wall of \`CREATE TABLE\` DDL because:
1. The underlying \`databricks.sql.exc.ServerOperationError\` carried the full SQL in \`str(exc)\`.
2. \`init_history_store\` was re-entered per slash command and re-emitted the same warning.

After this PR the user-visible warning is **one short line, fired once per process per (profile, schema)**:

\`\`\`
[WARNING] Shared run-history disabled this session: (databricks.sql.exc.ServerOperationError)
[SCHEMA_NOT_FOUND] The schema \`sap.amx\` cannot be found
(run \`/history-store disable\` to silence permanently, or
\`/history-store enable\` to re-bootstrap).
\`\`\`

The full traceback (with the offending SQL) goes to DEBUG only — useful when debugging, invisible during normal use.

Bump to 0.12.5.

### What this PR does NOT do

- **Does NOT auto-create the AMX schema.** User said \"Yahu, schema oluşturmak zorunda değil kullanıcı.\"
- **Does NOT auto-disable the shared-history setting.** That's the user's call — they get a clear hint instead.

## Test plan
- [x] \`pytest tests/ -q --ignore=tests/eval\` → **576 pass** (+3 new)
- [x] \`tests/test_history_store_warning_quiet.py\`:
  - \`_short_error\` strips the SQL dump and the SQLAlchemy footer
  - \`_warn_bootstrap_failure_once\` fires exactly one WARNING per key, even after three calls
  - Distinct (profile, schema) keys each get their own one-shot warning
- [x] Smoke: simulated the user's exact multi-line ServerOperationError → warning collapses to one line, second/third calls silent at WARNING
