### PR TITLE
fix(db,history-store): make shared-history host explicit on /use-db and /remove-db-profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Changed — `/use-db` and `/remove-db-profile` now make the shared run-history host explicit
+
+The shared run-history is pinned to whichever DB profile the user
+passed to `/history-store enable`, not to the *active* DB profile.
+That distinction was not surfaced anywhere in the CLI, so users who
+switched the active scope with `/use-db` to a different profile
+reasonably worried that history was now writing to the wrong place,
+or worse, that switching had detached the store. It hadn't — but the
+silence was the bug.
+
+Two UX hardenings:
+
+1. **`/use-db` now prints a one-line confirmation** when the chosen
+   active profile differs from `cfg.history_store_profile`:
+
+   ```
+   Shared run-history is still hosted on profile 'A' (this switch
+   does not detach it). Run `/history-store status` to inspect.
+   ```
+
+   Suppressed when host == active (no point restating the obvious).
+   This is text-only — no behavior change to the switch itself.
+
+2. **`/remove-db-profile <host>` now leads with the headline and
+   reassures about local data**, plus offers to drain a non-empty
+   outbox to the remote backend before the profile vanishes:
+
+   - `Heads up — shared run-history is enabled on this profile.`
+     (was buried mid-paragraph)
+   - `Your local run history (~/.amx/history.db) stays intact. Past
+     runs and events created on this machine remain queryable via
+     /history-runs after deletion.` (new — addresses the "did I
+     just lose my data?" reflex)
+   - The shared remote schema reassurance stays.
+   - When `pending_count() > 0`, the prompt asks `Flush them to the
+     remote backend before deleting? (Recommended)` (default Yes)
+     and reuses the existing `_action_flush(cfg)` plumbing. Any rows
+     still queued after flush are reported, but do not block delete.
+   - Final confirm prompt remains default-No, so accidental Enter
+     never destroys a host profile.
+
+No change to `cmd_use` /`set_active_db_profile*`, `init_history_store`,
+or the bootstrap path — switching has always been non-destructive,
+this commit just makes that visible.
+
 ### Fixed — Shared-history bootstrap warning no longer floods the terminal with SQL
 
 User report (against 0.12.4): every slash command in an interactive

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -393,11 +393,7 @@ def cmd_use(
         # whichever profile was passed to `/history-store enable` until
         # the user explicitly disables it or removes the host profile.
         host = (getattr(cfg, "history_store_profile", "") or "").strip()
-        if (
-            getattr(cfg, "history_store_enabled", False)
-            and host
-            and host != chosen[0]
-        ):
+        if getattr(cfg, "history_store_enabled", False) and host and host != chosen[0]:
             info(
                 f"Shared run-history is still hosted on profile {host!r} "
                 "(this switch does not detach it). "

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -388,6 +388,21 @@ def cmd_use(
             )
         else:
             success(f"Active DB scope: {', '.join(chosen)} (default = {chosen[0]} [{p.backend}])")
+        # Reassure the user that switching the *active* scope does not
+        # detach the shared run-history store: that one stays pinned to
+        # whichever profile was passed to `/history-store enable` until
+        # the user explicitly disables it or removes the host profile.
+        host = (getattr(cfg, "history_store_profile", "") or "").strip()
+        if (
+            getattr(cfg, "history_store_enabled", False)
+            and host
+            and host != chosen[0]
+        ):
+            info(
+                f"Shared run-history is still hosted on profile {host!r} "
+                "(this switch does not detach it). "
+                "Run `/history-store status` to inspect."
+            )
         if log_event is not None:
             log_event(
                 event_type="db_profile_switch",
@@ -924,21 +939,60 @@ def cmd_remove_profile(cfg: AMXConfig, rest: list[str]) -> None:
     # Guard: removing the profile that hosts the shared run-history
     # schema would orphan the connection on the next AMX startup
     # (factory falls back to local-only with a warning, but the user
-    # would not necessarily notice). Make the consequence explicit
-    # before dropping the profile.
+    # would not necessarily notice). Lead with the headline, reassure
+    # the user that local rows survive, and offer to drain a non-empty
+    # outbox to the remote backend before the profile disappears.
     if (
         getattr(cfg, "history_store_enabled", False)
         and getattr(cfg, "history_store_profile", "") == name
     ):
         schema = cfg.history_store_schema or "AMX"
         warn(
-            f"Profile {name!r} is the host for shared run-history "
-            f"(schema {schema!r}). Removing it will:\n"
-            "  • Disable shared mode on this machine.\n"
-            "  • Leave the shared schema on the remote untouched (your\n"
-            "    teammates' rows are safe).\n"
-            "  • Strand any pending shared writes still in the local outbox."
+            "Heads up — shared run-history is enabled on this profile.\n"
+            f"  Profile {name!r} hosts the AMX schema {schema!r}."
         )
+        info(
+            "Your local run history (~/.amx/history.db) stays intact. "
+            "Past runs and events created on this machine remain "
+            "queryable via `/history-runs` after deletion."
+        )
+        info(
+            "The shared schema on the remote backend is also untouched — "
+            "your teammates' rows are safe."
+        )
+        # Lazy import to avoid a circular dependency between the db and
+        # history_store command modules.
+        from amx.cli_support.commands.history_store import (
+            _action_flush,
+            _resolve_history_dual_store,
+        )
+
+        store = _resolve_history_dual_store()
+        depth = 0
+        if store is not None:
+            try:
+                depth = store.pending_count()
+            except Exception:
+                depth = 0
+        if depth > 0:
+            warn(
+                f"Outbox has {depth} pending shared write(s) that have NOT "
+                "reached the team backend yet."
+            )
+            if confirm(
+                "Flush them to the remote backend before deleting? (Recommended)",
+                default=True,
+            ):
+                _action_flush(cfg)
+                try:
+                    depth = store.pending_count() if store is not None else 0
+                except Exception:
+                    depth = 0
+            if depth > 0:
+                warn(
+                    f"{depth} write(s) still queued — they will not be retried "
+                    "after the profile is removed."
+                )
         if not confirm(
             f"Remove profile {name!r} AND disable shared run-history?",
             default=False,


### PR DESCRIPTION
## Summary

- The shared run-history store is pinned to whichever DB profile the user passed to `/history-store enable`, **not** to the *active* DB profile. Switching the active scope with `/use-db` does **not** detach it. That has always been the behaviour, but nothing in the CLI surfaced it, so users who switched scope reasonably worried history was now writing to the wrong place. The silence was the bug.
- `/use-db` now prints a one-line confirmation when the chosen active profile differs from `cfg.history_store_profile`, naming the host and pointing at `/history-store status`. Suppressed when host == active.
- `/remove-db-profile <host>` now leads its warning with the headline (`shared run-history is enabled on this profile`), explicitly reassures that `~/.amx/history.db` and prior `/history-runs` rows are untouched, and — when `pending_count() > 0` — offers to flush the outbox via the existing `_action_flush` helper before deletion. Final confirm stays default-No.

No behaviour change to `cmd_use` / `set_active_db_profile*`, `init_history_store`, or the bootstrap path. Verified by running the existing 192 db/profile/history-store tests (all green).

## Test plan

- [x] `pytest -k "history_store or remove_profile or use_db or use_profile"` — 32 passed
- [x] `pytest -k "db or profile"` — 192 passed
- [ ] Manual walkthrough on a live shell:
  - `/add-db-profile A`, `/history-store enable` → A
  - `/add-db-profile B`, `/use-db B` → expect new host-hint line naming `A`
  - `/use-db A` → expect host-hint **suppressed** (host == active)
  - `/remove-db-profile A` → expect new headline + local-data reassurance + (with non-empty outbox) flush prompt defaulting to Yes