### PR TITLE
feat(rag,llm): /use-rag-llm pins the RAG agent to its own LLM profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,62 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added — `/use-rag-llm` lets the RAG agent run on a different LLM profile
+
+Until now every agent in AMX (Profile, Code, RAG) shared a single
+`active_llm_profile`. Users who wanted to pair a small/cheap model
+for RAG retrieval-grounded summarisation with a larger model for the
+main run had to swap the active profile back and forth. The new
+`rag_llm_profile` config field decouples the RAG agent from the
+global LLM choice.
+
+User-visible:
+
+- `/use-rag-llm` — interactive picker over `cfg.llm_profiles` plus a
+  leading `(none)` entry that means "fall back to the active
+  profile". Inline form: `/use-rag-llm <name>`. Pass any of
+  `none / off / clear / default / -` to clear the override.
+- `/llm-profiles` table now shows two marks: `*` (active) and `R`
+  (RAG override). The header reads
+  `LLM profiles (* = active, R = RAG override)`. A footer line
+  spells out the current state in plain English so the marks alone
+  are never load-bearing.
+
+Behaviour:
+
+- Empty / unset (default): RAG keeps using `cfg.llm` exactly as
+  before — zero behaviour change for existing configs.
+- Set to a real profile: `Orchestrator` and the standalone RAG path
+  (`/doc-analyze`) build a second `LLMProvider` pinned to that
+  profile and wire it into `RAGAgent`. `ProfileAgent` and `CodeAgent`
+  continue to use the global LLM.
+- Set to a deleted profile: silently falls back to the active
+  profile via `cfg.effective_rag_llm()`. The dangling value is also
+  scrubbed at load time so the YAML self-heals on the next save.
+- `/remove-llm-profile <name>` clears `rag_llm_profile` when the
+  removed name matches, so deleting the override target never leaves
+  a ghost reference.
+
+Persistence:
+
+- `rag_llm_profile: str = ""` added to `AMXConfig` next to
+  `active_llm_profile`, included in `_PERSISTED_FIELDS`, written and
+  read by `save()` / `load()`. Old configs missing the field load as
+  empty (no override).
+
+Helper:
+
+- `AMXConfig.effective_rag_llm()` returns the LLMConfig the RAG
+  agent should use right now — single source of truth for callers.
+  Identity-equal to `cfg.llm` when there is no override, so callers
+  gate on `rag_cfg is not cfg.llm` to avoid building a redundant
+  `LLMProvider` in the no-override path.
+
+`tests/test_rag_llm_profile.py` pins the contract: fallback when
+unset, fallback when dangling, removal clears the override, YAML
+round-trip, dangling self-heal on load, and the orchestrator wiring
+itself.
+
 ### Changed — `/use-db` and `/remove-db-profile` now make the shared run-history host explicit
 
 The shared run-history is pinned to whichever DB profile the user

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -372,6 +372,8 @@ class Orchestrator:
         run_id: int | None = None,
         search_profile: str = "default",
         missing_only: bool = False,
+        *,
+        rag_llm: LLMProvider | None = None,
     ):
         self.db = db
         self.llm = llm
@@ -379,7 +381,11 @@ class Orchestrator:
         self.search_profile = search_profile or "default"
         self.code_report = code_report
         self.profile_agent = ProfileAgent(llm)
-        self.rag_agent = RAGAgent(llm, rag_store) if rag_store else None
+        # ``rag_llm`` lets the caller pin the RAG agent to a different
+        # LLM profile (cfg.rag_llm_profile) than the global one. None
+        # falls back to the global ``llm`` so old call sites keep their
+        # existing behaviour without a code change.
+        self.rag_agent = RAGAgent(rag_llm or llm, rag_store) if rag_store else None
         self.code_agent = CodeAgent(llm, code_report) if code_report else None
         # ``missing_only`` skips tables that already have a table comment AND
         # every column already has a comment, and filters individual columns

--- a/amx/cli_support/commands/_analyze/run_loop.py
+++ b/amx/cli_support/commands/_analyze/run_loop.py
@@ -68,10 +68,18 @@ def run_per_schema_loop(
     rendering and the apply step.
     """
     from amx.agents.orchestrator import Orchestrator
+    from amx.llm.provider import LLMProvider
     from amx.utils.live_display import get_display
 
     result = PerSchemaLoopResult()
     display = get_display()
+
+    # Build the RAG-specific provider once per loop. Identity check vs
+    # cfg.llm: effective_rag_llm() returns the same object when there
+    # is no override, in which case we leave rag_llm=None so the
+    # orchestrator falls back to the global llm.
+    rag_cfg = cfg.effective_rag_llm()
+    rag_llm = LLMProvider(rag_cfg) if rag_cfg is not cfg.llm else None
 
     for schema_name, assets in scope.items():
         asset_kinds = {name: db.resolve_asset_kind(schema_name, name) for name in assets}
@@ -83,6 +91,7 @@ def run_per_schema_loop(
             run_id=run_id,
             search_profile=cfg.active_db_profile or "default",
             missing_only=missing_only,
+            rag_llm=rag_llm,
         )
         if dedup_outcome is not None and dedup_outcome.skip_set:
             # Tell the orchestrator which (schema, table, column)

--- a/amx/cli_support/commands/docs.py
+++ b/amx/cli_support/commands/docs.py
@@ -276,6 +276,12 @@ def register_docs_commands(
         token_tracker.reset()
 
         llm = LLMProvider(cfg.llm)
+        # Honour /use-rag-llm: build a separate provider for the RAG
+        # agent when the user has pinned a different LLM profile to
+        # retrieval. Identity check on cfg.llm avoids redundant work
+        # when no override is set.
+        rag_cfg = cfg.effective_rag_llm()
+        rag_llm = LLMProvider(rag_cfg) if rag_cfg is not cfg.llm else llm
         db = DatabaseConnector(cfg.db)
         with command_display(
             schema=schema or cfg.current_schema or "",
@@ -296,7 +302,7 @@ def register_docs_commands(
             schema_name = next(iter(scope))
             tables = scope[schema_name]
 
-            agent = RAGAgent(llm, store)
+            agent = RAGAgent(rag_llm, store)
             all_suggestions = []
             for table_name in tables:
                 with step_spinner(f"Profiling {schema_name}.{table_name}"):

--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -190,11 +190,28 @@ def cmd_temperature(cfg: AMXConfig, rest: list[str]) -> None:
 
 
 def cmd_llm_profiles(cfg: AMXConfig) -> None:
+    rag_override = (cfg.rag_llm_profile or "").strip()
     rows = []
     for name, llm in sorted(cfg.llm_profiles.items(), key=lambda x: x[0]):
-        mark = "*" if name == cfg.active_llm_profile else " "
-        rows.append([f"{mark} {name}", llm.provider, llm.model])
-    render_table("LLM profiles (* = active)", ["Profile", "Provider", "Model"], rows)
+        marks = ""
+        marks += "*" if name == cfg.active_llm_profile else " "
+        marks += "R" if rag_override and name == rag_override else " "
+        rows.append([f"{marks} {name}", llm.provider, llm.model])
+    render_table(
+        "LLM profiles (* = active, R = RAG override)",
+        ["Profile", "Provider", "Model"],
+        rows,
+    )
+    if rag_override and rag_override in cfg.llm_profiles:
+        if rag_override == cfg.active_llm_profile:
+            info(
+                f"RAG override set to {rag_override!r} — same as the active profile, "
+                "so it has no effect. Run /use-rag-llm to pick a different profile."
+            )
+        else:
+            info(f"RAG agent uses {rag_override!r} (override). Run `/use-rag-llm none` to clear.")
+    else:
+        info("RAG agent uses the active profile. Run `/use-rag-llm` to override.")
 
 
 def cmd_use_llm(cfg: AMXConfig, rest: list[str]) -> None:
@@ -212,6 +229,75 @@ def cmd_use_llm(cfg: AMXConfig, rest: list[str]) -> None:
         success(f"Switched active LLM profile to: {name}")
     except Exception as exc:
         error(str(exc))
+
+
+_RAG_LLM_CLEAR_TOKENS = {"none", "(none)", "off", "clear", "default", "-"}
+
+
+def cmd_use_rag_llm(cfg: AMXConfig, rest: list[str]) -> None:
+    """Pin a different LLM profile to the RAG agent, or clear that pin.
+
+    Without args, opens an interactive picker that lists every LLM
+    profile plus a leading ``(none)`` entry meaning "RAG falls back to
+    the active profile". With a name, switches directly. Pass any of
+    ``none / off / clear / default / -`` to clear the override
+    non-interactively.
+
+    The override is stored in ``cfg.rag_llm_profile``; it has no effect
+    when empty.
+    """
+    names = sorted(cfg.llm_profiles.keys())
+    if not names:
+        error("No LLM profiles configured. Use /add-llm-profile first.")
+        return
+
+    if len(rest) >= 1:
+        raw = rest[0].strip()
+        if raw.lower() in _RAG_LLM_CLEAR_TOKENS:
+            cfg.rag_llm_profile = ""
+            cfg.save()
+            success(
+                f"RAG override cleared. RAG agent now uses the active LLM "
+                f"profile {cfg.active_llm_profile!r}."
+            )
+            return
+        if raw not in cfg.llm_profiles:
+            error(f"Unknown LLM profile: {raw}. Available: {', '.join(names)}")
+            return
+        name = raw
+    else:
+        choices = ["(none)"] + names
+        default_choice = (
+            cfg.rag_llm_profile if cfg.rag_llm_profile in cfg.llm_profiles else "(none)"
+        )
+        picked = ask_choice(
+            "Select LLM profile for the RAG agent",
+            choices,
+            default=default_choice,
+        )
+        if picked == "(none)" or not picked:
+            cfg.rag_llm_profile = ""
+            cfg.save()
+            success(
+                f"RAG override cleared. RAG agent now uses the active LLM "
+                f"profile {cfg.active_llm_profile!r}."
+            )
+            return
+        name = picked
+
+    cfg.rag_llm_profile = name
+    cfg.save()
+    if name == cfg.active_llm_profile:
+        info(
+            f"RAG override set to {name!r} — same as the active profile, "
+            "so behaviour is unchanged. Pick a different profile to actually "
+            "split RAG from the rest."
+        )
+    else:
+        success(
+            f"RAG agent now uses LLM profile {name!r} "
+            f"(active profile for everything else: {cfg.active_llm_profile!r})."
+        )
 
 
 def cmd_add_llm_profile(cfg: AMXConfig, rest: list[str]) -> None:

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -94,6 +94,9 @@ from amx.cli_support.commands.profiles import (
 from amx.cli_support.commands.profiles import (
     cmd_use_llm as _cmd_use_llm,
 )
+from amx.cli_support.commands.profiles import (
+    cmd_use_rag_llm as _cmd_use_rag_llm,
+)
 from amx.cli_support.commands.usage import cmd_usage as _cmd_usage
 from amx.cli_support.slash_commands import (
     cmd_heads_for_namespace as _registry_cmd_heads,
@@ -722,6 +725,11 @@ def _handle_session_builtin(
         if not _require_namespace(head, namespace, "llm", "use-llm"):
             return True
         _cmd_use_llm(cfg, parts[1:])
+        return True
+    if head == "use-rag-llm":
+        if not _require_namespace(head, namespace, "llm", "use-rag-llm"):
+            return True
+        _cmd_use_rag_llm(cfg, parts[1:])
         return True
     if head == "add-llm-profile":
         if not _require_namespace(head, namespace, "llm", "add-llm-profile"):

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -182,6 +182,11 @@ _LLM_COMMANDS: tuple[SlashCommand, ...] = (
     # Profile management
     SlashCommand("/llm-profiles", "llm", "List LLM profiles"),
     SlashCommand("/use-llm", "llm", "Switch LLM profile (/use-llm <name>)"),
+    SlashCommand(
+        "/use-rag-llm",
+        "llm",
+        "Pin a different LLM profile to the RAG agent (/use-rag-llm [<name>|none])",
+    ),
     SlashCommand("/add-llm-profile", "llm", "Add/update LLM profile"),
     SlashCommand("/remove-llm-profile", "llm", "Remove LLM profile (/remove-llm-profile <name>)"),
     # Prompt control (input shape)

--- a/amx/config.py
+++ b/amx/config.py
@@ -1160,6 +1160,12 @@ class AMXConfig:
     current_table: str = ""
     llm_profiles: dict[str, LLMConfig] = field(default_factory=dict)
     active_llm_profile: str = "default"
+    # Per-agent override: when non-empty AND present in ``llm_profiles``,
+    # the RAG agent uses this profile instead of ``active_llm_profile``.
+    # Lets the user pair, e.g., a small-and-cheap retrieval model with a
+    # bigger reasoning model on the global profile (or vice versa).
+    # Empty string ("") = no override, RAG uses the active profile.
+    rag_llm_profile: str = ""
     doc_profiles: dict[str, list[str]] = field(default_factory=dict)
     active_doc_profile: str = ""
     code_profiles: dict[str, str] = field(default_factory=dict)
@@ -1211,6 +1217,7 @@ class AMXConfig:
             "current_table",
             "llm_profiles",
             "active_llm_profile",
+            "rag_llm_profile",
             "doc_profiles",
             "active_doc_profile",
             "code_profiles",
@@ -1311,6 +1318,7 @@ class AMXConfig:
                         cfg.llm_profiles[str(name)] = _llm_from_mapping(m)
 
             cfg.active_llm_profile = str(data.get("active_llm_profile") or "default")
+            cfg.rag_llm_profile = str(data.get("rag_llm_profile") or "")
 
             doc_prof_raw = data.get("doc_profiles") or {}
             if isinstance(doc_prof_raw, dict):
@@ -1370,12 +1378,18 @@ class AMXConfig:
 
         if not cfg.llm_profiles:
             cfg.active_llm_profile = ""
+            cfg.rag_llm_profile = ""
         else:
             try:
                 cfg.apply_active_llm_profile()
             except Exception:
                 cfg.active_llm_profile = next(iter(cfg.llm_profiles.keys()))
                 cfg.llm = replace(cfg.llm_profiles[cfg.active_llm_profile])
+            # Drop the RAG override when it points at a deleted profile so
+            # the orchestrator silently falls back to the active profile
+            # instead of failing later with KeyError on rag_llm_profile.
+            if cfg.rag_llm_profile and cfg.rag_llm_profile not in cfg.llm_profiles:
+                cfg.rag_llm_profile = ""
 
         if not cfg.doc_profiles and cfg.doc_paths:
             cfg.doc_profiles["default"] = list(cfg.doc_paths)
@@ -1460,6 +1474,7 @@ class AMXConfig:
                 data["llm"] = _llm_to_mapping(self.llm)
             data["llm_profiles"] = {k: _llm_to_mapping(v) for k, v in self.llm_profiles.items()}
             data["active_llm_profile"] = self.active_llm_profile
+            data["rag_llm_profile"] = str(self.rag_llm_profile or "")
             data["doc_paths"] = doc_paths_yaml
             data["doc_profiles"] = {k: list(v) for k, v in self.doc_profiles.items()}
             data["active_doc_profile"] = self.active_doc_profile
@@ -1715,7 +1730,24 @@ class AMXConfig:
         if self.active_llm_profile == name:
             self.active_llm_profile = next(iter(self.llm_profiles.keys()))
             self.llm = replace(self.llm_profiles[self.active_llm_profile])
+        if self.rag_llm_profile == name:
+            self.rag_llm_profile = ""
         self._autosave()
+
+    def effective_rag_llm(self) -> LLMConfig:
+        """Return the LLMConfig the RAG agent should use right now.
+
+        Falls back to ``self.llm`` (the active profile) when
+        ``rag_llm_profile`` is empty or names a profile that no longer
+        exists. The fallback is intentionally silent: a stale value is
+        already cleaned up at load time, but a mid-session race (profile
+        deleted while another module holds an old cfg) should still land
+        on the active profile rather than raise.
+        """
+        name = (self.rag_llm_profile or "").strip()
+        if name and name in self.llm_profiles:
+            return self.llm_profiles[name]
+        return self.llm
 
     def upsert_doc_profile(self, name: str, paths: list[str]) -> None:
         self.doc_profiles[name] = list(paths)

--- a/amx/core/inference.py
+++ b/amx/core/inference.py
@@ -55,12 +55,19 @@ def infer_table_metadata(
 
     db = DatabaseConnector(cfg.db)
     llm = LLMProvider(cfg.llm)
+    # When the user has set ``rag_llm_profile`` (via /use-rag-llm) we
+    # build a second provider pinned to that profile so the RAG agent
+    # uses it instead of the global one. Identity check vs cfg.llm —
+    # effective_rag_llm() returns the same object when no override.
+    rag_cfg = cfg.effective_rag_llm()
+    rag_llm = LLMProvider(rag_cfg) if rag_cfg is not cfg.llm else None
     orch = Orchestrator(
         db,
         llm,
         rag_store=rag_store,
         code_report=code_report,
         search_profile=cfg.active_db_profile or "default",
+        rag_llm=rag_llm,
     )
     results = orch.process_table(schema, table, interactive_review=False)
     return [asdict(r) for r in results]

--- a/tests/test_rag_llm_profile.py
+++ b/tests/test_rag_llm_profile.py
@@ -1,0 +1,145 @@
+"""Pin the rag_llm_profile override contract.
+
+The user can run ``/use-rag-llm <name>`` to point the RAG agent at a
+different LLM profile than the global ``active_llm_profile``. The
+override must:
+
+- round-trip through YAML save/load,
+- fall back to the active profile when empty OR when pointed at a
+  deleted profile (silent self-heal so a stale value never raises),
+- be cleared automatically when the named profile is removed.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from amx.config import AMXConfig, LLMConfig
+
+
+def _seeded_cfg() -> AMXConfig:
+    cfg = AMXConfig()
+    cfg.llm_profiles["big"] = LLMConfig(
+        provider="anthropic", model="claude-sonnet-4-5", api_key="k1"
+    )
+    cfg.llm_profiles["small"] = LLMConfig(provider="openai", model="gpt-4o-mini", api_key="k2")
+    cfg.set_active_llm_profile("big")
+    return cfg
+
+
+def test_effective_rag_llm_falls_back_to_active_when_unset() -> None:
+    cfg = _seeded_cfg()
+    assert cfg.rag_llm_profile == ""
+    # Identity matters: callers gate on `rag_cfg is not cfg.llm` to
+    # avoid building a redundant LLMProvider when there is no override.
+    assert cfg.effective_rag_llm() is cfg.llm
+
+
+def test_effective_rag_llm_returns_named_profile_when_set() -> None:
+    cfg = _seeded_cfg()
+    cfg.rag_llm_profile = "small"
+    eff = cfg.effective_rag_llm()
+    assert eff.model == "gpt-4o-mini"
+    assert eff is not cfg.llm
+
+
+def test_effective_rag_llm_falls_back_when_pointing_at_missing_profile() -> None:
+    cfg = _seeded_cfg()
+    cfg.rag_llm_profile = "ghost"
+    # Silent self-heal: callers must never see a KeyError because the
+    # YAML on disk lagged behind a profile deletion.
+    assert cfg.effective_rag_llm() is cfg.llm
+
+
+def test_remove_llm_profile_clears_rag_override_when_it_matches() -> None:
+    cfg = _seeded_cfg()
+    cfg.rag_llm_profile = "small"
+    cfg.remove_llm_profile("small")
+    assert cfg.rag_llm_profile == ""
+
+
+def test_remove_llm_profile_leaves_rag_override_when_unrelated() -> None:
+    cfg = _seeded_cfg()
+    cfg.llm_profiles["other"] = LLMConfig(provider="openai", model="gpt-4o", api_key="k3")
+    cfg.rag_llm_profile = "small"
+    cfg.remove_llm_profile("other")
+    assert cfg.rag_llm_profile == "small"
+
+
+def test_rag_llm_profile_round_trips_through_yaml() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "config.yml"
+        cfg = _seeded_cfg()
+        cfg.rag_llm_profile = "small"
+        cfg.save(str(path))
+
+        reloaded = AMXConfig.load(str(path))
+        assert reloaded.rag_llm_profile == "small"
+        assert reloaded.effective_rag_llm().model == "gpt-4o-mini"
+
+
+def test_dangling_rag_llm_profile_is_dropped_on_load() -> None:
+    """A YAML that names a profile no longer in llm_profiles must
+    self-heal to an empty override on load — otherwise the orchestrator
+    would silently fall back per call but the YAML would keep pointing
+    at a ghost forever."""
+    import yaml
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "config.yml"
+        cfg = _seeded_cfg()
+        cfg.save(str(path))
+
+        # Hand-edit the YAML to inject a dangling override.
+        data = yaml.safe_load(path.read_text())
+        data["rag_llm_profile"] = "ghost"
+        path.write_text(yaml.dump(data, sort_keys=False))
+
+        reloaded = AMXConfig.load(str(path))
+        assert reloaded.rag_llm_profile == ""
+
+
+def test_orchestrator_routes_rag_agent_to_override_llm() -> None:
+    """The Orchestrator builds RAGAgent with rag_llm when supplied,
+    falls back to the global llm otherwise. This guards the wiring at
+    amx/agents/orchestrator.py:382."""
+    from amx.agents.orchestrator import Orchestrator
+
+    class _StubLLM:
+        def __init__(self, tag: str) -> None:
+            self.tag = tag
+
+    class _StubDB:
+        pass
+
+    class _StubRAGStore:
+        pass
+
+    main = _StubLLM("global")
+    rag = _StubLLM("rag-only")
+
+    orch = Orchestrator(
+        db=_StubDB(),
+        llm=main,
+        rag_store=_StubRAGStore(),
+        rag_llm=rag,
+    )
+    assert orch.rag_agent is not None
+    assert orch.rag_agent.llm is rag
+    # The other agents (profile, code) keep using the global llm.
+    assert orch.profile_agent.llm is main
+
+    orch_default = Orchestrator(
+        db=_StubDB(),
+        llm=main,
+        rag_store=_StubRAGStore(),
+    )
+    assert orch_default.rag_agent is not None
+    assert orch_default.rag_agent.llm is main
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- New AMXConfig field `rag_llm_profile` (default `""`) lets the user point the RAG agent at a different LLM profile than `active_llm_profile` — pair a cheap retrieval-grounded summariser with a bigger main reasoning model without swapping `/use-llm` back and forth between commands.
- `/use-rag-llm` mirrors `/use-llm` (interactive picker with a leading `(none)` entry; inline `/use-rag-llm <name>`; `none/off/clear/default/-` clears). `/llm-profiles` now shows two marks: `*` (active) and `R` (RAG override), with a plain-English footer.
- `Orchestrator` gains a kw-only `rag_llm: LLMProvider | None`. When `None`, RAGAgent uses the global `llm` — zero behaviour change for existing call sites that haven't opted in. The 4 call sites that build a RAGAgent (orchestrator default path, `amx/core/inference.py`, the analyze run loop, `/doc-analyze`) resolve the override via `cfg.effective_rag_llm()` and build a second `LLMProvider` only when it differs from `cfg.llm`.
- Self-healing: if `rag_llm_profile` names a deleted profile, `effective_rag_llm()` silently falls back to `cfg.llm`; the load path scrubs the dangling value so the YAML self-heals on next save; `/remove-llm-profile <name>` clears `rag_llm_profile` when the names match.

## Test plan

- [x] `pytest tests/test_rag_llm_profile.py -v` — 8 new cases (unset fallback, override, dangling fallback, removal-clears, removal-leaves-unrelated, YAML round-trip, dangling self-heal on load, orchestrator wiring) all pass
- [x] `pytest tests/` — 604 pass, 19 deselected
- [x] `ruff check amx tests` + `ruff format --check amx tests` — clean
- [ ] Manual: `/add-llm-profile big`, `/add-llm-profile small`, `/use-llm big`, `/use-rag-llm small`, run `/doc-analyze` — RAG hits `small`, other agents hit `big`. `/llm-profiles` shows `*  big` and ` R small`. `/use-rag-llm none` clears.