### PR TITLE
fix(storage): instant amx startup + close SCHEMA_NOT_FOUND on shared-history bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — `amx` startup is back to <100ms even on a Databricks-backed shared run-history
+
+User report (2026-05-04 against 0.12.5 + the just-shipped lifecycle
+hardening): every `amx` invocation took 3-4 seconds before the
+welcome banner appeared, and surfaced a one-line `SCHEMA_NOT_FOUND`
+warning against the configured Databricks history-store target
+(catalog `<X>`, schema `AMX`).
+
+Root causes:
+
+1. **The startup bootstrap path skipped `CREATE SCHEMA`**.
+   `/history-store enable` calls
+   `adapter.create_history_schema(engine, schema)` (idempotent
+   `CREATE SCHEMA IF NOT EXISTS`) before `MetaData.create_all`. The
+   process-startup path in `_build_shared_store` did not, so any
+   user whose schema disappeared (or was never created on this
+   host) hit `SCHEMA_NOT_FOUND` from `create_all` on every single
+   `amx` invocation.
+
+2. **Shared-history bootstrap ran synchronously at startup**.
+   `init_history_store` opened the SQLAlchemy engine, ran `CREATE
+   SCHEMA`, and then `MetaData.create_all` against the team backend
+   on every `amx` invocation — even for `/help`, `/db-profiles`,
+   and other commands that never touch history. On Databricks that
+   meant a 2-3 second blocker between the user pressing Enter and
+   the welcome banner.
+
+Fixes:
+
+- `_build_shared_store` now calls
+  `adapter.create_history_schema(engine, schema)` before building
+  the SQLAlchemy store. The DDL is `CREATE SCHEMA IF NOT EXISTS`,
+  so it's a no-op when the schema already exists. Permission
+  failures here are downgraded to debug logs (the schema may
+  already exist — `MetaData.create_all` will succeed regardless).
+- New `_LazyDualWriteStore` wraps the local SQLite store eagerly
+  but defers shared-backend bootstrap to the first method call.
+  `init_history_store` returns the lazy wrapper when shared mode is
+  on; the welcome banner is no longer blocked by a Databricks /
+  Postgres / Snowflake round-trip. Bootstrap failures still surface
+  as a one-line warning (cached per profile/schema as before), but
+  only the first time a call actually needs the shared backend.
+- `db_path` and `.local` on the lazy wrapper are zero-cost reads,
+  so existing `hasattr(hs, "shared")` and `hs.db_path` consumers
+  keep working without forcing a build.
+
+Tests added:
+
+- `tests/test_history_store_schema_precreate.py` pins the call
+  order (`create_engine` → `create_history_schema` → store ctor)
+  and that pre-create permission failures are downgraded to debug
+  log instead of aborting the bootstrap.
+- `tests/test_history_store_lazy_bootstrap.py` pins that
+  `init_history_store` returns a lazy wrapper that is NOT built at
+  init time, builds on first method call, does not rebuild on
+  subsequent calls, exposes `db_path`/`.local` without a build, and
+  falls back to local-only on bootstrap failure.
+
 ### Added — `/use-rag-llm` lets the RAG agent run on a different LLM profile
 
 Until now every agent in AMX (Profile, Code, RAG) shared a single

--- a/amx/storage/factory.py
+++ b/amx/storage/factory.py
@@ -143,6 +143,27 @@ def _build_shared_store(cfg: AMXConfig):
 
     schema_name = (getattr(cfg, "history_store_schema", "") or "AMX").strip() or "AMX"
     engine = adapter.create_engine()
+    # Pre-create the AMX schema before MetaData.create_all reaches for
+    # CREATE TABLE. The DDL is `CREATE SCHEMA IF NOT EXISTS …` so it
+    # is a no-op when the schema already exists; without this call,
+    # users whose schema was dropped (or never created on this host)
+    # see a SCHEMA_NOT_FOUND on every startup because create_all
+    # assumes the parent schema exists. Symmetric with the call that
+    # `/history-store enable` already issues.
+    #
+    # Best-effort: a permission failure here is downgraded to debug
+    # log because in practice the schema may already exist and
+    # create_all will succeed regardless. A genuinely missing schema +
+    # missing CREATE SCHEMA grant still surfaces via the create_all
+    # error, with the original phrasing preserved.
+    try:
+        adapter.create_history_schema(engine, schema_name)
+    except Exception as exc:
+        log.debug(
+            "Pre-create schema %r failed (will let create_all decide): %s",
+            schema_name,
+            exc,
+        )
     store = SQLAlchemyHistoryStore(engine=engine, schema=schema_name)
     return store
 
@@ -173,32 +194,17 @@ def _warn_bootstrap_failure_once(
     log.debug("Shared history bootstrap full traceback:", exc_info=exc)
 
 
-def init_history_store(cfg: AMXConfig):
-    """Build the singleton history store and attach it to the legacy global.
+def _bootstrap_dual_or_local(local: SQLiteHistoryStore, cfg: AMXConfig):
+    """Build the dual-write store, or fall back to *local* on failure.
 
-    The returned object always implements :class:`amx.storage.protocol.IHistoryStore`.
-    When shared mode is enabled, the result is a
-    :class:`amx.storage.dual_write.DualWriteHistoryStore` wrapping local
-    SQLite + the shared SQLAlchemy store; otherwise it is a vanilla
-    :class:`SQLiteHistoryStore`. Both are pin-compatible with every
-    existing call site that uses ``history_store()`` from
-    :mod:`amx.storage.sqlite_store`.
+    Network-bound — runs the SQLAlchemy engine creation, schema bootstrap,
+    and table create_all on the remote backend. Errors are caught and
+    downgraded to a one-line warning (cached per profile/schema so the
+    same failure is not announced twice in one process).
 
-    On bootstrap failure (network unreachable, schema lacks DDL
-    permissions, etc.) we DO NOT raise — we fall back to local-only and
-    log a single one-line warning per process. The user can fix the
-    issue and re-run ``/history-store enable`` without losing the
-    active session, or run ``/history-store disable`` to stop AMX from
-    even trying.
+    Used by :class:`_LazyDualWriteStore` to defer all of the above out
+    of the ``amx`` startup path.
     """
-    config_dir = getattr(cfg, "CONFIG_DIR", str(Path.home() / ".amx"))
-    db_path = Path(config_dir) / "history.db"
-    local = SQLiteHistoryStore(db_path)
-    try:
-        local.init()
-    except Exception as exc:
-        log.warning("Could not initialise local SQLite history: %s", exc)
-
     profile_key = (
         str(getattr(cfg, "history_store_profile", "") or ""),
         str(getattr(cfg, "history_store_schema", "") or ""),
@@ -220,14 +226,123 @@ def init_history_store(cfg: AMXConfig):
             shared = None
 
     if shared is None:
-        sqlite_store._store = local  # type: ignore[assignment]
         return local
 
     from amx.storage.dual_write import DualWriteHistoryStore
 
-    dual = DualWriteHistoryStore(local=local, shared=shared)
-    sqlite_store._store = dual  # type: ignore[assignment]
-    return dual
+    return DualWriteHistoryStore(local=local, shared=shared)
+
+
+class _LazyDualWriteStore:
+    """Defer shared-history bootstrap until first method call.
+
+    Building the shared backend (Databricks, Postgres, Snowflake, …)
+    means an SQLAlchemy engine + a schema-create + a CREATE TABLE
+    round-trip — easily 2-3 seconds on a remote warehouse. Most ``amx``
+    invocations never write to history (they list profiles, run /help,
+    /db-profiles, …) so blocking the welcome banner on that work is
+    pure user-perceived latency.
+
+    This wrapper holds the local SQLite store eagerly (already cheap
+    to build) and constructs the real
+    :class:`~amx.storage.dual_write.DualWriteHistoryStore` on demand —
+    typically the first ``/run`` or any other call that hits a write
+    method. After the first call the wrapper proxies straight through
+    to the real store with no extra overhead.
+
+    On bootstrap failure the wrapper transparently falls back to the
+    local-only :class:`SQLiteHistoryStore`, mirroring the historical
+    eager path but without the startup tax.
+    """
+
+    def __init__(self, local: SQLiteHistoryStore, cfg: AMXConfig) -> None:
+        # Stored under leading-underscore names so __getattr__ can
+        # cleanly distinguish "wrapper internals" (never proxied) from
+        # delegate attributes (always proxied).
+        self._local = local
+        self._cfg = cfg
+        self._wrapped: object | None = None
+        # Public ``db_path`` is read by callers that expect the
+        # IHistoryStore-style local path attribute (notably the outbox
+        # bookkeeping in DualWriteHistoryStore tests). Mirror it from
+        # the local store so it works without forcing a build.
+        self.db_path = local.db_path
+
+    @property
+    def local(self) -> SQLiteHistoryStore:
+        """Always-available local store; reading this never bootstraps."""
+        return self._local
+
+    @property
+    def shared(self):  # noqa: ANN201 — duck-typed for `hasattr(store, "shared")` callers
+        """Real shared store, or ``None`` when bootstrap failed.
+
+        Reading this property triggers the lazy build because every
+        existing ``hasattr(hs, "shared")`` consumer is gating a real
+        write/read against the team backend; that work was always
+        going to be the moment we paid the bootstrap cost anyway.
+        """
+        target = self._ensure_built()
+        return getattr(target, "shared", None)
+
+    def pending_count(self) -> int:
+        target = self._ensure_built()
+        method = getattr(target, "pending_count", None)
+        return int(method()) if callable(method) else 0
+
+    def flush_pending(self) -> tuple[int, int]:
+        target = self._ensure_built()
+        method = getattr(target, "flush_pending", None)
+        return method() if callable(method) else (0, 0)
+
+    def _ensure_built(self) -> object:
+        if self._wrapped is None:
+            self._wrapped = _bootstrap_dual_or_local(self._local, self._cfg)
+        return self._wrapped
+
+    def __getattr__(self, name: str) -> object:
+        # Only fires for attrs not in the instance __dict__ and not
+        # defined on the class above. Keeps wrapper internals
+        # (``_local`` / ``_cfg`` / ``_wrapped``) out of the lazy-proxy
+        # path so reading them never triggers a bootstrap.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        target = self._ensure_built()
+        return getattr(target, name)
+
+
+def init_history_store(cfg: AMXConfig):
+    """Build the singleton history store and attach it to the legacy global.
+
+    The returned object always implements :class:`amx.storage.protocol.IHistoryStore`.
+    When shared mode is enabled, the result is a
+    :class:`_LazyDualWriteStore` that wraps a local SQLite store
+    eagerly and bootstraps the shared SQLAlchemy backend on first use;
+    otherwise it is a plain :class:`SQLiteHistoryStore`. Both are
+    pin-compatible with every existing call site that reads from
+    ``history_store()``.
+
+    The deferred build keeps ``amx`` startup local-only — the welcome
+    banner appears in <100ms even on Databricks/PG-backed shared
+    history. Bootstrap failures are still announced (one-line warning,
+    cached per profile/schema) but only the first time a call actually
+    needs the shared backend.
+    """
+    config_dir = getattr(cfg, "CONFIG_DIR", str(Path.home() / ".amx"))
+    db_path = Path(config_dir) / "history.db"
+    local = SQLiteHistoryStore(db_path)
+    try:
+        local.init()
+    except Exception as exc:
+        log.warning("Could not initialise local SQLite history: %s", exc)
+
+    if not getattr(cfg, "history_store_enabled", False):
+        sqlite_store._store = local  # type: ignore[assignment]
+        return local
+
+    lazy = _LazyDualWriteStore(local, cfg)
+    sqlite_store._store = lazy  # type: ignore[assignment]
+    return lazy
 
 
 def history_store():
@@ -237,6 +352,7 @@ def history_store():
 
 __all__ = [
     "HistoryStoreBootstrapError",
+    "_LazyDualWriteStore",
     "apply_history_db_override",
     "history_store",
     "init_history_store",

--- a/tests/test_history_store_lazy_bootstrap.py
+++ b/tests/test_history_store_lazy_bootstrap.py
@@ -1,0 +1,145 @@
+"""Pin the lazy-bootstrap contract for the shared history store.
+
+Symptom that motivated this: ``amx`` CLI startup was taking 3-4
+seconds because :func:`init_history_store` was synchronously building
+the SQLAlchemy engine + running ``CREATE SCHEMA`` and
+``MetaData.create_all`` against the team backend on every invocation.
+Most ``amx`` invocations never write history (the user types /help,
+/db-profiles, etc.), so blocking the welcome banner on that work was
+pure user-perceived latency.
+
+After the fix:
+- Local SQLite still inits eagerly (it's cheap).
+- When ``history_store_enabled`` is True, ``init_history_store``
+  returns a :class:`_LazyDualWriteStore` that has NOT yet built the
+  shared backend.
+- The first method call (``pending_count``, ``log_event``, accessing
+  ``shared``, …) bootstraps it once.
+- Bootstrap failure transparently falls back to local-only.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from amx.config import AMXConfig
+from amx.storage.factory import _LazyDualWriteStore, init_history_store
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _local_only_cfg(td: str) -> AMXConfig:
+    cfg = AMXConfig()
+    cfg.CONFIG_DIR = td
+    return cfg
+
+
+def _shared_mode_cfg_pointing_at_missing_profile(td: str) -> AMXConfig:
+    cfg = AMXConfig()
+    cfg.CONFIG_DIR = td
+    cfg.history_store_enabled = True
+    # Profile name that intentionally does NOT exist in db_profiles —
+    # _build_shared_store will short-circuit when the lazy build runs.
+    cfg.history_store_profile = "definitely-not-a-real-profile"
+    return cfg
+
+
+def test_init_returns_plain_sqlite_when_shared_mode_disabled() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _local_only_cfg(td)
+        store = init_history_store(cfg)
+        assert isinstance(store, SQLiteHistoryStore)
+        # Sanity: the returned store is initialised and queryable.
+        assert isinstance(store.db_path, Path)
+
+
+def test_init_returns_lazy_wrapper_when_shared_mode_enabled() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _shared_mode_cfg_pointing_at_missing_profile(td)
+        store = init_history_store(cfg)
+        assert isinstance(store, _LazyDualWriteStore)
+        # The whole point of this PR: at startup the wrapper has NOT
+        # built its shared target yet. If this assertion ever flips,
+        # the welcome banner is paying the bootstrap cost again.
+        assert store._wrapped is None
+
+
+def test_lazy_wrapper_builds_target_on_first_method_call() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _shared_mode_cfg_pointing_at_missing_profile(td)
+        store = init_history_store(cfg)
+        assert store._wrapped is None
+
+        # pending_count() goes through the wrapper; it must trigger a
+        # build. With a bogus profile the build falls back to local
+        # SQLite, so pending_count() returns 0 (the local store has
+        # no outbox table).
+        depth = store.pending_count()
+        assert depth == 0
+        assert store._wrapped is not None
+        # Falls back to the local store on bogus-profile bootstrap.
+        assert isinstance(store._wrapped, SQLiteHistoryStore)
+
+
+def test_lazy_wrapper_does_not_rebuild_on_subsequent_calls() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _shared_mode_cfg_pointing_at_missing_profile(td)
+        store = init_history_store(cfg)
+        store.pending_count()  # triggers first build
+        first_target = store._wrapped
+        store.pending_count()
+        store.pending_count()
+        store.flush_pending()
+        # Identity preserved — no spurious rebuilds.
+        assert store._wrapped is first_target
+
+
+def test_lazy_wrapper_exposes_db_path_without_bootstrap() -> None:
+    """``db_path`` is read by IHistoryStore consumers and by tests; it
+    must work without forcing a network round-trip. The wrapper mirrors
+    it from the local SQLite store at construction time."""
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _shared_mode_cfg_pointing_at_missing_profile(td)
+        store = init_history_store(cfg)
+        assert store._wrapped is None
+        path = store.db_path
+        assert isinstance(path, Path)
+        # Reading db_path must NOT have triggered a build — that was
+        # the whole point of mirroring the attribute.
+        assert store._wrapped is None
+
+
+def test_lazy_wrapper_local_property_is_zero_cost() -> None:
+    """Reading ``.local`` must not trigger a build either."""
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _shared_mode_cfg_pointing_at_missing_profile(td)
+        store = init_history_store(cfg)
+        assert store._wrapped is None
+        local = store.local
+        assert isinstance(local, SQLiteHistoryStore)
+        assert store._wrapped is None
+
+
+def test_lazy_wrapper_falls_back_to_local_on_bootstrap_failure() -> None:
+    """Bootstrap failure (bogus profile) must NOT raise to the caller —
+    it falls back to local-only and the wrapper from then on proxies
+    every call to the local store. This preserves the historical
+    behaviour where a misconfigured shared backend never broke the
+    user's session, just disabled team visibility."""
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _shared_mode_cfg_pointing_at_missing_profile(td)
+        store = init_history_store(cfg)
+        # First call triggers build → fallback → wrapped == local.
+        store.pending_count()
+        assert isinstance(store._wrapped, SQLiteHistoryStore)
+        # Subsequent IHistoryStore calls go straight through.
+        run_id = store.create_run(
+            command="test",
+            mode="chat",
+            db_backend="postgresql",
+            db_profile="default",
+            llm_provider="unit",
+            llm_model="unit-model",
+            scope={},
+        )
+        assert isinstance(run_id, int)

--- a/tests/test_history_store_schema_precreate.py
+++ b/tests/test_history_store_schema_precreate.py
@@ -1,0 +1,127 @@
+"""Regression: startup bootstrap must pre-create the AMX schema.
+
+User report (2026-05-04 against 0.12.5): on every ``amx`` startup,
+
+    [WARNING] Shared run-history disabled this session: …
+    SCHEMA_NOT_FOUND The schema `sap.amx` cannot be found.
+
+The asymmetry: ``/history-store enable`` already calls
+``adapter.create_history_schema(engine, schema_name)`` (idempotent
+``CREATE SCHEMA IF NOT EXISTS``) before running ``MetaData.create_all``.
+The startup path inside ``_build_shared_store`` did NOT, so any user
+whose schema disappeared (or was never created on this host) saw
+SCHEMA_NOT_FOUND on every startup.
+
+This test pins the ordering: ``create_history_schema`` runs before
+``SQLAlchemyHistoryStore`` is built. Failures from the pre-create
+step are downgraded to debug logs (the schema may already exist —
+``MetaData.create_all`` will succeed regardless).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from amx.storage import factory
+
+
+@dataclass
+class _StubCapabilities:
+    supports_shared_history: bool = True
+    schema_comments: bool = False
+
+
+class _StubAdapter:
+    """Records the call order of ``create_engine`` / ``create_history_schema``
+    so tests can assert ordering without a real SQLAlchemy engine."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.capabilities = _StubCapabilities()
+
+    def create_engine(self):
+        self.calls.append("create_engine")
+        return object()
+
+    def create_history_schema(self, engine, schema_name: str) -> None:
+        self.calls.append(f"create_history_schema:{schema_name}")
+
+    def create_history_schema_ddl(self, schema_name: str) -> str:
+        return f"CREATE SCHEMA IF NOT EXISTS {schema_name}"
+
+
+@dataclass
+class _StubDBProfile:
+    backend: str = "postgresql"
+
+
+class _StubAMXConfig:
+    history_store_enabled = True
+    history_store_profile = "team_pg"
+    history_store_schema = "AMX"
+    history_store_database = ""
+    db_profiles = {"team_pg": _StubDBProfile()}
+
+
+@pytest.fixture
+def patched_factory(monkeypatch: pytest.MonkeyPatch) -> _StubAdapter:
+    """Wire ``_build_shared_store`` against a stub adapter and a no-op
+    ``SQLAlchemyHistoryStore`` so we can assert the call order without
+    a real backend."""
+    adapter = _StubAdapter()
+    monkeypatch.setattr("amx.db.adapters.get_adapter", lambda _db_cfg: adapter)
+
+    class _NoopStore:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def init(self) -> None:
+            adapter.calls.append("SQLAlchemyHistoryStore.init")
+
+    monkeypatch.setattr(
+        "amx.storage.sqlalchemy_store.SQLAlchemyHistoryStore",
+        _NoopStore,
+    )
+    return adapter
+
+
+def test_build_shared_store_pre_creates_schema_before_init(
+    patched_factory: _StubAdapter,
+) -> None:
+    cfg = _StubAMXConfig()
+    store = factory._build_shared_store(cfg)
+    assert store is not None
+    # Ordering contract: create_engine → create_history_schema → store ctor.
+    # ``store.init()`` is invoked by the caller (init_history_store /
+    # _LazyDualWriteStore), not by _build_shared_store itself.
+    assert patched_factory.calls == [
+        "create_engine",
+        "create_history_schema:AMX",
+    ]
+
+
+def test_pre_create_schema_failure_is_swallowed_to_debug(
+    patched_factory: _StubAdapter,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If the pre-create step fails (e.g. user lacks CREATE SCHEMA but
+    the schema already exists), we must NOT abort. ``MetaData.create_all``
+    will get its chance to succeed; only a real SCHEMA_NOT_FOUND from
+    that path should reach the user."""
+
+    def _raise(_engine, _schema):
+        raise RuntimeError("permission denied: cannot CREATE SCHEMA")
+
+    monkeypatch.setattr(patched_factory, "create_history_schema", _raise)
+
+    cfg = _StubAMXConfig()
+    caplog.set_level("DEBUG", logger="amx.storage.factory")
+    store = factory._build_shared_store(cfg)
+    # Build still succeeded — the failure was logged at debug level so
+    # MetaData.create_all is given the chance to run.
+    assert store is not None
+    debug_messages = [record.message for record in caplog.records if record.levelname == "DEBUG"]
+    assert any("Pre-create schema" in msg for msg in debug_messages)


### PR DESCRIPTION
## Summary

Two fixes for a user report on a Databricks-backed shared run-history:

1. **`amx` startup is back to <100ms.** Shared-history bootstrap (engine + `CREATE SCHEMA` + `MetaData.create_all`) used to run synchronously on every `amx` invocation. Most invocations never touch history (`/help`, `/db-profiles`, …), so blocking the welcome banner on a 2-3s Databricks round-trip was pure user-perceived latency. New `_LazyDualWriteStore` wraps the local SQLite store eagerly and defers the shared-backend bootstrap to the first method call.
2. **`SCHEMA_NOT_FOUND` no longer fires on every startup.** `/history-store enable` always called `adapter.create_history_schema(engine, schema)` (idempotent `CREATE SCHEMA IF NOT EXISTS`) before `MetaData.create_all`. The startup path in `_build_shared_store` did not — so any user whose schema was dropped (or never created on this host) hit SCHEMA_NOT_FOUND every time. The startup path now runs the same `create_history_schema` call. Permission failures during pre-create are downgraded to debug log because the schema may already exist; `MetaData.create_all` will succeed regardless.

`db_path` and `.local` on the lazy wrapper are zero-cost reads, so existing `hasattr(hs, "shared")` / `hs.db_path` consumers (`amx/cli_support/commands/analyze_flow.py:703`, `_resolve_history_dual_store` in `amx/cli_support/commands/history_store.py:64`) keep working without forcing a build.

## Test plan

- [x] `pytest tests/test_history_store_schema_precreate.py tests/test_history_store_lazy_bootstrap.py tests/test_history_store_warning_quiet.py -v` — 12 pass (2 schema-precreate, 7 lazy bootstrap, 3 existing quiet warning regressions)
- [x] `pytest tests/` — 613 pass, 19 deselected
- [x] `ruff check amx tests` + `ruff format --check amx tests` — clean
- [ ] Manual: launch `amx` on a Databricks-backed shared history config — banner appears immediately, no SCHEMA_NOT_FOUND warning. Run a command that writes (`/run` or anything that calls `log_event`); first call pays the bootstrap cost (3-4s). Subsequent commands are instant. If the schema is missing on the remote, the new pre-create step recovers it silently.