### PR TITLE
fix(storage): /ask no longer crashes with 'Ask failed: _lock' when shared mode is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — `/ask` no longer crashes with `Ask failed: _lock` when shared mode is on
+
+Follow-up to the lazy-bootstrap fix below. `ChatSessionStore` (the
+backbone of `/ask`) reaches into the history-store singleton via
+`self._history._lock` and `self._history._connect()` — both
+SQLite-level primitives that were never proxied by the dual-write
+facade. Two regressions converged:
+
+1. The lazy wrapper introduced in this changelog rejected every
+   underscore-prefixed name in `__getattr__`, so `_lock` raised
+   `AttributeError("_lock")` → "/ask failed: _lock" before the
+   first message was even composed.
+2. `DualWriteHistoryStore` itself never exposed `_connect()`; the
+   only reason this was not a pre-existing crash for shared-mode
+   `/ask` users is that few of them stress-tested that path.
+
+Both shapes now route directly to the local SQLite store: the lazy
+wrapper exposes `_lock` (property) and `_connect()` (method)
+without forcing a shared bootstrap, and `DualWriteHistoryStore`
+gains a matching `_connect()` delegate. Bootstrap is still deferred;
+chat-session writes were always meant to be local-only, so this
+keeps the welcome banner instant and `/ask` responsive.
+
+`tests/test_history_store_lazy_bootstrap.py` adds
+`test_lazy_wrapper_exposes_lock_and_connect_without_bootstrap` to
+pin the contract: `_lock` and `_connect()` must not trigger the
+lazy build.
+
 ### Fixed — `amx` startup is back to <100ms even on a Databricks-backed shared run-history
 
 User report (2026-05-04 against 0.12.5 + the just-shipped lifecycle

--- a/amx/storage/dual_write.py
+++ b/amx/storage/dual_write.py
@@ -76,6 +76,13 @@ class DualWriteHistoryStore:
     def _lock(self) -> Any:  # pragma: no cover - delegate accessor
         return self.local._lock
 
+    def _connect(self) -> Any:  # pragma: no cover - delegate accessor
+        # ``ChatSessionStore`` opens its own transactions via
+        # ``hs._connect()`` — the chat_sessions table is part of the
+        # local SQLite layer, not the shared team backend, so the
+        # delegate just routes through to the local store.
+        return self.local._connect()
+
     # ── Outbox housekeeping ───────────────────────────────────────────────
 
     def _ensure_outbox(self) -> None:

--- a/amx/storage/factory.py
+++ b/amx/storage/factory.py
@@ -273,6 +273,22 @@ class _LazyDualWriteStore:
         """Always-available local store; reading this never bootstraps."""
         return self._local
 
+    # ── Local SQLite delegates (zero-cost; never bootstrap shared) ────────
+    # ``_lock`` and ``_connect`` are part of the SQLite-level API that
+    # ``ChatSessionStore`` and the migration helpers reach into directly
+    # via ``self._history._lock`` / ``self._history._connect()``. They
+    # are inherently LOCAL operations (the chat-session table lives in
+    # ``~/.amx/history.db``, not on the team backend), so we route them
+    # straight to the eager local store. Without this, ``/ask`` raised
+    # ``Ask failed: _lock`` because ``__getattr__`` rejects underscore
+    # names by design.
+    @property
+    def _lock(self):  # noqa: ANN201 — returned object is a threading.Lock
+        return self._local._lock
+
+    def _connect(self):  # noqa: ANN201 — returns sqlite3.Connection ctxmgr
+        return self._local._connect()
+
     @property
     def shared(self):  # noqa: ANN201 — duck-typed for `hasattr(store, "shared")` callers
         """Real shared store, or ``None`` when bootstrap failed.

--- a/tests/test_history_store_lazy_bootstrap.py
+++ b/tests/test_history_store_lazy_bootstrap.py
@@ -94,6 +94,34 @@ def test_lazy_wrapper_does_not_rebuild_on_subsequent_calls() -> None:
         assert store._wrapped is first_target
 
 
+def test_lazy_wrapper_exposes_lock_and_connect_without_bootstrap() -> None:
+    """``ChatSessionStore`` and the migration helpers reach directly
+    into ``hs._lock`` and ``hs._connect()`` — both are SQLite-level
+    primitives owned by the local store. The lazy wrapper must route
+    them without forcing a shared bootstrap, otherwise ``/ask`` (which
+    builds a ChatSessionStore at session start) raises
+    ``Ask failed: _lock`` before any work happens."""
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _shared_mode_cfg_pointing_at_missing_profile(td)
+        store = init_history_store(cfg)
+        assert store._wrapped is None
+
+        lock = store._lock
+        assert lock is not None
+        # Acquiring + releasing the lock must work — same contract as
+        # ``threading.Lock`` so callers can use ``with hs._lock:``.
+        with lock:
+            pass
+
+        with store._connect() as conn:
+            row = conn.execute("SELECT 1").fetchone()
+        assert row[0] == 1
+
+        # Crucially: neither access triggered the lazy build, because
+        # the chat-session and migration paths are LOCAL-only.
+        assert store._wrapped is None
+
+
 def test_lazy_wrapper_exposes_db_path_without_bootstrap() -> None:
     """``db_path`` is read by IHistoryStore consumers and by tests; it
     must work without forcing a network round-trip. The wrapper mirrors


### PR DESCRIPTION
## Summary

Follow-up to the just-shipped lazy-bootstrap fix. `ChatSessionStore` (the backbone of `/ask`) reaches into the history-store singleton via `self._history._lock` and `self._history._connect()` — both SQLite-level primitives that were never properly proxied by the dual-write facade. Two regressions converged:

1. The new `_LazyDualWriteStore.__getattr__` rejected every underscore-prefixed name on principle, so reading `hs._lock` raised `AttributeError("_lock")`. `/ask` surfaced this as `Ask failed: _lock` before the first turn even started.
2. `DualWriteHistoryStore` itself only exposed `_lock` as a property; it had no `_connect()` at all. The only reason this never crashed shared-mode `/ask` before was that the path was rarely exercised.

Both shapes now route to the local SQLite store: `_LazyDualWriteStore` exposes `_lock` (property) and `_connect()` (method) that delegate to `self._local` **without triggering the shared bootstrap**, and `DualWriteHistoryStore` gains a matching `_connect()` delegate. Chat-session writes were always meant to be local-only, so the deferred bootstrap stays deferred — the welcome banner remains instant and `/ask` is responsive on the very first message.

## Test plan

- [x] `pytest tests/test_history_store_lazy_bootstrap.py` — 8 cases pass, including the new `test_lazy_wrapper_exposes_lock_and_connect_without_bootstrap` that pins both accesses succeed AND `._wrapped` stays `None`
- [x] `pytest tests/` — 614 pass, 19 deselected
- [x] `ruff check amx tests` + `ruff format --check amx tests` — clean
- [ ] Manual: `amx` → `/ask` → "naber" — expect a real response, not `Ask failed: _lock`. Banner still instant; lazy bootstrap still deferred to a write that actually needs the team backend (e.g. `/run`).