### PR TITLE
fix(ask): /ask discovers the catalog when the DB profile didn't pin one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — `/ask` discovers the catalog itself when the active DB profile didn't pin one
+
+User report (2026-05-04): defining a Databricks DB profile without
+filling in a catalog made the very first `/ask` listing call fail with
+`[NO_SUCH_CATALOG_EXCEPTION] Catalog 'none' was not found.` because
+`SHOW SCHEMAS` ran against the SQLAlchemy default catalog (Python
+`None` rendered as the literal string). The wizard told the user the
+catalog was "optional"; in practice it wasn't, and the deferred error
+only surfaced inside `/ask`, which is the worst possible place to find
+out.
+
+The tool-calling agent now has dedicated discovery tools:
+
+* `list_catalogs` — runs `SHOW CATALOGS` (or the equivalent) on the
+  active live connection and returns the role-visible catalogs. Used
+  on Databricks Unity Catalog and BigQuery (project = catalog).
+* `list_server_databases` — runs `SHOW DATABASES` for 2-level backends
+  (PostgreSQL, Snowflake, MySQL, MSSQL, Redshift, ClickHouse). Distinct
+  from `list_databases`, which lists AMX DB profiles.
+
+The existing `list_schemas` and `list_tables_in_schema` tools accept an
+optional `catalog` argument, so the LLM can drill into a chosen
+catalog without the user editing the saved profile. When a 3-level
+backend has no catalog pinned and no `catalog` argument is supplied,
+`list_schemas` returns `needs_catalog=true` plus the visible catalog
+list and a hint instead of letting the warehouse error escape.
+
+The `/ask` system prompt also now warns up-front when the active
+profile has no catalog/database pinned and tells the LLM to call the
+discovery tools before any other listing tool — so the user's exact
+question ("which tables do you see") works on a half-configured
+Databricks profile without a backend error.
+
+`tests/test_compare.py::CatalogDiscoveryToolsTests` covers the new
+behaviour: graceful catalog list on no-catalog profiles, `catalog`-
+scoped listings via temporary `cfg.catalog` pinning (restored after
+the call), and the schema-shape contract for the LLM.
+
 ### Fixed — `/ask` no longer crashes with `Ask failed: _lock` when shared mode is on
 
 Follow-up to the lazy-bootstrap fix below. `ChatSessionStore` (the

--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -100,9 +100,28 @@ class ToolBox:
                         "Return the list of schema names (namespaces) visible in the active "
                         "database. Use this when the user asks 'which schemas do we have?', "
                         "'what schemas exist?', 'sap_test ne tür bir şema?', or as a discovery "
-                        "step before drilling into one specific schema."
+                        "step before drilling into one specific schema.\n"
+                        "Pass ``catalog`` to scope the listing to a Unity-Catalog catalog or "
+                        "BigQuery project the active profile has not pinned. When the active "
+                        "profile is a 3-level backend (Databricks UC) and no catalog is pinned "
+                        "AND no ``catalog`` argument is given, the tool returns the visible "
+                        "catalog list with a hint instead of failing — call ``list_catalogs`` "
+                        "(or pass ``catalog`` here) to drill in."
                     ),
-                    "parameters": {"type": "object", "properties": {}, "required": []},
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "catalog": {
+                                "type": "string",
+                                "description": (
+                                    "Optional Unity-Catalog catalog (Databricks) or BigQuery "
+                                    "project to scope the listing to. Omit to use whatever the "
+                                    "active profile has pinned."
+                                ),
+                            },
+                        },
+                        "required": [],
+                    },
                 },
             },
             {
@@ -112,7 +131,9 @@ class ToolBox:
                     "description": (
                         "Return the tables, views, and materialized views inside a given "
                         "schema. Use this when the user asks 'what tables are under sap_test?', "
-                        "'list all tables in sap_s6p', or to disambiguate a bare table name."
+                        "'list all tables in sap_s6p', or to disambiguate a bare table name. "
+                        "Pass ``catalog`` to scope the listing to a Unity-Catalog catalog the "
+                        "active profile has not pinned."
                     ),
                     "parameters": {
                         "type": "object",
@@ -120,6 +141,14 @@ class ToolBox:
                             "schema": {
                                 "type": "string",
                                 "description": "Exact schema name. Case-insensitive.",
+                            },
+                            "catalog": {
+                                "type": "string",
+                                "description": (
+                                    "Optional Unity-Catalog catalog (Databricks) or BigQuery "
+                                    "project. Omit to use whatever the active profile has "
+                                    "pinned."
+                                ),
                             },
                         },
                         "required": ["schema"],
@@ -306,6 +335,41 @@ class ToolBox:
                         "List the databases the agent currently has access to (one per active "
                         "DB profile). Use this only when the user explicitly asks 'which "
                         "databases do we have?' / 'hangi veritabanları var?'."
+                    ),
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "list_catalogs",
+                    "description": (
+                        "Run ``SHOW CATALOGS`` (or the equivalent) on the active live "
+                        "connection and return every catalog / project visible to the role. "
+                        "Use this on 3-level backends (Databricks Unity Catalog, BigQuery) "
+                        "when the active DB profile has no catalog pinned and the user asks "
+                        "to see tables / schemas — call this first, then pass the chosen "
+                        "catalog to ``list_schemas`` or ``list_tables_in_schema``. Returns "
+                        "``supports_catalogs=false`` for 2-level backends so the LLM can "
+                        "fall back to ``list_server_databases`` instead."
+                    ),
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "list_server_databases",
+                    "description": (
+                        "Run ``SHOW DATABASES`` (or the equivalent) on the active live "
+                        "connection and return every database visible to the role. Use this "
+                        "on 2-level backends (PostgreSQL, Snowflake, MySQL, MSSQL, Redshift, "
+                        "ClickHouse) when the user asks 'which databases live on this "
+                        "server?' or when the active profile has no database pinned and you "
+                        "need to discover it. Different from ``list_databases`` — that lists "
+                        "AMX DB profiles, this lists databases on the live server. Returns "
+                        "an empty list with a hint for backends that don't expose a multi-"
+                        "database server."
                     ),
                     "parameters": {"type": "object", "properties": {}, "required": []},
                 },
@@ -790,51 +854,179 @@ class ToolBox:
             return _safe_json({"error": f"Tool {name} failed: {exc}"})
 
     # ------------------------------------------------------------------ implementations
-    def _tool_list_schemas(self) -> dict[str, Any]:
+    @contextlib.contextmanager
+    def _scoped_catalog(self, db: DatabaseConnector, catalog: str | None):
+        """Temporarily pin ``cfg.catalog`` so connector methods route by it.
+
+        Used by ``list_schemas`` / ``list_tables_in_schema`` when the LLM
+        passes a catalog argument to drill into a Unity-Catalog catalog
+        the active profile has not pinned. Empty / None ``catalog`` is a
+        no-op so callers can pass through unconditionally.
+        """
+        cat = (catalog or "").strip()
+        if not cat:
+            yield
+            return
+        cfg = getattr(db, "cfg", None)
+        if cfg is None:
+            yield
+            return
+        previous = getattr(cfg, "catalog", "")
         try:
-            schemas = [str(s) for s in self._live_db().list_schemas()]
+            cfg.catalog = cat
+            yield
+        finally:
+            cfg.catalog = previous
+
+    def _tool_list_schemas(self, catalog: str = "") -> dict[str, Any]:
+        db = self._live_db()
+        cat_arg = (catalog or "").strip()
+        pinned_catalog = str(getattr(self.cfg.db, "catalog", "") or "").strip()
+        supports_catalogs = False
+        try:
+            supports_catalogs = bool(db.supports_catalogs())
+        except Exception:
+            supports_catalogs = False
+        # 3-level backend (Databricks UC, BigQuery): when neither the
+        # active profile nor the LLM has named a catalog, listing schemas
+        # against the SQLAlchemy default surfaces the literal "Catalog
+        # 'none' was not found" error from the warehouse. Surface the
+        # visible catalogs instead so the LLM can pick one and recurse —
+        # the user-reported "/ask which tables do you see" path on a
+        # catalog-less profile.
+        if supports_catalogs and not cat_arg and not pinned_catalog:
+            try:
+                catalogs = [str(c) for c in db.list_catalogs()]
+            except Exception as exc:
+                raise _ToolError(
+                    f"Active DB profile has no catalog pinned and SHOW CATALOGS failed: {exc}. "
+                    "Edit the profile to pin a catalog or pass `catalog` to this tool."
+                ) from exc
+            return {
+                "database": "(no catalog pinned)",
+                "schemas": [],
+                "count": 0,
+                "catalogs": catalogs,
+                "needs_catalog": True,
+                "message": (
+                    "The active DB profile has no catalog pinned. Pick one of the catalogs "
+                    "above and call this tool again with the `catalog` argument, or run "
+                    "`/edit` to pin a catalog permanently."
+                ),
+            }
+
+        try:
+            with self._scoped_catalog(db, cat_arg):
+                schemas = [str(s) for s in db.list_schemas()]
         except Exception as exc:
             raise _ToolError(f"Could not list schemas live: {exc}") from exc
         database = (
-            self.cfg.db.database
+            cat_arg
+            or self.cfg.db.database
             or self.cfg.db.catalog
             or self.cfg.db.project
             or "(active database)"
         )
         return {"database": database, "schemas": schemas, "count": len(schemas)}
 
-    def _tool_list_tables_in_schema(self, schema: str) -> dict[str, Any]:
+    def _tool_list_tables_in_schema(self, schema: str, catalog: str = "") -> dict[str, Any]:
         target = (schema or "").strip()
         if not target:
             raise _ToolError("Argument 'schema' is required.")
         db = self._live_db()
-        # Resolve case-insensitively against the live schema list.
+        cat_arg = (catalog or "").strip()
+        # Resolve case-insensitively against the live schema list within
+        # the chosen catalog (when one was supplied). The same scoping
+        # applies to the listing call below — without it, a Databricks UC
+        # backend without a pinned catalog would issue ``SHOW TABLES FROM
+        # None.<schema>`` and fail with NO_SUCH_CATALOG_EXCEPTION.
+        with self._scoped_catalog(db, cat_arg):
+            try:
+                available = list(db.list_schemas())
+            except Exception as exc:
+                raise _ToolError(f"Could not list schemas: {exc}") from exc
+            match = next((s for s in available if str(s).lower() == target.lower()), None)
+            if match is None:
+                return {
+                    "schema": target,
+                    "catalog": cat_arg or None,
+                    "found": False,
+                    "available_schemas": [str(s) for s in available],
+                    "message": (
+                        f"No schema named '{target}'. Available schemas: "
+                        + ", ".join(str(s) for s in available)
+                    ),
+                }
+            items: list[dict[str, str]] = []
+            try:
+                if hasattr(db, "list_assets"):
+                    for name, kind in db.list_assets(match):
+                        items.append({"name": str(name), "kind": str(kind)})
+                else:
+                    for name in db.list_tables(match):
+                        items.append({"name": str(name), "kind": "table"})
+            except Exception as exc:
+                raise _ToolError(f"Could not list tables in {match}: {exc}") from exc
+        return {
+            "schema": match,
+            "catalog": cat_arg or None,
+            "found": True,
+            "tables": items,
+            "count": len(items),
+        }
+
+    def _tool_list_catalogs(self) -> dict[str, Any]:
+        db = self._live_db()
         try:
-            available = list(db.list_schemas())
-        except Exception as exc:
-            raise _ToolError(f"Could not list schemas: {exc}") from exc
-        match = next((s for s in available if str(s).lower() == target.lower()), None)
-        if match is None:
+            supports = bool(db.supports_catalogs())
+        except Exception:
+            supports = False
+        if not supports:
             return {
-                "schema": target,
-                "found": False,
-                "available_schemas": [str(s) for s in available],
+                "supports_catalogs": False,
+                "catalogs": [],
+                "count": 0,
                 "message": (
-                    f"No schema named '{target}'. Available schemas: "
-                    + ", ".join(str(s) for s in available)
+                    "The active backend does not expose multiple catalogs. Use "
+                    "`list_server_databases` for 2-level backends (PostgreSQL, "
+                    "Snowflake, MySQL, MSSQL, Redshift, ClickHouse)."
                 ),
             }
-        items: list[dict[str, str]] = []
         try:
-            if hasattr(db, "list_assets"):
-                for name, kind in db.list_assets(match):
-                    items.append({"name": str(name), "kind": str(kind)})
-            else:
-                for name in db.list_tables(match):
-                    items.append({"name": str(name), "kind": "table"})
+            catalogs = [str(c) for c in db.list_catalogs()]
         except Exception as exc:
-            raise _ToolError(f"Could not list tables in {match}: {exc}") from exc
-        return {"schema": match, "found": True, "tables": items, "count": len(items)}
+            raise _ToolError(f"SHOW CATALOGS failed: {exc}") from exc
+        pinned = str(getattr(self.cfg.db, "catalog", "") or "").strip()
+        return {
+            "supports_catalogs": True,
+            "catalogs": catalogs,
+            "count": len(catalogs),
+            "active_catalog": pinned or None,
+        }
+
+    def _tool_list_server_databases(self) -> dict[str, Any]:
+        db = self._live_db()
+        try:
+            databases = [str(d) for d in db.list_databases()]
+        except Exception as exc:
+            raise _ToolError(f"Listing databases failed: {exc}") from exc
+        pinned = str(getattr(self.cfg.db, "database", "") or "").strip()
+        if not databases:
+            return {
+                "databases": [],
+                "count": 0,
+                "active_database": pinned or None,
+                "message": (
+                    "The active backend does not expose multiple databases on this server, "
+                    "or the role has no privilege to list them. For 3-level backends "
+                    "(Databricks Unity Catalog, BigQuery) use `list_catalogs`."
+                ),
+            }
+        return {
+            "databases": databases,
+            "count": len(databases),
+            "active_database": pinned or None,
+        }
 
     def _tool_find_table_by_name(self, name: str) -> dict[str, Any]:
         target = (name or "").strip()

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -76,6 +76,22 @@ def _agent_system_prompt(cfg: AMXConfig, schema_hint: list[str]) -> str:
     without us having to regex-classify the question.
     """
     db_name = cfg.db.database or cfg.db.catalog or cfg.db.project or "(active database)"
+    db_unpinned_hint = ""
+    if not (cfg.db.database or cfg.db.catalog or cfg.db.project):
+        backend = (cfg.db.backend or "").lower()
+        if backend in {"databricks", "bigquery"}:
+            db_unpinned_hint = (
+                "  ⚠ No catalog/project is pinned for this profile. Call list_catalogs "
+                "before list_schemas, or pass `catalog` to list_schemas / "
+                "list_tables_in_schema. Listing schemas without a catalog will fail with "
+                "NO_SUCH_CATALOG_EXCEPTION on Databricks Unity Catalog."
+            )
+        elif backend:
+            db_unpinned_hint = (
+                "  ⚠ No database is pinned for this profile. Call list_server_databases "
+                "to discover what's available, then ask the user to switch via /use-db or "
+                "pin one with /edit."
+            )
     schema_line = (
         ", ".join(schema_hint)
         if schema_hint
@@ -105,7 +121,8 @@ def _agent_system_prompt(cfg: AMXConfig, schema_hint: list[str]) -> str:
         "You are AMX's metadata-search assistant. Answer the user's question by calling the "
         "tools available to you. NEVER guess; ALWAYS ground every claim in a tool result.\n\n"
         f"Active database: {db_name}\n"
-        f"Schemas in this DB: {schema_line}\n"
+        + (f"{db_unpinned_hint}\n" if db_unpinned_hint else "")
+        + f"Schemas in this DB: {schema_line}\n"
         f"User's pinned schema: {current_schema}\n"
         f"User's pinned table: {current_table}\n"
         f"User's language preference: {metadata_lang}\n"
@@ -120,7 +137,19 @@ def _agent_system_prompt(cfg: AMXConfig, schema_hint: list[str]) -> str:
         "  call list_tables_in_schema with that exact schema. The user said 'tables', not\n"
         "  'a table named X'.\n"
         "* User asks 'which schemas / what schemas / how many schemas' → call list_schemas.\n"
+        "  If list_schemas comes back with `needs_catalog=true` (3-level backend whose\n"
+        "  active profile has no catalog pinned), DO NOT report 'no schemas found' — call\n"
+        "  list_catalogs (or pass the most likely catalog into list_schemas as the\n"
+        "  `catalog` argument) and recurse. The `catalogs` field already lists what's\n"
+        "  visible. Same applies for list_tables_in_schema: pass `catalog` to scope the\n"
+        "  listing when the profile is unpinned.\n"
         "* User asks 'which databases / hangi veritabanları' → call list_databases.\n"
+        "* User asks 'which catalogs / hangi cataloglar / show catalogs' → call list_catalogs.\n"
+        "  Same tool also rescues 'show me tables' on a catalog-less Databricks profile.\n"
+        "* User asks 'which databases live on this server / show databases / hangi\n"
+        "  databaseler var bu sunucuda' on a 2-level backend (PostgreSQL, Snowflake,\n"
+        "  MySQL, MSSQL, Redshift, ClickHouse) → call list_server_databases. Different\n"
+        "  from list_databases (which lists AMX DB profiles).\n"
         "* User asks 'tables with boolean columns' / 'date columns' / 'all int columns' → \n"
         "  call find_columns_by_dtype with the type token. NEVER fall back to\n"
         "  search_columns_by_concept for dtype questions; concept search matches NAMES, not types.\n"

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1111,7 +1111,7 @@ class CatalogDiscoveryToolsTests(unittest.TestCase):
     listing tools accept an optional ``catalog`` argument so the LLM can
     drill in without mutating the saved profile."""
 
-    def _toolbox(self, fake_db, *, pinned_catalog: str = "", pinned_database: str = "") -> Any:
+    def _toolbox(self, fake_db, *, pinned_catalog: str = "", pinned_database: str = ""):
         from unittest.mock import MagicMock
 
         from amx.search.agent_tools import ToolBox

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1103,5 +1103,135 @@ class AskHistoryToolsTests(unittest.TestCase):
         self.assertIn("/session resume", payload["note"])
 
 
+class CatalogDiscoveryToolsTests(unittest.TestCase):
+    """User report 2026-05-04: defining a Databricks DB profile without
+    pinning a catalog made ``/ask`` fail with NO_SUCH_CATALOG_EXCEPTION on
+    the first listing call. The agent now has dedicated catalog-discovery
+    tools (``list_catalogs`` / ``list_server_databases``) and the schema-
+    listing tools accept an optional ``catalog`` argument so the LLM can
+    drill in without mutating the saved profile."""
+
+    def _toolbox(self, fake_db, *, pinned_catalog: str = "", pinned_database: str = "") -> Any:
+        from unittest.mock import MagicMock
+
+        from amx.search.agent_tools import ToolBox
+
+        cfg = AMXConfig()
+        cfg.db.backend = "databricks"
+        cfg.db.catalog = pinned_catalog
+        cfg.db.database = pinned_database
+        catalog = MagicMock()
+        return ToolBox(cfg, catalog, db_factory=lambda: fake_db)
+
+    def test_list_schemas_returns_catalog_list_when_no_catalog_pinned(self) -> None:
+        """Without a pinned catalog on a 3-level backend, list_schemas
+        must NOT attempt the listing — it must surface the catalog list
+        and a ``needs_catalog`` flag so the LLM can recurse."""
+
+        class FakeDB:
+            def supports_catalogs(self) -> bool:
+                return True
+
+            def list_catalogs(self) -> list[str]:
+                return ["main", "samples", "workspace"]
+
+            cfg = type("DBCfg", (), {"catalog": ""})()
+
+        toolbox = self._toolbox(FakeDB())
+        payload = toolbox._tool_list_schemas()
+        self.assertTrue(payload["needs_catalog"])
+        self.assertEqual(payload["catalogs"], ["main", "samples", "workspace"])
+        self.assertIn("no catalog pinned", payload["message"])
+
+    def test_list_schemas_with_catalog_argument_scopes_listing(self) -> None:
+        """Passing ``catalog=X`` must temporarily pin cfg.catalog so the
+        connector emits ``SHOW SCHEMAS IN X`` instead of failing on the
+        SQLAlchemy default. The pin must be restored afterwards."""
+
+        class FakeDB:
+            def __init__(self) -> None:
+                self.cfg = type("DBCfg", (), {"catalog": ""})()
+                self.observed_catalog: str = ""
+
+            def supports_catalogs(self) -> bool:
+                return True
+
+            def list_schemas(self) -> list[str]:
+                self.observed_catalog = self.cfg.catalog
+                return ["sales", "ops"]
+
+        fake = FakeDB()
+        toolbox = self._toolbox(fake)
+        payload = toolbox._tool_list_schemas(catalog="main")
+        self.assertEqual(payload["schemas"], ["sales", "ops"])
+        self.assertEqual(payload["database"], "main")
+        # Connector saw the temporary pin while listing.
+        self.assertEqual(fake.observed_catalog, "main")
+        # And the pin was restored afterwards (no leak into cfg).
+        self.assertEqual(fake.cfg.catalog, "")
+
+    def test_list_catalogs_tool_returns_show_catalogs_result(self) -> None:
+        class FakeDB:
+            def supports_catalogs(self) -> bool:
+                return True
+
+            def list_catalogs(self) -> list[str]:
+                return ["main", "samples"]
+
+            cfg = type("DBCfg", (), {"catalog": "main"})()
+
+        toolbox = self._toolbox(FakeDB(), pinned_catalog="main")
+        payload = toolbox._tool_list_catalogs()
+        self.assertTrue(payload["supports_catalogs"])
+        self.assertEqual(payload["catalogs"], ["main", "samples"])
+        self.assertEqual(payload["active_catalog"], "main")
+
+    def test_list_catalogs_tool_signals_2_level_backend(self) -> None:
+        class FakeDB:
+            def supports_catalogs(self) -> bool:
+                return False
+
+        toolbox = self._toolbox(FakeDB())
+        payload = toolbox._tool_list_catalogs()
+        self.assertFalse(payload["supports_catalogs"])
+        self.assertEqual(payload["catalogs"], [])
+        self.assertIn("list_server_databases", payload["message"])
+
+    def test_list_server_databases_returns_databases_with_active_marker(self) -> None:
+        class FakeDB:
+            def list_databases(self) -> list[str]:
+                return ["app", "analytics"]
+
+            cfg = type("DBCfg", (), {"database": "app"})()
+
+        toolbox = self._toolbox(FakeDB(), pinned_database="app")
+        payload = toolbox._tool_list_server_databases()
+        self.assertEqual(payload["databases"], ["app", "analytics"])
+        self.assertEqual(payload["active_database"], "app")
+
+    def test_new_discovery_tools_appear_in_tool_schemas(self) -> None:
+        """The new tools must show up in ``ToolBox.schemas()`` so LiteLLM
+        forwards them to the LLM. Otherwise the system prompt's
+        instructions to call them produce a hallucinated function-call
+        name the agent loop can't dispatch."""
+        from amx.search.agent_tools import ToolBox
+
+        names = {entry["function"]["name"] for entry in ToolBox.schemas()}
+        self.assertIn("list_catalogs", names)
+        self.assertIn("list_server_databases", names)
+        # list_schemas / list_tables_in_schema both accept the optional
+        # catalog argument now.
+        for entry in ToolBox.schemas():
+            fn = entry["function"]
+            if fn["name"] in {"list_schemas", "list_tables_in_schema"}:
+                self.assertIn(
+                    "catalog",
+                    fn["parameters"]["properties"],
+                    f"{fn['name']} should advertise an optional `catalog` argument so "
+                    "the LLM can drill into a Unity-Catalog catalog without mutating "
+                    "the saved profile.",
+                )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- `/ask` on a Databricks profile saved without a catalog used to crash on the very first listing call with `[NO_SUCH_CATALOG_EXCEPTION] Catalog 'none' was not found.` (the Python `None` was rendered as the literal string `"None"` because `SHOW SCHEMAS` had no catalog default to fall back to).
- The tool-calling agent now has dedicated discovery tools — `list_catalogs` (3-level backends: Databricks UC, BigQuery) and `list_server_databases` (2-level backends: PG / Snowflake / MySQL / MSSQL / Redshift / ClickHouse) — and the existing `list_schemas` / `list_tables_in_schema` tools accept an optional `catalog` argument so the LLM can drill into a catalog without editing the saved profile.
- When a 3-level backend has no catalog pinned and the LLM didn't pass one, `list_schemas` returns `needs_catalog=true` plus the visible catalog list and a hint instead of letting the warehouse error escape. The `/ask` system prompt warns up-front when the active profile has no catalog/database pinned and points the LLM at the discovery tools.

## Test plan

- [x] `pytest tests/test_compare.py::CatalogDiscoveryToolsTests` (new — 6 tests covering graceful no-catalog branch, scoped pinning + restore, schema contract, both 3- and 2-level fallbacks).
- [x] `pytest tests/test_compare.py tests/test_search_catalog.py tests/test_chat_sessions.py tests/test_runtime_pickers.py tests/test_db_multi_backend_expansion.py tests/test_postgresql_list_databases_filter.py tests/test_db_profile_optional_database.py` — 195 passed, no regressions.
- [ ] Manual: `/ask which tables do you see` against a Databricks profile saved without a catalog — agent now lists catalogs first and answers without `NO_SUCH_CATALOG_EXCEPTION`.