### PR TITLE
feat(db): /edit-db-profile + validating catalog/database picker, drop /schema /table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,59 @@ behaviour: graceful catalog list on no-catalog profiles, `catalog`-
 scoped listings via temporary `cfg.catalog` pinning (restored after
 the call), and the schema-shape contract for the LLM.
 
+### Changed — DB profile mutation surface tightened: `/edit-db-profile`, validating picker, `/schema` and `/table` removed
+
+User report (2026-05-04): nothing prevented saving — and silently
+using — a DB profile that pointed at a catalog/database the live
+backend could not see. Their Databricks profile had a typo'd
+`catalog` value; the catalog did not exist on the workspace, and
+every `amx` startup blew up with `SCHEMA_NOT_FOUND` even after the
+lazy-bootstrap fix landed (deferring the warning ≠ making the
+catalog real). The `/schema` and `/table` commands had the same
+shape: blindly write the typed value, never validate.
+
+Three coordinated changes:
+
+- **New `/edit-db-profile`** under the `/db` namespace. Walks the
+  same wizard as `/add-db-profile` but pre-fills every prompt with
+  the existing value, so the user can press Enter to skip
+  unchanged fields. Editing an inactive profile leaves the active
+  scope alone — touching one profile must never silently move the
+  user's working scope.
+- **`/add-db-profile` refuses name collisions.** It used to switch
+  silently into edit mode when the name matched. It now errors and
+  points the user at `/edit-db-profile X`. Add and edit are two
+  clean, non-overlapping channels.
+- **Inline catalog/database picker in the wizard.** After the user
+  enters host/credentials, the wizard probes the live backend
+  (`DatabaseConnector.list_catalogs` / `list_databases`) and
+  presents the discovered values as an `ask_choice`. A leading
+  `(keep current: <X>)` entry, an optional `(none)` entry, and a
+  trailing `(type custom value)` escape hatch round it out. The
+  custom-value path issues `warn()` + `confirm("Save anyway?",
+  default=False)` if the typed value is NOT in the listing — the
+  exact gate that would have blocked the original typo. Listing
+  failure (no driver, permission denied, network down) falls back
+  to the historical free-form prompt with one warn(). Wired into
+  Databricks (catalog), PostgreSQL, Snowflake, MySQL, MSSQL,
+  Redshift, ClickHouse (database). BigQuery free-form stays for
+  now (no `list_projects`).
+- **`/schema` and `/table` removed.** They wrote
+  `cfg.current_schema` / `cfg.current_table` blindly, with no
+  connectivity check, and were the reason the "olmayan bir şeye
+  bağlan" footgun stayed reachable. The fields stay (tests and
+  `/run`'s default scope still read them) — only the slash
+  commands go. The standard scope path is now positional (`/run
+  <schema> <table>`) or the existing `finalize_scope` interactive
+  picker.
+
+`tests/test_edit_db_profile.py` pins the contract end to end:
+add-on-collision refuses, edit walks the wizard with current values
+as defaults, edit of an inactive profile does not move active
+scope, picker offers listings + falls back gracefully, custom-value
+override is gated by an explicit confirm, and the `/schema` /
+`/table` heads stay gone from the registry.
+
 ### Fixed — `/ask` no longer crashes with `Ask failed: _lock` when shared mode is on
 
 Follow-up to the lazy-bootstrap fix below. `ChatSessionStore` (the

--- a/amx/cli_support/commands/code.py
+++ b/amx/cli_support/commands/code.py
@@ -156,9 +156,7 @@ def register_code_commands(
 
         schema_name = schema or cfg.current_schema
         if not schema_name:
-            error(
-                "Missing schema: use --schema sap_s6p or set context with `/db` then `/schema …` in session."
-            )
+            error("Missing schema: pass --schema sap_s6p (or use /run's interactive picker).")
             sys.exit(1)
 
         try:

--- a/amx/cli_support/commands/compare.py
+++ b/amx/cli_support/commands/compare.py
@@ -140,8 +140,8 @@ def _resolve_runs(
 
     if not eff_schema and not eff_table:
         error(
-            "No scope to compare — pass run IDs, set /schema, or use "
-            "--schema/--table. Example: /compare --schema sales --last 3."
+            "No scope to compare — pass run IDs or use --schema/--table. "
+            "Example: /compare --schema sales --last 3."
         )
         return []
 

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -422,6 +422,129 @@ def cmd_use(
         error(str(exc))
 
 
+def _ask_catalog_or_database_with_picker(
+    *,
+    label: str,
+    current_value: str,
+    optional: bool,
+    probe_cfg: DBConfig,
+    listing_kind: str,
+) -> str:
+    """Offer a picker over the catalogs/databases the live backend reports.
+
+    Replaces the historical free-form prompt at this stage of the
+    wizard. The user typed a non-existent catalog (``sap``) on a
+    Databricks workspace where it didn't exist; the profile saved
+    silently, and every subsequent ``amx`` startup raised
+    SCHEMA_NOT_FOUND when the lazy bootstrap reached for the missing
+    schema. With a picker, that class of footgun cannot happen unless
+    the user explicitly bypasses it via "type custom value" + a
+    "save anyway?" confirm.
+
+    Falls back to the free-form prompt when listing fails (no driver,
+    permission denied, network down). The fallback path emits one
+    ``warn()`` so the user knows validation is degraded, but the wizard
+    still progresses — you can configure a profile while offline.
+    """
+    from amx.db.connector import DatabaseConnector
+
+    info(f"Probing the {probe_cfg.backend} backend for available {listing_kind}…")
+    candidates: list[str] = []
+    listing_error: BaseException | None = None
+    try:
+        connector = DatabaseConnector(probe_cfg)
+        if listing_kind == "catalogs":
+            candidates = list(connector.list_catalogs() or [])
+        else:
+            candidates = list(connector.list_databases() or [])
+    except BaseException as exc:  # noqa: BLE001 — we genuinely want every failure mode
+        listing_error = exc
+
+    if not candidates:
+        if listing_error is not None:
+            warn(
+                f"Could not probe {listing_kind} ({listing_error.__class__.__name__}). "
+                "Falling back to free-form input — double-check spelling."
+            )
+        else:
+            warn(
+                f"Backend returned no {listing_kind} (role lacks visibility, or "
+                "discovery is unsupported). Falling back to free-form input."
+            )
+        return _ask_update_text(
+            f"{label.capitalize()} (optional)" if optional else label.capitalize(),
+            current_value,
+            required=not optional,
+            allow_clear=optional,
+        )
+
+    keep_label = f"(keep current: {current_value})" if current_value else ""
+    custom_label = "(type custom value)"
+    none_label = "(none)" if optional else ""
+
+    choices: list[str] = []
+    descriptions: dict[str, str] = {}
+    if keep_label:
+        choices.append(keep_label)
+        descriptions[keep_label] = (
+            f"Keep the existing value {current_value!r}."
+            if current_value in candidates
+            else f"Keep {current_value!r} (NOT visible in current listing)."
+        )
+    if none_label:
+        choices.append(none_label)
+        descriptions[none_label] = f"Leave {label} unset — pick at command time."
+    for value in candidates:
+        if value == current_value:
+            continue  # already covered by the keep-current entry
+        choices.append(value)
+    choices.append(custom_label)
+    descriptions[custom_label] = (
+        "Type a name not in the listing (only when discovery is permission-blocked)."
+    )
+
+    default = keep_label or none_label or candidates[0]
+    picked = ask_choice(
+        f"Select {label}",
+        choices,
+        default=default,
+        descriptions=descriptions,
+    )
+
+    if not picked or picked == keep_label:
+        return current_value
+    if picked == none_label:
+        return ""
+    if picked != custom_label:
+        return picked
+
+    # Free-form escape hatch — keep the listing visible so the user can
+    # tell whether they're typing a real name or going off-piste.
+    info(f"Available {listing_kind}: {', '.join(candidates) or '(none)'}")
+    typed = _ask_update_text(
+        f"{label.capitalize()} (custom)",
+        current_value,
+        required=not optional,
+        allow_clear=optional,
+    )
+    if typed and typed not in candidates:
+        warn(
+            f"{typed!r} is NOT in the listing returned by the backend. "
+            f"This is the same class of bug that produced the SCHEMA_NOT_FOUND "
+            f"warning — only override if you know discovery is permission-blocked."
+        )
+        if not confirm("Save anyway?", default=False):
+            warn("Re-opening the picker so you can pick a real value.")
+            return _ask_catalog_or_database_with_picker(
+                label=label,
+                current_value=current_value,
+                optional=optional,
+                probe_cfg=probe_cfg,
+                listing_kind=listing_kind,
+            )
+    return typed
+
+
 def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
     """Interactive prompts to build a DBConfig for any supported backend.
 
@@ -537,12 +660,24 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         password = _ask_update_secret("Password", defaults.password or "", required=True)
         # Pinning a default database is now OPTIONAL (0.11.0). When the
         # user leaves it blank we connect to the server and they can pick
-        # the database at /run / /sync / /ask time. Encourage filling it
-        # in for single-DB workflows by keeping the prompt example and
-        # using ``allow_clear=True`` so an explicit blank is accepted.
-        database = _ask_update_text(
-            "Database name (optional, e.g. postgres — leave blank to pick at command time)",
-            defaults.database or "",
+        # the database at /run / /sync / /ask time. The picker below
+        # confirms the typed name actually exists on the server before
+        # saving — same gate the Databricks catalog prompt added.
+        probe_cfg_for_db = replace(
+            defaults,
+            backend="postgresql",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            database="",
+        )
+        database = _ask_catalog_or_database_with_picker(
+            label="database",
+            current_value=defaults.database or "",
+            optional=True,
+            probe_cfg=probe_cfg_for_db,
+            listing_kind="databases",
         )
         return replace(
             defaults,
@@ -565,10 +700,21 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             "Username (e.g. ANALYST)", defaults.user, required=True, allow_clear=False
         )
         password = _ask_update_secret("Password", defaults.password or "", required=True)
-        # Optional in 0.11.0 — see note on PostgreSQL above.
-        database = _ask_update_text(
-            "Database name (optional, e.g. ANALYTICS — leave blank to pick at command time)",
-            defaults.database,
+        # Optional in 0.11.0 — same picker pattern as PostgreSQL.
+        probe_cfg_for_db = replace(
+            defaults,
+            backend="snowflake",
+            account=account,
+            user=user,
+            password=password,
+            database="",
+        )
+        database = _ask_catalog_or_database_with_picker(
+            label="database",
+            current_value=defaults.database or "",
+            optional=True,
+            probe_cfg=probe_cfg_for_db,
+            listing_kind="databases",
         )
         warehouse = _ask_update_text(
             "Warehouse (optional, e.g. COMPUTE_WH)", defaults.warehouse or ""
@@ -605,7 +751,26 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         access_token = _ask_update_secret(
             "Access token", defaults.access_token or "", required=True
         )
-        catalog = _ask_update_text("Unity Catalog name (optional)", defaults.catalog or "")
+        # Probe the workspace for catalogs the user can actually see.
+        # Without this, a typo here ("sap" vs. "amx_test") silently
+        # saves and every ``amx`` startup later trips the
+        # SCHEMA_NOT_FOUND bootstrap warning.
+        probe_cfg_for_catalog = replace(
+            defaults,
+            backend="databricks",
+            host=host,
+            http_path=http_path,
+            access_token=access_token,
+            catalog="",
+            database="",
+        )
+        catalog = _ask_catalog_or_database_with_picker(
+            label="Unity Catalog",
+            current_value=defaults.catalog or "",
+            optional=True,
+            probe_cfg=probe_cfg_for_catalog,
+            listing_kind="catalogs",
+        )
         database = _ask_update_text("Schema / database (optional)", defaults.database or "")
         tls_trusted_ca_file = _ask_update_text(
             "Trusted CA bundle path (optional, for corporate/self-signed TLS)",
@@ -672,9 +837,21 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             "Username (e.g. analyst)", defaults.user or "", required=True, allow_clear=False
         )
         password = _ask_update_secret("Password", defaults.password or "", required=True)
-        database = _ask_update_text(
-            "Database name (optional — leave blank to pick at command time)",
-            defaults.database or "",
+        probe_cfg_for_db = replace(
+            defaults,
+            backend="mysql",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            database="",
+        )
+        database = _ask_catalog_or_database_with_picker(
+            label="database",
+            current_value=defaults.database or "",
+            optional=True,
+            probe_cfg=probe_cfg_for_db,
+            listing_kind="databases",
         )
         return replace(
             defaults,
@@ -754,9 +931,21 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             "Username (e.g. sa)", defaults.user or "", required=True, allow_clear=False
         )
         password = _ask_update_secret("Password", defaults.password or "", required=True)
-        database = _ask_update_text(
-            "Database name (optional — leave blank to pick at command time)",
-            defaults.database or "",
+        probe_cfg_for_db = replace(
+            defaults,
+            backend="mssql",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            database="",
+        )
+        database = _ask_catalog_or_database_with_picker(
+            label="database",
+            current_value=defaults.database or "",
+            optional=True,
+            probe_cfg=probe_cfg_for_db,
+            listing_kind="databases",
         )
         driver = _ask_update_text(
             "ODBC driver name (default: 'ODBC Driver 18 for SQL Server')",
@@ -805,9 +994,21 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             "Username (e.g. admin)", defaults.user or "", required=True, allow_clear=False
         )
         password = _ask_update_secret("Password", defaults.password or "", required=True)
-        database = _ask_update_text(
-            "Database name (e.g. dev — leave blank to pick at command time)",
-            defaults.database or "",
+        probe_cfg_for_db = replace(
+            defaults,
+            backend="redshift",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            database="",
+        )
+        database = _ask_catalog_or_database_with_picker(
+            label="database",
+            current_value=defaults.database or "",
+            optional=True,
+            probe_cfg=probe_cfg_for_db,
+            listing_kind="databases",
         )
         cluster = _ask_update_text(
             "Cluster identifier (optional, only needed for IAM auth)",
@@ -853,9 +1054,22 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             defaults.password or "",
             required=False,
         )
-        database = _ask_update_text(
-            "Database (e.g. analytics — leave blank to pick at command time)",
-            defaults.database or "",
+        probe_cfg_for_db = replace(
+            defaults,
+            backend="clickhouse",
+            host=host,
+            port=int(port_raw),
+            user=user,
+            password=password,
+            database="",
+            secure=secure,
+        )
+        database = _ask_catalog_or_database_with_picker(
+            label="database",
+            current_value=defaults.database or "",
+            optional=True,
+            probe_cfg=probe_cfg_for_db,
+            listing_kind="databases",
         )
         return replace(
             defaults,
@@ -893,17 +1107,20 @@ def cmd_add_profile(
     name = rest[0] if len(rest) >= 1 else ask("Profile name", default="local")
     existing = cfg.db_profiles.get(name)
     if existing is not None:
-        info(f"Editing profile: {name}")
-        # Editing an existing profile — keep its current values as
-        # defaults so the user can press Enter to skip unchanged fields.
-        db = interactive_db_block(existing)
-    else:
-        info(f"Creating new profile: {name}")
-        # New profile — every prompt starts blank. We deliberately do
-        # NOT use ``cfg.db`` (the active profile) as defaults here, or a
-        # /add-db-profile would silently pre-fill with the active
-        # profile's host / token / etc.
-        db = interactive_db_block(None)
+        # Add and edit are now two clean, non-overlapping channels —
+        # silently switching to edit mode here used to surprise users
+        # who typed an existing name by accident. Surface the collision
+        # and point them at /edit-db-profile.
+        error(
+            f"Profile {name!r} already exists. Run `/edit-db-profile {name}` to change its values."
+        )
+        return
+    info(f"Creating new profile: {name}")
+    # New profile — every prompt starts blank. We deliberately do
+    # NOT use ``cfg.db`` (the active profile) as defaults here, or a
+    # /add-db-profile would silently pre-fill with the active
+    # profile's host / token / etc.
+    db = interactive_db_block(None)
     # Use the safe upsert + transactional set_active path. The previous inline
     # ``cfg.active_db_profile = name; cfg.db = db`` ordering tripped the
     # autosave hook between the two assignments — the intermediate save() ran
@@ -923,6 +1140,70 @@ def cmd_add_profile(
             event_type="db_profile_upsert",
             status="success",
             command="add-db-profile",
+            details={"profile": name, "backend": db.backend},
+        )
+
+
+def cmd_edit_profile(
+    cfg: AMXConfig,
+    rest: list[str],
+    *,
+    log_event: LogEvent | None = None,
+) -> None:
+    """Edit an existing DB profile — pick by name, walk the wizard
+    with current values prefilled.
+
+    Replaces the silent edit-on-collision behaviour that ``/add-db-profile``
+    used to have. The wizard helpers (``_ask_update_text`` /
+    ``_ask_update_secret`` / ``_ask_update_bool``) already render
+    ``[Enter keeps current]`` hints, so the user can step through and
+    only change what they need. Saving never auto-switches the active
+    profile unless the edited profile WAS already active — touching one
+    profile must not silently move the user's working scope.
+    """
+    available = sorted(cfg.db_profiles.keys())
+    if not available:
+        error("No profiles configured. Use `/add-db-profile` to create one.")
+        return
+
+    if len(rest) >= 1:
+        name = rest[0]
+        if name not in cfg.db_profiles:
+            error(f"Unknown profile: {name!r}. Available: {', '.join(available)}.")
+            return
+    else:
+        descriptions = {n: f"[{p.backend}] {p.display_summary}" for n, p in cfg.db_profiles.items()}
+        picked = ask_choice(
+            "Select profile to edit",
+            available,
+            default=cfg.active_db_profile or available[0],
+            descriptions=descriptions,
+        )
+        if not picked:
+            error("No profile selected.")
+            return
+        name = picked
+
+    info(f"Editing profile: {name}")
+    existing = cfg.db_profiles[name]
+    db = interactive_db_block(existing)
+
+    was_active = cfg.active_db_profile == name
+    with cfg.transaction():
+        cfg.upsert_db_profile(name, db)
+        if was_active:
+            # Refresh cfg.db / mirrors so the rest of the session sees
+            # the edits without forcing the user to re-run /use-db.
+            cfg.set_active_db_profile(name)
+    if was_active:
+        success(f"Profile saved (still active): {name} [{db.backend}]")
+    else:
+        success(f"Profile saved: {name} [{db.backend}] (active stays {cfg.active_db_profile!r})")
+    if log_event is not None:
+        log_event(
+            event_type="db_profile_edit",
+            status="success",
+            command="edit-db-profile",
             details={"profile": name, "backend": db.backend},
         )
 

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -22,6 +22,9 @@ from amx.cli_support.commands.db import (
     cmd_cleanup_placeholders as _cmd_cleanup_placeholders,
 )
 from amx.cli_support.commands.db import (
+    cmd_edit_profile as _cmd_edit_profile,
+)
+from amx.cli_support.commands.db import (
     cmd_inspect as _cmd_inspect,
 )
 from amx.cli_support.commands.db import (
@@ -226,27 +229,25 @@ Commands (in order):
   Profile management:
   2) /db-profiles                  List DB profiles (Backend + connection summary)
   3) /use-db [name]                Switch profile (interactive list shows [engine] per profile)
-  4) /add-db-profile [name]        Create/update profile — pick PostgreSQL, Snowflake, Databricks, or BigQuery
-  5) /remove-db-profile <name>     Remove a DB profile (cannot remove last)
+  4) /add-db-profile [name]        Create a new profile — pick engine, then connection details
+  5) /edit-db-profile [name]       Edit an existing profile — current values prefilled,
+                                   catalog/database validated against the live backend
+  6) /remove-db-profile <name>     Remove a DB profile (cannot remove last)
 
   Profile settings:
-  6) /profiling [mode] [max] [N]   Show/set profiling guardrails
-  7) /tls [on|off] [ca|clear]      Show/set Databricks TLS settings
-
-  Active context:
-  8) /schema <name>                Set current schema context (used by /tables)
-  9) /table <name>                 Set current table context (used by /profile)
+  7) /profiling [mode] [max] [N]   Show/set profiling guardrails
+  8) /tls [on|off] [ca|clear]      Show/set Databricks TLS settings
 
   Connection & inspection:
- 10) /connect                      Test DB connectivity
- 11) /schemas                      List schemas
- 12) /tables [schema]              List tables (defaults to current schema)
- 13) /profile [schema] [table]     Profile a table (defaults to current context)
- 14) /inspect [profile]            Diagnose a profile: backend, capabilities, connection
+  9) /connect                      Test DB connectivity
+ 10) /schemas                      List schemas
+ 11) /tables [schema]              List tables in <schema>
+ 12) /profile [schema] [table]     Profile a table — pass schema + table positionally
+ 13) /inspect [profile]            Diagnose a profile: backend, capabilities, connection
                                    test, visible schemas, table counts. Read-only.
 
   Team collaboration:
- 15) /history-store                Configure shared run-history. Bare command opens an
+ 14) /history-store                Configure shared run-history. Bare command opens an
                                    interactive picker — Status, Enable, Disable,
                                    Migrate from local, Flush pending, Dump DDL — based
                                    on whether shared mode is on. Power-user shortcuts
@@ -254,7 +255,7 @@ Commands (in order):
                                    /history-store status).
 
   Maintenance:
- 16) /cleanup-placeholders [schema]
+ 15) /cleanup-placeholders [schema]
                                    Remove auto-inference fallback placeholder strings
                                    ("Auto-inference missed a reliable description; please
                                    review manually.") from the live DB. Use this once when
@@ -445,7 +446,7 @@ Commands (in order):
                                      Database — all schemas, all assets
                                      Schema   — select schema(s), all assets
                                      Asset    — specific tables/views
-                                     Default  — current /db schema and optional /table
+                                     Default  — interactive picker if no scope flags
   3) /run-apply [ASSET …] [--schema …] [--table …]   Same as /run --apply
   4) /apply                        Write pending comments to the database
 
@@ -543,7 +544,7 @@ Getting started (in order):
  10) /history                      Local SQLite history (/list, /show, /stats, /events)
 
 Inside namespaces (examples):
-  [bright_white]/db[/bright_white]   → /db-profiles, /schema, /table, /connect, /history-store, …
+  [bright_white]/db[/bright_white]   → /db-profiles, /add-db-profile, /edit-db-profile, /connect, /history-store, …
   [bright_white]/llm[/bright_white]   → /llm-profiles, /add-llm-profile, …
   [bright_white]/docs[/bright_white] → /doc-profiles, /add-doc-profile, /ingest, …
   [bright_white]/code[/bright_white] → /code-profiles, /add-code-profile, …
@@ -561,12 +562,9 @@ Examples:
   [bright_white]/db[/bright_white]
   [bright_white]/connect[/bright_white]
   [bright_white]/schemas[/bright_white]
-  [bright_white]/schema sap_s6p[/bright_white]
-  [bright_white]/tables[/bright_white]
-  [bright_white]/table t001[/bright_white]
-  [bright_white]/profile[/bright_white]
+  [bright_white]/tables sap_s6p[/bright_white]
+  [bright_white]/profile sap_s6p t001[/bright_white]
   [bright_white]/analyze[/bright_white]
-  [bright_white]/code-scan[/bright_white]  (after /schema …, uses active /code profile path)
   [bright_white]/code-scan https://github.com/org/repo --schema sap_s6p[/bright_white]
   [bright_white]/code-analyze vbrk vbrp[/bright_white]  (run Code Agent standalone on specific tables)
   [bright_white]/doc-analyze vbrk[/bright_white]  (run RAG Agent standalone)
@@ -831,6 +829,11 @@ def _handle_session_builtin(
             return True
         _cmd_add_profile(cfg, parts[1:], log_event=log_event)
         return True
+    if head == "edit-db-profile":
+        if not _require_namespace(head, namespace, "db", "edit-db-profile"):
+            return True
+        _cmd_edit_profile(cfg, parts[1:], log_event=log_event)
+        return True
     if head == "remove-db-profile":
         if not _require_namespace(head, namespace, "db", "remove-db-profile"):
             return True
@@ -885,26 +888,6 @@ def _handle_session_builtin(
         if not _require_namespace(head, namespace, "search", head):
             return True
         _cmd_embeddings(cfg, parts[1:])
-        return True
-    if head == "schema":
-        if not _require_namespace(head, namespace, "db", "schema"):
-            return True
-        if len(parts) < 2:
-            error("Usage: /schema <name> (inside /db)")
-            return True
-        cfg.current_schema = parts[1]
-        cfg.save()
-        info(f"Current schema set to: {cfg.current_schema}")
-        return True
-    if head == "table":
-        if not _require_namespace(head, namespace, "db", "table"):
-            return True
-        if len(parts) < 2:
-            error("Usage: /table <name> (inside /db)")
-            return True
-        cfg.current_table = parts[1]
-        cfg.save()
-        info(f"Current table set to: {cfg.current_table}")
         return True
     return False
 

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -113,6 +113,11 @@ _DB_COMMANDS: tuple[SlashCommand, ...] = (
         "Switch DB scope. Single: /use-db prod_pg. Multi (0.11+): /use-db prod_pg analytics_bq → persisted multi-profile scope for /ask /run /sync.",
     ),
     SlashCommand("/add-db-profile", "db", "Add profile — choose engine then connection details"),
+    SlashCommand(
+        "/edit-db-profile",
+        "db",
+        "Edit existing DB profile — current values prefilled, validates catalog/database against the live backend (/edit-db-profile [<name>])",
+    ),
     SlashCommand("/remove-db-profile", "db", "Remove DB profile (/remove-db-profile <name>)"),
     # Profile settings
     SlashCommand(
@@ -121,9 +126,6 @@ _DB_COMMANDS: tuple[SlashCommand, ...] = (
         "Show/set profiling guardrails (/profiling [full|sampled|metadata] [max_rows|off] [sample_size])",
     ),
     SlashCommand("/tls", "db", "Show/set Databricks TLS settings (/tls [on|off] [ca_path|clear])"),
-    # Active context
-    SlashCommand("/schema", "db", "Set current schema (/schema <name>)"),
-    SlashCommand("/table", "db", "Set current table (/table <name>)"),
     # Connection & inspection
     SlashCommand("/connect", "db", "Test DB connectivity"),
     SlashCommand("/schemas", "db", "List schemas"),

--- a/tests/test_edit_db_profile.py
+++ b/tests/test_edit_db_profile.py
@@ -1,0 +1,279 @@
+"""Pin the /edit-db-profile contract.
+
+User report (2026-05-04): the user accidentally pinned a Databricks
+profile to a non-existent ``catalog="sap"`` and every subsequent
+``amx`` startup tripped the SCHEMA_NOT_FOUND bootstrap warning. To
+make that whole class of bug unreachable, AMX now ships:
+
+- A dedicated ``/edit-db-profile`` (no more silent edit-on-collision
+  via ``/add-db-profile``).
+- An inline catalog/database picker in the wizard that lists what the
+  live backend can actually see, with a "type custom value" + "save
+  anyway?" gate for the rare permission-blocked-listing case.
+- Removal of ``/schema`` and ``/table`` (those wrote
+  ``cfg.current_schema`` / ``cfg.current_table`` blindly without any
+  check). The fields stay; only the slash commands go.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from amx.cli_support.commands.db import (
+    _ask_catalog_or_database_with_picker,
+    cmd_add_profile,
+    cmd_edit_profile,
+    cmd_remove_profile,  # noqa: F401 — sanity import; keeps the module in sync
+)
+from amx.cli_support.slash_commands import cmd_heads_for_namespace
+from amx.config import AMXConfig, DBConfig
+
+# ── /add-db-profile and /edit-db-profile are non-overlapping ─────────────
+
+
+def test_add_profile_refuses_when_name_already_exists() -> None:
+    cfg = AMXConfig()
+    cfg.db_profiles = {"foo": DBConfig(backend="postgresql", host="db.example.com")}
+    cfg.active_db_profile = "foo"
+
+    with patch("amx.cli_support.commands.db.interactive_db_block") as wizard:
+        cmd_add_profile(cfg, ["foo"])
+        # Crucial: the collision is rejected BEFORE the wizard runs.
+        wizard.assert_not_called()
+
+
+def test_edit_profile_unknown_name_errors_without_wizard() -> None:
+    cfg = AMXConfig()
+    cfg.db_profiles = {"foo": DBConfig(backend="postgresql", host="db.example.com")}
+    cfg.active_db_profile = "foo"
+
+    with patch("amx.cli_support.commands.db.interactive_db_block") as wizard:
+        cmd_edit_profile(cfg, ["nonexistent"])
+        wizard.assert_not_called()
+
+
+def test_edit_profile_walks_wizard_with_existing_as_defaults() -> None:
+    cfg = AMXConfig()
+    original = DBConfig(
+        backend="postgresql", host="db.example.com", user="alice", database="orders"
+    )
+    cfg.db = original
+    cfg.db_profiles = {"foo": original}
+    cfg.active_db_profile = "foo"
+
+    edited = DBConfig(backend="postgresql", host="db.example.com", user="alice", database="reports")
+    captured: dict[str, object] = {}
+
+    def spy(defaults):
+        captured["defaults"] = defaults
+        return edited
+
+    with patch("amx.cli_support.commands.db.interactive_db_block", side_effect=spy):
+        cmd_edit_profile(cfg, ["foo"])
+
+    # Wizard saw the existing profile as defaults — Enter-to-keep can work.
+    assert captured["defaults"] is original
+    # The edit landed in db_profiles AND in cfg.db (because foo was active).
+    assert cfg.db_profiles["foo"] is edited
+    assert cfg.db.database == "reports"
+
+
+def test_edit_profile_does_not_change_active_when_editing_inactive_profile() -> None:
+    cfg = AMXConfig()
+    active = DBConfig(backend="postgresql", host="active.example.com")
+    other = DBConfig(backend="postgresql", host="other.example.com")
+    cfg.db = active
+    cfg.db_profiles = {"active": active, "other": other}
+    cfg.active_db_profile = "active"
+
+    edited = DBConfig(backend="postgresql", host="other-edited.example.com")
+    with patch("amx.cli_support.commands.db.interactive_db_block", return_value=edited):
+        cmd_edit_profile(cfg, ["other"])
+
+    # The edit landed only in the other profile — active scope unchanged.
+    assert cfg.db_profiles["other"] is edited
+    assert cfg.active_db_profile == "active"
+    assert cfg.db is active
+
+
+# ── /schema and /table are gone from the registry ────────────────────────
+
+
+def test_schema_and_table_slash_commands_are_gone() -> None:
+    """They used to live under the /db namespace and silently wrote
+    cfg.current_schema / cfg.current_table without any validation.
+    They were the reason "olmayan bir şeye bağlanmak" was even
+    possible. Make sure the heads stay gone — re-introducing them
+    should be a deliberate, reviewed decision."""
+    db_heads = cmd_heads_for_namespace("db")
+    assert "schema" not in db_heads
+    assert "table" not in db_heads
+    # And the new edit head is wired up.
+    assert "edit-db-profile" in db_heads
+
+
+# ── Inline catalog/database picker — happy path & override ───────────────
+
+
+class _FakeConnector:
+    """Stand-in for DatabaseConnector that returns canned listings."""
+
+    def __init__(
+        self, catalogs: list[str] | None = None, databases: list[str] | None = None
+    ) -> None:
+        self._catalogs = catalogs or []
+        self._databases = databases or []
+
+    def list_catalogs(self) -> list[str]:
+        return list(self._catalogs)
+
+    def list_databases(self) -> list[str]:
+        return list(self._databases)
+
+
+def test_picker_falls_back_to_freeform_when_listing_is_empty() -> None:
+    """Connection works but role lacks visibility — wizard must still
+    let the user finish, just with a one-line warn."""
+    cfg = DBConfig(backend="postgresql", host="db.example.com")
+    with (
+        patch(
+            "amx.db.connector.DatabaseConnector",
+            return_value=_FakeConnector(databases=[]),
+        ),
+        patch(
+            "amx.cli_support.commands.db._ask_update_text",
+            return_value="manual_typed_value",
+        ),
+    ):
+        result = _ask_catalog_or_database_with_picker(
+            label="database",
+            current_value="",
+            optional=True,
+            probe_cfg=cfg,
+            listing_kind="databases",
+        )
+    assert result == "manual_typed_value"
+
+
+def test_picker_offers_listing_and_returns_selection() -> None:
+    cfg = DBConfig(
+        backend="databricks", host="ws.example.com", http_path="/sql/1.0/x", access_token="t"
+    )
+    with (
+        patch(
+            "amx.db.connector.DatabaseConnector",
+            return_value=_FakeConnector(catalogs=["amx_test", "main", "system"]),
+        ),
+        patch(
+            "amx.cli_support.commands.db.ask_choice",
+            return_value="main",
+        ),
+    ):
+        result = _ask_catalog_or_database_with_picker(
+            label="Unity Catalog",
+            current_value="",
+            optional=True,
+            probe_cfg=cfg,
+            listing_kind="catalogs",
+        )
+    assert result == "main"
+
+
+def test_picker_keep_current_returns_existing_value() -> None:
+    cfg = DBConfig(
+        backend="databricks", host="ws.example.com", http_path="/sql/1.0/x", access_token="t"
+    )
+    with (
+        patch(
+            "amx.db.connector.DatabaseConnector",
+            return_value=_FakeConnector(catalogs=["amx_test", "main"]),
+        ),
+        patch(
+            "amx.cli_support.commands.db.ask_choice",
+            return_value="(keep current: amx_test)",
+        ),
+    ):
+        result = _ask_catalog_or_database_with_picker(
+            label="Unity Catalog",
+            current_value="amx_test",
+            optional=True,
+            probe_cfg=cfg,
+            listing_kind="catalogs",
+        )
+    assert result == "amx_test"
+
+
+def test_picker_custom_value_in_listing_is_accepted_silently() -> None:
+    """Custom value path that happens to match the listing — no warn,
+    no extra confirm, just save the typed name."""
+    cfg = DBConfig(
+        backend="databricks", host="ws.example.com", http_path="/sql/1.0/x", access_token="t"
+    )
+    with (
+        patch(
+            "amx.db.connector.DatabaseConnector",
+            return_value=_FakeConnector(catalogs=["amx_test", "main"]),
+        ),
+        patch(
+            "amx.cli_support.commands.db.ask_choice",
+            return_value="(type custom value)",
+        ),
+        patch(
+            "amx.cli_support.commands.db._ask_update_text",
+            return_value="amx_test",
+        ),
+        patch("amx.cli_support.commands.db.confirm") as confirm_mock,
+    ):
+        result = _ask_catalog_or_database_with_picker(
+            label="Unity Catalog",
+            current_value="",
+            optional=True,
+            probe_cfg=cfg,
+            listing_kind="catalogs",
+        )
+    assert result == "amx_test"
+    # The confirm should NOT have fired — the typed value was in the listing.
+    confirm_mock.assert_not_called()
+
+
+def test_picker_off_listing_value_blocks_unless_user_confirms_override() -> None:
+    """Custom value not in the listing — that's the SCHEMA_NOT_FOUND
+    footgun. The picker must ask 'Save anyway?' and re-open if the
+    user says No, accept if they say Yes."""
+    cfg = DBConfig(
+        backend="databricks", host="ws.example.com", http_path="/sql/1.0/x", access_token="t"
+    )
+    with (
+        patch(
+            "amx.db.connector.DatabaseConnector",
+            return_value=_FakeConnector(catalogs=["amx_test", "main"]),
+        ),
+        patch(
+            "amx.cli_support.commands.db.ask_choice",
+            return_value="(type custom value)",
+        ),
+        patch(
+            "amx.cli_support.commands.db._ask_update_text",
+            return_value="ghost_catalog",
+        ),
+        patch(
+            "amx.cli_support.commands.db.confirm",
+            return_value=True,
+        ) as confirm_mock,
+    ):
+        result = _ask_catalog_or_database_with_picker(
+            label="Unity Catalog",
+            current_value="",
+            optional=True,
+            probe_cfg=cfg,
+            listing_kind="catalogs",
+        )
+    assert result == "ghost_catalog"
+    # The confirm fired — that's the override gate.
+    confirm_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -18,7 +18,6 @@ from amx.agents.code_agent import CodeAgent
 from amx.agents.orchestrator import Orchestrator, ReviewResult, apply_review_results_to_db
 from amx.cli_support import inject_session_defaults, session_to_click_args
 from amx.cli_support.commands.db import (
-    cmd_add_profile,
     cmd_profiling,
     cmd_tls,
     databricks_connect_with_recovery,
@@ -1021,7 +1020,9 @@ class ProfilingGuardrailTests(unittest.TestCase):
         self.assertEqual(cfg.db.backend, "databricks")
         self.assertEqual(cfg.db_profiles["databricks-default"].backend, "databricks")
 
-    def test_cmd_add_profile_overwrites_active_profile_atomically(self) -> None:
+    def test_cmd_edit_profile_overwrites_active_profile_atomically(self) -> None:
+        from amx.cli_support.commands.db import cmd_edit_profile
+
         cfg = AMXConfig()
         original = DBConfig(backend="postgresql", host="localhost", database="SAP")
         updated = DBConfig(
@@ -1038,7 +1039,7 @@ class ProfilingGuardrailTests(unittest.TestCase):
         cfg.active_db_profile = "databricks-default"
 
         with patch("amx.cli_support.commands.db.interactive_db_block", return_value=updated):
-            cmd_add_profile(cfg, ["databricks-default"])
+            cmd_edit_profile(cfg, ["databricks-default"])
 
         self.assertIs(cfg.db, updated)
         self.assertEqual(cfg.db.backend, "databricks")
@@ -2242,10 +2243,10 @@ class ProfileCreationLeakageTests(unittest.TestCase):
             self.assertEqual(new_profile.http_path, "")
             self.assertEqual(new_profile.catalog, "")
 
-    def test_db_add_profile_existing_name_passes_existing_as_defaults(self) -> None:
+    def test_db_edit_profile_passes_existing_as_defaults(self) -> None:
         """Editing an existing profile keeps its values as defaults so
         the user can press Enter to skip unchanged fields."""
-        from amx.cli_support.commands.db import cmd_add_profile
+        from amx.cli_support.commands.db import cmd_edit_profile
 
         with tempfile.TemporaryDirectory() as td:
             cfg_path = Path(td) / "config.yml"
@@ -2276,10 +2277,29 @@ class ProfileCreationLeakageTests(unittest.TestCase):
                 "amx.cli_support.commands.db.interactive_db_block",
                 side_effect=spy,
             ):
-                cmd_add_profile(cfg, ["edit-me"])
+                cmd_edit_profile(cfg, ["edit-me"])
 
             self.assertIsNotNone(captured["defaults"])
             self.assertEqual(captured["defaults"].host, "db.example.com")
+
+    def test_db_add_profile_refuses_existing_name(self) -> None:
+        """Add and edit are two clean, non-overlapping channels —
+        /add-db-profile errors on collision and points the user at
+        /edit-db-profile. Pins the new contract so the silent
+        edit-on-collision shape cannot regress."""
+        from amx.cli_support.commands.db import cmd_add_profile
+
+        cfg = AMXConfig()
+        cfg.db_profiles = {
+            "already-here": DBConfig(backend="postgresql", host="db.example.com"),
+        }
+        cfg.active_db_profile = "already-here"
+
+        with patch("amx.cli_support.commands.db.interactive_db_block") as mock_wizard:
+            cmd_add_profile(cfg, ["already-here"])
+            # Wizard must NOT have been invoked — the command refused
+            # the collision before reaching that code path.
+            mock_wizard.assert_not_called()
 
     def test_interactive_db_block_resets_cross_backend_defaults(self) -> None:
         """If the caller passes a Databricks profile but the user picks


### PR DESCRIPTION
## Summary

User report (2026-05-04): nothing prevented saving — and silently using — a DB profile that pointed at a catalog/database the live backend could not see. Their Databricks profile had a typo'd `catalog` value, the catalog did not exist on the workspace, and every `amx` startup blew up with `SCHEMA_NOT_FOUND` even after the just-shipped lazy-bootstrap fix (deferring the warning ≠ making the catalog real). The `/schema` and `/table` commands had the same shape: blindly write the typed value, never validate.

Three coordinated changes:

- **New `/edit-db-profile`** under `/db`. Walks the same wizard as `/add-db-profile` but pre-fills every prompt with the existing value, so the user can press Enter to skip unchanged fields. Editing an inactive profile leaves the active scope alone.
- **`/add-db-profile` refuses name collisions** instead of silently switching to edit mode — `Profile 'foo' already exists. Run /edit-db-profile foo to change its values.` Add and edit are two clean, non-overlapping channels.
- **Inline catalog/database picker in the wizard.** After host/credentials are entered, the wizard probes the live backend (`DatabaseConnector.list_catalogs` / `list_databases`) and presents the discovered values as an `ask_choice` — `(keep current: <X>)`, `(none)`, real values, `(type custom value)`. The custom-value path issues `warn()` + `confirm("Save anyway?", default=False)` when the typed value is NOT in the listing — the exact gate that would have blocked the original `sap` typo. Listing failure falls back to the historical free-form prompt with one warn(). Wired into Databricks (catalog), PostgreSQL, Snowflake, MySQL, MSSQL, Redshift, ClickHouse (database). BigQuery free-form stays for now (no `list_projects`).
- **`/schema` and `/table` removed.** They wrote `cfg.current_schema` / `cfg.current_table` blindly. Fields stay (tests and `/run`'s default scope still read them); the standard scope path is now positional (`/run <schema> <table>`) or the existing `finalize_scope` interactive picker.

## Test plan

- [x] `pytest tests/test_edit_db_profile.py -v` — 10 cases (add-collision refused, edit happy path, inactive-profile edit doesn't move active scope, registry contract for `/schema` `/table` removal, picker fallback, picker happy path, keep-current, custom-value-in-listing silent accept, custom-value-off-listing gated by confirm)
- [x] `pytest tests/` — 631 passed, 19 deselected
- [x] `ruff check amx tests` + `ruff format --check amx tests` — clean
- [ ] Manual: `amx` → `/help` (no `/schema` `/table` listed) → `/db-profiles` → `/edit-db-profile <existing>` (catalog picker shows live values) → `/add-db-profile <same-name>` (errors with edit hint) → typo a custom value (warn + confirm gate)