### PR TITLE
fix(ask): list_catalogs eagerly attaches schemas of the obvious user catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — `list_catalogs` itself auto-resolves the schemas now, so kimi-thinking can't loop on the catalog list either
+
+Second-round follow-up. After the previous fix landed, the user
+reported the loop returned in a slightly different shape: the model
+called `list_catalogs` first (per the no-catalog-pinned hint we'd
+added to the system prompt) and then narrated the 4-entry result
+("1. amx_test - This appears to be the main user catalog 2. samples
+- Sample data …") instead of recursing into `list_schemas`.
+
+Two fixes:
+
+1. `list_catalogs` now eagerly attaches `auto_picked_catalog` plus
+   the schemas of that catalog (`schemas_in_auto_picked_catalog`)
+   when the workspace exposes exactly one non-system user catalog.
+   The next iteration of the agent loop has no decision left to
+   make — there's nothing to enumerate at the user.
+2. The no-catalog-pinned hint in the agent system prompt now points
+   at `list_schemas` first (which already auto-picked) instead of
+   `list_catalogs`, and explicitly forbids "I see N catalogs"
+   narration prose.
+
+`tests/test_compare.py::CatalogDiscoveryToolsTests::test_list_catalogs_tool_auto_resolves_single_user_catalog`
+covers the user's exact `[amx_test, samples, system, workspace]`
+shape from the second loop report.
+
 ### Fixed — `/ask` no longer loops on Kimi-thinking when a Databricks workspace exposes one obvious user catalog
 
 Follow-up to the catalog-discovery fix below. User report 2026-05-04

--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -1059,12 +1059,40 @@ class ToolBox:
         except Exception as exc:
             raise _ToolError(f"SHOW CATALOGS failed: {exc}") from exc
         pinned = str(getattr(self.cfg.db, "catalog", "") or "").strip()
-        return {
+        user_catalogs = self._user_catalogs(catalogs)
+        payload: dict[str, Any] = {
             "supports_catalogs": True,
             "catalogs": catalogs,
+            "user_catalogs": user_catalogs,
             "count": len(catalogs),
             "active_catalog": pinned or None,
         }
+        # When no catalog is pinned and the workspace exposes exactly
+        # one user catalog, eagerly attach its schema list. This breaks
+        # the kimi-thinking loop where the model would call
+        # list_catalogs, see the 4-catalog Databricks listing, and
+        # narrate the obvious choice instead of calling list_schemas.
+        # Embedding the answer in the same response means the next
+        # iteration of the agent loop already has the schemas to work
+        # with — there's nothing left to "decide".
+        if not pinned and len(user_catalogs) == 1:
+            try:
+                with self._scoped_catalog(db, user_catalogs[0]):
+                    schemas = [str(s) for s in db.list_schemas()]
+                payload["auto_picked_catalog"] = user_catalogs[0]
+                payload["schemas_in_auto_picked_catalog"] = schemas
+                payload["instruction"] = (
+                    f"Only one user catalog (`{user_catalogs[0]}`) is visible. "
+                    "Treat it as the active catalog for this turn — the schemas "
+                    "are already in `schemas_in_auto_picked_catalog`. Answer the "
+                    "user's question directly using these schemas; do NOT enumerate "
+                    "the catalog list back to the user."
+                )
+            except Exception as exc:
+                # Don't block the catalog list on a follow-up failure;
+                # the LLM can still pick manually from the list above.
+                payload["auto_pick_failed"] = str(exc)
+        return payload
 
     def _tool_list_server_databases(self) -> dict[str, Any]:
         db = self._live_db()

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -81,10 +81,13 @@ def _agent_system_prompt(cfg: AMXConfig, schema_hint: list[str]) -> str:
         backend = (cfg.db.backend or "").lower()
         if backend in {"databricks", "bigquery"}:
             db_unpinned_hint = (
-                "  ⚠ No catalog/project is pinned for this profile. Call list_catalogs "
-                "before list_schemas, or pass `catalog` to list_schemas / "
-                "list_tables_in_schema. Listing schemas without a catalog will fail with "
-                "NO_SUCH_CATALOG_EXCEPTION on Databricks Unity Catalog."
+                "  ⚠ No catalog/project is pinned for this profile. Just call list_schemas "
+                "(no catalog argument) — when there's a single non-system user catalog "
+                "the tool auto-resolves it and returns schemas directly. Only fall back "
+                "to list_catalogs if list_schemas comes back with `needs_catalog=true`. "
+                "Never compose a 'I see N catalogs' paragraph at the user — the auto-"
+                "pick handles it silently and you should just answer their actual "
+                "question (which tables / schemas / etc.)."
             )
         elif backend:
             db_unpinned_hint = (

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1233,6 +1233,39 @@ class CatalogDiscoveryToolsTests(unittest.TestCase):
         self.assertEqual(payload["catalogs"], ["main", "samples"])
         self.assertEqual(payload["active_catalog"], "main")
 
+    def test_list_catalogs_tool_auto_resolves_single_user_catalog(self) -> None:
+        """User report 2026-05-04 (second loop): kimi-thinking still
+        looped because the system prompt's no-catalog hint pushed it
+        toward list_catalogs first; then it narrated the 4-entry list
+        instead of calling list_schemas. list_catalogs now eagerly
+        attaches the schemas of the single user catalog when the
+        workspace exposes one — the next agent iteration has no
+        decision to make and no list to enumerate at the user."""
+
+        class FakeDB:
+            def __init__(self) -> None:
+                self.cfg = type("DBCfg", (), {"catalog": ""})()
+
+            def supports_catalogs(self) -> bool:
+                return True
+
+            def list_catalogs(self) -> list[str]:
+                return ["amx_test", "samples", "system", "workspace"]
+
+            def list_schemas(self) -> list[str]:
+                return ["sales", "ops"]
+
+        toolbox = self._toolbox(FakeDB())
+        payload = toolbox._tool_list_catalogs()
+        self.assertEqual(payload["catalogs"], ["amx_test", "samples", "system", "workspace"])
+        self.assertEqual(payload["user_catalogs"], ["amx_test"])
+        self.assertEqual(payload["auto_picked_catalog"], "amx_test")
+        self.assertEqual(payload["schemas_in_auto_picked_catalog"], ["sales", "ops"])
+        # Instruction nudges the LLM to answer directly instead of
+        # narrating the catalog list.
+        self.assertIn("schemas_in_auto_picked_catalog", payload["instruction"])
+        self.assertIn("not enumerate", payload["instruction"].lower())
+
     def test_list_catalogs_tool_signals_2_level_backend(self) -> None:
         class FakeDB:
             def supports_catalogs(self) -> bool:


### PR DESCRIPTION
## Summary

- **Bug (second loop)**: After PR #106 landed, kimi-k2-thinking still looped — the model followed the system prompt's no-catalog-pinned hint, called \`list_catalogs\` first, and then narrated the 4-entry list (\"1. amx_test - This appears to be the main user catalog 2. samples - Sample data …\") instead of recursing into \`list_schemas\`.
- **Fix**:
  - \`list_catalogs\` now eagerly attaches \`auto_picked_catalog\` + \`schemas_in_auto_picked_catalog\` when the workspace exposes exactly one non-system user catalog. The next agent iteration has no decision left to make and no list to enumerate at the user.
  - The no-catalog-pinned hint in the agent system prompt now points at \`list_schemas\` first (which already auto-picked) instead of \`list_catalogs\`, and explicitly forbids \"I see N catalogs\" narration prose.

## Test plan

- [x] \`pytest tests/test_compare.py::CatalogDiscoveryToolsTests\` — 8 tests, including the new \`test_list_catalogs_tool_auto_resolves_single_user_catalog\` covering the user's exact \`[amx_test, samples, system, workspace]\` shape.
- [x] \`pytest tests/test_compare.py tests/test_search_catalog.py\` — 84 passed, no regressions.
- [x] \`ruff check amx tests\` clean.
- [ ] Manual: \`/ask which tables do you see\` against the kimi-thinking + Databricks profile saved without a catalog — agent now answers in a single round-trip without enumerating catalogs.