### PR TITLE
release: 0.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+## [0.12.6] - 2026-05-04
+
 ### Fixed — every catalog-scoped `/ask` tool now auto-picks the catalog, not just `list_schemas`
 
 Third-round follow-up. User report 2026-05-04: after the previous

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.12.5"
+__version__ = "0.12.6"
 
 __all__ = [
     "AMXApplication",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx-cli"
-version = "0.12.5"
+version = "0.12.6"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Release 0.12.6.

Fixes shipped:

- `/ask` discovers the catalog itself when the active DB profile didn't pin one (PR #104)
- `/ask` no longer loops on Kimi-thinking when a Databricks workspace exposes one obvious user catalog (PR #106)
- `list_catalogs` itself auto-resolves the schemas now (PR #107)
- Every catalog-scoped `/ask` tool auto-picks the catalog, not just `list_schemas` (PR #108)

## Test plan

- [x] Local \`python -m build\` produces \`amx_cli-0.12.6.tar.gz\` + \`amx_cli-0.12.6-py3-none-any.whl\` cleanly.
- [x] \`pyproject.toml\` and \`amx/__init__.py.__version__\` are in sync at 0.12.6.
- [ ] CI green.
- [ ] Tag \`v0.12.6\` triggers PyPI publish via OIDC + GitHub release.