### PR TITLE
fix(db): ask TLS before probing catalogs in the Databricks wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — Databricks wizard asks TLS first and gates the catalog probe behind a yes/no
+
+User report 2026-05-04: a corporate Databricks workspace behind a
+self-signed TLS proxy crashed the very first ``SHOW CATALOGS`` round-
+trip with ``SSLCertVerificationError`` because the wizard probed
+*before* asking about TLS — the user had no chance to disable verify
+or point at a CA bundle, the picker silently fell back to free-form
+input, and the cert problem stayed hidden.
+
+Two changes to ``amx db /add-profile`` and ``/edit-db-profile`` for
+the Databricks backend:
+
+1. The TLS trusted-CA path and the ``Disable TLS certificate
+   verification?`` prompts now fire **before** the catalog probe.
+   The probe config carries those values so self-signed setups work
+   on the first try.
+2. A ``List the available Unity Catalog catalogs from the workspace?``
+   yes/no gate sits between TLS and the catalog picker. Users who
+   already know their catalog name skip the round-trip entirely; the
+   listing only happens when the user explicitly opts in.
+
+Tests in ``tests/test_regressions.py::ProfilingGuardrailTests`` are
+updated for the new prompt order and a new test pins the relative
+ordering of TLS vs. catalog-probe prompts.
+
 ## [0.12.6] - 2026-05-04
 
 ### Fixed — every catalog-scoped `/ask` tool now auto-picks the catalog, not just `list_schemas`

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -751,27 +751,13 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         access_token = _ask_update_secret(
             "Access token", defaults.access_token or "", required=True
         )
-        # Probe the workspace for catalogs the user can actually see.
-        # Without this, a typo here ("sap" vs. "amx_test") silently
-        # saves and every ``amx`` startup later trips the
-        # SCHEMA_NOT_FOUND bootstrap warning.
-        probe_cfg_for_catalog = replace(
-            defaults,
-            backend="databricks",
-            host=host,
-            http_path=http_path,
-            access_token=access_token,
-            catalog="",
-            database="",
-        )
-        catalog = _ask_catalog_or_database_with_picker(
-            label="Unity Catalog",
-            current_value=defaults.catalog or "",
-            optional=True,
-            probe_cfg=probe_cfg_for_catalog,
-            listing_kind="catalogs",
-        )
-        database = _ask_update_text("Schema / database (optional)", defaults.database or "")
+        # Ask TLS settings BEFORE probing the workspace. Corporate
+        # Databricks setups frequently sit behind a self-signed proxy,
+        # and the previous wizard order (probe-then-TLS) blew up with
+        # SSLCertVerificationError on the very first ``SHOW CATALOGS``
+        # call — the fallback masked the cert problem and pushed the
+        # user back to free-form input. Asking TLS first means the
+        # picker probe respects the user's trust settings.
         tls_trusted_ca_file = _ask_update_text(
             "Trusted CA bundle path (optional, for corporate/self-signed TLS)",
             defaults.tls_trusted_ca_file or "",
@@ -780,6 +766,42 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
             "Disable TLS certificate verification? (insecure; use only if a trusted CA bundle is not available)",
             bool(defaults.tls_no_verify),
         )
+        # Gate the catalog probe behind an explicit yes/no. Probing
+        # always involves a live SHOW CATALOGS round-trip; on flaky or
+        # restricted networks that's a 30-second wait followed by an
+        # unhelpful warning. When the user already knows their catalog
+        # name (typical second-time-through case) they should just type
+        # it instead of paying the round-trip cost.
+        probe_catalogs = _ask_update_bool(
+            "List the available Unity Catalog catalogs from the workspace? "
+            "(uses the credentials you just entered to run SHOW CATALOGS)",
+            current=False,
+        )
+        if probe_catalogs:
+            probe_cfg_for_catalog = replace(
+                defaults,
+                backend="databricks",
+                host=host,
+                http_path=http_path,
+                access_token=access_token,
+                catalog="",
+                database="",
+                tls_trusted_ca_file=tls_trusted_ca_file,
+                tls_no_verify=tls_no_verify,
+            )
+            catalog = _ask_catalog_or_database_with_picker(
+                label="Unity Catalog",
+                current_value=defaults.catalog or "",
+                optional=True,
+                probe_cfg=probe_cfg_for_catalog,
+                listing_kind="catalogs",
+            )
+        else:
+            catalog = _ask_update_text(
+                "Unity Catalog (optional)",
+                defaults.catalog or "",
+            )
+        database = _ask_update_text("Schema / database (optional)", defaults.database or "")
         return replace(
             defaults,
             backend="databricks",

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1133,9 +1133,18 @@ class ProfilingGuardrailTests(unittest.TestCase):
             tls_trusted_ca_file="/tmp/old.pem",
         )
 
-        ask_values = iter(["databricks", "new-host", "/sql/new", "newcat", "-", "-"])
+        # New wizard order (post-2026-05-04 fix): host → http_path → token →
+        # tls_ca → tls_no_verify → probe_catalogs → catalog → database. The
+        # TLS prompts now come BEFORE the catalog probe so corporate
+        # self-signed setups don't blow up on the very first SHOW CATALOGS
+        # before the user has a chance to disable verify or point at a CA
+        # bundle. The probe itself is gated behind an explicit yes/no so
+        # users who already know their catalog name don't pay the round-
+        # trip cost.
+        ask_values = iter(["databricks", "new-host", "/sql/new", "-", "newcat", "-"])
         secret_values = iter(["new-token"])
-        choice_values = iter(["yes"])
+        # Order: tls_no_verify=yes, probe_catalogs=no.
+        choice_values = iter(["yes", "no"])
 
         with (
             patch(
@@ -1177,9 +1186,13 @@ class ProfilingGuardrailTests(unittest.TestCase):
             tls_trusted_ca_file="/tmp/old.pem",
         )
 
+        # Blank inputs → keep existing values for every text field.
+        # Order matches the new wizard: host → http_path → tls_ca →
+        # catalog (free-form because probe_catalogs=no) → database.
         ask_values = iter(["databricks", "", "", "", "", ""])
         secret_values = iter([""])
-        choice_values = iter(["no"])
+        # Order: tls_no_verify=no (toggle off), probe_catalogs=no.
+        choice_values = iter(["no", "no"])
 
         with (
             patch(
@@ -1208,6 +1221,87 @@ class ProfilingGuardrailTests(unittest.TestCase):
         self.assertEqual(updated.database, "olddb")
         self.assertEqual(updated.tls_trusted_ca_file, "/tmp/old.pem")
         self.assertFalse(updated.tls_no_verify)
+
+    def test_databricks_wizard_asks_tls_before_probing_catalogs(self) -> None:
+        """User report 2026-05-04: corporate Databricks behind a self-
+        signed proxy hit ``SSLCertVerificationError`` on the first
+        ``SHOW CATALOGS`` because the wizard probed BEFORE the user
+        had a chance to disable TLS verify or point at a CA bundle.
+        The fix moves the TLS prompts above the catalog probe AND
+        gates the probe behind an explicit yes/no — the picker now
+        forwards the user's TLS selections into the probe config so
+        self-signed setups work, and the probe only fires when the
+        user opts in. The test pins the prompt order by recording
+        every ``ask`` / ``ask_choice`` call in sequence."""
+        defaults = DBConfig(
+            backend="databricks",
+            host="",
+            http_path="",
+            access_token="",
+            catalog="",
+            database="",
+            tls_no_verify=False,
+            tls_trusted_ca_file="",
+        )
+
+        # New wizard order: backend / host / http_path / token / tls_ca /
+        # tls_no_verify / probe_catalogs / catalog (free-form because
+        # probe=no) / database. Capture each label as it fires so we
+        # can assert the relative ordering of TLS vs. catalog probe.
+        ask_values = iter(
+            [
+                "host.example",  # Workspace host
+                "/sql/x",  # SQL warehouse HTTP path
+                "/etc/ca.pem",  # Trusted CA bundle path (TLS)
+                "amx_test",  # Unity Catalog (free-form because probe=no)
+                "",  # Schema / database — clear-by-blank keeps default ""
+            ]
+        )
+        choice_values = iter(
+            [
+                "databricks",  # Select database backend
+                "no",  # Disable TLS certificate verification?
+                "no",  # List the available Unity Catalog catalogs?
+            ]
+        )
+
+        prompts: list[str] = []
+
+        def record_ask(label, *args, **kwargs):
+            prompts.append(label.split("\n")[0])
+            return next(ask_values)
+
+        def record_choice(label, *args, **kwargs):
+            prompts.append(label.split("\n")[0])
+            return next(choice_values)
+
+        with (
+            patch("amx.cli_support.commands.db.ask_choice", side_effect=record_choice),
+            patch("amx.cli_support.commands.db.ask", side_effect=record_ask),
+            patch(
+                "amx.cli_support.commands.db.ask_password",
+                side_effect=lambda *args, **kwargs: "tok",
+            ),
+        ):
+            updated = interactive_db_block(defaults)
+
+        self.assertEqual(updated.tls_trusted_ca_file, "/etc/ca.pem")
+        self.assertFalse(updated.tls_no_verify)
+        self.assertEqual(updated.catalog, "amx_test")
+
+        # The probe-gate prompt MUST land after both TLS prompts AND
+        # before the catalog choice prompt.
+        tls_ca_idx = next(i for i, p in enumerate(prompts) if "Trusted CA bundle path" in p)
+        tls_verify_idx = next(
+            i for i, p in enumerate(prompts) if "Disable TLS certificate verification?" in p
+        )
+        probe_gate_idx = next(
+            i for i, p in enumerate(prompts) if "List the available Unity Catalog catalogs" in p
+        )
+        catalog_idx = next(i for i, p in enumerate(prompts) if "Unity Catalog (optional)" in p)
+        self.assertLess(tls_ca_idx, probe_gate_idx, "TLS CA must precede probe gate")
+        self.assertLess(tls_verify_idx, probe_gate_idx, "TLS verify must precede probe gate")
+        self.assertLess(probe_gate_idx, catalog_idx, "Probe gate must precede catalog")
 
     def test_metadata_mode_does_not_open_data_connection(self) -> None:
         class FakeEngine:


### PR DESCRIPTION
## Summary

- **Bug**: Corporate Databricks behind a self-signed TLS proxy crashed the first \`SHOW CATALOGS\` round-trip in the wizard with \`SSLCertVerificationError\`. The wizard probed BEFORE asking about TLS, so the user had no chance to disable verify or point at a CA bundle; the picker silently fell back to free-form input and the cert problem stayed hidden.
- **Fix**:
  1. TLS trusted-CA path + \`Disable TLS certificate verification?\` prompts now fire BEFORE the catalog probe. The probe config carries those values so self-signed setups work first try.
  2. A new \`List the available Unity Catalog catalogs from the workspace?\` yes/no gate sits between TLS and the catalog picker. Users who already know their catalog name skip the round-trip entirely.

## Test plan

- [x] \`pytest tests/test_regressions.py::ProfilingGuardrailTests\` — including the new \`test_databricks_wizard_asks_tls_before_probing_catalogs\` that pins TLS-before-probe ordering, plus the two existing wizard tests retuned for the new prompt order.
- [x] \`pytest tests/test_edit_db_profile.py tests/test_regressions.py::ProfilingGuardrailTests\` — 22 passed.
- [x] \`ruff check amx tests\` + \`ruff format --check amx tests\` clean.
- [ ] Manual: \`/add-profile\` against a Databricks profile pointing at a self-signed proxy — TLS prompts come first, "List catalogs?" gate appears, picker probe runs only on yes.