### PR TITLE
fix(llm): flatten OpenAI-Responses-style structured content before pydantic validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — Databricks gpt-oss / OpenAI Responses-style structured `content` no longer crashes the LLM call
+
+User report 2026-05-04: a Databricks Foundation Model Serving endpoint
+(``gpt-oss-120b``) reached via the ``local`` provider returned
+``message.content`` as an OpenAI Responses-API-style list — a reasoning
+summary followed by the actual text answer:
+
+```
+[
+  {"type": "reasoning", "summary": [...]},
+  {"type": "text", "text": "OK"},
+]
+```
+
+LiteLLM's ``Message`` pydantic model declares ``content: str`` and
+rejected the payload with ``ValidationError: 1 validation error for
+Message — content: Input should be a valid string``. AMX surfaced
+this as a confusing ``InternalServerError: Invalid response object``
+that retried 3× before failing — even though the upstream API had
+returned a perfectly valid (and successful) answer.
+
+The provider now installs a one-shot shim around
+``litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response.convert_to_model_response_object``
+that flattens structured content lists in place before pydantic
+validation runs:
+
+* Recognises both ``{"type": "text", ...}`` (chat-completions) and
+  ``{"type": "output_text", ...}`` (Responses API) chunk shapes.
+* Drops reasoning summaries — they're already exposed via the
+  streaming ``on_thinking`` callback; embedding them in
+  ``message.content`` would corrupt downstream parsers (catalog/code
+  agent JSON, deterministic answer extraction).
+* Patches both ``message.content`` and streaming ``delta.content``.
+* Idempotent — safe to call across repeated LiteLLM imports.
+
+Coverage: ``tests/test_llm_structured_content.py`` (13 tests) covers
+the user's exact failing payload shape, plus the Responses-API
+``output_text`` alias, multi-chunk concatenation, reasoning-only
+responses, streaming deltas, and shim idempotency.
+
 ### Added — `/ask` knows about Databricks Volumes via a new `list_volumes` tool
 
 User report 2026-05-04: `/ask "Is there any volume under schemas?"` answered

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -83,8 +83,108 @@ def _litellm() -> ModuleType:
             except Exception:
                 pass
 
+        _install_structured_content_shim(lm)
         _litellm_module = lm
     return _litellm_module
+
+
+def _flatten_structured_content(content: Any) -> str | None:
+    """Coerce OpenAI-Responses-style structured content into a plain string.
+
+    Some hosted endpoints — Databricks Foundation Models (gpt-oss family),
+    OpenAI's o1 / o3 over the Responses API, certain self-hosted reasoning
+    models — return ``message.content`` as a list of structured items::
+
+        [
+            {"type": "reasoning", "summary": [{"type": "summary_text", ...}]},
+            {"type": "text", "text": "OK"},
+        ]
+
+    LiteLLM's ``Message`` pydantic model declares ``content: str``, so the
+    response normalizer rejects the payload with::
+
+        ValidationError: 1 validation error for Message
+        content: Input should be a valid string
+
+    Without a fix the call retries 3× and ultimately surfaces a confusing
+    ``InternalServerError: Invalid response object`` to the user despite
+    the upstream API having returned a valid (and successful) answer.
+
+    This helper extracts every ``text`` chunk from the list and concatenates
+    them. Reasoning summaries are dropped on the floor — the LLM provider's
+    streaming path already exposes reasoning content separately via
+    ``on_thinking``; embedding it in ``content`` would corrupt downstream
+    parsers (catalog/code agent JSON, deterministic answer extraction, …).
+
+    Returns ``None`` when the input isn't a list — caller should leave the
+    original value untouched.
+    """
+    if not isinstance(content, list):
+        return None
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        kind = str(item.get("type") or "").lower()
+        if kind in {"text", "output_text"}:
+            text = item.get("text")
+            if isinstance(text, str) and text:
+                parts.append(text)
+    return "".join(parts)
+
+
+def _normalize_response_dict_in_place(response_obj: Any) -> None:
+    """Walk a LiteLLM response dict and flatten any structured ``content`` lists.
+
+    Mutates in place. Safe to call on any value — non-dict / non-list inputs
+    are ignored. Touches both ``message.content`` (chat completions) and
+    ``delta.content`` (streaming chunks).
+    """
+    if not isinstance(response_obj, dict):
+        return
+    choices = response_obj.get("choices")
+    if not isinstance(choices, list):
+        return
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        for slot in ("message", "delta"):
+            payload = choice.get(slot)
+            if not isinstance(payload, dict):
+                continue
+            content = payload.get("content")
+            flattened = _flatten_structured_content(content)
+            if flattened is not None:
+                payload["content"] = flattened
+
+
+def _install_structured_content_shim(lm: ModuleType) -> None:
+    """Wrap ``litellm.litellm_core_utils...convert_to_model_response_object``
+    so it auto-flattens structured ``content`` lists before pydantic
+    validation. Idempotent — safe to call once per LiteLLM import.
+    """
+    try:
+        from litellm.litellm_core_utils.llm_response_utils import (
+            convert_dict_to_response as _conv_mod,
+        )
+    except Exception:  # pragma: no cover - defensive against LiteLLM internals shifting
+        return
+    if getattr(_conv_mod, "_amx_structured_content_shim", False):
+        return
+    original = _conv_mod.convert_to_model_response_object
+
+    def _patched(*args: Any, **kwargs: Any):
+        response_object = kwargs.get("response_object")
+        if response_object is None and args:
+            response_object = args[0]
+        try:
+            _normalize_response_dict_in_place(response_object)
+        except Exception:  # pragma: no cover - never block a real response on a flatten error
+            pass
+        return original(*args, **kwargs)
+
+    _conv_mod.convert_to_model_response_object = _patched
+    _conv_mod._amx_structured_content_shim = True
 
 
 PROVIDER_MODEL_PREFIX = {

--- a/tests/test_llm_structured_content.py
+++ b/tests/test_llm_structured_content.py
@@ -1,0 +1,220 @@
+"""Tests for the structured-content flatten shim in amx/llm/provider.py.
+
+User report 2026-05-04: Databricks Foundation Model Serving's gpt-oss-120b
+endpoint returns ``message.content`` as an OpenAI-Responses-style list of
+``{"type": "reasoning", ...}`` + ``{"type": "text", "text": "OK"}`` items.
+LiteLLM's ``Message`` pydantic model declares ``content: str`` and rejects
+the payload with a confusing
+``InternalServerError: Invalid response object`` despite the upstream API
+having returned a valid answer. The provider now installs a shim that
+flattens structured content lists in place before LiteLLM's normalizer
+runs.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from amx.llm.provider import (
+    _flatten_structured_content,
+    _normalize_response_dict_in_place,
+)
+
+
+class FlattenStructuredContentTests(unittest.TestCase):
+    def test_plain_string_returns_none_so_caller_keeps_it(self) -> None:
+        # The shim must not rewrite a content field that's already a string —
+        # returning ``None`` signals "leave it alone".
+        self.assertIsNone(_flatten_structured_content("hello"))
+        self.assertIsNone(_flatten_structured_content(""))
+        self.assertIsNone(_flatten_structured_content(None))
+
+    def test_databricks_gpt_oss_shape_returns_text_content(self) -> None:
+        """The user-reported Databricks gpt-oss-120b shape: a reasoning
+        summary followed by the actual text answer. The reasoning summary
+        must be dropped (it's surfaced via ``on_thinking`` separately) and
+        only the user-facing text retained."""
+        content = [
+            {
+                "type": "reasoning",
+                "summary": [
+                    {"type": "summary_text", "text": "The user says reply OK"},
+                ],
+            },
+            {"type": "text", "text": "OK"},
+        ]
+        self.assertEqual(_flatten_structured_content(content), "OK")
+
+    def test_multiple_text_chunks_concatenate(self) -> None:
+        content = [
+            {"type": "text", "text": "Hello, "},
+            {"type": "text", "text": "world!"},
+        ]
+        self.assertEqual(_flatten_structured_content(content), "Hello, world!")
+
+    def test_responses_api_output_text_alias_recognised(self) -> None:
+        """OpenAI's Responses API uses ``output_text`` as the type key.
+        The shim must accept both spellings so o3 / gpt-5 reasoning models
+        over the Responses path work too."""
+        content = [
+            {"type": "output_text", "text": "Answer"},
+        ]
+        self.assertEqual(_flatten_structured_content(content), "Answer")
+
+    def test_unknown_chunk_types_are_silently_ignored(self) -> None:
+        """An unfamiliar chunk type (image / tool / ...) must NOT crash the
+        shim — we drop it and keep the text we recognise."""
+        content = [
+            {"type": "tool_use", "id": "call_1"},
+            {"type": "text", "text": "result"},
+        ]
+        self.assertEqual(_flatten_structured_content(content), "result")
+
+    def test_reasoning_only_response_returns_empty_string(self) -> None:
+        """Some endpoints emit only a reasoning summary with no text body
+        when the model produced thinking but nothing user-facing. We
+        return an empty string so LiteLLM's pydantic Message accepts the
+        payload and the caller can inspect finish_reason / usage."""
+        content = [
+            {"type": "reasoning", "summary": [{"type": "summary_text", "text": "..."}]},
+        ]
+        self.assertEqual(_flatten_structured_content(content), "")
+
+
+class NormalizeResponseDictInPlaceTests(unittest.TestCase):
+    def test_message_content_list_flattened_in_place(self) -> None:
+        payload = {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {"type": "reasoning"},
+                            {"type": "text", "text": "OK"},
+                        ],
+                        "role": "assistant",
+                    }
+                }
+            ]
+        }
+        _normalize_response_dict_in_place(payload)
+        self.assertEqual(payload["choices"][0]["message"]["content"], "OK")
+
+    def test_streaming_delta_content_list_also_flattened(self) -> None:
+        """Streaming chunks land in ``choices[i].delta.content`` — the
+        shim must cover both shapes so Server-Sent-Events payloads from
+        reasoning models work too."""
+        payload = {
+            "choices": [
+                {
+                    "delta": {
+                        "content": [{"type": "text", "text": "hello"}],
+                    }
+                }
+            ]
+        }
+        _normalize_response_dict_in_place(payload)
+        self.assertEqual(payload["choices"][0]["delta"]["content"], "hello")
+
+    def test_string_content_left_untouched(self) -> None:
+        payload = {"choices": [{"message": {"content": "already a string"}}]}
+        _normalize_response_dict_in_place(payload)
+        self.assertEqual(payload["choices"][0]["message"]["content"], "already a string")
+
+    def test_non_dict_input_is_a_noop(self) -> None:
+        # Defensive: the shim must not raise on weird inputs.
+        _normalize_response_dict_in_place(None)
+        _normalize_response_dict_in_place("not a dict")
+        _normalize_response_dict_in_place([])
+
+    def test_missing_choices_field_is_a_noop(self) -> None:
+        payload = {"id": "x", "usage": {}}
+        _normalize_response_dict_in_place(payload)
+        self.assertEqual(payload, {"id": "x", "usage": {}})
+
+
+class LiteLLMShimInstallationTests(unittest.TestCase):
+    def test_litellm_import_installs_idempotent_shim(self) -> None:
+        """Importing ``_litellm()`` twice must register the shim once and
+        not double-wrap the LiteLLM normalizer (otherwise every call
+        re-flattens content twice with no harm but with extra work)."""
+        from amx.llm.provider import _litellm
+
+        _litellm()
+        from litellm.litellm_core_utils.llm_response_utils import (
+            convert_dict_to_response as conv,
+        )
+
+        self.assertTrue(getattr(conv, "_amx_structured_content_shim", False))
+        first_fn = conv.convert_to_model_response_object
+        _litellm()
+        self.assertIs(conv.convert_to_model_response_object, first_fn)
+
+    def test_litellm_normalizer_returns_a_string_for_databricks_gpt_oss_payload(self) -> None:
+        """Integration test: feed the LiteLLM normalizer a synthetic copy
+        of the user's reported Databricks gpt-oss-120b response shape and
+        confirm we get back a ModelResponse with ``content`` as a plain
+        string (the same flow that previously raised a
+        ``ValidationError`` on every call). Pinned to the user-reported
+        failure so a future LiteLLM upgrade that changes the call
+        signature surfaces here instead of in the field."""
+        from amx.llm.provider import _litellm
+
+        _litellm()
+        from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+            convert_to_model_response_object,
+        )
+        from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+        payload = {
+            "id": "chatcmpl_test",
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "index": 0,
+                    "logprobs": None,
+                    "message": {
+                        "content": [
+                            {
+                                "type": "reasoning",
+                                "summary": [
+                                    {"type": "summary_text", "text": "say OK"},
+                                ],
+                            },
+                            {"type": "text", "text": "OK"},
+                        ],
+                        "role": "assistant",
+                    },
+                }
+            ],
+            "created": 0,
+            "model": "gpt-oss-120b",
+            "object": "chat.completion",
+            "usage": {"completion_tokens": 1, "prompt_tokens": 10, "total_tokens": 11},
+        }
+        scaffold = ModelResponse(
+            model=None,
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content=None, role="assistant"),
+                )
+            ],
+            usage=Usage(),
+        )
+        result = convert_to_model_response_object(
+            response_object=payload,
+            model_response_object=scaffold,
+            response_type="completion",
+            stream=False,
+            start_time=None,
+            end_time=None,
+            hidden_params={},
+            convert_tool_call_to_json_mode=None,
+        )
+        self.assertEqual(result.choices[0].message.content, "OK")
+        self.assertEqual(int(result.usage.completion_tokens or 0), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Bug**: A Databricks Foundation Model Serving endpoint (gpt-oss-120b family) reached via the \`local\` provider returned \`message.content\` as a Responses-API-style list of \`{type:reasoning,…}\` + \`{type:text,text:\"OK\"}\` chunks. LiteLLM's \`Message\` pydantic model declares \`content: str\` and rejected the payload with a \`ValidationError\`; AMX surfaced this as \`InternalServerError: Invalid response object\` and retried 3× even though the upstream API had returned a successful answer.
- **Fix**: \`amx.llm.provider._install_structured_content_shim\` wraps LiteLLM's \`convert_to_model_response_object\` to flatten structured content lists in place before pydantic validation:
  - Recognises both chat-completions \`{type:\"text\"}\` and Responses API \`{type:\"output_text\"}\` chunks.
  - Drops reasoning summaries (already streamed via \`on_thinking\`).
  - Patches both \`message.content\` and streaming \`delta.content\`.
  - Idempotent across repeated LiteLLM imports.

## Test plan

- [x] \`pytest tests/test_llm_structured_content.py\` — 13 tests covering the user's exact failing payload, the Responses API \`output_text\` alias, multi-chunk concatenation, reasoning-only responses, streaming deltas, and shim idempotency.
- [x] \`pytest tests/test_llm_structured_content.py tests/test_compare.py tests/test_search_catalog.py tests/test_runtime_pickers.py\` — 113 passed.
- [x] \`ruff check amx tests\` + \`ruff format --check\` clean.
- [x] No workspace identifiers / endpoint IDs / paths from the user's report leaked into the diff (pre-push grep clean).
- [ ] Manual: \`local\` provider pointing at a Databricks Foundation Model Serving \`gpt-oss-120b\` endpoint, run \`/llm test\` — connection succeeds first try without retries.