### PR TITLE
feat(llm): first-class databricks_serving provider in /llm wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added — first-class `databricks_serving` LLM provider
+
+User report 2026-05-04: connecting Databricks Foundation Model Serving
+required users to pick the `local` provider, manually compute
+`https://<workspace>/serving-endpoints` for `api_base`, and stash a
+PAT in `OPENAI_API_KEY` — every step a footgun and the wizard had no
+hint that any of it was needed.
+
+`databricks_serving` is now a first-class entry in the `/llm` wizard's
+provider picker. Picking it changes the prompts to:
+
+* `Serving endpoint name` (e.g. `databricks-meta-llama-3-1-70b-instruct`,
+  `databricks-dbrx-instruct`, or any custom serving endpoint name).
+* `Databricks workspace host` (the same hostname the DB profile uses
+  for the SQL warehouse). The wizard normalises pasted URLs (strips
+  `https://`, trailing slash, accidental path) and auto-builds
+  `api_base = https://<host>/serving-endpoints`.
+* `Databricks personal access token (PAT)` — stored in `api_key` and
+  forwarded via the `DATABRICKS_TOKEN` env var (does not collide with
+  any `OPENAI_API_KEY` already in the shell).
+
+`_normalized_api_base("databricks_serving", …)` is also tolerant when
+the saved profile contains the workspace URL with or without the
+`/serving-endpoints` suffix — it converges to the canonical form on
+every call.
+
+Coverage: `tests/test_databricks_serving_provider.py` (10 tests)
+covers the provider registration, `api_base` normalisation across
+host / URL / pre-suffixed inputs, model-name de-prefixing
+(`openai/<endpoint>` → `<endpoint>`), and the wizard end-to-end with
+mocked prompts.
+
 ### Fixed — Databricks gpt-oss / OpenAI Responses-style structured `content` no longer crashes the LLM call
 
 User report 2026-05-04: a Databricks Foundation Model Serving endpoint

--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from amx.config import DISABLED_PROFILE, AMXConfig, LLMConfig, normalize_llm_model
+from amx.config import (
+    DISABLED_PROFILE,
+    AMXConfig,
+    LLMConfig,
+    _normalize_db_host,
+    normalize_llm_model,
+)
 from amx.utils.console import (
     ask,
     ask_choice,
@@ -29,6 +35,9 @@ def default_model(provider: str) -> str:
         "local": "llama3",
         "kimi": "kimi",
         "ollama": "llama3",
+        # Databricks Foundation Model Serving — common managed endpoints. The
+        # actual catalog is workspace-specific; users override at the prompt.
+        "databricks_serving": "databricks-meta-llama-3-1-70b-instruct",
     }.get(provider, "gpt-4o")
 
 
@@ -49,7 +58,17 @@ def interactive_llm_block(defaults: LLMConfig | None = None) -> LLMConfig:
         defaults = LLMConfig()
     provider = ask_choice(
         "Select AI provider",
-        ["openai", "openrouter", "anthropic", "gemini", "deepseek", "local", "kimi", "ollama"],
+        [
+            "openai",
+            "openrouter",
+            "anthropic",
+            "gemini",
+            "deepseek",
+            "local",
+            "kimi",
+            "ollama",
+            "databricks_serving",
+        ],
         default=defaults.provider or "openai",
     )
 
@@ -80,11 +99,40 @@ def interactive_llm_block(defaults: LLMConfig | None = None) -> LLMConfig:
         info("DeepSeek model example: deepseek-chat")
     elif provider == "ollama":
         info("Ollama model example: llama3")
+    elif provider == "databricks_serving":
+        info(
+            "Databricks Serving model = the SERVING ENDPOINT NAME from your "
+            "workspace's 'Serving' tab (Foundation Models or your custom endpoint)."
+        )
+        info(
+            "  Examples: databricks-meta-llama-3-1-70b-instruct, "
+            "databricks-dbrx-instruct, my-custom-mistral-endpoint"
+        )
     model = ask(
-        "Model name", normalize_llm_model(provider, defaults.model) or default_model(provider)
+        "Model name" if provider != "databricks_serving" else "Serving endpoint name",
+        normalize_llm_model(provider, defaults.model) or default_model(provider),
     )
+
     api_base = defaults.api_base
-    if provider in ("local", "ollama", "kimi", "openrouter"):
+    if provider == "databricks_serving":
+        # Ask for the workspace host (the same hostname the DB profile uses for
+        # SQL warehouse connections). The api_base is constructed from it so
+        # users don't have to remember the ``/serving-endpoints`` suffix.
+        existing_host = ""
+        if api_base:
+            stripped = api_base.strip().rstrip("/")
+            for scheme in ("https://", "http://"):
+                if stripped.lower().startswith(scheme):
+                    stripped = stripped[len(scheme) :]
+                    break
+            existing_host = stripped.split("/", 1)[0]
+        host = ask(
+            "Databricks workspace host (e.g. adb-xxxxxxxxxxxxxxxx.0.azuredatabricks.net)",
+            existing_host,
+        )
+        host = _normalize_db_host(host)
+        api_base = f"https://{host}/serving-endpoints" if host else api_base
+    elif provider in ("local", "ollama", "kimi", "openrouter"):
         default_api_base = (
             "http://localhost:11434" if provider == "ollama" else "http://localhost:11434/v1"
         )
@@ -94,6 +142,8 @@ def interactive_llm_block(defaults: LLMConfig | None = None) -> LLMConfig:
 
     if provider in ("local", "ollama"):
         api_key = ask("API key (optional)", defaults.api_key or "")
+    elif provider == "databricks_serving":
+        api_key = ask_password("Databricks personal access token (PAT)") or defaults.api_key
     else:
         api_key = ask_password("API key") or defaults.api_key
 

--- a/amx/config.py
+++ b/amx/config.py
@@ -294,7 +294,7 @@ def normalize_llm_model(provider: str, model: str) -> str:
     if provider_norm and lower.startswith(f"{provider_norm}/"):
         raw = raw[len(provider_norm) + 1 :]
         lower = raw.lower()
-    if provider_norm in {"local", "kimi"} and lower.startswith("openai/"):
+    if provider_norm in {"local", "kimi", "databricks_serving"} and lower.startswith("openai/"):
         raw = raw.split("/", 1)[1]
     if provider_norm == "openrouter" and lower.startswith("openrouter/"):
         raw = raw.split("/", 1)[1]

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -205,6 +205,14 @@ PROVIDER_MODEL_PREFIX = {
     "local": "openai/",
     "kimi": "openai/",
     "ollama": "ollama/",
+    # Databricks Foundation Model Serving + custom serving endpoints expose
+    # an OpenAI-compatible REST surface at
+    # ``<workspace>/serving-endpoints/<endpoint>/invocations`` (and the
+    # chat-completions alias). LiteLLM routes those via the openai client,
+    # so we use the same prefix as ``local`` / ``kimi``. The wizard adds the
+    # ``serving-endpoints`` suffix to the api_base so users only paste the
+    # workspace host.
+    "databricks_serving": "openai/",
 }
 
 PROVIDER_ENV_KEY = {
@@ -213,6 +221,7 @@ PROVIDER_ENV_KEY = {
     "anthropic": "ANTHROPIC_API_KEY",
     "gemini": "GEMINI_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
+    "databricks_serving": "DATABRICKS_TOKEN",
 }
 
 # OpenAI "reasoning" models (gpt-5*, o-series) may spend the whole max_tokens budget on
@@ -827,6 +836,29 @@ def _normalized_api_base(provider: str, api_base: str | None) -> str | None:
         lower = base.lower().rstrip("/")
         if lower.endswith("/v1"):
             return base.rstrip("/")[:-3].rstrip("/")
+    if provider == "databricks_serving":
+        # Users routinely paste either:
+        #   * the bare workspace host (``adb-xxxxxxxxxxxxxxxx.0.azuredatabricks.net``)
+        #   * the workspace URL (``https://adb-…/``)
+        #   * the full chat-completions path the wizard built (``…/serving-endpoints``)
+        # Coerce all of them to the Databricks chat-completions root —
+        # ``https://<host>/serving-endpoints`` — which is what LiteLLM's
+        # OpenAI client appends ``/<endpoint>/invocations`` to.
+        stripped = base.rstrip("/")
+        scheme = ""
+        host_path = stripped
+        for candidate in ("https://", "http://"):
+            if host_path.lower().startswith(candidate):
+                scheme = candidate
+                host_path = host_path[len(candidate) :]
+                break
+        if not scheme:
+            scheme = "https://"
+        # Drop any leading double-slash artefact and trim again.
+        host_path = host_path.lstrip("/")
+        if "/serving-endpoints" not in host_path.lower():
+            host_path = host_path.split("/", 1)[0] + "/serving-endpoints"
+        return f"{scheme}{host_path}".rstrip("/")
     return base
 
 
@@ -961,9 +993,12 @@ class LLMProvider:
             )
             self.cfg.api_base = normalized_base
 
-        if self.cfg.provider in ("local", "kimi"):
+        if self.cfg.provider in ("local", "kimi", "databricks_serving"):
             if self.cfg.api_base:
                 os.environ["OPENAI_API_BASE"] = self.cfg.api_base
+            # Databricks Serving rejects an empty bearer; fall back to a
+            # placeholder so LiteLLM doesn't strip the Authorization header,
+            # but the real PAT (when supplied) wins.
             os.environ.setdefault("OPENAI_API_KEY", self.cfg.api_key or "local")
         elif self.cfg.provider == "openrouter":
             if self.cfg.api_base:
@@ -1133,7 +1168,14 @@ class LLMProvider:
         log.debug("LLM call → model=%s, max_tokens=%d", model, mt)
         call_api_base = (
             self.cfg.api_base
-            if self.cfg.provider in ("local", "kimi", "ollama", "openrouter")
+            if self.cfg.provider
+            in (
+                "local",
+                "kimi",
+                "ollama",
+                "openrouter",
+                "databricks_serving",
+            )
             else None
         )
 

--- a/tests/test_databricks_serving_provider.py
+++ b/tests/test_databricks_serving_provider.py
@@ -1,0 +1,150 @@
+"""Tests for the first-class ``databricks_serving`` LLM provider.
+
+User report 2026-05-04: Databricks Foundation Model Serving used to be
+reachable only via the ``local`` provider with a manual api_base override.
+The new ``databricks_serving`` provider gives it a proper place in the
+``/llm`` wizard with workspace-host + endpoint-name + PAT prompts, an
+auto-built ``api_base`` (``https://<host>/serving-endpoints``), and a
+dedicated env var (``DATABRICKS_TOKEN``).
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from amx.cli_support.commands.profiles import default_model, interactive_llm_block
+from amx.config import LLMConfig, normalize_llm_model
+from amx.llm.provider import (
+    PROVIDER_ENV_KEY,
+    PROVIDER_MODEL_PREFIX,
+    _normalized_api_base,
+)
+
+
+class ProviderRegistrationTests(unittest.TestCase):
+    def test_databricks_serving_is_registered_in_provider_prefix_table(self) -> None:
+        # LiteLLM routes ``databricks_serving`` via the OpenAI-compatible
+        # client (Databricks Foundation Models exposes the same shape), so
+        # the prefix is ``openai/`` — same as ``local`` / ``kimi``.
+        self.assertEqual(PROVIDER_MODEL_PREFIX["databricks_serving"], "openai/")
+
+    def test_databricks_serving_uses_databricks_token_env_var(self) -> None:
+        # The PAT lands in DATABRICKS_TOKEN so it doesn't collide with any
+        # OpenAI/OpenRouter key the user has set in the same shell.
+        self.assertEqual(PROVIDER_ENV_KEY["databricks_serving"], "DATABRICKS_TOKEN")
+
+    def test_default_model_returns_a_concrete_serving_endpoint_name(self) -> None:
+        model = default_model("databricks_serving")
+        self.assertTrue(model)
+        self.assertNotIn("/", model, "Default should be the bare endpoint name, not prefixed")
+
+    def test_normalize_llm_model_strips_a_duplicate_openai_prefix(self) -> None:
+        # Users routinely paste ``openai/<endpoint>`` into the prompt. The
+        # provider-prefix table already adds ``openai/``, so leaving the
+        # duplicate would produce ``openai/openai/<endpoint>`` and LiteLLM
+        # would reject it as an unknown provider.
+        self.assertEqual(
+            normalize_llm_model("databricks_serving", "openai/databricks-dbrx-instruct"),
+            "databricks-dbrx-instruct",
+        )
+
+
+class ApiBaseNormalizationTests(unittest.TestCase):
+    def test_workspace_host_alone_gets_serving_endpoints_suffix(self) -> None:
+        # User pastes the bare host — we must build the chat-completions root.
+        result = _normalized_api_base(
+            "databricks_serving", "adb-xxxxxxxxxxxxxxxx.0.azuredatabricks.net"
+        )
+        self.assertEqual(
+            result,
+            "https://adb-xxxxxxxxxxxxxxxx.0.azuredatabricks.net/serving-endpoints",
+        )
+
+    def test_full_workspace_url_is_normalised(self) -> None:
+        # User pastes the workspace URL — strip trailing slash, keep scheme.
+        result = _normalized_api_base(
+            "databricks_serving", "https://my-workspace.cloud.databricks.com/"
+        )
+        self.assertEqual(
+            result,
+            "https://my-workspace.cloud.databricks.com/serving-endpoints",
+        )
+
+    def test_already_normalised_url_passes_through(self) -> None:
+        # Wizard-built api_base already carries the suffix — don't double it.
+        result = _normalized_api_base(
+            "databricks_serving",
+            "https://my-workspace.cloud.databricks.com/serving-endpoints",
+        )
+        self.assertEqual(
+            result,
+            "https://my-workspace.cloud.databricks.com/serving-endpoints",
+        )
+
+    def test_other_providers_are_untouched(self) -> None:
+        # The Databricks-specific normalisation only kicks in for
+        # ``databricks_serving``. ``local`` / ``openai`` URLs are left as-is.
+        self.assertEqual(
+            _normalized_api_base("local", "http://localhost:11434/v1"),
+            "http://localhost:11434/v1",
+        )
+
+    def test_empty_api_base_passes_through(self) -> None:
+        self.assertIsNone(_normalized_api_base("databricks_serving", None))
+        self.assertEqual(_normalized_api_base("databricks_serving", ""), "")
+
+
+class WizardTests(unittest.TestCase):
+    def test_wizard_builds_api_base_from_workspace_host_and_stores_pat(self) -> None:
+        """Walking through the new prompts: select databricks_serving →
+        type the endpoint name → type the workspace host (with scheme
+        and trailing slash, to prove the normaliser strips them) → type
+        the PAT → accept defaults for the generation/threshold prompts.
+        The resulting LLMConfig must carry the auto-built api_base and
+        the PAT in api_key (NOT the bare host or a leftover OpenAI key)."""
+        ask_values = iter(
+            [
+                # endpoint name
+                "databricks-meta-llama-3-1-70b-instruct",
+                # workspace host (with scheme + trailing slash + path noise)
+                "https://adb-xxxxxxxxxxxxxxxx.0.azuredatabricks.net/extra/path",
+                # generation settings (n_alt / batch / temperature)
+                "3",
+                "10",
+                "0.2",
+                # logprob thresholds (high / medium)
+                "0.85",
+                "0.50",
+            ]
+        )
+        choice_values = iter(["databricks_serving"])
+
+        with (
+            patch(
+                "amx.cli_support.commands.profiles.ask_choice",
+                side_effect=lambda *args, **kwargs: next(choice_values),
+            ),
+            patch(
+                "amx.cli_support.commands.profiles.ask",
+                side_effect=lambda *args, **kwargs: next(ask_values),
+            ),
+            patch(
+                "amx.cli_support.commands.profiles.ask_password",
+                side_effect=lambda *args, **kwargs: "dapi-test-token",
+            ),
+            patch("amx.cli_support.commands.profiles.info"),
+        ):
+            built = interactive_llm_block(LLMConfig())
+
+        self.assertEqual(built.provider, "databricks_serving")
+        self.assertEqual(built.model, "databricks-meta-llama-3-1-70b-instruct")
+        self.assertEqual(
+            built.api_base,
+            "https://adb-xxxxxxxxxxxxxxxx.0.azuredatabricks.net/serving-endpoints",
+        )
+        self.assertEqual(built.api_key, "dapi-test-token")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Background**: Connecting Databricks Foundation Model Serving used to require picking the \`local\` provider, manually computing \`https://<workspace>/serving-endpoints\` for \`api_base\`, and stashing a PAT in \`OPENAI_API_KEY\`. Every step a footgun and the wizard had no hint that any of it was needed.
- **Now**: \`databricks_serving\` is a first-class entry in the \`/llm\` wizard's provider picker. Picking it asks dedicated prompts (serving endpoint name → workspace host → PAT) and auto-builds \`api_base\`. PAT is forwarded via \`DATABRICKS_TOKEN\` (no collision with \`OPENAI_API_KEY\`).
- Tolerant \`api_base\` normaliser: accepts bare host, full URL, or pre-suffixed URL and converges on \`https://<host>/serving-endpoints\`.
- Combined with the structured-content shim from PR #112, gpt-oss / DBRX reasoning endpoints work out of the box.

## Test plan

- [x] \`pytest tests/test_databricks_serving_provider.py\` — 10 tests (provider registration, \`api_base\` normalisation across host / URL / pre-suffixed forms, model de-prefixing, full wizard walk-through with mocked prompts).
- [x] \`pytest tests/test_databricks_serving_provider.py tests/test_llm_structured_content.py tests/test_compare.py tests/test_search_catalog.py tests/test_runtime_pickers.py tests/test_db_multi_backend_expansion.py\` — 191 passed.
- [x] \`ruff check amx tests\` + \`ruff format --check amx tests\` clean.
- [x] No real workspace IDs / endpoint IDs / paths from the user's environment leaked into the diff (pre-push grep clean; only generic \`adb-xxxxxxxxxxxxxxxx\` placeholders).
- [ ] Manual: \`/add-llm-profile\` → pick \`databricks_serving\` → endpoint name → workspace host (pasted as full URL) → PAT → \`/llm test\` succeeds first try.