### PR TITLE
release: 0.12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+## [0.12.7] - 2026-05-04
+
 ### Added — first-class `databricks_serving` LLM provider
 
 User report 2026-05-04: connecting Databricks Foundation Model Serving

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.12.6"
+__version__ = "0.12.7"
 
 __all__ = [
     "AMXApplication",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx-cli"
-version = "0.12.6"
+version = "0.12.7"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Release 0.12.7. Bundles five fixes / enhancements landed since 0.12.6:

- \`/ask\` knows about Databricks Volumes via a new \`list_volumes\` tool (PR #111)
- Databricks DB-profile wizard asks TLS first and gates the catalog probe behind a yes/no (PR #110)
- Databricks gpt-oss / OpenAI Responses-style structured \`content\` no longer crashes the LLM call (PR #112)
- First-class \`databricks_serving\` LLM provider in \`/llm\` wizard (PR #113)

## Test plan

- [x] Local \`python -m build\` produces \`amx_cli-0.12.7.tar.gz\` + \`amx_cli-0.12.7-py3-none-any.whl\` cleanly.
- [x] \`pyproject.toml\` and \`amx/__init__.py.__version__\` are in sync at 0.12.7.
- [ ] CI green.
- [ ] Tag \`v0.12.7\` triggers PyPI publish via OIDC + GitHub release.