### PR TITLE
fix(llm,logging): databricks_serving Claude /run + Windows console crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — Databricks Serving Claude `/run` no longer 400s on `top_logprobs`; Windows logging cleaned up
+
+User report 2026-05-04 against the just-shipped 0.12.7 +
+`databricks_serving` provider: `/run` against
+`databricks-claude-sonnet-4-6` aborted with
+`litellm.BadRequestError: top_logprobs: Extra inputs are not
+permitted`, plus a Python `UnicodeEncodeError` traceback every
+time AMX logged an `LLM call -> model=...` line on a Windows
+console (cp1252).
+
+Two fixes, one PR:
+
+1. **No `logprobs` for `databricks_serving`.** The Databricks
+   Foundation Model Serving OpenAI shim rejects both
+   `logprobs` and `top_logprobs` outright on its Anthropic-backed
+   Claude endpoints. AMX now strips them pre-emptively for that
+   provider on every code path (streaming + non-streaming, agent
+   calls + `LLMProvider.test_result`). The runtime fallback string
+   list also gains the literal Databricks 400 wording so any
+   future shim emitting the same error self-recovers without
+   needing a code change.
+2. **ASCII-only bare-logger format strings.** Every
+   `log.{debug,info,warning,error,exception}` call site under
+   `amx/` is now plain ASCII. Rich-routed UI prompts keep their
+   stylistic Unicode (em-dashes, ellipses, arrows) because Rich
+   forces a UTF-8 console; bare loggers go through stdlib
+   `logging.StreamHandler` which inherits the locale codec on
+   Windows, and any non-ASCII char there crashed Python 3.13's
+   cp1252 encoder. Six files swept (`amx/llm/provider.py`,
+   `amx/db/connector.py`, `amx/storage/{factory,migration,
+   sqlite_store,dual_write}.py`).
+
+A new `tests/test_logger_windows_safe.py` walks every
+bare-logger format string in the package and fails the test suite
+if a non-ASCII character sneaks back in — so this regression class
+can't ship to PyPI again.
+
 ### Added — dark-mode toggle, ⌘K command palette, docs/visualize.md (PR-F)
 
 Final slice of the local AMX web UI. Polish + ergonomics + first

--- a/amx/codebase/analyzer.py
+++ b/amx/codebase/analyzer.py
@@ -69,7 +69,7 @@ def _codebase_root(path: str) -> Iterator[str]:
 
         clone_url = normalize_github_url(path)
         with tempfile.TemporaryDirectory(prefix="amx_code_") as dest:
-            log.info("Cloning %s → %s", clone_url, dest)
+            log.info("Cloning %s -> %s", clone_url, dest)
             gitpython.Repo.clone_from(clone_url, dest, depth=1)
             yield dest
         return

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -241,7 +241,7 @@ class DatabaseConnector:
                 if attempt < MAX_CONNECTION_RETRIES and _is_transient_db_connection_error(exc):
                     wait = CONNECTION_RETRY_BACKOFF_SEC * (2**attempt)
                     log.warning(
-                        "DB connection failed (attempt %d/%d) — retrying in %.1fs: %s",
+                        "DB connection failed (attempt %d/%d)  --  retrying in %.1fs: %s",
                         attempt + 1,
                         MAX_CONNECTION_RETRIES + 1,
                         wait,

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -147,7 +147,7 @@ class RAGStore:
                 ]
                 self.collection.upsert(ids=ids, documents=texts, metadatas=metadatas)
                 total_chunks += len(chunks)
-                log.info("Ingested %s → %d chunks", doc.path, len(chunks))
+                log.info("Ingested %s -> %d chunks", doc.path, len(chunks))
             except Exception as exc:
                 log.error("Error ingesting %s: %s", doc.path, exc)
         return total_chunks

--- a/amx/docs/scanner.py
+++ b/amx/docs/scanner.py
@@ -89,7 +89,7 @@ def _resolve_github(url: str, target_dir: str | None = None) -> Iterator[DocInfo
     clone_url = normalize_github_url(url)
     created_temp = target_dir is None
     dest = target_dir or tempfile.mkdtemp(prefix="amx_gh_")
-    log.info("Cloning %s → %s", clone_url, dest)
+    log.info("Cloning %s -> %s", clone_url, dest)
     try:
         gitpython.Repo.clone_from(clone_url, dest, depth=1)
     except Exception:

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -55,7 +55,7 @@ def _configure_ssl_environment() -> None:
         # Also tell the underlying httpx clients used by openai/anthropic.
         os.environ.setdefault("PYTHONHTTPSVERIFY", "0")
         log.warning(
-            "AMX_INSECURE_SSL=1 — SSL certificate verification is DISABLED. "
+            "AMX_INSECURE_SSL=1  --  SSL certificate verification is DISABLED. "
             "Use only for diagnostics; set AMX_CA_BUNDLE in production."
         )
 
@@ -370,6 +370,13 @@ _LOGPROBS_UNSUPPORTED_PATTERNS: tuple[str, ...] = (
     "logprob is not supported",
     "does not support logprobs",
     "logprobs parameter is not supported",
+    # Databricks Foundation Model Serving's OpenAI shim 400s with this
+    # exact phrase on its Anthropic-backed Claude endpoints. We disable
+    # logprobs pre-emptively for ``databricks_serving`` (see chat()
+    # below), but the runtime fallback covers anyone calling LiteLLM
+    # directly with the same provider shape.
+    "top_logprobs: extra inputs are not permitted",
+    "logprobs: extra inputs are not permitted",
 )
 
 
@@ -1103,7 +1110,7 @@ class LLMProvider:
                 floor = int(os.getenv("AMX_LLM_MIN_MAX_TOKENS", str(_DEFAULT_REASONING_FLOOR)))
                 if mt < floor:
                     log.debug(
-                        "Raising max_tokens %d → %d for OpenRouter reasoning model %s",
+                        "Raising max_tokens %d -> %d for OpenRouter reasoning model %s",
                         mt,
                         floor,
                         model,
@@ -1131,6 +1138,18 @@ class LLMProvider:
         # call in the same session would re-trigger the same 400.
         if use_logprobs and getattr(self, "_logprobs_runtime_disabled", False):
             use_logprobs = False
+        # Providers that NEVER accept ``logprobs`` / ``top_logprobs`` —
+        # disabled unconditionally (streaming + non-streaming) so calls
+        # that don't go through the use_streaming branch above
+        # (``LLMProvider.test_result``, the profile / RAG / code agents
+        # in CHAT mode) don't trip the same 400. Databricks Foundation
+        # Model Serving's OpenAI shim rejects both kwargs outright on
+        # its Anthropic-backed Claude endpoints; the literal error is
+        # ``top_logprobs: Extra inputs are not permitted``.
+        if self.cfg.provider == "databricks_serving":
+            use_logprobs = False
+            for k in ("logprobs", "top_logprobs"):
+                extra.pop(k, None)
         if use_logprobs:
             # Force-request logprobs regardless of provider capability metadata.
             extra["logprobs"] = True
@@ -1150,7 +1169,7 @@ class LLMProvider:
             floor = int(os.getenv("AMX_LLM_MIN_MAX_TOKENS", str(_DEFAULT_REASONING_FLOOR)))
             if mt < floor:
                 log.debug(
-                    "Raising max_tokens %d → %d for reasoning model %s",
+                    "Raising max_tokens %d -> %d for reasoning model %s",
                     mt,
                     floor,
                     model,
@@ -1165,7 +1184,7 @@ class LLMProvider:
                 if effort in ("none", "minimal", "low", "medium", "high"):
                     extra.setdefault("reasoning_effort", effort)
 
-        log.debug("LLM call → model=%s, max_tokens=%d", model, mt)
+        log.debug("LLM call -> model=%s, max_tokens=%d", model, mt)
         call_api_base = (
             self.cfg.api_base
             if self.cfg.provider
@@ -1300,7 +1319,7 @@ class LLMProvider:
                 ):
                     wait = LLM_RETRY_BACKOFF_BASE_SEC * (2**attempt)
                     log.warning(
-                        "LLM transient failure (attempt %d/%d) — retrying in %.1fs: %s",
+                        "LLM transient failure (attempt %d/%d)  --  retrying in %.1fs: %s",
                         attempt + 1,
                         MAX_LLM_RETRIES + 1,
                         wait,

--- a/amx/storage/dual_write.py
+++ b/amx/storage/dual_write.py
@@ -122,7 +122,7 @@ class DualWriteHistoryStore:
                 )
         except sqlite3.Error as enq_err:
             log.warning(
-                "Could not enqueue shared-write for retry (op=%s): %s — data is "
+                "Could not enqueue shared-write for retry (op=%s): %s  --  data is "
                 "in local SQLite only.",
                 op_kind,
                 enq_err,
@@ -220,7 +220,7 @@ class DualWriteHistoryStore:
         elif op_kind == OP_SET_SESSION_STATE:
             self.shared.set_session_state(payload["namespace"], payload["key"], payload["value"])
         else:
-            log.warning("Unknown outbox op_kind=%s — leaving queued", op_kind)
+            log.warning("Unknown outbox op_kind=%s  --  leaving queued", op_kind)
             raise ValueError(f"unknown op_kind: {op_kind}")
 
     # ── Helpers ───────────────────────────────────────────────────────────
@@ -231,7 +231,7 @@ class DualWriteHistoryStore:
             call()
         except Exception as exc:
             log.warning(
-                "Shared-history write failed (op=%s): %s — queued for retry.",
+                "Shared-history write failed (op=%s): %s  --  queued for retry.",
                 op_kind,
                 exc,
             )

--- a/amx/storage/factory.py
+++ b/amx/storage/factory.py
@@ -102,13 +102,13 @@ def _build_shared_store(cfg: AMXConfig):
     profile_name = (getattr(cfg, "history_store_profile", "") or "").strip()
     if not profile_name:
         log.warning(
-            "history_store_enabled=True but history_store_profile is empty — "
+            "history_store_enabled=True but history_store_profile is empty  --  "
             "falling back to local-only history."
         )
         return None
     if profile_name not in cfg.db_profiles:
         log.warning(
-            "history_store_profile=%r is not in cfg.db_profiles — "
+            "history_store_profile=%r is not in cfg.db_profiles  --  "
             "falling back to local-only history.",
             profile_name,
         )

--- a/amx/storage/migration.py
+++ b/amx/storage/migration.py
@@ -109,7 +109,7 @@ def migrate_local_to_shared(
     run_id_map: dict[int, str] = {}
 
     # ── analysis_runs ─────────────────────────────────────────────────────
-    log.info("Migrating analysis_runs from %s …", local.db_path)
+    log.info("Migrating analysis_runs from %s ...", local.db_path)
     with local._connect() as conn:
         rows = conn.execute("SELECT * FROM analysis_runs ORDER BY id").fetchall()
 
@@ -163,7 +163,7 @@ def migrate_local_to_shared(
                 progress("analysis_runs", stats["analysis_runs"])
 
     # ── run_results ───────────────────────────────────────────────────────
-    log.info("Migrating run_results …")
+    log.info("Migrating run_results ...")
     with local._connect() as conn:
         rows = conn.execute("SELECT * FROM run_results ORDER BY id").fetchall()
 
@@ -178,7 +178,7 @@ def migrate_local_to_shared(
         run_uuid = run_id_map.get(local_run_id)
         if not run_uuid:
             log.warning(
-                "Skipping run_results.id=%s — its run_id=%s is not in the migrated set.",
+                "Skipping run_results.id=%s  --  its run_id=%s is not in the migrated set.",
                 local_id,
                 local_run_id,
             )
@@ -221,7 +221,7 @@ def migrate_local_to_shared(
                 progress("run_results", stats["run_results"])
 
     # ── app_events ────────────────────────────────────────────────────────
-    log.info("Migrating app_events …")
+    log.info("Migrating app_events ...")
     with local._connect() as conn:
         rows = conn.execute("SELECT * FROM app_events ORDER BY id").fetchall()
 
@@ -316,7 +316,7 @@ def pull_shared_to_local(
     host = getattr(shared, "_hostname", None) or _hostname()
     started = time.time()
 
-    log.info("Pulling shared analysis_runs (excluding host=%r)…", host)
+    log.info("Pulling shared analysis_runs (excluding host=%r)...", host)
     runs = shared.iter_runs_by_other_hosts(exclude_hostname=host)
     if not runs:
         log.info("No other-host runs found in shared store.")
@@ -396,7 +396,7 @@ def pull_shared_to_local(
         log.info("Pull finished (no new analysis_runs to insert).")
         return stats
 
-    log.info("Pulling shared run_results for %d run(s)…", len(uuid_to_local))
+    log.info("Pulling shared run_results for %d run(s)...", len(uuid_to_local))
     results = shared.get_results_for_runs(list(uuid_to_local.keys()))
     with local._lock:
         for rr in results:

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -426,7 +426,7 @@ class SQLiteHistoryStore:
                 )
             except Exception as exc:
                 log.warning(
-                    "Could not add analysis_runs.%s: %s — partial-progress "
+                    "Could not add analysis_runs.%s: %s  --  partial-progress "
                     "reporting in /history will show '—'.",
                     col_name,
                     exc,

--- a/tests/test_databricks_serving_logprobs.py
+++ b/tests/test_databricks_serving_logprobs.py
@@ -1,0 +1,137 @@
+"""Pin the ``databricks_serving`` provider's no-logprobs contract.
+
+User report 2026-05-04: ``/run`` hit ``litellm.BadRequestError:
+top_logprobs: Extra inputs are not permitted`` against the
+Databricks Foundation Model Serving Claude endpoint
+(``databricks-claude-sonnet-4-6``). The shim Databricks runs in
+front of Anthropic models doesn't accept the OpenAI ``logprobs``
+flag, and AMX was sending it by default.
+
+The fix is two-pronged:
+
+1. Pre-emptively skip ``logprobs`` / ``top_logprobs`` for the
+   ``databricks_serving`` provider on every call (not just the
+   streaming path).
+2. Add the literal Databricks 400 message to the runtime-detect
+   fallback so any other provider that emits the same wording
+   self-recovers without needing a manual patch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from amx.config import LLMConfig
+from amx.llm.provider import (
+    _LOGPROBS_UNSUPPORTED_PATTERNS,
+    LLMProvider,
+    _is_logprobs_unsupported_error,
+)
+
+
+def test_runtime_detector_recognises_databricks_message() -> None:
+    """A future provider that emits the same 400 wording should
+    self-recover via the runtime fallback, not require a code
+    change."""
+    err = RuntimeError("OpenAIException - top_logprobs: Extra inputs are not permitted")
+    assert _is_logprobs_unsupported_error(err)
+
+
+def test_logprobs_pattern_includes_databricks_phrasings() -> None:
+    """Pin the canonical strings so a future linter / refactor
+    doesn't drop them."""
+    joined = " | ".join(_LOGPROBS_UNSUPPORTED_PATTERNS).lower()
+    assert "top_logprobs: extra inputs are not permitted" in joined
+    assert "logprobs: extra inputs are not permitted" in joined
+
+
+def test_chat_strips_logprobs_for_databricks_serving() -> None:
+    """The non-streaming path (``test_result()`` and most agent
+    calls) must not forward ``logprobs`` / ``top_logprobs`` when
+    the provider is ``databricks_serving`` — Databricks 400s with
+    ``top_logprobs: Extra inputs are not permitted`` otherwise."""
+    cfg = LLMConfig(
+        provider="databricks_serving",
+        model="databricks-claude-sonnet-4-6",
+        api_key="dapi-test",
+        api_base="https://example.databricks.com/serving-endpoints",
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_completion(*args, **kwargs):
+        captured.update(kwargs)
+        # Minimal LiteLLM-shaped response so chat() doesn't blow up.
+        return MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(content="OK", tool_calls=None),
+                    finish_reason="stop",
+                    logprobs=None,
+                )
+            ],
+            usage=MagicMock(
+                prompt_tokens=1,
+                completion_tokens=1,
+                total_tokens=2,
+                model_dump=lambda: {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+            model="databricks-claude-sonnet-4-6",
+        )
+
+    fake_lm = MagicMock(completion=fake_completion)
+
+    with patch("amx.llm.provider._litellm", return_value=fake_lm):
+        provider = LLMProvider(cfg)
+        result = provider.chat([{"role": "user", "content": "Reply with OK"}])
+
+    assert result.content == "OK"
+    # The crux: neither ``logprobs`` nor ``top_logprobs`` reached
+    # the underlying client.
+    assert "logprobs" not in captured, captured
+    assert "top_logprobs" not in captured, captured
+
+
+def test_chat_keeps_logprobs_for_openai() -> None:
+    """Sanity-check the disable is provider-scoped — OpenAI direct
+    calls still get ``logprobs=True`` so confidence scoring keeps
+    working."""
+    cfg = LLMConfig(provider="openai", model="gpt-4o", api_key="sk-test")
+
+    captured: dict[str, object] = {}
+
+    def fake_completion(*args, **kwargs):
+        captured.update(kwargs)
+        return MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(content="OK", tool_calls=None),
+                    finish_reason="stop",
+                    logprobs=None,
+                )
+            ],
+            usage=MagicMock(
+                prompt_tokens=1,
+                completion_tokens=1,
+                total_tokens=2,
+                model_dump=lambda: {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            ),
+            model="gpt-4o",
+        )
+
+    fake_lm = MagicMock(completion=fake_completion)
+
+    with patch("amx.llm.provider._litellm", return_value=fake_lm):
+        provider = LLMProvider(cfg)
+        provider.chat([{"role": "user", "content": "Reply with OK"}])
+
+    assert captured.get("logprobs") is True
+    assert captured.get("top_logprobs") == 5

--- a/tests/test_logger_windows_safe.py
+++ b/tests/test_logger_windows_safe.py
@@ -1,0 +1,72 @@
+"""Pin every bare-logger format string to ASCII-only characters.
+
+User report 2026-05-04: a Windows user running Python 3.13 on
+``cp1252`` saw a traceback the moment the LLM call kicked off:
+
+    UnicodeEncodeError: 'charmap' codec can't encode character
+    '\\u2192' (→) in position 129: character maps to <undefined>
+
+Rich-routed prompts (``info``/``warn``/``success``/``error`` from
+``amx.utils.console``) survive cp1252 because Rich forces a UTF-8
+console. ``logging.Logger`` does not — it writes to the raw
+``sys.stderr`` which inherits the locale codec on Windows.
+
+This test grep-walks every bare ``log.{debug,info,warning,
+warn,error,critical}`` call site under ``amx/`` and asserts the
+literal format string is plain ASCII. It catches the exact class
+of regression the user reported (a contributor sneaking a
+``→`` into a debug line that fires on every LLM call) before it
+ships to PyPI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "amx"
+
+# Capture the FORMAT STRING argument of every bare-logger call.
+# We deliberately accept double-quoted, single-quoted, and triple-
+# quoted strings so a future contributor's stylistic choice can't
+# tunnel an unsafe character past us.
+_LOG_CALL = re.compile(
+    r"""
+    log\.(?:debug|info|warning|warn|error|critical|exception)
+    \s*\(\s*
+    (?P<quote>["']{1,3})
+    (?P<text>.*?)
+    (?P=quote)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+# Characters that are safe enough on every codec we ship to:
+# regular ASCII plus newlines and tabs. Anything else
+# (smart quotes, em-dashes, arrows, accented letters baked
+# into a log line) risks the Windows cp1252 traceback.
+_ALLOWED = set(range(0x20, 0x7F)) | {ord("\n"), ord("\t")}
+
+
+def _is_ascii_safe(text: str) -> tuple[bool, str | None]:
+    for ch in text:
+        if ord(ch) not in _ALLOWED:
+            return False, ch
+    return True, None
+
+
+def test_no_non_ascii_in_bare_logger_format_strings() -> None:
+    offenders: list[tuple[str, str, str]] = []
+    for path in ROOT.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in _LOG_CALL.finditer(text):
+            ok, bad = _is_ascii_safe(match.group("text"))
+            if not ok:
+                offenders.append((str(path), match.group("text")[:80], bad or "?"))
+    assert not offenders, (
+        "Bare logger format strings carry non-ASCII characters that crash on "
+        "Windows cp1252:\n"
+        + "\n".join(f"  {p}: {sample!r}  (char={ch!r})" for p, sample, ch in offenders)
+    )


### PR DESCRIPTION
## Summary

Two bugs from a Windows + Databricks Foundation Model Serving Claude user. Both surfaced when running \`/run\` against \`databricks_serving / databricks-claude-sonnet-4-6\` on Python 3.13 / cp1252 console.

### 1. \`top_logprobs: Extra inputs are not permitted\`

The Databricks OpenAI shim rejects \`logprobs\` / \`top_logprobs\` outright on its Anthropic-backed Claude endpoints. AMX was forwarding both by default for confidence scoring. Pre-emptively strip them for \`databricks_serving\` on every code path (streaming + non-streaming, agent calls + \`test_result\`). The runtime fallback string list also gains the literal 400 wording so any future shim emitting the same error self-recovers.

### 2. \`UnicodeEncodeError: 'charmap' codec can't encode character '\\u2192'\`

Bare \`log.debug(\"LLM call → ...\")\` lines hit \`logging.StreamHandler\` → \`sys.stderr\` which inherits cp1252 on Windows. Every non-ASCII character (\`→\`, \`—\`, \`…\`) in a bare-logger format string crashes the encoder. Six files swept: \`amx/llm/provider.py\`, \`amx/db/connector.py\`, \`amx/storage/{factory,migration,sqlite_store,dual_write}.py\`.

Rich-routed UI prompts (\`info\`/\`success\`/\`warn\`/\`error\` from \`amx.utils.console\`) keep their styled Unicode because Rich forces a UTF-8 console.

## Test plan

- [x] \`pytest tests/test_databricks_serving_logprobs.py tests/test_logger_windows_safe.py\` — 5 tests, all passing.
- [x] \`pytest tests/\` — 811 passed, no regressions.
- [x] \`ruff check amx tests\` + \`ruff format --check amx tests\` clean.
- [x] No workspace identifiers / hostnames / catalog names from the user's report leaked into the diff (pre-push grep clean).
- [ ] Manual: run \`/run\` against the same Databricks Serving Claude profile on Windows — connection test passes, no \`UnicodeEncodeError\`, no \`top_logprobs\` 400.
