### PR TITLE
fix(edit): /edit Bulk-by-table respects mode + survives stale catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed — `/edit` "Bulk by table" no longer surfaces columns and no longer dies on a stale catalog
+
+User report 2026-05-04: picking `world.City` in the `/edit` →
+"Bulk by name → Pick a table" wizard returned **33 column matches
+and zero table matches** — the same flow had earlier failed with
+"No tables or columns named 'country'" after picking `cars.country`.
+The user's actual selection was being thrown away.
+
+Two root causes:
+
+1. **Mode information was lost** between `_resolve_bulk_target_name`
+   (which knew the user picked a TABLE) and `_run_bulk_edit_by_name`
+   (which queried both table and column indices unconditionally).
+   A "table" run silently returned every column with the same name
+   — misleading and dangerous if the user had picked "Apply same
+   comment to all" without checking the kind column.
+2. **Catalog-only lookup**: when the on-disk SQLite catalog was
+   stale (a fresh profile, an unsynced schema, or just a recently
+   added table), the search returned nothing — even though the user
+   had literally just picked the entity from the live-DB picker one
+   step earlier.
+
+Fix: the resolver now returns `(bare_name, kind, seed)` and the
+runner honours both. Concretely:
+
+- `kind="table"` → only `find_tables_by_exact_name` runs; columns
+  are no longer surfaced.
+- `kind="column"` → only `find_columns_by_exact_name` runs.
+- `kind="any"` (the bare-name CLI invocation) keeps the legacy
+  search-both behaviour.
+- The user's live-picker selection (`seed`) is spliced into results
+  if the catalog miss it, so a stale index can never make their own
+  pick vanish.
+- For `kind="table"`, when the catalog returns nothing, the runner
+  **falls back to a live-DB scan** across every schema (one
+  `list_tables(schema)` call per schema; fast). This decouples the
+  table-bulk-edit flow from `/search sync` freshness entirely.
+
+Coverage: `tests/test_edit_bulk_table_mode.py` (10 tests) pins the
+mode-respect behaviour, the seed-splice logic (insert + de-dup),
+the live-DB fallback, the resolver's new return shape for all three
+modes, and the kind-aware error messages.
+
 ### Added — `/visualize` runs the doc RAG flow end-to-end (Stage 4)
 
 Settings → Docs no longer needs the CLI for the operational path.

--- a/amx/cli_support/commands/manual.py
+++ b/amx/cli_support/commands/manual.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Callable
+from typing import Any
 
 import click
 
@@ -325,27 +326,38 @@ def _select_column_for_wizard(db: object, schema: str, table: str) -> str | None
     return _ask_text_or_cancel("Column")
 
 
-def _resolve_bulk_target_name(cfg: AMXConfig, bulk_pick_mode: str) -> str | None:
-    """Resolve the bare entity name for a bulk-edit run.
+def _resolve_bulk_target_name(
+    cfg: AMXConfig, bulk_pick_mode: str
+) -> tuple[str, str, dict[str, str] | None] | None:
+    """Resolve the bare entity name + kind for a bulk-edit run.
 
-    There are three paths:
-    * ``Pick a column`` — drill DB → schema → table → column. Uses the
-      picked column's NAME (not the fully qualified path) so that
-      ``_run_bulk_edit_by_name`` can fan out to every other table/schema
-      that has a column with the same name.
-    * ``Pick a table`` — drill DB → schema → table. Uses the table NAME
-      so the bulk-edit picks up the same table name across every schema.
-    * ``Type a name manually`` — keeps the legacy text-entry path for
-      power users who already know the name.
+    Returns a triple ``(bare_name, kind, seed)`` where:
+
+    * ``bare_name`` is the column or table name to fan out on.
+    * ``kind`` is one of ``"table"`` / ``"column"`` / ``"any"``. The
+      first two restrict the catalog lookup so a "Pick a table" run
+      doesn't surface columns named the same thing — that was the user-
+      reported bug where picking ``world.City`` returned 33 column
+      matches for ``city`` and zero tables.
+    * ``seed`` is the (schema, table[, column]) the user actually picked
+      in the live-DB picker. We carry it forward so a stale catalog
+      index can never make the user's own selection vanish from the
+      results — the bulk-edit fans out around the seed, never away
+      from it.
 
     Returns ``None`` if the user cancels at any step.
     """
     mode = (bulk_pick_mode or "").lower()
     if mode.startswith("type"):
-        return _ask_text_or_cancel(
+        typed = _ask_text_or_cancel(
             "Entity name to bulk-edit (column or table; AMX finds every match)",
             default="",
         )
+        if typed is None:
+            return None
+        # ``any`` because a free-form name could be either; the caller
+        # searches both indices.
+        return typed, "any", None
 
     selected = _select_db_profile_for_wizard(cfg)
     if selected is None:
@@ -368,14 +380,14 @@ def _resolve_bulk_target_name(cfg: AMXConfig, bulk_pick_mode: str) -> str | None
             f"  Using column name '{column}' (from {schema}.{table}) as bulk target — "
             "AMX will find every other column that shares this name."
         )
-        return column
+        return column, "column", {"schema": schema, "table": table, "column": column}
 
     # "Pick a table" path
     info(
         f"  Using table name '{table}' (from schema {schema}) as bulk target — "
         "AMX will find every other table that shares this name."
     )
-    return table
+    return table, "table", {"schema": schema, "table": table}
 
 
 def _run_edit_wizard(cfg: AMXConfig) -> ManualEditTarget | None:
@@ -411,8 +423,12 @@ def _run_edit_wizard(cfg: AMXConfig) -> ManualEditTarget | None:
         )
         if bulk_pick_mode is None:
             return None
-        bare_name = _resolve_bulk_target_name(cfg, bulk_pick_mode)
-        if bare_name is None or not bare_name.strip():
+        resolved = _resolve_bulk_target_name(cfg, bulk_pick_mode)
+        if resolved is None:
+            warn("Bulk edit cancelled.")
+            return None
+        bare_name, kind, seed = resolved
+        if not bare_name.strip():
             warn("Bulk edit cancelled.")
             return None
         # The bulk flow runs to completion on its own (writes to DB,
@@ -427,6 +443,8 @@ def _run_edit_wizard(cfg: AMXConfig) -> ManualEditTarget | None:
             skip_confirm=False,
             log_event=None,
             preselected_mode="bulk",
+            kind=kind,
+            seed=seed,
         )
         return None
 
@@ -533,6 +551,42 @@ def _parse_multiselect(raw: str, total: int) -> list[int]:
     return sorted(indices)
 
 
+def _scan_live_db_for_tables_named(cfg: AMXConfig, name: str) -> list[dict[str, Any]]:
+    """Walk every schema in the active DB profile and return tables
+    whose name matches ``name`` exactly (case-insensitive). Used as
+    the live-DB fallback when the catalog has no entry for a table
+    the user explicitly picked from the live picker.
+
+    Row shape mirrors the catalog's ``find_tables_by_exact_name``
+    output so downstream code is uniform.
+    """
+    from amx.db.connector import DatabaseConnector
+
+    needle = (name or "").strip().lower()
+    if not needle:
+        return []
+    db = DatabaseConnector(cfg.db)
+    rows: list[dict[str, Any]] = []
+    try:
+        schemas = list(db.list_schemas())
+    except Exception:
+        return []
+    for schema in schemas:
+        try:
+            for tbl in db.list_tables(schema):
+                if str(tbl).lower() == needle:
+                    rows.append(
+                        {
+                            "schema_name": schema,
+                            "table_name": tbl,
+                            "effective_description": "",
+                        }
+                    )
+        except Exception:
+            continue
+    return rows
+
+
 def _run_bulk_edit_by_name(
     cfg: AMXConfig,
     *,
@@ -541,6 +595,8 @@ def _run_bulk_edit_by_name(
     skip_confirm: bool,
     log_event: LogEvent | None,
     preselected_mode: str | None = None,
+    kind: str = "any",
+    seed: dict[str, str] | None = None,
 ) -> None:
     """Bulk-edit comment by bare entity name.
 
@@ -549,40 +605,134 @@ def _run_bulk_edit_by_name(
     bulk-vs-individual question. Accepted values: ``"bulk"`` ,
     ``"individual"`` , or ``None`` (ask the user as usual).
 
+    ``kind`` (``"table"`` / ``"column"`` / ``"any"``) restricts the
+    catalog lookup so a "Pick a table" wizard run doesn't surface
+    columns named the same thing — that was the user-reported bug
+    where picking ``world.City`` returned 33 column matches and zero
+    tables. ``"any"`` keeps the legacy bare-name search across both
+    indices for power-user CLI invocations.
+
+    ``seed`` is the (schema, table[, column]) the user actually picked
+    in the live-DB picker. We carry it forward so a stale catalog
+    index can never make the user's own selection vanish from the
+    results — the bulk-edit fans out around the seed, never away
+    from it. For the table case we additionally fall back to a live-
+    DB scan so users who haven't run ``/search sync`` recently still
+    see every match.
+
     Searches the catalog for tables and columns matching the name, then
     offers a multi-select picker. The same comment text is applied to
     every selected entity via the live DB ``COMMENT ON …`` SQL. Catalog
     state is then refreshed so the new comments are immediately visible
     to ``/ask``.
     """
-    from amx.db.connector import DatabaseConnector
     from amx.search.catalog import SearchCatalog
 
     db_profile = cfg.active_db_profile or "default"
     catalog = SearchCatalog.from_history_store()
-    if catalog is None:
-        error(
-            "Catalog is unavailable; bulk-edit by name needs an indexed catalog. Run /search /sync first."
-        )
-        return
 
-    try:
-        table_rows = catalog.find_tables_by_exact_name(db_profile, bare_name, limit=200)
-    except Exception as exc:
-        error(f"Catalog lookup for tables failed: {exc}")
-        table_rows = []
-    try:
-        column_rows = catalog.find_columns_by_exact_name(db_profile, bare_name, limit=500)
-    except Exception as exc:
-        error(f"Catalog lookup for columns failed: {exc}")
-        column_rows = []
+    table_rows: list[dict[str, Any]] = []
+    column_rows: list[dict[str, Any]] = []
+
+    if kind in ("table", "any"):
+        if catalog is not None:
+            try:
+                table_rows = catalog.find_tables_by_exact_name(db_profile, bare_name, limit=200)
+            except Exception as exc:
+                error(f"Catalog lookup for tables failed: {exc}")
+                table_rows = []
+        # Catalog miss for an explicitly picked table → live-DB scan.
+        # Scoped to ``kind == "table"`` so the legacy "any" path
+        # (bare-name CLI invocation) preserves its old behaviour.
+        if kind == "table" and not table_rows:
+            if catalog is None:
+                info(
+                    "Catalog isn't initialised yet — scanning the live DB for "
+                    f"tables named '{bare_name}'."
+                )
+            else:
+                info(
+                    f"No catalog entry for '{bare_name}' yet — scanning the live "
+                    "DB for matching tables (run /search sync to populate the "
+                    "index next time)."
+                )
+            table_rows = _scan_live_db_for_tables_named(cfg, bare_name)
+
+    if kind in ("column", "any"):
+        if catalog is None:
+            error(
+                "Catalog is unavailable; bulk-edit by column name needs an "
+                "indexed catalog. Run /search sync first."
+            )
+            return
+        try:
+            column_rows = catalog.find_columns_by_exact_name(db_profile, bare_name, limit=500)
+        except Exception as exc:
+            error(f"Catalog lookup for columns failed: {exc}")
+            column_rows = []
+
+    # Splice in the user's live picker selection if it isn't already
+    # present, so the seed is never silently dropped by a stale index.
+    if seed is not None:
+        seed_schema = seed.get("schema") or ""
+        seed_table = seed.get("table") or ""
+        seed_column = seed.get("column") or ""
+        if seed_column and kind in ("column", "any"):
+            already = any(
+                str(r.get("schema_name") or "") == seed_schema
+                and str(r.get("table_name") or "") == seed_table
+                and str(r.get("column_name") or "") == seed_column
+                for r in column_rows
+            )
+            if not already:
+                column_rows.insert(
+                    0,
+                    {
+                        "schema_name": seed_schema,
+                        "table_name": seed_table,
+                        "column_name": seed_column,
+                        "dtype": "",
+                        "effective_description": "",
+                    },
+                )
+        elif seed_table and not seed_column and kind in ("table", "any"):
+            already = any(
+                str(r.get("schema_name") or "") == seed_schema
+                and str(r.get("table_name") or "") == seed_table
+                for r in table_rows
+            )
+            if not already:
+                table_rows.insert(
+                    0,
+                    {
+                        "schema_name": seed_schema,
+                        "table_name": seed_table,
+                        "effective_description": "",
+                    },
+                )
 
     if not table_rows and not column_rows:
-        error(
-            f"No tables or columns named '{bare_name}' in the catalog for profile "
-            f"'{db_profile}'. If you just sync'd /run-apply or recently added a table, "
-            "run `/search sync` to refresh the catalog index, then retry."
-        )
+        if kind == "column":
+            error(
+                f"No columns named '{bare_name}' in the catalog for profile "
+                f"'{db_profile}'. If you just /run-apply'd or recently added a "
+                "column, run `/search sync` to refresh the catalog index, "
+                "then retry."
+            )
+        elif kind == "table":
+            error(
+                f"No tables named '{bare_name}' visible in profile "
+                f"'{db_profile}' (live DB scanned, catalog checked). Verify the "
+                "DB profile points at the right host and that the role has "
+                "schema visibility."
+            )
+        else:
+            error(
+                f"No tables or columns named '{bare_name}' in the catalog for "
+                f"profile '{db_profile}'. If you just sync'd /run-apply or "
+                "recently added a table, run `/search sync` to refresh the "
+                "catalog index, then retry."
+            )
         return
 
     # Build a unified entity list: each row is one (kind, schema, table, column).
@@ -733,6 +883,8 @@ def _run_bulk_edit_by_name(
         if not confirmed:
             warn("Bulk edit cancelled.")
             return
+
+    from amx.db.connector import DatabaseConnector
 
     db = DatabaseConnector(cfg.db)
     try:

--- a/tests/test_edit_bulk_table_mode.py
+++ b/tests/test_edit_bulk_table_mode.py
@@ -1,0 +1,313 @@
+"""Tests for the ``/edit`` bulk-by-name flow's mode + seed contract.
+
+User report 2026-05-04: picking ``world.City`` from the live-DB
+picker in "Bulk by table" mode returned 33 *column* matches and zero
+table matches, plus picking ``cars.country`` showed "No tables or
+columns" even though the user had clearly just selected the table
+from the live picker. Two root causes:
+
+1. ``_run_bulk_edit_by_name`` always queried both catalog indices
+   regardless of how the user identified the entity. The "Pick a
+   table" mode lost its kind information between the resolver and
+   the lookup.
+2. The catalog query was the only source — a stale index made the
+   user's own selection invisible.
+
+The fix:
+
+* The resolver now returns ``(bare_name, kind, seed)``.
+* The runner takes ``kind`` and filters catalog queries by it.
+* The runner takes ``seed`` and splices the user's picker selection
+  into the result list when the catalog miss it.
+* For ``kind="table"`` we additionally fall back to a live-DB scan
+  so a stale catalog can never make a real table vanish.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from amx.cli_support.commands import manual as manual_module
+
+
+@pytest.fixture()
+def cfg():
+    from amx.config import AMXConfig
+
+    cfg = AMXConfig()
+    cfg.active_db_profile = "local-postgre"
+    return cfg
+
+
+def _stub_catalog(monkeypatch, *, table_rows=None, column_rows=None):
+    catalog = MagicMock()
+    catalog.find_tables_by_exact_name.return_value = list(table_rows or [])
+    catalog.find_columns_by_exact_name.return_value = list(column_rows or [])
+    monkeypatch.setattr(
+        "amx.search.catalog.SearchCatalog.from_history_store",
+        classmethod(lambda cls: catalog),
+    )
+    return catalog
+
+
+def _stub_picker(monkeypatch):
+    """Replace the multi-select picker so the test runs to completion
+    without prompting. Returns the list of entries the runner *would*
+    have shown the user."""
+    captured: dict[str, list] = {"entries": []}
+
+    def fake_render_table(_title, _columns, rows):
+        captured["entries"] = list(rows)
+
+    def fake_ask(*_args, **_kwargs):
+        return ""  # user cancels — test only cares about the rendered list.
+
+    monkeypatch.setattr(manual_module, "render_table", fake_render_table)
+    monkeypatch.setattr(manual_module, "ask", fake_ask)
+    monkeypatch.setattr(manual_module, "confirm", lambda *a, **k: False)
+    return captured
+
+
+def test_table_mode_skips_column_lookup_entirely(cfg, monkeypatch) -> None:
+    """User picks "Pick a table" → only ``find_tables_by_exact_name``
+    runs. Even when columns named the same thing exist in the catalog,
+    they must NOT show up in the result list."""
+    catalog = _stub_catalog(
+        monkeypatch,
+        table_rows=[{"schema_name": "world", "table_name": "City"}],
+        column_rows=[{"schema_name": "x", "table_name": "y", "column_name": "city"}],
+    )
+    captured = _stub_picker(monkeypatch)
+
+    manual_module._run_bulk_edit_by_name(
+        cfg,
+        bare_name="City",
+        comment=None,
+        skip_confirm=False,
+        log_event=None,
+        kind="table",
+    )
+
+    catalog.find_tables_by_exact_name.assert_called_once()
+    catalog.find_columns_by_exact_name.assert_not_called()
+    kinds = {row[1] for row in captured["entries"]}  # second column is Kind
+    assert kinds == {"TABLE"}, f"Table mode should not surface columns; got {kinds}"
+
+
+def test_column_mode_skips_table_lookup(cfg, monkeypatch) -> None:
+    catalog = _stub_catalog(
+        monkeypatch,
+        table_rows=[{"schema_name": "world", "table_name": "City"}],
+        column_rows=[{"schema_name": "x", "table_name": "y", "column_name": "city"}],
+    )
+    captured = _stub_picker(monkeypatch)
+
+    manual_module._run_bulk_edit_by_name(
+        cfg,
+        bare_name="city",
+        comment=None,
+        skip_confirm=False,
+        log_event=None,
+        kind="column",
+    )
+
+    catalog.find_columns_by_exact_name.assert_called_once()
+    catalog.find_tables_by_exact_name.assert_not_called()
+    kinds = {row[1] for row in captured["entries"]}
+    assert kinds == {"COL"}
+
+
+def test_any_mode_queries_both(cfg, monkeypatch) -> None:
+    catalog = _stub_catalog(
+        monkeypatch,
+        table_rows=[{"schema_name": "s", "table_name": "City"}],
+        column_rows=[{"schema_name": "x", "table_name": "y", "column_name": "city"}],
+    )
+    _stub_picker(monkeypatch)
+
+    manual_module._run_bulk_edit_by_name(
+        cfg,
+        bare_name="City",
+        comment=None,
+        skip_confirm=False,
+        log_event=None,
+        kind="any",
+    )
+
+    catalog.find_tables_by_exact_name.assert_called_once()
+    catalog.find_columns_by_exact_name.assert_called_once()
+
+
+def test_seed_table_is_inserted_when_catalog_misses_it(cfg, monkeypatch) -> None:
+    """User picked ``world.City`` from the live picker, but the
+    catalog hasn't indexed it yet. The runner must splice the seed
+    into the result list so the user's own selection never vanishes."""
+    _stub_catalog(
+        monkeypatch,
+        table_rows=[{"schema_name": "other", "table_name": "City"}],
+    )
+    # Disable the live-DB fallback; we only want to test the seed path
+    # in isolation here.
+    monkeypatch.setattr(manual_module, "_scan_live_db_for_tables_named", lambda cfg, name: [])
+    captured = _stub_picker(monkeypatch)
+
+    manual_module._run_bulk_edit_by_name(
+        cfg,
+        bare_name="City",
+        comment=None,
+        skip_confirm=False,
+        log_event=None,
+        kind="table",
+        seed={"schema": "world", "table": "City"},
+    )
+
+    labels = [row[2] for row in captured["entries"]]  # Schema.Table[.Column]
+    assert "world.City" in labels, f"Seed table must appear in results; got {labels}"
+
+
+def test_seed_table_is_not_duplicated_when_catalog_already_has_it(cfg, monkeypatch) -> None:
+    """If the catalog already has the seed entry, we must NOT
+    duplicate it."""
+    _stub_catalog(
+        monkeypatch,
+        table_rows=[
+            {"schema_name": "world", "table_name": "City"},
+            {"schema_name": "other", "table_name": "City"},
+        ],
+    )
+    monkeypatch.setattr(manual_module, "_scan_live_db_for_tables_named", lambda cfg, name: [])
+    captured = _stub_picker(monkeypatch)
+
+    manual_module._run_bulk_edit_by_name(
+        cfg,
+        bare_name="City",
+        comment=None,
+        skip_confirm=False,
+        log_event=None,
+        kind="table",
+        seed={"schema": "world", "table": "City"},
+    )
+
+    labels = [row[2] for row in captured["entries"]]
+    assert labels.count("world.City") == 1
+
+
+def test_table_mode_falls_back_to_live_db_when_catalog_empty(cfg, monkeypatch) -> None:
+    """The user-reported scenario: catalog is stale, picked
+    ``cars.country`` returned no matches. The runner must scan the
+    live DB and surface every table named ``country`` so the bulk
+    edit still works."""
+    _stub_catalog(monkeypatch, table_rows=[])
+
+    monkeypatch.setattr(
+        manual_module,
+        "_scan_live_db_for_tables_named",
+        lambda cfg, name: [
+            {"schema_name": "cars", "table_name": "country"},
+            {"schema_name": "world", "table_name": "Country"},
+        ],
+    )
+    captured = _stub_picker(monkeypatch)
+
+    manual_module._run_bulk_edit_by_name(
+        cfg,
+        bare_name="country",
+        comment=None,
+        skip_confirm=False,
+        log_event=None,
+        kind="table",
+    )
+
+    labels = sorted(row[2] for row in captured["entries"])
+    assert labels == ["cars.country", "world.Country"]
+
+
+def test_table_mode_with_no_matches_anywhere_emits_actionable_error(
+    cfg, monkeypatch, capsys
+) -> None:
+    _stub_catalog(monkeypatch, table_rows=[])
+    monkeypatch.setattr(manual_module, "_scan_live_db_for_tables_named", lambda cfg, name: [])
+    _stub_picker(monkeypatch)
+
+    manual_module._run_bulk_edit_by_name(
+        cfg,
+        bare_name="nope",
+        comment=None,
+        skip_confirm=False,
+        log_event=None,
+        kind="table",
+    )
+    out = capsys.readouterr().out + capsys.readouterr().err
+    # The kind-aware message should mention "tables" and "live DB
+    # scanned" so the user knows the catalog isn't the only thing
+    # checked.
+    assert "tables" in out.lower() or "table" in out.lower()
+
+
+def test_resolver_returns_kind_and_seed_for_table_path(monkeypatch, cfg) -> None:
+    """The resolver carries ``kind`` and ``seed`` forward so the
+    runner doesn't have to re-parse the prompt string."""
+    monkeypatch.setattr(
+        manual_module,
+        "_select_db_profile_for_wizard",
+        lambda cfg: ("local-postgre", cfg.db),
+    )
+    monkeypatch.setattr(manual_module, "_connector_for_profile", lambda cfg: MagicMock())
+    monkeypatch.setattr(
+        manual_module, "_select_schema_for_wizard", lambda db, default=None: "world"
+    )
+    monkeypatch.setattr(
+        manual_module,
+        "_select_table_for_wizard",
+        lambda db, schema, default=None: "City",
+    )
+
+    result = manual_module._resolve_bulk_target_name(cfg, "Pick a table from the catalog")
+    assert result is not None
+    bare_name, kind, seed = result
+    assert bare_name == "City"
+    assert kind == "table"
+    assert seed == {"schema": "world", "table": "City"}
+
+
+def test_resolver_returns_kind_and_seed_for_column_path(monkeypatch, cfg) -> None:
+    monkeypatch.setattr(
+        manual_module,
+        "_select_db_profile_for_wizard",
+        lambda cfg: ("local-postgre", cfg.db),
+    )
+    monkeypatch.setattr(manual_module, "_connector_for_profile", lambda cfg: MagicMock())
+    monkeypatch.setattr(
+        manual_module, "_select_schema_for_wizard", lambda db, default=None: "world"
+    )
+    monkeypatch.setattr(
+        manual_module,
+        "_select_table_for_wizard",
+        lambda db, schema, default=None: "City",
+    )
+    monkeypatch.setattr(
+        manual_module, "_select_column_for_wizard", lambda db, schema, table: "Name"
+    )
+
+    result = manual_module._resolve_bulk_target_name(cfg, "Pick a column from the catalog")
+    assert result is not None
+    bare_name, kind, seed = result
+    assert bare_name == "Name"
+    assert kind == "column"
+    assert seed == {"schema": "world", "table": "City", "column": "Name"}
+
+
+def test_resolver_returns_any_for_typed_path(monkeypatch, cfg) -> None:
+    monkeypatch.setattr(
+        manual_module,
+        "_ask_text_or_cancel",
+        lambda *args, **kwargs: "customer_id",
+    )
+    result = manual_module._resolve_bulk_target_name(cfg, "Type a name manually")
+    assert result is not None
+    bare_name, kind, seed = result
+    assert bare_name == "customer_id"
+    assert kind == "any"
+    assert seed is None


### PR DESCRIPTION
## Summary

User report: picking \`world.City\` in \`/edit -> Bulk by name -> Pick a table\` returned 33 column matches and 0 table matches; an earlier try with \`cars.country\` failed with 'No tables or columns'. The user's actual live-picker selection was being thrown away.

Two root causes:

1. Mode lost between resolver and runner: \`_resolve_bulk_target_name\` knew the user picked a TABLE, but \`_run_bulk_edit_by_name\` queried both indices unconditionally.
2. Catalog-only lookup: a stale SQLite index made the user's own selection invisible.

## Fix

- \`_resolve_bulk_target_name\` now returns \`(bare_name, kind, seed)\`.
- \`_run_bulk_edit_by_name\` takes \`kind\` ('table' / 'column' / 'any') and filters catalog queries accordingly. Legacy bare-name CLI keeps 'any'.
- The user's live picker selection is spliced into results when the catalog misses it (de-duped when already present).
- For \`kind=table\` the runner falls back to a live-DB scan across every schema — table-bulk-edit is independent of \`/search sync\` freshness.
- Kind-aware error messages.

## Test plan

- [x] pytest tests/test_edit_bulk_table_mode.py — 10 tests covering mode-respect, seed splice, live-DB fallback, resolver shape, errors.
- [x] pytest tests/ — 844 passed.
- [x] ruff check + format clean.