### PR TITLE
docs: add repository conventions doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# Repository conventions for Claude Code
+
+## Commit messages
+
+**Do not add a `Co-Authored-By: Claude` trailer (or any
+`<noreply@anthropic.com>` co-author) to commit messages.** GitHub
+uses these trailers to populate the Contributors graph; the entry is
+not wanted on this repo.
+
+## Pull request descriptions
+
+**Do not append `🤖 Generated with [Claude Code](...)` (or any
+similar attribution line) to PR bodies.**
+
+Keep PR bodies focused on Summary + Test plan.


### PR DESCRIPTION
## Summary

Adds a top-level conventions document describing commit message and pull request description standards for this repo.

## Test plan

- [x] Documentation-only change; no runtime impact.