### PR TITLE
chore(release): 0.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+## [0.12.8] - 2026-05-05
+
+The `/visualize` umbrella release. Thirteen UI-overhaul PRs + Stage 2–7
+parity work + the design-system reset land together: the local web UI now
+has full feature parity with the REPL surface for run / review / apply /
+ask, with full DB / LLM / Docs / Code wizards, a System page (doctor /
+usage / catalog status / team history-store / maintenance), per-asset
+LLM-generate from any Browse page, and a complete pixel-art rebrand.
+README and amxcli.com both grow a `/visualize` entry point with the
+Overview screenshot.
+
 ### Added — `/visualize` per-asset generate + favicon swap (UI overhaul, PR 13)
 
 * **Favicon is now the AMX pixel-art mark.** Replaces the old

--- a/amx/__init__.py
+++ b/amx/__init__.py
@@ -1,6 +1,6 @@
 """AMX — Agentic Metadata Extractor."""
 
-__version__ = "0.12.7"
+__version__ = "0.12.8"
 
 __all__ = [
     "AMXApplication",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amx-cli"
-version = "0.12.7"
+version = "0.12.8"
 description = "Agentic Metadata Extractor — AI-powered CLI to infer and manage database metadata"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` and `amx/__init__.py` to **0.12.8**.
- Promotes the entire `[Unreleased]` block in `CHANGELOG.md` to `[0.12.8] - 2026-05-05` with a one-paragraph release header.

## What's in 0.12.8

The `/visualize` umbrella release. Thirteen UI-overhaul PRs (PRs 1/4 → 13) + Stage 2–7 parity work + a design-system reset land together:

- **Run lifecycle in the browser.** `POST /api/runs` now drives the real Orchestrator end-to-end with live SSE progress; tabbed Run detail (Summary / Results / Scope / Settings) with per-row alternatives carousel + skip + custom-edit + restore.
- **Full profile management.** DB / LLM / Docs / Code wizards on Settings — same fields as the CLI's `/add-*-profile` wizards, all 10 backends + 8 providers.
- **System page.** Doctor / token usage / catalog status / team history-store enable + disable / one-click placeholder cleanup.
- **Per-asset Generate.** Database / Schema / Table / Column pages each get inline-edit + per-asset Generate that runs one focused LLM call (or a scope-modal-driven full run, both routed through the human-in-the-loop queue).
- **Brand + theme.** Dark-only, warm-amber palette, pixel-art AMX wordmark, footer pointing at amxcli.com.
- **Misc.** `Ctrl-C` interrupts the running command instead of tearing down the whole REPL session; `/edit` Bulk-by-table respects mode + survives a stale catalog.

Matching documentation lands in:
- amxcli.com `/visualize` page: [omeryasirkucuk/amx-docs@d574816](https://github.com/omeryasirkucuk/amx-docs/commit/d574816)
- README `/visualize` section + screenshot: #156

## Release plan

After merge, tag `v0.12.8` on `main`:

```bash
git checkout main && git pull
git tag v0.12.8
git push origin v0.12.8
```

The `release.yml` workflow will build, verify the tag matches `pyproject.toml`, publish to PyPI via OIDC trusted publisher, and create the GitHub Release with auto-generated notes.

## Test plan

- [ ] CI green on this branch (lint / type / test py3.10–3.12 / web-build-freshness / build).
- [ ] After tag push: `pip install amx-cli==0.12.8` resolves on PyPI.
- [ ] `amx --version` prints `0.12.8`.
- [ ] amxcli.com footer shows `0.12.8` (separate amx-docs PR / push).