### PR TITLE
chore(lint): apply ruff format to clear pre-existing formatting debt

### DIFF
--- a/amx/cli_support/commands/embeddings.py
+++ b/amx/cli_support/commands/embeddings.py
@@ -41,6 +41,7 @@ def _configure_from_amx_config(*args, **kwargs):  # type: ignore[no-untyped-def]
 
     return configure_from_amx_config(*args, **kwargs)
 
+
 _LABEL_MINILM = "MiniLM"
 _LABEL_OPENAI = "OpenAI-compatible"
 _LABEL_LOCAL = "Local sentence-transformers"

--- a/amx/docs/scanner.py
+++ b/amx/docs/scanner.py
@@ -301,6 +301,7 @@ def _google_drive_build_service():
     )
     from googleapiclient.discovery import build
     from googleapiclient.errors import HttpError
+
     creds = _google_drive_credentials()
     return build("drive", "v3", credentials=creds, cache_discovery=False), HttpError
 

--- a/amx/utils/optional_deps.py
+++ b/amx/utils/optional_deps.py
@@ -143,17 +143,14 @@ def ensure(packages: Iterable[PackageSpec], *, feature: str) -> None:
         proc = subprocess.run(cmd, check=False)
     except OSError as exc:
         manual = "pip install " + " ".join(missing_pip)
-        raise RuntimeError(
-            f"Could not invoke pip ({exc}). Install manually: {manual}"
-        ) from exc
+        raise RuntimeError(f"Could not invoke pip ({exc}). Install manually: {manual}") from exc
 
     if proc.returncode != 0:
         for key in seen_keys:
             _VERIFIED.discard(key)
         manual = "pip install " + " ".join(missing_pip)
         raise RuntimeError(
-            f"pip install failed (exit code {proc.returncode}). "
-            f"Run manually: {manual}"
+            f"pip install failed (exit code {proc.returncode}). Run manually: {manual}"
         )
 
     # Newly-installed packages weren't on sys.path at process start;


### PR DESCRIPTION
## Summary

Three files on `main` are unformatted (`ruff format --check` fails on every PR), so every new branch inherits a red lint check through no fault of its own. Ran `ruff format` on the three flagged files — pure whitespace/line-length changes, no semantic edits.

- `amx/cli_support/commands/embeddings.py`
- `amx/docs/scanner.py`
- `amx/utils/optional_deps.py`

Unblocks #158 (favicon PR) and any other in-flight branches.

## Test plan

- [ ] `Lint & format` job goes green on this PR
- [ ] After merge, #158 re-runs CI and lint passes