### PR TITLE
feat(ask): multi-profile retrieval scope plumbing (PR-A)

### DIFF
--- a/amx/cli_support/commands/chat_session.py
+++ b/amx/cli_support/commands/chat_session.py
@@ -61,13 +61,69 @@ def register_chat_session_commands(
         if store is None:
             error("History store is not initialized; cannot start a session.")
             return
+        # Multi-profile scope: seed the new session with whatever
+        # cfg.effective_db_profiles() resolves to (cfg.active_db_profiles
+        # set by /use-db, or the legacy single-active fallback). The
+        # /ask-scope command can override this for the chat without
+        # touching the persisted config-level scope.
+        try:
+            scope_profiles = list(cfg.effective_db_profiles()) or None
+        except Exception:
+            scope_profiles = None
         sid = store.start_session(
             db_profile=cfg.active_db_profile or "default",
             llm_profile=cfg.active_llm_profile or "default",
             title=title,
+            scope_profiles=scope_profiles,
         )
         cfg.active_chat_session_id = sid
         success(f"Started chat session #{sid}." + (f" Title: {title!r}." if title else ""))
+
+    @session.command("scope")
+    @click.argument("profiles", nargs=-1)
+    @pass_config
+    def session_scope(cfg: AMXConfig, profiles: tuple[str, ...]) -> None:
+        """Show or set the sticky scope for the active chat session.
+
+        ``/session scope`` (no args) prints the current scope. ``/session
+        scope clear`` resets to the config default. ``/session scope
+        prod_pg analytics_bq`` pins multi-profile scope only for THIS
+        chat (separate from the persisted ``/use-db`` scope).
+        """
+        store = _store()
+        if store is None:
+            error("History store is not initialized; cannot manage scope.")
+            return
+        sid = getattr(cfg, "active_chat_session_id", None) or 0
+        if not sid:
+            error("No active chat session. Run `/session new` first.")
+            return
+        if not profiles:
+            current = store.get_scope(int(sid))
+            if current:
+                info(f"Sticky scope for session #{sid}: {', '.join(current)}")
+            else:
+                info(
+                    f"Session #{sid} uses the config default ({len(cfg.db_profiles)} "
+                    f"profile{'s' if len(cfg.db_profiles) != 1 else ''})."
+                )
+            return
+        if profiles == ("clear",):
+            store.update_scope(int(sid), scope_profiles=None)
+            success(f"Cleared sticky scope on session #{sid}; back to config default.")
+            return
+        unknown = [p for p in profiles if p not in cfg.db_profiles]
+        if unknown:
+            error(
+                f"Unknown DB profile(s): {', '.join(unknown)}. "
+                f"Available: {', '.join(sorted(cfg.db_profiles)) or '(none)'}."
+            )
+            return
+        store.update_scope(int(sid), scope_profiles=list(profiles))
+        success(
+            f"Sticky scope on session #{sid}: {', '.join(profiles)}. "
+            "Subsequent /ask questions in this chat use this scope."
+        )
 
     @session.command("list")
     @click.option(

--- a/amx/search/_agent/session_memory.py
+++ b/amx/search/_agent/session_memory.py
@@ -66,9 +66,18 @@ class SessionMemoryMixin:
             return self._session_id
         if self._session_id is not None:
             return self._session_id
+        # Persist the multi-profile scope on the new session record so
+        # the Studio "/api/ask/sessions/{id}" GET (and the CLI's own
+        # follow-up turns) honour the same sticky scope without
+        # rebuilding it from cfg each time. ``self.db_profiles`` is the
+        # SearchAgent-collected scope (caller kwarg > config default).
+        scope_profiles: list[str] | None = None
+        if getattr(self, "db_profiles", None):
+            scope_profiles = list(self.db_profiles)
         sid = store.start_session(
             db_profile=self.db_profile,
             llm_profile=self._llm_profile,
+            scope_profiles=scope_profiles,
         )
         self._session_id = sid
         with contextlib.suppress(Exception):

--- a/amx/search/_agent/short_circuits.py
+++ b/amx/search/_agent/short_circuits.py
@@ -286,6 +286,11 @@ class ShortCircuitsMixin:
             # the user sees real thinking content rather than a blank
             # spinner. The panel clears the moment the loop returns.
             with step_spinner("Search Agent: thinking with tools"):
+                # Multi-profile scope (0.13+): SearchAgent collects the
+                # active profile list at construction time
+                # (cfg.effective_db_profiles or the explicit kwarg), and
+                # forwards it through to the tool agent so catalog
+                # search/find tools span every profile in scope.
                 result = run_tool_agent(
                     cfg=self.cfg,
                     catalog=self.catalog,
@@ -294,6 +299,7 @@ class ShortCircuitsMixin:
                     answer_language=question_language,
                     session_memory=prior_turns,
                     display=display if display.is_active else None,
+                    db_profiles=list(self.db_profiles) if self.db_profiles else None,
                 )
             elapsed = round(time.monotonic() - t0, 4)
         except Exception as exc:

--- a/amx/search/_catalog/search.py
+++ b/amx/search/_catalog/search.py
@@ -300,28 +300,36 @@ class SearchMixin:
             ).fetchall()
         return [dict(row) for row in rows]
 
-    def known_databases(self, db_profile: str) -> list[dict[str, Any]]:
+    def known_databases(self, db_profile: DBProfileFilter) -> list[dict[str, Any]]:
+        """Distinct database names indexed for the given scope.
+
+        ``db_profile`` accepts a single name (str) or a sequence of
+        names — multi-profile callers union the listing across all
+        configured profiles.
+        """
+        clause, binds = build_db_profile_clause(db_profile)
         with self._connect() as conn:
             rows = conn.execute(
-                """
+                f"""
                 SELECT database_name, COUNT(*) AS entity_count
                 FROM catalog_entities
-                WHERE db_profile = ? AND COALESCE(database_name, '') != ''
+                WHERE {clause} AND COALESCE(database_name, '') != ''
                 GROUP BY database_name
                 ORDER BY database_name
                 """,
-                (db_profile,),
+                tuple(binds),
             ).fetchall()
         return [dict(row) for row in rows]
 
     def known_schemas(
         self,
-        db_profile: str,
+        db_profile: DBProfileFilter,
         *,
         database_name: str | None = None,
     ) -> list[dict[str, Any]]:
-        params: list[Any] = [db_profile]
-        where = ["db_profile = ?", "entity_kind = 'table'", "COALESCE(schema_name, '') != ''"]
+        clause, binds = build_db_profile_clause(db_profile)
+        params: list[Any] = list(binds)
+        where = [clause, "entity_kind = 'table'", "COALESCE(schema_name, '') != ''"]
         if database_name:
             where.append("LOWER(database_name) = LOWER(?)")
             params.append(database_name)
@@ -329,11 +337,12 @@ class SearchMixin:
             SELECT
                 schema_name,
                 MIN(database_name) AS database_name,
+                MIN(db_profile) AS db_profile,
                 COUNT(*) AS table_count
             FROM catalog_entities
             WHERE {" AND ".join(where)}
-            GROUP BY schema_name
-            ORDER BY schema_name
+            GROUP BY schema_name, db_profile
+            ORDER BY schema_name, db_profile
         """
         with self._connect() as conn:
             rows = conn.execute(query, tuple(params)).fetchall()
@@ -341,13 +350,14 @@ class SearchMixin:
 
     def count_tables(
         self,
-        db_profile: str,
+        db_profile: DBProfileFilter,
         *,
         schema_name: str | None = None,
         database_name: str | None = None,
     ) -> int:
-        params: list[Any] = [db_profile]
-        where = ["db_profile = ?", "entity_kind = 'table'"]
+        clause, binds = build_db_profile_clause(db_profile)
+        params: list[Any] = list(binds)
+        where = [clause, "entity_kind = 'table'"]
         if schema_name:
             where.append("LOWER(schema_name) = LOWER(?)")
             params.append(schema_name)
@@ -361,15 +371,22 @@ class SearchMixin:
 
     def schema_inventory(
         self,
-        db_profile: str,
+        db_profile: DBProfileFilter,
         *,
         schema_name: str | None = None,
         database_name: str | None = None,
         limit: int = 500,
     ) -> list[dict[str, Any]]:
-        """Return table-level structural inventory with column counts."""
-        params: list[Any] = [db_profile]
-        where = ["t.db_profile = ?", "t.entity_kind = 'table'"]
+        """Return table-level structural inventory with column counts.
+
+        ``db_profile`` is a :class:`DBProfileFilter` — a single name or a
+        sequence. Multi-profile callers get rows from every requested
+        profile in one SQL pass; the result row carries ``db_profile``
+        so callers can route per-profile.
+        """
+        clause, binds = build_db_profile_clause(db_profile, column="t.db_profile")
+        params: list[Any] = list(binds)
+        where = [clause, "t.entity_kind = 'table'"]
         if schema_name:
             where.append("LOWER(t.schema_name) = LOWER(?)")
             params.append(schema_name)
@@ -379,6 +396,7 @@ class SearchMixin:
         query = f"""
             SELECT
                 t.id,
+                t.db_profile,
                 t.database_name,
                 t.schema_name,
                 t.table_name,
@@ -397,7 +415,7 @@ class SearchMixin:
             LEFT JOIN catalog_descriptions cd ON cd.id = c.effective_description_id
             WHERE {" AND ".join(where)}
             GROUP BY t.id
-            ORDER BY t.schema_name, t.table_name
+            ORDER BY t.db_profile, t.schema_name, t.table_name
             LIMIT ?
         """
         params.append(max(1, int(limit)))

--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -62,10 +62,39 @@ class ToolBox:
         catalog: SearchCatalog,
         *,
         db_factory: Callable[[], DatabaseConnector] | None = None,
+        db_profiles: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         self.cfg = cfg
         self.catalog = catalog
-        self.db_profile = cfg.active_db_profile or "default"
+        # Resolve the multi-profile retrieval scope.
+        # ``db_profiles`` (caller-supplied) > ``cfg.active_db_profiles`` (the
+        # 0.11.0 multi-pick scope) > legacy single-active fallback. Anchor
+        # ``self.db_profile`` to the first entry so legacy single-profile
+        # call-sites that read it still resolve to a valid name; full
+        # multi-profile callers use ``self.db_profile_filter`` instead.
+        configured: list[str] = []
+        if db_profiles:
+            configured = [str(name).strip() for name in db_profiles if str(name).strip()]
+        elif callable(getattr(cfg, "effective_db_profiles", None)):
+            try:
+                configured = [
+                    str(name).strip() for name in cfg.effective_db_profiles() if str(name).strip()
+                ]
+            except Exception:
+                configured = []
+        if not configured:
+            fallback = (cfg.active_db_profile or "default").strip() or "default"
+            configured = [fallback]
+        # Dedupe while preserving order.
+        seen: set[str] = set()
+        scope: list[str] = []
+        for name in configured:
+            if name in seen:
+                continue
+            seen.add(name)
+            scope.append(name)
+        self.db_profiles: list[str] = scope
+        self.db_profile: str = scope[0]  # anchor for legacy single-profile reads
         self._db_factory = db_factory or (lambda: DatabaseConnector(cfg.db))
         # Only build the live DB connector lazily — many tools never need it.
         self._db: DatabaseConnector | None = None
@@ -77,8 +106,30 @@ class ToolBox:
         # collapses the 2nd and 3rd call to a free memory lookup.
         # ToolBox is instantiated per /ask question so the cache never
         # outlives a single point-in-time view of the database.
-        self._tool_cache: dict[tuple[str, str], str] = {}
+        # The cache key includes the tuple of profiles — a multi-profile
+        # call's results are NOT interchangeable with a single-profile
+        # call's results, so they must miss when the scope changes.
+        self._tool_cache: dict[tuple[str, str, tuple[str, ...]], str] = {}
         self._tool_cache_hits: int = 0
+
+    @property
+    def db_profile_filter(self) -> str | list[str]:
+        """Return the scope in the form catalog tools accept.
+
+        Catalog methods type their ``db_profile`` parameter as
+        ``DBProfileFilter = str | Sequence[str]``. We hand back a scalar
+        for the single-profile case (so the SQL stays ``db_profile = ?``,
+        cheap path) and a list for multi-profile (which expands to
+        ``db_profile IN (?, ?, ?)``).
+        """
+        if len(self.db_profiles) <= 1:
+            return self.db_profile
+        return list(self.db_profiles)
+
+    @property
+    def is_multi_profile(self) -> bool:
+        """``True`` when the scope spans 2+ profiles."""
+        return len(self.db_profiles) > 1
 
     # ------------------------------------------------------------------ helpers
     def _live_db(self) -> DatabaseConnector:
@@ -926,10 +977,19 @@ class ToolBox:
         # (e.g. {"a":1,"b":2} vs {"b":2,"a":1}) hash to the same key.
         # Falls through to the handler on TypeError if some arg isn't
         # JSON-serialisable (no caching, but no crash either).
-        cache_key: tuple[str, str] | None = None
+        # The third element of the key is the (sorted) tuple of profiles
+        # in scope; a multi-profile result MUST NOT be served to a
+        # single-profile call or vice versa, so the scope tuple
+        # disambiguates them.
+        cache_key: tuple[str, str, tuple[str, ...]] | None = None
         if name not in self._UNCACHED_TOOLS:
             try:
-                cache_key = (name, json.dumps(args, sort_keys=True, default=str))
+                profile_key = tuple(sorted(self.db_profiles))
+                cache_key = (
+                    name,
+                    json.dumps(args, sort_keys=True, default=str),
+                    profile_key,
+                )
                 cached = self._tool_cache.get(cache_key)
                 if cached is not None:
                     self._tool_cache_hits += 1
@@ -1366,13 +1426,26 @@ class ToolBox:
         if not target:
             raise _ToolError("Argument 'name' is required.")
         # ── Stage 1 — exact match in both catalog + live DB ──
-        catalog_rows = self.catalog.find_tables_by_exact_name(self.db_profile, target, limit=20)
+        # Multi-profile scope: ``find_tables_by_exact_name`` accepts a
+        # DBProfileFilter, so a single SQL pass covers every profile.
+        # Result rows carry their own ``db_profile`` field; we tag each
+        # match path with it so the LLM can disambiguate cross-profile.
+        catalog_rows = self.catalog.find_tables_by_exact_name(
+            self.db_profile_filter, target, limit=20
+        )
         catalog_paths: list[str] = []
         for row in catalog_rows:
             schema_name = str(row.get("schema_name") or "")
             table_name = str(row.get("table_name") or "")
+            row_profile = str(row.get("db_profile") or "")
             if schema_name and table_name:
-                catalog_paths.append(f"{schema_name}.{table_name}")
+                # In multi-profile mode prefix the path with profile so
+                # downstream dedupe doesn't collapse same-named tables
+                # from different profiles into one.
+                if self.is_multi_profile and row_profile:
+                    catalog_paths.append(f"{row_profile}::{schema_name}.{table_name}")
+                else:
+                    catalog_paths.append(f"{schema_name}.{table_name}")
         live_paths: list[str] = []
         # Walk live DB once and remember every table name we see; the
         # exact-match check happens here, fuzzy fallback (Stage 2)
@@ -1457,13 +1530,17 @@ class ToolBox:
 
         # Catalog-side fuzzy: also scan catalog entities so we catch
         # tables that exist in the catalog but aren't in the live DB
-        # listing yet (or live discovery failed).
+        # listing yet (or live discovery failed). Multi-profile scope
+        # expands ``WHERE db_profile = ?`` to ``IN (?, ?, …)``.
+        from amx.search._catalog._db_profile_clause import build_db_profile_clause
+
         try:
+            clause, binds = build_db_profile_clause(self.db_profile_filter)
             with self.catalog._connect() as conn:  # noqa: SLF001
                 catalog_all = conn.execute(
-                    "SELECT schema_name, table_name FROM catalog_entities "
-                    "WHERE db_profile = ? AND entity_kind = 'table'",
-                    (self.db_profile,),
+                    f"SELECT db_profile, schema_name, table_name FROM catalog_entities "
+                    f"WHERE {clause} AND entity_kind = 'table'",
+                    tuple(binds),
                 ).fetchall()
             for r in catalog_all:
                 schema_name = str(r["schema_name"] or "")
@@ -1715,12 +1792,17 @@ class ToolBox:
         return head
 
     def _tool_search_tables_by_concept(self, concept: str, limit: int = 10) -> dict[str, Any]:
-        rows = self.catalog.search_tables(self.db_profile, concept or "", limit=int(limit))
+        # ``db_profile_filter`` collapses to a scalar in single-profile
+        # scope and a list in multi-profile scope — search_tables expands
+        # the WHERE clause via build_db_profile_clause either way, so the
+        # SQL stays one query regardless of how many profiles are in scope.
+        rows = self.catalog.search_tables(self.db_profile_filter, concept or "", limit=int(limit))
         return {
             "concept": concept,
             "count": len(rows),
             "matches": [
                 {
+                    "db_profile": str(r.get("db_profile") or ""),
                     "schema": str(r.get("schema_name") or ""),
                     "table": str(r.get("table_name") or ""),
                     "score": float(r.get("rank_score") or r.get("score") or 0.0),
@@ -1731,12 +1813,13 @@ class ToolBox:
         }
 
     def _tool_search_columns_by_concept(self, concept: str, limit: int = 10) -> dict[str, Any]:
-        rows = self.catalog.search_columns(self.db_profile, concept or "", limit=int(limit))
+        rows = self.catalog.search_columns(self.db_profile_filter, concept or "", limit=int(limit))
         return {
             "concept": concept,
             "count": len(rows),
             "matches": [
                 {
+                    "db_profile": str(r.get("db_profile") or ""),
                     "schema": str(r.get("schema_name") or ""),
                     "table": str(r.get("table_name") or ""),
                     "column": str(r.get("column_name") or ""),
@@ -1995,13 +2078,19 @@ class ToolBox:
         if not token:
             raise _ToolError("Argument 'dtype' is required.")
         family = self._DTYPE_FAMILIES.get(token, [token])
+        from amx.search._catalog._db_profile_clause import build_db_profile_clause as _bdp
+
+        profile_clause, profile_binds = _bdp(self.db_profile_filter, column="ce.db_profile")
         # Build a single SQL OR-set so we run one query.
         with self.catalog._connect() as conn:  # noqa: SLF001 — internal helper
             placeholders = ", ".join(["?"] * len(family))
+            like_clause = " OR ".join(["LOWER(dtype) LIKE ?"] * len(family))
             query = f"""
-                SELECT schema_name, table_name, column_name, dtype, effective_description
+                SELECT db_profile, schema_name, table_name, column_name, dtype,
+                       effective_description
                 FROM (
                     SELECT
+                        ce.db_profile,
                         ce.schema_name,
                         ce.table_name,
                         ce.column_name,
@@ -2009,15 +2098,15 @@ class ToolBox:
                         cd.description_text AS effective_description
                     FROM catalog_entities ce
                     LEFT JOIN catalog_descriptions cd ON cd.id = ce.effective_description_id
-                    WHERE ce.db_profile = ?
+                    WHERE {profile_clause}
                       AND ce.entity_kind = 'column'
                       AND ce.dtype IS NOT NULL
                 ) WHERE LOWER(dtype) IN ({placeholders})
-                   OR {" OR ".join(["LOWER(dtype) LIKE ?"] * len(family))}
-                ORDER BY schema_name, table_name, column_name
+                   OR {like_clause}
+                ORDER BY db_profile, schema_name, table_name, column_name
                 LIMIT ?
             """
-            params: list[Any] = [self.db_profile]
+            params: list[Any] = list(profile_binds)
             params.extend(family)
             params.extend([f"%{f}%" for f in family])
             params.append(int(limit))
@@ -2049,6 +2138,7 @@ class ToolBox:
                 kind = "exact_dtype_match"
             results.append(
                 {
+                    "db_profile": str(r["db_profile"] or ""),
                     "schema": str(r["schema_name"] or ""),
                     "table": str(r["table_name"] or ""),
                     "column": str(r["column_name"] or ""),
@@ -2098,21 +2188,24 @@ class ToolBox:
                 # OR-of name LIKE patterns AND OR-of string dtype LIKE patterns
                 name_like_clause = " OR ".join("LOWER(column_name) LIKE ?" for _ in name_patterns)
                 dtype_like_clause = " OR ".join("LOWER(dtype) LIKE ?" for _ in string_dtypes_like)
+                profile_clause2, profile_binds2 = _bdp(
+                    self.db_profile_filter, column="ce.db_profile"
+                )
                 q = f"""
-                    SELECT ce.schema_name, ce.table_name, ce.column_name,
+                    SELECT ce.db_profile, ce.schema_name, ce.table_name, ce.column_name,
                            ce.dtype,
                            cd.description_text AS effective_description
                     FROM catalog_entities ce
                     LEFT JOIN catalog_descriptions cd ON cd.id = ce.effective_description_id
-                    WHERE ce.db_profile = ?
+                    WHERE {profile_clause2}
                       AND ce.entity_kind = 'column'
                       AND ce.dtype IS NOT NULL
                       AND ({name_like_clause})
                       AND ({dtype_like_clause})
-                    ORDER BY ce.schema_name, ce.table_name, ce.column_name
+                    ORDER BY ce.db_profile, ce.schema_name, ce.table_name, ce.column_name
                     LIMIT ?
                 """
-                params2: list[Any] = [self.db_profile]
+                params2: list[Any] = list(profile_binds2)
                 params2.extend(name_patterns)
                 params2.extend(string_dtypes_like)
                 params2.append(int(limit))
@@ -2128,6 +2221,7 @@ class ToolBox:
                     continue
                 results.append(
                     {
+                        "db_profile": str(r["db_profile"] or ""),
                         "schema": schema_n,
                         "table": table_n,
                         "column": column_n,
@@ -2170,8 +2264,12 @@ class ToolBox:
         if not target:
             raise _ToolError("Argument 'table' is required.")
         # Resolve to schema.table when only the table name was provided.
+        # Multi-profile scope: search across every configured profile;
+        # if the table exists in only one profile we anchor there. The
+        # cross-profile join expansion (joinable across profile X and
+        # profile Y) lands in PR-C as a dedicated tool.
         if "." not in target:
-            exact = self.catalog.find_tables_by_exact_name(self.db_profile, target, limit=5)
+            exact = self.catalog.find_tables_by_exact_name(self.db_profile_filter, target, limit=5)
             if not exact:
                 return {
                     "table": target,

--- a/amx/search/session_store.py
+++ b/amx/search/session_store.py
@@ -88,16 +88,26 @@ class ChatSessionStore:
         db_profile: str,
         llm_profile: str,
         title: str | None = None,
+        scope_profiles: list[str] | None = None,
     ) -> int:
+        """Open a new chat session row.
+
+        ``scope_profiles`` is the multi-profile ask scope sticky for this
+        session — Studio's dropdown and CLI's ``/ask-scope`` write through
+        :meth:`update_scope`. Empty / ``None`` means "use config default
+        (every saved DB profile)".
+        """
         now = time.time()
+        scope_json = json.dumps(list(scope_profiles)) if scope_profiles else None
         with self._history._lock, self._history._connect() as conn:
             cur = conn.execute(
                 """
                 INSERT INTO chat_sessions
-                    (db_profile, llm_profile, started_at, last_active_at, title)
-                VALUES (?, ?, ?, ?, ?)
+                    (db_profile, llm_profile, started_at, last_active_at, title,
+                     scope_profiles_json)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (str(db_profile), str(llm_profile), now, now, title),
+                (str(db_profile), str(llm_profile), now, now, title, scope_json),
             )
             return int(cur.lastrowid or 0)
 
@@ -115,6 +125,49 @@ class ChatSessionStore:
                 (int(session_id),),
             ).fetchone()
         return dict(row) if row else None
+
+    def update_scope(
+        self,
+        session_id: int,
+        *,
+        scope_profiles: list[str] | None,
+        focus_profile: str | None = None,
+    ) -> None:
+        """Replace the sticky scope on an existing session.
+
+        ``scope_profiles=None`` clears the override and falls back to
+        config default. ``focus_profile`` is the auto-detected
+        conversation focus (computed in tool_agent); the SPA stores it
+        for read-only display.
+        """
+        scope_json = json.dumps(list(scope_profiles)) if scope_profiles is not None else None
+        with self._history._lock, self._history._connect() as conn:
+            conn.execute(
+                "UPDATE chat_sessions SET scope_profiles_json = ?, "
+                "focus_profile = ?, last_active_at = ? WHERE id = ?",
+                (scope_json, focus_profile, time.time(), int(session_id)),
+            )
+
+    def get_scope(self, session_id: int) -> list[str] | None:
+        """Return the sticky scope for *session_id* or ``None`` when
+        unset (caller should fall back to config default)."""
+        with self._history._connect() as conn:
+            row = conn.execute(
+                "SELECT scope_profiles_json FROM chat_sessions WHERE id = ?",
+                (int(session_id),),
+            ).fetchone()
+        if not row:
+            return None
+        raw = row["scope_profiles_json"]
+        if not raw:
+            return None
+        try:
+            value = json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(value, list):
+            return None
+        return [str(name).strip() for name in value if str(name).strip()]
 
     def list_sessions(
         self,

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -391,6 +391,7 @@ def run_tool_agent(
     on_thinking_delta: Callable[[str], None] | None = None,
     on_tool_call: Callable[[dict[str, Any]], None] | None = None,
     cancel_token: threading.Event | None = None,
+    db_profiles: list[str] | None = None,
 ) -> ToolAgentResult:
     """Run the tool-calling loop and return the final synthesised answer.
 
@@ -402,6 +403,13 @@ def run_tool_agent(
     ``display`` is forwarded to the LLM call so reasoning models can stream
     their thinking text into the live thinking panel; for models that don't
     expose reasoning, it's a no-op.
+
+    ``db_profiles`` is the multi-profile retrieval scope — every catalog
+    tool call (``search_tables_by_concept``, ``find_joinable_tables``, …)
+    expands its WHERE clause to ``db_profile IN (?, ?, …)`` so a single
+    question can union evidence from N profiles. Empty / ``None`` falls
+    back to ``cfg.active_db_profile`` (legacy single-profile behaviour) so
+    pre-multi-profile callers keep working unchanged.
 
     The remaining kwargs are additive hooks AMX Studio's
     ``/api/ask`` SSE endpoint plugs into:
@@ -426,7 +434,7 @@ def run_tool_agent(
     # pool) is disposed at the end of every question. Without this, each
     # ``/ask`` turn leaks a few file descriptors; after enough turns the
     # process hits ``OSError: Too many open files`` (the user-reported case).
-    with ToolBox(cfg, catalog) as toolbox:
+    with ToolBox(cfg, catalog, db_profiles=db_profiles) as toolbox:
         return _run_tool_loop(
             toolbox=toolbox,
             cfg=cfg,

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -327,10 +327,20 @@ class SQLiteHistoryStore:
                     title TEXT,
                     turn_count INTEGER NOT NULL DEFAULT 0,
                     total_tokens INTEGER NOT NULL DEFAULT 0,
-                    compaction_state_json TEXT
+                    compaction_state_json TEXT,
+                    scope_profiles_json TEXT,
+                    focus_profile TEXT
                 )
                 """
             )
+            # Backwards-compatible migration for older history DBs created
+            # before multi-profile ask shipped (PR ask-multi-profile-A).
+            for stmt in (
+                "ALTER TABLE chat_sessions ADD COLUMN scope_profiles_json TEXT",
+                "ALTER TABLE chat_sessions ADD COLUMN focus_profile TEXT",
+            ):
+                with contextlib.suppress(sqlite3.OperationalError):
+                    conn.execute(stmt)
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_chat_sessions_profile_active "
                 "ON chat_sessions(db_profile, llm_profile, last_active_at DESC)"

--- a/amx/web/routers/ask.py
+++ b/amx/web/routers/ask.py
@@ -50,8 +50,69 @@ class AskRequest(BaseModel):
     )
     db_profile: str | None = Field(
         default=None,
-        description="Override the active DB profile for retrieval scope.",
+        description=(
+            "Anchor profile for chat session metadata (history rows, LLM "
+            "settings). The actual retrieval scope is the list in "
+            "``scope_profiles`` or, when omitted, the session's sticky scope "
+            "(see PATCH /api/ask/sessions/{id}). Kept for back-compat with "
+            "pre-multi-profile clients."
+        ),
     )
+    scope_profiles: list[str] | None = Field(
+        default=None,
+        description=(
+            "Multi-profile retrieval scope for THIS question. When provided, "
+            "overrides the session's sticky scope without persisting. To set "
+            "a sticky scope across the whole chat, PATCH /api/ask/sessions/"
+            "{id} instead."
+        ),
+    )
+
+
+class UpdateSessionRequest(BaseModel):
+    """Body for ``PATCH /api/ask/sessions/{id}`` — sticky scope update.
+
+    ``scope_profiles=None`` clears the override and the session falls back
+    to ``cfg.db_profiles.keys()``. ``focus_profile`` is informational
+    (auto-detected from prior turns) and persisted for cross-tab display.
+    """
+
+    scope_profiles: list[str] | None = None
+    focus_profile: str | None = None
+
+
+def _resolve_ask_scope(
+    cfg: AMXConfig,
+    body_scope: list[str] | None,
+    session_scope: list[str] | None,
+) -> list[str]:
+    """Pick the effective scope for a single ask request.
+
+    Precedence: per-question body > session sticky > config default.
+    Returns the dedup'd, valid list of DB profile names.
+    """
+    candidates: list[str] = []
+    if body_scope is not None:
+        candidates = list(body_scope)
+    elif session_scope is not None:
+        candidates = list(session_scope)
+    else:
+        # Default: every saved DB profile in the config. The user picked
+        # this in PR-A planning — Studio is multi-profile by default.
+        candidates = list(cfg.db_profiles.keys())
+    seen: set[str] = set()
+    out: list[str] = []
+    for name in candidates:
+        clean = (name or "").strip()
+        if not clean or clean in seen:
+            continue
+        if clean not in cfg.db_profiles:
+            # Drop ghost profiles (config edited mid-session) silently —
+            # the agent operates only on profiles that exist now.
+            continue
+        seen.add(clean)
+        out.append(clean)
+    return out
 
 
 @router.post("")
@@ -67,13 +128,29 @@ def submit_ask(
 
     session_id = body.session_id
     store = _session_store_or_none()
+
+    # Pull the session's sticky scope (set via PATCH /api/ask/sessions/{id})
+    # so an /ask without an explicit scope_profiles in the body still
+    # honours what the user picked in the dropdown for THIS chat.
+    session_scope: list[str] | None = None
+    if store is not None and session_id is not None:
+        try:
+            session_scope = store.get_scope(int(session_id))
+        except Exception:
+            session_scope = None
+
     if store is not None and session_id is None:
+        # First message of a new session — also seed the sticky scope so
+        # the SPA can resume cleanly if the page is reloaded.
+        initial_scope = list(body.scope_profiles) if body.scope_profiles is not None else None
         try:
             session_id = store.start_session(
                 db_profile=db_profile,
                 llm_profile=llm_profile,
                 title=body.question[:80],
+                scope_profiles=initial_scope,
             )
+            session_scope = initial_scope
         except Exception:
             session_id = None
     if store is not None and session_id is not None:
@@ -83,15 +160,56 @@ def submit_ask(
             # Persistence is best-effort — never fail the SSE handshake.
             pass
 
+    scope_profiles = _resolve_ask_scope(cfg, body.scope_profiles, session_scope)
+
     job = jobs.new_job("ask")
     thread = threading.Thread(
         target=_ask_worker,
-        args=(cfg, job, body.question, session_id, db_profile),
+        args=(cfg, job, body.question, session_id, db_profile, scope_profiles),
         name=f"amx-studio-ask-{job.id}",
         daemon=True,
     )
     thread.start()
-    return {"job_id": job.id, "session_id": session_id, "status": job.status}
+    return {
+        "job_id": job.id,
+        "session_id": session_id,
+        "status": job.status,
+        "scope_profiles": list(scope_profiles),
+    }
+
+
+@router.patch("/sessions/{session_id}")
+def update_session(
+    session_id: int,
+    body: UpdateSessionRequest,
+) -> dict[str, Any]:
+    """Update sticky scope (and optionally focus_profile) on a chat
+    session. The Studio dropdown writes through here so the new scope
+    persists across page reloads and shows on the CLI's ``/ask-scope``
+    output if the user inspects the same session.
+    """
+    store = _session_store_or_none()
+    if store is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Chat history isn't available — initialise the history store first.",
+        )
+    if store.get_session(session_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No chat session {session_id}.",
+        )
+    store.update_scope(
+        session_id,
+        scope_profiles=body.scope_profiles,
+        focus_profile=body.focus_profile,
+    )
+    return {
+        "ok": True,
+        "session_id": int(session_id),
+        "scope_profiles": body.scope_profiles,
+        "focus_profile": body.focus_profile,
+    }
 
 
 # NOTE: ``/sessions`` routes are declared BEFORE the ``/{job_id}``
@@ -239,10 +357,17 @@ def _ask_worker(
     question: str,
     session_id: int | None,
     db_profile: str,
+    scope_profiles: list[str],
 ) -> None:
     """Run the tool-calling agent + stream every reasoning chunk and
     tool result back to the SSE consumer. Persists the assistant
-    turn to chat_sessions on success."""
+    turn to chat_sessions on success.
+
+    ``scope_profiles`` is the resolved retrieval scope for this turn
+    (per-question body override > session sticky > config default).
+    Passed through to ``run_tool_agent`` which threads it into every
+    catalog tool call.
+    """
     job.status = "running"
     emit(job.queue, "activity.added", {"idx": 0, "label": "Thinking"})
     emit(job.queue, "activity.begin", {"idx": 0})
@@ -296,6 +421,7 @@ def _ask_worker(
             on_thinking_delta=_on_thinking,
             on_tool_call=_on_tool_call,
             cancel_token=job.cancel,
+            db_profiles=list(scope_profiles) if scope_profiles else None,
         )
     except RunCancelled:
         job.status = "cancelled"

--- a/tests/test_ask_toolbox_cache.py
+++ b/tests/test_ask_toolbox_cache.py
@@ -31,6 +31,11 @@ def _make_toolbox_with_counters() -> tuple[ToolBox, dict[str, int]]:
     tb._tool_cache = {}
     tb._tool_cache_hits = 0
     tb._UNCACHED_TOOLS = frozenset()
+    # Multi-profile cache key uses self.db_profiles tuple — set to a
+    # single-profile scope so the bypass-init test fixture doesn't
+    # crash on AttributeError when invoke() builds the key.
+    tb.db_profiles = ["test"]
+    tb.db_profile = "test"
 
     counters = {"echo": 0, "fail_echo": 0, "non_json": 0}
 

--- a/tests/test_toolbox_multi_profile.py
+++ b/tests/test_toolbox_multi_profile.py
@@ -1,0 +1,141 @@
+"""Multi-profile ToolBox + scope-resolution tests for PR ask-A.
+
+The actual catalog/SQL multi-profile path is exercised by
+``test_search_catalog_multi_profile.py`` against a real SQLite store —
+this file focuses on the agent-side glue: ToolBox correctly accepts a
+``db_profiles`` list, exposes ``db_profile_filter`` in the right
+shape, propagates the scope into the per-tool cache key, and the
+``run_tool_agent`` entry point forwards the kwarg into the ToolBox
+constructor.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from amx.config import AMXConfig, DBConfig
+from amx.search.agent_tools import ToolBox
+
+
+@pytest.fixture()
+def cfg_with_profiles() -> AMXConfig:
+    cfg = AMXConfig()
+    cfg.db_profiles = {
+        "alpha": DBConfig(backend="postgresql", host="a.local", database="appa"),
+        "beta": DBConfig(backend="postgresql", host="b.local", database="appb"),
+        "gamma": DBConfig(backend="snowflake", host="acct", account="acct"),
+    }
+    cfg.active_db_profile = "alpha"
+    cfg.active_db_profiles = []
+    cfg.db = cfg.db_profiles["alpha"]
+    return cfg
+
+
+def test_toolbox_single_profile_filter_returns_scalar(cfg_with_profiles) -> None:
+    catalog = MagicMock()
+    box = ToolBox(cfg_with_profiles, catalog, db_profiles=["alpha"])
+    assert box.db_profile == "alpha"
+    assert box.db_profiles == ["alpha"]
+    # Scalar in single-profile mode so ``db_profile = ?`` stays the
+    # cheap path through build_db_profile_clause.
+    assert box.db_profile_filter == "alpha"
+    assert box.is_multi_profile is False
+
+
+def test_toolbox_multi_profile_filter_returns_list(cfg_with_profiles) -> None:
+    catalog = MagicMock()
+    box = ToolBox(cfg_with_profiles, catalog, db_profiles=["alpha", "beta"])
+    assert box.db_profile == "alpha"  # anchor = first
+    assert box.db_profiles == ["alpha", "beta"]
+    assert box.db_profile_filter == ["alpha", "beta"]
+    assert box.is_multi_profile is True
+
+
+def test_toolbox_falls_back_to_effective_db_profiles(cfg_with_profiles) -> None:
+    """When the caller doesn't pass db_profiles, ToolBox reads
+    cfg.effective_db_profiles() (the multi-pick scope set by /use-db).
+    """
+    cfg_with_profiles.active_db_profiles = ["alpha", "beta", "gamma"]
+    catalog = MagicMock()
+    box = ToolBox(cfg_with_profiles, catalog)
+    assert box.db_profiles == ["alpha", "beta", "gamma"]
+    assert box.is_multi_profile is True
+
+
+def test_toolbox_dedupes_scope(cfg_with_profiles) -> None:
+    catalog = MagicMock()
+    box = ToolBox(cfg_with_profiles, catalog, db_profiles=["alpha", "alpha", "beta", "alpha"])
+    assert box.db_profiles == ["alpha", "beta"]
+
+
+def test_toolbox_scope_falls_back_to_active_when_empty(cfg_with_profiles) -> None:
+    cfg_with_profiles.active_db_profiles = []
+    catalog = MagicMock()
+    box = ToolBox(cfg_with_profiles, catalog)
+    assert box.db_profiles == ["alpha"]
+
+
+def test_cache_key_disambiguates_by_scope(cfg_with_profiles) -> None:
+    """Two ToolBox instances with different scopes must NOT share cache
+    entries — a multi-profile result is not interchangeable with a
+    single-profile one.
+    """
+    catalog = MagicMock()
+    catalog.search_tables = MagicMock(return_value=[])
+    box_single = ToolBox(cfg_with_profiles, catalog, db_profiles=["alpha"])
+    box_multi = ToolBox(cfg_with_profiles, catalog, db_profiles=["alpha", "beta"])
+
+    # Hand-poke the cache to verify keys are distinct shape.
+    box_single._tool_cache[("search_tables_by_concept", "{}", ("alpha",))] = "S"
+    box_multi._tool_cache[("search_tables_by_concept", "{}", ("alpha", "beta"))] = "M"
+
+    # The single-profile box should NOT see the multi-profile box's entry.
+    assert ("search_tables_by_concept", "{}", ("alpha", "beta")) not in box_single._tool_cache
+    # And vice-versa.
+    assert ("search_tables_by_concept", "{}", ("alpha",)) not in box_multi._tool_cache
+
+
+def test_run_tool_agent_passes_db_profiles_to_toolbox(cfg_with_profiles, monkeypatch) -> None:
+    """run_tool_agent threads its db_profiles kwarg into ToolBox()."""
+    captured: dict[str, object] = {}
+
+    class FakeBox:
+        def __init__(self, cfg, catalog, *, db_profiles=None, **kwargs):
+            captured["db_profiles"] = list(db_profiles) if db_profiles else None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    def fake_loop(**kwargs):
+        # Don't actually run the LLM loop; just confirm we got here.
+        from amx.search.tool_agent import ToolAgentResult
+
+        return ToolAgentResult(
+            answer="ok",
+            tool_calls=[],
+            iterations=0,
+            usage={},
+            finish_reason="stop",
+        )
+
+    from amx.search import tool_agent as _ta
+
+    monkeypatch.setattr(_ta, "ToolBox", FakeBox)
+    monkeypatch.setattr(_ta, "_run_tool_loop", fake_loop)
+
+    catalog = MagicMock()
+    llm = MagicMock()
+    _ta.run_tool_agent(
+        cfg=cfg_with_profiles,
+        catalog=catalog,
+        llm=llm,
+        question="anything",
+        answer_language="english",
+        db_profiles=["alpha", "beta"],
+    )
+    assert captured["db_profiles"] == ["alpha", "beta"]

--- a/tests/web/test_ask_scope.py
+++ b/tests/web/test_ask_scope.py
@@ -1,0 +1,144 @@
+"""Per-question + sticky scope plumbing tests for /api/ask.
+
+PR ask-A: AskRequest gains ``scope_profiles`` (per-question override),
+chat_sessions gains a ``scope_profiles_json`` column for sticky scope,
+and a new ``PATCH /api/ask/sessions/{id}`` lets the SPA's dropdown
+update the sticky scope without flipping global config.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amx.config import DBConfig
+from amx.web.routers import ask as ask_router
+
+
+@pytest.fixture()
+def cfg_with_profiles(cfg):
+    cfg.db_profiles["alpha"] = DBConfig(backend="postgresql", host="a", database="appa")
+    cfg.db_profiles["beta"] = DBConfig(backend="postgresql", host="b", database="appb")
+    cfg.db_profiles["gamma"] = DBConfig(backend="postgresql", host="c", database="appc")
+    cfg.active_db_profile = "alpha"
+    cfg.db = cfg.db_profiles["alpha"]
+    return cfg
+
+
+def test_resolve_ask_scope_dedupes_and_drops_ghosts(cfg_with_profiles) -> None:
+    out = ask_router._resolve_ask_scope(
+        cfg_with_profiles,
+        body_scope=["alpha", "alpha", "beta", "ghost"],
+        session_scope=None,
+    )
+    assert out == ["alpha", "beta"]
+
+
+def test_resolve_ask_scope_body_overrides_session(cfg_with_profiles) -> None:
+    out = ask_router._resolve_ask_scope(
+        cfg_with_profiles,
+        body_scope=["beta"],
+        session_scope=["alpha"],
+    )
+    assert out == ["beta"]
+
+
+def test_resolve_ask_scope_session_when_body_missing(cfg_with_profiles) -> None:
+    out = ask_router._resolve_ask_scope(
+        cfg_with_profiles,
+        body_scope=None,
+        session_scope=["beta", "gamma"],
+    )
+    assert out == ["beta", "gamma"]
+
+
+def test_resolve_ask_scope_falls_back_to_all_profiles(cfg_with_profiles) -> None:
+    out = ask_router._resolve_ask_scope(
+        cfg_with_profiles,
+        body_scope=None,
+        session_scope=None,
+    )
+    assert sorted(out) == ["alpha", "beta", "gamma"]
+
+
+def test_resolve_ask_scope_empty_body_distinct_from_none(cfg_with_profiles) -> None:
+    """Body=[] (explicit empty list) means "scope to nothing valid"
+    which collapses to []. Body=None falls back to session/default.
+    """
+    out_empty = ask_router._resolve_ask_scope(cfg_with_profiles, body_scope=[], session_scope=None)
+    assert out_empty == []
+    out_none = ask_router._resolve_ask_scope(cfg_with_profiles, body_scope=None, session_scope=None)
+    assert sorted(out_none) == ["alpha", "beta", "gamma"]
+
+
+def test_patch_session_scope_404_when_unknown(client, auth_headers, cfg_with_profiles) -> None:
+    """PATCH /api/ask/sessions/{id} returns 404 if the session is
+    missing or the history store isn't initialised yet."""
+    # Without a history store, the 503 fast-path applies.
+    response = client.patch(
+        "/api/ask/sessions/9999",
+        headers=auth_headers,
+        json={"scope_profiles": ["alpha"]},
+    )
+    assert response.status_code in (404, 503)
+
+
+def test_submit_ask_threads_scope_into_worker(
+    client, auth_headers, cfg_with_profiles, monkeypatch
+) -> None:
+    """The worker spawn carries the resolved scope so run_tool_agent
+    sees the per-question profiles."""
+    captured: dict[str, object] = {}
+
+    def fake_thread(*, target, args, name=None, daemon=None):
+        # _ask_worker(cfg, job, question, session_id, db_profile, scope_profiles)
+        captured["scope_profiles"] = list(args[5])
+
+        class _T:
+            def start(self_inner) -> None:
+                return None
+
+        return _T()
+
+    import threading as _th
+
+    monkeypatch.setattr(_th, "Thread", fake_thread)
+
+    response = client.post(
+        "/api/ask",
+        headers=auth_headers,
+        json={
+            "question": "test",
+            "scope_profiles": ["beta", "gamma"],
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["scope_profiles"] == ["beta", "gamma"]
+    assert captured["scope_profiles"] == ["beta", "gamma"]
+
+
+def test_submit_ask_falls_back_to_all_profiles(
+    client, auth_headers, cfg_with_profiles, monkeypatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_thread(*, target, args, name=None, daemon=None):
+        captured["scope_profiles"] = list(args[5])
+
+        class _T:
+            def start(self_inner) -> None:
+                return None
+
+        return _T()
+
+    import threading as _th
+
+    monkeypatch.setattr(_th, "Thread", fake_thread)
+
+    response = client.post(
+        "/api/ask",
+        headers=auth_headers,
+        json={"question": "no scope here"},
+    )
+    assert response.status_code == 200
+    # Default = every saved DB profile.
+    assert sorted(captured["scope_profiles"]) == ["alpha", "beta", "gamma"]


### PR DESCRIPTION
## Summary
- Foundational layer for cross-profile /ask: every catalog tool spans the configured DB profile list in a single SQL pass via `db_profile IN (?, ?, …)`, scope is sticky per chat session, and Studio + CLI surface the same kwargs.
- New `AskRequest.scope_profiles` (per-question override) + `chat_sessions.scope_profiles_json` (sticky) + `PATCH /api/ask/sessions/{id}` for the Studio dropdown to write through.
- `ToolBox.db_profile_filter` returns scalar in single-profile mode (cheap path) / list in multi-profile (IN-clause expansion). 6 catalog tools migrated. Cache key disambiguates by scope tuple.
- CLI parity: `short_circuits.py:289` bugfix (was dropping `SearchAgent.db_profiles`). New `/session scope` slash command mirrors the Studio dropdown without touching the persisted `/use-db` scope.

Live-DB fan-out (list_schemas across N profiles in parallel) and the aggressive cross-profile JOIN tool land in PR-B and PR-C respectively.

## Test plan
- [x] `pytest tests/` — 886 passing (5 pre-existing tests in test_ask_toolbox_cache.py adapted to new cache key shape via the bypass-init fixture)
- [x] New tests: 7 in `test_toolbox_multi_profile.py`, 7 in `test_ask_scope.py`
- [x] Ruff format + check clean
- [ ] Manual: with two profiles configured, ask "what tables match X" — every tool result row shows `db_profile` and the LLM can mention both profiles in the answer
- [ ] Manual: change session scope via `PATCH /api/ask/sessions/{id}` then re-ask — the next /api/ask response carries the new `scope_profiles` field
- [ ] Manual: CLI `/session scope a b` then `/search ask "..."` — short_circuits forwards the scope into the tool agent