### PR TITLE
fix(ask): resumed chats replay history into the agent

### DIFF
--- a/amx/web/routers/ask.py
+++ b/amx/web/routers/ask.py
@@ -380,6 +380,83 @@ def _event_generator(job: Job):
             break
 
 
+#: How many prior Q/A pairs to feed back into the agent when
+#: resuming a chat. The CLI's SessionMemoryMixin reads
+#: ``conversation_memory_turns`` from search settings (default 4);
+#: Studio mirrors that default — covers the typical "follow-up to a
+#: question 2-3 turns ago" pattern without ballooning the prompt.
+_MEMORY_TURN_PAIRS = 4
+
+
+def _load_session_memory(session_id: int | None) -> list[dict[str, Any]] | None:
+    """Hydrate the prior-turn context the agent loop replays.
+
+    When a Studio user reopens an old chat session and asks a follow-up,
+    ``run_tool_agent`` needs to see what was said before so references
+    like "that table", "the second one", "in Turkish" resolve. Without
+    this, every /ask in a resumed session looks like a fresh question
+    — exactly the user-reported "old chat forgot history" bug.
+
+    Skips the most-recent user row, which the caller has already
+    inserted via ``append_user_turn`` for the current question; if we
+    forwarded it the LLM would see the question twice and double-
+    process. Compaction summary rows are surfaced as a synthetic
+    ``user`` message tagged "(prior conversation summary)" so the
+    model uses them as context rather than treating them as the next
+    user turn.
+
+    Returns ``None`` when session memory isn't available (no session,
+    no history store, or fetch failed) — the agent loop treats that
+    identically to an empty list.
+    """
+    if not session_id:
+        return None
+    store = _session_store_or_none()
+    if store is None:
+        return None
+    try:
+        turns = store.recent_turns(
+            int(session_id),
+            limit=_MEMORY_TURN_PAIRS,
+            include_summary=True,
+            include_compacted=False,
+        )
+    except Exception as exc:  # pragma: no cover — best-effort
+        log.warning("Could not load chat history for session %s: %s", session_id, exc)
+        return None
+    if not turns:
+        return None
+    # Drop the trailing user-row that ``submit_ask`` just inserted for
+    # the question we're about to answer; sending it back would double-
+    # post the question into the conversation.
+    pruned = list(turns)
+    while pruned and pruned[-1].get("role") == "user":
+        pruned.pop()
+    memory: list[dict[str, Any]] = []
+    for turn in pruned:
+        role = str(turn.get("role") or "")
+        if role == "summary":
+            summary_text = str(turn.get("answer_summary") or "").strip()
+            if summary_text:
+                memory.append(
+                    {
+                        "role": "user",
+                        "content": "(prior conversation summary) " + summary_text,
+                    }
+                )
+            continue
+        if role == "user":
+            content = str(turn.get("question") or "").strip()
+            if content:
+                memory.append({"role": "user", "content": content})
+            continue
+        if role == "assistant":
+            content = str(turn.get("answer_summary") or "").strip()
+            if content:
+                memory.append({"role": "assistant", "content": content})
+    return memory or None
+
+
 def _ask_worker(
     cfg: AMXConfig,
     job: Job,
@@ -464,6 +541,13 @@ def _ask_worker(
             },
         )
 
+    # Hydrate the prior-turn context so a resumed chat can resolve
+    # follow-up references ("that table", "the second one"). Pulled
+    # from chat_sessions/chat_turns; ``submit_ask`` has already
+    # appended the current user question, so the loader trims the
+    # trailing user row to avoid double-posting.
+    session_memory = _load_session_memory(session_id)
+
     try:
         result = run_tool_agent(
             cfg=cfg,
@@ -471,7 +555,7 @@ def _ask_worker(
             llm=llm,
             question=question,
             answer_language=cfg.llm.language or "english",
-            session_memory=None,  # PR-D ships without session memory wiring; PR-E adds it.
+            session_memory=session_memory,
             display=None,
             on_thinking_delta=_on_thinking,
             on_tool_call=_on_tool_call,

--- a/tests/web/test_ask_session_memory.py
+++ b/tests/web/test_ask_session_memory.py
@@ -1,0 +1,133 @@
+"""Resumed chat sessions replay history into the tool agent.
+
+The bug report: opening an old /ask chat in Studio and asking a
+follow-up makes the agent forget all prior turns — references like
+"that table" or "the second one" never resolve. Root cause: the
+``_ask_worker`` had ``session_memory=None`` hardcoded with a TODO.
+
+These tests pin the contract: when ``session_id`` is supplied,
+``_ask_worker`` loads the recent Q/A pairs from ChatSessionStore and
+forwards them to ``run_tool_agent`` so the model sees prior context.
+"""
+
+from __future__ import annotations
+
+from amx.web.routers import ask as ask_router
+
+
+def test_load_session_memory_returns_none_when_no_session() -> None:
+    assert ask_router._load_session_memory(None) is None
+    assert ask_router._load_session_memory(0) is None
+
+
+def test_load_session_memory_returns_none_when_store_unavailable(monkeypatch) -> None:
+    """No history store (fresh CLI session) → no memory, agent runs
+    without prior context. Falls into the same code path as a brand-
+    new session."""
+    monkeypatch.setattr(ask_router, "_session_store_or_none", lambda: None)
+    assert ask_router._load_session_memory(42) is None
+
+
+def test_load_session_memory_drops_trailing_user_row(monkeypatch) -> None:
+    """The current user question was already inserted via
+    ``append_user_turn`` before the worker spawned. Forwarding it
+    back into ``run_tool_agent`` would post the question twice. The
+    loader trims trailing user rows to prevent that."""
+
+    class StubStore:
+        def recent_turns(self, *_args, **_kwargs):
+            return [
+                {"role": "user", "question": "what tables sell things?"},
+                {
+                    "role": "assistant",
+                    "answer_summary": "sales.orders, sales.invoices, sales.returns",
+                },
+                {"role": "user", "question": "show me the first one"},  # current
+            ]
+
+    monkeypatch.setattr(ask_router, "_session_store_or_none", lambda: StubStore())
+    memory = ask_router._load_session_memory(99)
+    assert memory == [
+        {"role": "user", "content": "what tables sell things?"},
+        {
+            "role": "assistant",
+            "content": "sales.orders, sales.invoices, sales.returns",
+        },
+    ]
+
+
+def test_load_session_memory_surfaces_summary_as_synthetic_user(monkeypatch) -> None:
+    """Compaction inserts ``role='summary'`` rows that carry forward
+    older context. We surface them as ``user`` messages tagged
+    ``(prior conversation summary)`` so the model treats them as
+    context, not as a real user turn."""
+
+    class StubStore:
+        def recent_turns(self, *_args, **_kwargs):
+            return [
+                {
+                    "role": "summary",
+                    "answer_summary": "User asked about SAP tables; we listed VBRK, VBAK, ADRC.",
+                },
+                {"role": "user", "question": "and the customers table?"},
+                {"role": "assistant", "answer_summary": "KNA1 holds master records."},
+                {"role": "user", "question": "any more?"},  # current — trimmed
+            ]
+
+    monkeypatch.setattr(ask_router, "_session_store_or_none", lambda: StubStore())
+    memory = ask_router._load_session_memory(7)
+    assert memory is not None
+    assert memory[0]["role"] == "user"
+    assert memory[0]["content"].startswith("(prior conversation summary)")
+    assert memory[1] == {"role": "user", "content": "and the customers table?"}
+    assert memory[2] == {
+        "role": "assistant",
+        "content": "KNA1 holds master records.",
+    }
+    assert len(memory) == 3  # trailing user trimmed
+
+
+def test_load_session_memory_skips_empty_content_rows(monkeypatch) -> None:
+    """Defensive — DB rows with NULL question/answer_summary don't
+    show up as empty bubbles in the LLM's context."""
+
+    class StubStore:
+        def recent_turns(self, *_args, **_kwargs):
+            return [
+                {"role": "user", "question": ""},  # empty user
+                {"role": "assistant", "answer_summary": "real answer"},
+                {"role": "assistant", "answer_summary": ""},  # empty assistant
+                {"role": "user", "question": "current"},  # trimmed
+            ]
+
+    monkeypatch.setattr(ask_router, "_session_store_or_none", lambda: StubStore())
+    memory = ask_router._load_session_memory(1)
+    assert memory == [{"role": "assistant", "content": "real answer"}]
+
+
+def test_load_session_memory_returns_none_when_only_current_user_turn(
+    monkeypatch,
+) -> None:
+    """First message of a brand-new session: the only row is the
+    current user question, which gets trimmed → no history → return
+    None so the agent loop skips the empty-memory branch."""
+
+    class StubStore:
+        def recent_turns(self, *_args, **_kwargs):
+            return [{"role": "user", "question": "first question"}]
+
+    monkeypatch.setattr(ask_router, "_session_store_or_none", lambda: StubStore())
+    assert ask_router._load_session_memory(1) is None
+
+
+def test_load_session_memory_handles_store_exception(monkeypatch) -> None:
+    """recent_turns() raising (corrupt DB, transient lock, …) doesn't
+    crash the worker — we return None and the agent runs without
+    prior context."""
+
+    class StubStore:
+        def recent_turns(self, *_args, **_kwargs):
+            raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(ask_router, "_session_store_or_none", lambda: StubStore())
+    assert ask_router._load_session_memory(1) is None


### PR DESCRIPTION
## Summary
Reported: opening an old /ask chat and asking a follow-up makes the agent forget all prior turns — "that table", "the second one" never resolve. Root cause: ``_ask_worker`` had ``session_memory=None`` hardcoded with a TODO that never got done. Chat rows are persisted, the sidebar reloads them, but the agent never sees them.

- New ``_load_session_memory(session_id)`` pulls the recent 4 Q/A pairs from ChatSessionStore.recent_turns and projects them into the ``[{role, content}]`` shape ``run_tool_agent`` already accepts.
- Trims the trailing user row (current question — already in the agent loop's main message list, would otherwise double-post).
- Compaction summaries surface as ``user`` messages tagged "(prior conversation summary)" so the model treats them as context, not as a real user turn.
- Empty rows / store exceptions handled defensively.

## Test plan
- [x] `pytest tests/` — 922 passing (7 new in `test_ask_session_memory.py`)
- [x] Ruff format + check clean
- [ ] Manual: ask "list tables in sales", get answer with sales.orders + sales.invoices, ask "describe the first one" → agent answers about sales.orders without you re-naming it
- [ ] Manual: long chat with compaction → newest turns flow through normally, older summary surfaces as prior-context