### PR TITLE
fix(ask): list_databases returns full reach per profile, not just pinned

### DIFF
--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -673,9 +673,18 @@ class ToolBox:
                 "function": {
                     "name": "list_databases",
                     "description": (
-                        "List the databases the agent currently has access to (one per active "
-                        "DB profile). Use this only when the user explicitly asks 'which "
-                        "databases do we have?' / 'hangi veritabanları var?'."
+                        "List EVERY database (or catalog, on 3-level backends) reachable "
+                        "across the configured DB profiles. Fans out per profile in "
+                        "parallel and returns ``profiles: {name: {databases|catalogs, "
+                        "pinned_database, pinned_catalog, supports_catalogs}}``. Use "
+                        "this when the user asks 'which databases do I have?', 'hangi "
+                        "veritabanları var?', 'show me all databases', 'what's in each "
+                        "profile?'. The result enumerates the full reach of every "
+                        "connection — NOT just the database currently pinned in each "
+                        "profile's config. When composing the answer, list ALL entries "
+                        "per profile, grouped by profile name; cite per-profile counts. "
+                        "Profiles that errored / timed out are reported in "
+                        "``profiles_with_errors`` so the caveat is honest."
                     ),
                     "parameters": {"type": "object", "properties": {}, "required": []},
                 },
@@ -2559,18 +2568,113 @@ class ToolBox:
         }
 
     def _tool_list_databases(self) -> dict[str, Any]:
-        rows = []
-        for profile_name, db_cfg in sorted(self.cfg.db_profiles.items()):
-            db_name = db_cfg.database or db_cfg.catalog or db_cfg.project or ""
-            rows.append(
-                {
-                    "profile": profile_name,
-                    "database": db_name,
-                    "backend": db_cfg.backend or "",
-                    "is_active": profile_name == (self.cfg.active_db_profile or "default"),
+        """List EVERY database (or catalog) reachable across the
+        configured DB profiles — not just the one each profile has
+        pinned.
+
+        For each profile in scope:
+        - 3-level backend (Databricks UC, BigQuery) → ``list_catalogs``
+          on that connector returns every catalog the role can see.
+        - 2-level backend (PostgreSQL, Snowflake, MySQL, …) →
+          ``list_databases`` returns every server-side database.
+
+        The legacy single-pinned-db output ("dbr → amx_test") was
+        misleading — when the user asks "which databases do I have"
+        they expect to see the full reach of each connection, not the
+        currently-pinned default. The tool now answers that literally.
+
+        Per-profile fan-out runs through the same ThreadPoolExecutor
+        the live-DB tools use (cap 8 workers, 8s per-profile timeout)
+        so a slow / unreachable profile doesn't block the others.
+        """
+        from concurrent.futures import ThreadPoolExecutor, wait
+
+        targets = list(self.db_profiles)
+        if not targets:
+            return {"profiles": {}, "count": 0, "scope": []}
+
+        def _per_profile(profile_name: str) -> dict[str, Any]:
+            base = self.cfg.db_profiles.get(profile_name)
+            backend = (str(getattr(base, "backend", "") or "") if base else "").lower()
+            try:
+                conn = self._connector_for_profile(profile_name)
+            except _ToolError as exc:
+                return {
+                    "db_profile": profile_name,
+                    "backend": backend,
+                    "error": str(exc),
+                    "databases": [],
+                    "catalogs": [],
                 }
-            )
-        return {"databases": rows, "count": len(rows)}
+            try:
+                supports_catalogs = bool(conn.supports_catalogs())
+            except Exception:
+                supports_catalogs = False
+            payload: dict[str, Any] = {
+                "db_profile": profile_name,
+                "backend": backend,
+                "supports_catalogs": supports_catalogs,
+                "pinned_database": (str(getattr(base, "database", "") or "") if base else "")
+                or None,
+                "pinned_catalog": (str(getattr(base, "catalog", "") or "") if base else "") or None,
+                "databases": [],
+                "catalogs": [],
+            }
+            try:
+                if supports_catalogs:
+                    payload["catalogs"] = [str(c) for c in conn.list_catalogs()]
+                else:
+                    payload["databases"] = [str(d) for d in conn.list_databases()]
+            except Exception as exc:
+                payload["error"] = f"{exc.__class__.__name__}: {exc}"
+            return payload
+
+        max_workers = min(self._LIVE_FANOUT_MAX_WORKERS, max(1, len(targets)))
+        per_profile: dict[str, dict[str, Any]] = {}
+        with ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="amx-toolbox-fanout-databases",
+        ) as pool:
+            future_map = {pool.submit(_per_profile, name): name for name in targets}
+            done, not_done = wait(future_map, timeout=self._LIVE_FANOUT_TIMEOUT_SEC)
+            for future in done:
+                name = future_map[future]
+                try:
+                    per_profile[name] = future.result(timeout=0)
+                except Exception as exc:
+                    per_profile[name] = {
+                        "db_profile": name,
+                        "error": f"{exc.__class__.__name__}: {exc}",
+                        "databases": [],
+                        "catalogs": [],
+                    }
+            for future in not_done:
+                name = future_map[future]
+                future.cancel()
+                per_profile[name] = {
+                    "db_profile": name,
+                    "timeout": True,
+                    "error": (f"timed out after {self._LIVE_FANOUT_TIMEOUT_SEC:.0f}s"),
+                    "databases": [],
+                    "catalogs": [],
+                }
+
+        total_dbs = sum(
+            len(p.get("databases") or []) + len(p.get("catalogs") or [])
+            for p in per_profile.values()
+        )
+        with_errors = [
+            name
+            for name, payload in per_profile.items()
+            if payload.get("error") or payload.get("timeout")
+        ]
+        return {
+            "scope": targets,
+            "profiles": per_profile,
+            "total_reachable": total_dbs,
+            "profiles_with_errors": with_errors,
+            "count": len(per_profile),
+        }
 
     # ------------------------------------------------------------ dtype family
     # Map a user-supplied dtype token to a concrete SQL-LIKE pattern set so

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -141,6 +141,12 @@ def _agent_system_prompt(
     # connected" when the user asks cross-DB questions. ``in_scope`` flags
     # which profiles the current question is allowed to retrieve from —
     # the LLM should only return data from those.
+    #
+    # The ``→ <name>`` after the backend is the profile's PINNED default
+    # database/catalog/project (not the only one reachable). Pinned
+    # values are connection-time defaults; each profile can list MANY
+    # databases/catalogs via ``list_databases`` — the LLM must not
+    # treat the pinned name as the full reach.
     in_scope = set(scope_profiles or [])
     profile_lines: list[str] = []
     active_name = cfg.active_db_profile or "default"
@@ -153,7 +159,9 @@ def _agent_system_prompt(
         marker = f" ({', '.join(markers)})" if markers else ""
         db_target = db_cfg.database or db_cfg.catalog or db_cfg.project or "?"
         backend = db_cfg.backend or "?"
-        profile_lines.append(f"  - {profile_name}{marker}: {backend} → {db_target}")
+        profile_lines.append(
+            f"  - {profile_name}{marker}: {backend} (default db/catalog: {db_target})"
+        )
     profiles_block = (
         "\n".join(profile_lines)
         if profile_lines
@@ -236,13 +244,23 @@ def _agent_system_prompt(
         "  present in a list_schemas response, just mention briefly which catalog\n"
         "  the schemas live in (one sentence) and continue with the user's actual\n"
         "  question — don't dwell.\n"
-        "* User asks 'which databases / hangi veritabanları' → call list_databases.\n"
+        "* User asks 'which databases / hangi veritabanları / what databases do\n"
+        "  I have / show me all databases' → call list_databases. The tool fans\n"
+        "  out per profile and returns the FULL list of databases (or catalogs\n"
+        "  on 3-level backends) reachable through each connection — NOT just\n"
+        "  the one pinned in each profile's config. When composing the answer,\n"
+        "  enumerate every entry per profile, grouped by profile name, with\n"
+        "  per-profile counts. If a profile errored / timed out, mention it\n"
+        "  honestly — don't pretend the partial result is the full picture.\n"
+        "  Do NOT just regurgitate the 'default db/catalog' shown in the\n"
+        "  profiles header above; that's the connection-time default, not the\n"
+        "  full reach.\n"
         "* User asks 'which catalogs / hangi cataloglar / show catalogs' → call list_catalogs.\n"
         "  Same tool also rescues 'show me tables' on a catalog-less Databricks profile.\n"
         "* User asks 'which databases live on this server / show databases / hangi\n"
         "  databaseler var bu sunucuda' on a 2-level backend (PostgreSQL, Snowflake,\n"
         "  MySQL, MSSQL, Redshift, ClickHouse) → call list_server_databases. Different\n"
-        "  from list_databases (which lists AMX DB profiles).\n"
+        "  from list_databases (which on multi-profile fans out across every profile).\n"
         "* User asks about Databricks Volumes ('any volumes', 'managed/external\n"
         "  volumes', 'volumes under <schema>', 'volumelar var mı', 'unity catalog\n"
         "  volume', 'storage volumes') → call list_volumes. Volumes are NOT exposed\n"

--- a/tests/test_list_databases_full_reach.py
+++ b/tests/test_list_databases_full_reach.py
@@ -1,0 +1,160 @@
+"""``list_databases`` returns full reach per profile, not just the pinned one.
+
+Reported: Studio's /ask says "You have 2 database profiles available:
+dbr → amx_test on Databricks, and test-postgre → bird_train_desc on
+PostgreSQL". Each profile shows ONE database — the one pinned in that
+profile's config — even though both connections expose more
+databases / catalogs than that.
+
+Root cause: ``_tool_list_databases`` enumerated ``cfg.db_profiles``
+and surfaced each profile's pinned database/catalog/project field
+verbatim. To answer the literal question "which databases do I have"
+we need to call each profile's connector and list every reachable
+database (or catalog on 3-level backends).
+
+These tests pin the new contract: per-profile fan-out, full list
+returned, error-tolerant.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from amx.config import AMXConfig, DBConfig
+from amx.search.agent_tools import ToolBox
+
+
+@pytest.fixture()
+def cfg_two_profiles() -> AMXConfig:
+    cfg = AMXConfig()
+    cfg.db_profiles = {
+        "dbr": DBConfig(
+            backend="databricks",
+            host="dbc-xxx.databricks.com",
+            catalog="amx_test",
+        ),
+        "test-postgre": DBConfig(
+            backend="postgresql",
+            host="pg.local",
+            database="bird_train_desc",
+        ),
+    }
+    cfg.active_db_profile = "test-postgre"
+    cfg.active_db_profiles = ["dbr", "test-postgre"]
+    cfg.db = cfg.db_profiles["test-postgre"]
+    return cfg
+
+
+def _stub_pg_connector(databases: list[str]) -> MagicMock:
+    conn = MagicMock()
+    conn.supports_catalogs = MagicMock(return_value=False)
+    conn.list_databases = MagicMock(return_value=databases)
+    conn.list_catalogs = MagicMock(return_value=[])
+    return conn
+
+
+def _stub_databricks_connector(catalogs: list[str]) -> MagicMock:
+    conn = MagicMock()
+    conn.supports_catalogs = MagicMock(return_value=True)
+    conn.list_catalogs = MagicMock(return_value=catalogs)
+    conn.list_databases = MagicMock(return_value=[])
+    return conn
+
+
+def test_list_databases_returns_all_per_profile(cfg_two_profiles) -> None:
+    """The bug-report scenario: 2 profiles, each with multiple
+    databases / catalogs visible. The tool must surface ALL of them,
+    grouped by profile, not just the pinned ones."""
+    box = ToolBox(
+        cfg_two_profiles,
+        MagicMock(),
+        db_profiles=["dbr", "test-postgre"],
+        db_connectors={
+            "dbr": _stub_databricks_connector(["amx_test", "samples", "main", "system"]),
+            "test-postgre": _stub_pg_connector(["bird_train_desc", "postgres", "analytics", "raw"]),
+        },
+    )
+    result = box._tool_list_databases()
+
+    assert sorted(result["scope"]) == ["dbr", "test-postgre"]
+    assert result["count"] == 2
+    assert result["profiles_with_errors"] == []
+
+    dbr = result["profiles"]["dbr"]
+    assert dbr["supports_catalogs"] is True
+    assert dbr["catalogs"] == ["amx_test", "samples", "main", "system"]
+    assert dbr["pinned_catalog"] == "amx_test"
+
+    pg = result["profiles"]["test-postgre"]
+    assert pg["supports_catalogs"] is False
+    assert pg["databases"] == ["bird_train_desc", "postgres", "analytics", "raw"]
+    assert pg["pinned_database"] == "bird_train_desc"
+
+    # Total reach across BOTH profiles, not just the pinned ones.
+    assert result["total_reachable"] == 4 + 4
+
+
+def test_list_databases_propagates_errors_per_profile(cfg_two_profiles) -> None:
+    """One profile's connection refuses (auth, network) → that
+    profile reports the error, the other still returns its full
+    reach. Partial results, never blocked."""
+    bad = MagicMock()
+    bad.supports_catalogs = MagicMock(return_value=False)
+    bad.list_databases = MagicMock(side_effect=RuntimeError("auth failed"))
+
+    box = ToolBox(
+        cfg_two_profiles,
+        MagicMock(),
+        db_profiles=["dbr", "test-postgre"],
+        db_connectors={
+            "dbr": _stub_databricks_connector(["amx_test", "main"]),
+            "test-postgre": bad,
+        },
+    )
+    result = box._tool_list_databases()
+
+    assert "test-postgre" in result["profiles_with_errors"]
+    assert "auth failed" in result["profiles"]["test-postgre"]["error"]
+    # The healthy profile still returned its reach.
+    assert result["profiles"]["dbr"]["catalogs"] == ["amx_test", "main"]
+
+
+def test_list_databases_falls_back_to_pinned_when_no_reach(cfg_two_profiles) -> None:
+    """When the live connector returns an empty list (role can only
+    see the pinned db), the pinned name is still surfaced via
+    ``pinned_database`` / ``pinned_catalog`` so the LLM doesn't lose
+    the hint that the connection is configured."""
+    empty_pg = _stub_pg_connector([])
+    empty_dbr = _stub_databricks_connector([])
+
+    box = ToolBox(
+        cfg_two_profiles,
+        MagicMock(),
+        db_profiles=["dbr", "test-postgre"],
+        db_connectors={"dbr": empty_dbr, "test-postgre": empty_pg},
+    )
+    result = box._tool_list_databases()
+    assert result["profiles"]["dbr"]["catalogs"] == []
+    assert result["profiles"]["dbr"]["pinned_catalog"] == "amx_test"
+    assert result["profiles"]["test-postgre"]["databases"] == []
+    assert result["profiles"]["test-postgre"]["pinned_database"] == "bird_train_desc"
+
+
+def test_list_databases_single_profile_scope(cfg_two_profiles) -> None:
+    """Single-profile scope still uses the per-profile envelope —
+    consistent shape regardless of scope size means the LLM doesn't
+    branch its rendering on profile count."""
+    box = ToolBox(
+        cfg_two_profiles,
+        MagicMock(),
+        db_profiles=["test-postgre"],
+        db_connectors={
+            "test-postgre": _stub_pg_connector(["a", "b", "c"]),
+        },
+    )
+    result = box._tool_list_databases()
+    assert result["scope"] == ["test-postgre"]
+    assert result["count"] == 1
+    assert result["profiles"]["test-postgre"]["databases"] == ["a", "b", "c"]


### PR DESCRIPTION
## Summary
Reported: /ask "which databases do I have" answers "dbr → amx_test, test-postgre → bird_train_desc" — only the pinned database per profile, not the full reach. User expected the full enumeration of every database/catalog visible through each connection.

- Root cause: ``_tool_list_databases`` returned each profile's config-pinned ``database``/``catalog``/``project`` verbatim instead of querying the live connector.
- Fix: tool now fans out per profile via ThreadPoolExecutor (cap 8, 8s per-profile timeout — same machinery as PR-B's list_schemas / list_tables_in_schema). For each profile, probes ``supports_catalogs()`` then dispatches to ``list_catalogs()`` (3-level) or ``list_databases()`` (2-level).
- Result shape: ``{scope, profiles: {name: {backend, supports_catalogs, pinned_database, pinned_catalog, databases, catalogs, error?, timeout?}}, total_reachable, profiles_with_errors}``. Pinned names still surface for restricted roles where the live list is empty.
- System prompt clarifies "default db/catalog" wording (vs "→ X") and the routing guidance for the question explicitly says "do NOT regurgitate the default — enumerate every entry per profile".

## Test plan
- [x] `pytest tests/` — 926 passing (4 new in `test_list_databases_full_reach.py`)
- [x] Ruff format + check clean
- [ ] Manual: Studio /ask "which databases do I have" with 2 profiles configured (Databricks + Postgres) → response groups by profile, lists EVERY catalog on Databricks side and EVERY database on Postgres side, with per-profile counts
- [ ] Manual: kill one profile's connection → bad profile reports error, good profile still returns full reach