### PR TITLE
fix(profiles): allow deleting the active or last DB / LLM profile

### DIFF
--- a/amx/config.py
+++ b/amx/config.py
@@ -1681,20 +1681,35 @@ class AMXConfig:
         self._autosave()
 
     def remove_db_profile(self, name: str) -> None:
+        """Remove a DB profile. The user can wipe the last one too —
+        AMX surfaces the empty-config state via prompts and gates
+        downstream features (``/ask``, browse) cleanly when there is
+        no profile to operate on. Refusing the deletion forced a
+        roundabout reset (add throwaway → activate → delete → delete
+        throwaway) that's no easier than letting the user clear and
+        re-add from scratch.
+        """
         if name not in self.db_profiles:
             raise KeyError(f"Unknown DB profile: {name}")
-        if name == self.active_db_profile and len(self.db_profiles) == 1:
-            raise ValueError("Cannot remove the last DB profile")
         del self.db_profiles[name]
         # 0.11.0: also evict from the multi-pick scope to prevent ghost
         # selections after a profile is removed.
         if name in self.active_db_profiles:
             self.active_db_profiles = [n for n in self.active_db_profiles if n != name]
         if self.active_db_profile == name:
-            self.active_db_profile = next(iter(self.db_profiles.keys()))
-            self.db = self.db_profiles[self.active_db_profile]
-            if not self.active_db_profiles:
-                self.active_db_profiles = [self.active_db_profile]
+            # Promote the next available profile when there is one;
+            # otherwise clear the active pointer + reset cfg.db to an
+            # empty DBConfig so callers reading those fields don't see
+            # stale data from the just-deleted profile.
+            if self.db_profiles:
+                self.active_db_profile = next(iter(self.db_profiles.keys()))
+                self.db = self.db_profiles[self.active_db_profile]
+                if not self.active_db_profiles:
+                    self.active_db_profiles = [self.active_db_profile]
+            else:
+                self.active_db_profile = ""
+                self.db = DBConfig()
+                self.active_db_profiles = []
         self._autosave()
 
     def apply_active_llm_profile(self) -> None:
@@ -1732,14 +1747,27 @@ class AMXConfig:
         self._autosave()
 
     def remove_llm_profile(self, name: str) -> None:
+        """Remove an LLM profile. Symmetric with :meth:`remove_db_profile`
+        — the user can wipe the last one. ``/ask`` already gates on
+        :func:`SearchAgent._llm_available`; deleting the last LLM puts
+        AMX in the same state as a fresh install (no LLM configured),
+        and downstream surfaces (Studio /ask, CLI /search ask) show
+        the "configure an LLM profile" prompt.
+        """
         if name not in self.llm_profiles:
             raise KeyError(f"Unknown LLM profile: {name}")
-        if name == self.active_llm_profile and len(self.llm_profiles) == 1:
-            raise ValueError("Cannot remove the last LLM profile")
         del self.llm_profiles[name]
         if self.active_llm_profile == name:
-            self.active_llm_profile = next(iter(self.llm_profiles.keys()))
-            self.llm = replace(self.llm_profiles[self.active_llm_profile])
+            if self.llm_profiles:
+                self.active_llm_profile = next(iter(self.llm_profiles.keys()))
+                self.llm = replace(self.llm_profiles[self.active_llm_profile])
+            else:
+                # No remaining profiles → clear active pointer and reset
+                # cfg.llm to an empty LLMConfig. The /ask surfaces that
+                # state via the configure-llm 412 (Studio) and the
+                # `/search` discussion-requires-LLM message (CLI).
+                self.active_llm_profile = ""
+                self.llm = LLMConfig()
         if self.rag_llm_profile == name:
             self.rag_llm_profile = ""
         self._autosave()

--- a/amx/web/routers/profiles.py
+++ b/amx/web/routers/profiles.py
@@ -202,19 +202,26 @@ def upsert_db(
 
 @router.delete("/db/{name}")
 def delete_db(name: str, cfg: AMXConfig = Depends(get_cfg)) -> dict[str, Any]:
+    """Delete a DB profile. The active profile and the last remaining
+    profile can both be deleted — Studio surfaces the empty-config
+    state via the browse sidebar's "no profiles yet" empty state and
+    the /ask 412 ``configure-llm`` flow. Refusing the deletion forced
+    a roundabout reset; matching the CLI's ``/remove-db-profile``
+    behaviour means the SPA stops requiring users to first add a
+    decoy profile + activate it before they can clean up."""
     if name not in cfg.db_profiles:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No DB profile named {name!r}.",
         )
-    if name == (cfg.active_db_profile or ""):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot delete the active DB profile. Activate another profile first.",
-        )
-    del cfg.db_profiles[name]
+    cfg.remove_db_profile(name)
     cfg.save()
-    return {"ok": True, "name": name, "remaining": len(cfg.db_profiles)}
+    return {
+        "ok": True,
+        "name": name,
+        "remaining": len(cfg.db_profiles),
+        "active": cfg.active_db_profile or None,
+    }
 
 
 @router.post("/db/{name}/activate")
@@ -295,19 +302,25 @@ def upsert_llm(
 
 @router.delete("/llm/{name}")
 def delete_llm(name: str, cfg: AMXConfig = Depends(get_cfg)) -> dict[str, Any]:
+    """Delete an LLM profile. The active profile and the last
+    remaining profile can both be deleted — /ask gates on
+    :func:`SearchAgent._llm_available` (CLI) and the configure-llm
+    412 pre-flight (Studio), so an empty config surfaces a friendly
+    "configure an LLM profile" prompt rather than failing silently.
+    """
     if name not in cfg.llm_profiles:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No LLM profile named {name!r}.",
         )
-    if name == (cfg.active_llm_profile or ""):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot delete the active LLM profile. Activate another first.",
-        )
-    del cfg.llm_profiles[name]
+    cfg.remove_llm_profile(name)
     cfg.save()
-    return {"ok": True, "name": name, "remaining": len(cfg.llm_profiles)}
+    return {
+        "ok": True,
+        "name": name,
+        "remaining": len(cfg.llm_profiles),
+        "active": cfg.active_llm_profile or None,
+    }
 
 
 @router.post("/llm/{name}/activate")

--- a/tests/test_remove_last_profile.py
+++ b/tests/test_remove_last_profile.py
@@ -1,0 +1,125 @@
+"""Last / active profile deletion is allowed.
+
+Reported: AMX refused to delete the active or last DB / LLM profile
+("Cannot remove the last DB profile", "Cannot delete the active LLM
+profile"). Forced a roundabout reset (add throwaway → activate →
+delete → delete throwaway). The user wants the simpler "if I want to
+clear everything, let me clear everything" semantics — Studio and
+CLI both surface the empty-config state cleanly downstream.
+
+These tests pin the new behaviour at the config layer (which the
+web routers and CLI commands both compose).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amx.config import AMXConfig, DBConfig, LLMConfig
+
+
+@pytest.fixture()
+def cfg_one_db_one_llm() -> AMXConfig:
+    cfg = AMXConfig()
+    cfg.db_profiles = {"only-db": DBConfig(backend="postgresql", host="x")}
+    cfg.active_db_profile = "only-db"
+    cfg.active_db_profiles = ["only-db"]
+    cfg.llm_profiles = {"only-llm": LLMConfig(provider="openai", model="gpt-4o")}
+    cfg.active_llm_profile = "only-llm"
+    return cfg
+
+
+def test_remove_last_db_profile_clears_active(cfg_one_db_one_llm) -> None:
+    """The single DB profile can be deleted. cfg.db_profiles ends
+    empty, active pointer cleared, cfg.db reset so callers don't see
+    stale data from the deleted profile."""
+    cfg_one_db_one_llm.remove_db_profile("only-db")
+    assert cfg_one_db_one_llm.db_profiles == {}
+    assert cfg_one_db_one_llm.active_db_profile == ""
+    assert cfg_one_db_one_llm.active_db_profiles == []
+    # cfg.db is a fresh empty DBConfig, not the deleted profile.
+    assert cfg_one_db_one_llm.db.host != "x"
+
+
+def test_remove_last_llm_profile_clears_active(cfg_one_db_one_llm) -> None:
+    """The single LLM profile can be deleted. cfg.llm reset to an
+    empty LLMConfig so /ask sees an unconfigured state and surfaces
+    the friendly "configure LLM" prompt."""
+    cfg_one_db_one_llm.remove_llm_profile("only-llm")
+    assert cfg_one_db_one_llm.llm_profiles == {}
+    assert cfg_one_db_one_llm.active_llm_profile == ""
+    assert (cfg_one_db_one_llm.llm.provider or "") == ""
+    assert (cfg_one_db_one_llm.llm.model or "") == ""
+
+
+def test_remove_active_db_profile_promotes_next() -> None:
+    """When others exist, removing the active profile promotes the
+    next available one — no manual /use-db activation step needed."""
+    cfg = AMXConfig()
+    cfg.db_profiles = {
+        "alpha": DBConfig(backend="postgresql", host="a"),
+        "beta": DBConfig(backend="postgresql", host="b"),
+    }
+    cfg.active_db_profile = "alpha"
+    cfg.active_db_profiles = ["alpha"]
+    cfg.remove_db_profile("alpha")
+    assert "alpha" not in cfg.db_profiles
+    assert cfg.active_db_profile == "beta"
+
+
+def test_remove_active_llm_profile_promotes_next() -> None:
+    cfg = AMXConfig()
+    cfg.llm_profiles = {
+        "first": LLMConfig(provider="openai", model="gpt-4o"),
+        "second": LLMConfig(provider="anthropic", model="claude-3"),
+    }
+    cfg.active_llm_profile = "first"
+    cfg.remove_llm_profile("first")
+    assert "first" not in cfg.llm_profiles
+    assert cfg.active_llm_profile == "second"
+    # cfg.llm reflects the newly-promoted profile so downstream
+    # callers reading cfg.llm.provider / .model see the right thing.
+    assert cfg.llm.provider == "anthropic"
+
+
+def test_remove_inactive_db_profile_keeps_active_pointer() -> None:
+    cfg = AMXConfig()
+    cfg.db_profiles = {
+        "alpha": DBConfig(backend="postgresql", host="a"),
+        "beta": DBConfig(backend="postgresql", host="b"),
+    }
+    cfg.active_db_profile = "alpha"
+    cfg.remove_db_profile("beta")
+    assert cfg.active_db_profile == "alpha"
+
+
+def test_llm_available_returns_false_after_last_delete(cfg_one_db_one_llm) -> None:
+    """After wiping the last LLM profile, ``SearchAgent._llm_available``
+    must return False so /ask shows the configure-llm prompt instead
+    of trying to dispatch with an empty provider."""
+    from amx.search._agent.session_memory import SessionMemoryMixin
+
+    # Simulate the SearchAgent's check by reading the same fields.
+    cfg_one_db_one_llm.remove_llm_profile("only-llm")
+
+    # Mirror SessionMemoryMixin._llm_available's logic verbatim — the
+    # method itself needs `self.settings`/`self.cfg` so we replay
+    # the underlying read.
+    has_provider = bool(getattr(cfg_one_db_one_llm.llm, "provider", ""))
+    has_model = bool(getattr(cfg_one_db_one_llm.llm, "model", ""))
+    assert not (has_provider and has_model)
+    # Reference the mixin so the import is exercised by the test
+    # (catches accidental rename/removal of the method).
+    assert hasattr(SessionMemoryMixin, "_llm_available")
+
+
+def test_remove_unknown_profile_still_raises() -> None:
+    """Trying to remove a name that doesn't exist still raises
+    KeyError — no silent failure that masks typos."""
+    cfg = AMXConfig()
+    cfg.db_profiles = {"a": DBConfig()}
+    with pytest.raises(KeyError):
+        cfg.remove_db_profile("nonexistent")
+    cfg.llm_profiles = {"a": LLMConfig()}
+    with pytest.raises(KeyError):
+        cfg.remove_llm_profile("nonexistent")

--- a/tests/web/test_profiles.py
+++ b/tests/web/test_profiles.py
@@ -98,11 +98,36 @@ def test_put_db_profile_drops_unknown_fields(client, auth_headers) -> None:
     assert response.status_code == 200
 
 
-def test_delete_db_profile_blocks_active(client, auth_headers, cfg) -> None:
+def test_delete_db_profile_active_promotes_next(client, auth_headers, cfg) -> None:
+    """Deleting the active profile when others exist promotes the
+    next remaining one. The user no longer has to manually activate
+    a different profile before they can clean up."""
     _set_db_profile(cfg, "prod", backend="postgresql", host="x")
+    _set_db_profile(cfg, "stage", backend="postgresql", host="y")
     cfg.active_db_profile = "prod"
     response = client.delete("/api/profiles/db/prod", headers=auth_headers)
-    assert response.status_code == 400
+    assert response.status_code == 200
+    assert "prod" not in cfg.db_profiles
+    # Active pointer migrated to the remaining profile.
+    assert cfg.active_db_profile == "stage"
+    body = response.json()
+    assert body["active"] == "stage"
+    assert body["remaining"] == 1
+
+
+def test_delete_db_profile_last_one_clears_active(client, auth_headers, cfg) -> None:
+    """User can wipe the only profile they have. The downstream
+    surfaces (browse sidebar, /ask configure-llm flow, etc.) handle
+    the empty-config state with friendly prompts."""
+    _set_db_profile(cfg, "only", backend="postgresql", host="x")
+    cfg.active_db_profile = "only"
+    response = client.delete("/api/profiles/db/only", headers=auth_headers)
+    assert response.status_code == 200
+    assert cfg.db_profiles == {}
+    assert cfg.active_db_profile == ""
+    body = response.json()
+    assert body["active"] is None
+    assert body["remaining"] == 0
 
 
 def test_delete_db_profile_removes_inactive(client, auth_headers, cfg) -> None:
@@ -112,6 +137,7 @@ def test_delete_db_profile_removes_inactive(client, auth_headers, cfg) -> None:
     response = client.delete("/api/profiles/db/stage", headers=auth_headers)
     assert response.status_code == 200
     assert "stage" not in cfg.db_profiles
+    assert cfg.active_db_profile == "prod"
 
 
 def test_activate_db_profile_404_for_unknown(client, auth_headers) -> None:
@@ -181,6 +207,38 @@ def test_llm_profile_activate(client, auth_headers, cfg) -> None:
     response = client.post("/api/profiles/llm/gpt4/activate", headers=auth_headers)
     assert response.status_code == 200
     assert cfg.active_llm_profile == "gpt4"
+
+
+def test_delete_llm_profile_active_promotes_next(client, auth_headers, cfg) -> None:
+    """Same as DB: deleting the active LLM with others present
+    promotes the next remaining profile so the user can clean up
+    without an extra activation roundtrip."""
+    _set_llm_profile(cfg, "gpt4", provider="openai", model="gpt-4o")
+    _set_llm_profile(cfg, "claude", provider="anthropic", model="claude-3")
+    cfg.active_llm_profile = "gpt4"
+    response = client.delete("/api/profiles/llm/gpt4", headers=auth_headers)
+    assert response.status_code == 200
+    assert "gpt4" not in cfg.llm_profiles
+    assert cfg.active_llm_profile == "claude"
+
+
+def test_delete_llm_profile_last_one_clears_active(client, auth_headers, cfg) -> None:
+    """User can wipe the only LLM profile. The /ask 412 pre-flight
+    (Studio) and ``_llm_available()`` check (CLI) both surface a
+    "configure an LLM profile" prompt for the resulting empty
+    state."""
+    _set_llm_profile(cfg, "only", provider="openai", model="gpt-4o")
+    cfg.active_llm_profile = "only"
+    response = client.delete("/api/profiles/llm/only", headers=auth_headers)
+    assert response.status_code == 200
+    assert cfg.llm_profiles == {}
+    assert cfg.active_llm_profile == ""
+    # cfg.llm reset to a default empty LLMConfig — no stale provider
+    # leaking from the just-deleted profile.
+    assert (cfg.llm.provider or "") == ""
+    body = response.json()
+    assert body["active"] is None
+    assert body["remaining"] == 0
 
 
 def test_doc_profile_listing(client, auth_headers, cfg) -> None:


### PR DESCRIPTION
## Summary
Reported: with one DB / LLM profile left, deletion was refused ("Cannot remove the last DB profile" / "Cannot delete the active LLM profile"). Forced a roundabout reset (add throwaway → activate → delete original → delete throwaway).

- ``remove_db_profile`` / ``remove_llm_profile`` no longer guard on "active + last" — when others remain, the next is promoted; when none remain, active pointer clears and ``cfg.db`` / ``cfg.llm`` reset to empties.
- DELETE /api/profiles/db/{name} and /api/profiles/llm/{name} drop the 400 active-profile short-circuit; delegate to the config layer; return resulting ``active`` (null when none) + ``remaining`` so the Studio Settings UI refreshes.
- CLI commands already delegate to cfg.remove_*_profile so they inherit the new behaviour.

The "configure an LLM profile" prompt the user asked about already exists on both surfaces — verified:
- Studio: PR #172's 412 + ``configure-llm`` hint → ``AskErrorBanner`` with "Open LLM settings" + "Run doctor" CTAs.
- CLI: ``SearchAgent._llm_available()`` gates /search ask with "Configure one under /llm first" (search/agent.py:274).

## Test plan
- [x] `pytest tests/` — 936 passing (7 new in `test_remove_last_profile.py`, 3 updated in `test_profiles.py`)
- [x] Ruff format + check clean
- [ ] Manual Studio: Settings → only LLM profile → delete → it disappears, /ask now shows "Couldn't reach the LLM" banner with Settings CTA
- [ ] Manual CLI: `/remove-db-profile <only-name>` → succeeds, `/db-profiles` empty