### PR TITLE
fix(ask): CLI Ctrl-C cancels the running ask cleanly

### DIFF
--- a/amx/cli_support/commands/search.py
+++ b/amx/cli_support/commands/search.py
@@ -538,11 +538,59 @@ def _run_search_ask_body(
             model=cfg.llm.model,
         )
         started_display = True
+    # Ctrl-C cancellation: install a temporary SIGINT handler that sets
+    # a threading.Event the agent loop polls between iterations. Without
+    # this, a long-running LLM call (or a chained tool call sequence)
+    # had to drain to completion before Python's default KeyboardInterrupt
+    # path could reach the user — they reported "Ctrl-C can't end the
+    # ask session". The handler ALSO raises KeyboardInterrupt the second
+    # time it fires so a stuck HTTP socket eventually unblocks; the
+    # first press just sets the flag for a graceful between-iteration
+    # exit. Restored in ``finally`` so the REPL's own SIGINT handling
+    # (return-to-prompt on Ctrl-C) takes over after the ask returns.
+    import signal as _signal
+    import threading as _threading
+
+    cancel_token = _threading.Event()
+    interrupt_count = {"n": 0}
+    previous_handler = _signal.getsignal(_signal.SIGINT)
+
+    def _on_sigint(_signum, _frame):
+        interrupt_count["n"] += 1
+        cancel_token.set()
+        # First press: set the flag and let the agent loop exit cleanly.
+        # Second press: raise so any blocked I/O (e.g. mid-stream HTTP
+        # read that ignored the flag) terminates immediately.
+        if interrupt_count["n"] >= 2:
+            raise KeyboardInterrupt
+
     try:
-        answer = svc.ask(question_text)
+        _signal.signal(_signal.SIGINT, _on_sigint)
+    except Exception:
+        # Worker threads / Windows compat: fall through to default.
+        previous_handler = None
+    try:
+        answer = svc.ask(question_text, cancel_token=cancel_token)
+    except KeyboardInterrupt:
+        from amx.search.catalog import SearchAnswer
+
+        answer = SearchAnswer(
+            intent="cancelled",
+            question=question_text,
+            rows=[],
+            confidence="low",
+            summary="Cancelled by user.",
+            provenance=["user_cancelled"],
+            details={"reason": "cancelled_by_user"},
+        )
     finally:
         if started_display:
             display.stop()
+        if previous_handler is not None:
+            try:
+                _signal.signal(_signal.SIGINT, previous_handler)
+            except Exception:
+                pass
     hs = history_store()
     run_id: int | None = None
     if hs is not None:

--- a/amx/search/_agent/short_circuits.py
+++ b/amx/search/_agent/short_circuits.py
@@ -18,9 +18,11 @@ answer instead:
 from __future__ import annotations
 
 import re
+import threading
 import time
 from typing import Any
 
+from amx.agents.orchestrator import RunCancelled
 from amx.search._agent._types import SearchPlan
 from amx.search.catalog import SearchAnswer
 from amx.utils.console import step_spinner
@@ -235,6 +237,7 @@ class ShortCircuitsMixin:
         question: str,
         clean_question: str,
         question_language: str,
+        cancel_token: threading.Event | None = None,
     ) -> SearchAnswer | None:
         """Run the tool-calling loop and return a SearchAnswer.
 
@@ -300,8 +303,16 @@ class ShortCircuitsMixin:
                     session_memory=prior_turns,
                     display=display if display.is_active else None,
                     db_profiles=list(self.db_profiles) if self.db_profiles else None,
+                    cancel_token=cancel_token,
                 )
             elapsed = round(time.monotonic() - t0, 4)
+        except RunCancelled:
+            # User pressed Ctrl-C; let the cancellation propagate so
+            # SearchAgent.ask can render the "Cancelled by user"
+            # answer instead of bailing into the legacy router (which
+            # would try to re-ask the LLM and ignore the user's
+            # interrupt).
+            raise
         except Exception as exc:
             log.warning("Tool agent failed (%s); falling back to legacy router.", exc)
             return None

--- a/amx/search/agent.py
+++ b/amx/search/agent.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import contextlib
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from amx.agents.orchestrator import RunCancelled
 from amx.config import AMXConfig
 from amx.db.connector import DatabaseConnector
 from amx.llm.provider import LLMProvider
@@ -249,7 +251,20 @@ class SearchAgent(
         r"^\s*(?:neden|niye|niçin|nicin|nasıl|nasil)\s*[\.\?\!]*\s*$",
     )
 
-    def ask(self, question: str) -> SearchAnswer:
+    def ask(
+        self,
+        question: str,
+        *,
+        cancel_token: threading.Event | None = None,
+    ) -> SearchAnswer:
+        """Run one /ask turn.
+
+        ``cancel_token`` lets the CLI install a SIGINT handler that
+        sets the event when the user presses Ctrl-C, so the agent
+        loop bails between iterations even if the in-flight LLM HTTP
+        call is mid-stream. The web layer (Studio /api/ask) plugs in
+        its own JobRegistry-backed token for the same purpose.
+        """
         clean_question = (question or "").strip()
         question_language = _question_language_hint(clean_question)
         if not clean_question:
@@ -318,11 +333,33 @@ class SearchAgent(
             str(self.settings.get("use_tool_agent", "true") or "true").strip().lower() == "true"
         )
         if use_tool_agent:
-            tool_answer = self._answer_via_tool_agent(
-                question=question,
-                clean_question=clean_question,
-                question_language=question_language,
-            )
+            try:
+                tool_answer = self._answer_via_tool_agent(
+                    question=question,
+                    clean_question=clean_question,
+                    question_language=question_language,
+                    cancel_token=cancel_token,
+                )
+            except RunCancelled:
+                # User pressed Ctrl-C (CLI) or hit Cancel (Studio).
+                # Surface a clean SearchAnswer instead of bubbling the
+                # exception up to the REPL — that way the chat session
+                # stays open at the next prompt instead of dropping
+                # the user out of /search.
+                summary = (
+                    "Soru kullanıcı tarafından iptal edildi."
+                    if (question_language or "") == "turkish"
+                    else "Cancelled by user."
+                )
+                return SearchAnswer(
+                    intent="cancelled",
+                    question=question,
+                    rows=[],
+                    confidence="low",
+                    summary=summary,
+                    provenance=["user_cancelled"],
+                    details={"reason": "cancelled_by_user"},
+                )
             if tool_answer is not None:
                 return tool_answer
 

--- a/amx/search/service.py
+++ b/amx/search/service.py
@@ -15,6 +15,7 @@ must use :class:`SearchService`.
 from __future__ import annotations
 
 import contextlib
+import threading
 from typing import Any
 
 from amx.config import AMXConfig
@@ -92,8 +93,19 @@ class SearchService:
     def __exit__(self, exc_type, exc, tb) -> None:
         self.close()
 
-    def ask(self, question: str) -> SearchAnswer:
-        return self._agent.ask(question)
+    def ask(
+        self,
+        question: str,
+        *,
+        cancel_token: threading.Event | None = None,
+    ) -> SearchAnswer:
+        """Run one /ask turn.
+
+        ``cancel_token`` lets the CLI's Ctrl-C handler signal a clean
+        cancellation between agent-loop iterations. Forwarded to
+        :meth:`SearchAgent.ask`.
+        """
+        return self._agent.ask(question, cancel_token=cancel_token)
 
     def explain(self, question: str) -> dict[str, Any]:
         answer = self.ask(question)

--- a/tests/test_ask_cancel_token.py
+++ b/tests/test_ask_cancel_token.py
@@ -1,0 +1,161 @@
+"""CLI Ctrl-C cancellation reaches the ask agent loop.
+
+Reported: pressing Ctrl-C in CLI ask mode doesn't terminate the
+session — Python's default KeyboardInterrupt eventually fires but the
+LLM HTTP call (or a chained tool-call sequence) holds the GIL long
+enough that the user sees no response to their first press.
+
+Fix: ``SearchAgent.ask`` accepts ``cancel_token`` and forwards it
+through to ``run_tool_agent``. The CLI installs a temporary SIGINT
+handler that sets the token (graceful) and raises on the second
+press (force). On cancellation, the agent surfaces a clean
+``intent='cancelled'`` SearchAnswer instead of bailing into the
+legacy router or leaving the chat in an inconsistent state.
+
+These tests pin the wiring at the SearchAgent layer; the SIGINT
+handler in search.py is exercised manually since signal-based tests
+are flaky in CI.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from amx.agents.orchestrator import RunCancelled
+from amx.config import AMXConfig, DBConfig, LLMConfig
+from amx.search.agent import SearchAgent
+from amx.search.catalog import SearchAnswer
+
+
+@pytest.fixture()
+def cfg_minimal() -> AMXConfig:
+    cfg = AMXConfig()
+    cfg.db_profiles = {"local": DBConfig(backend="postgresql", host="x", database="y")}
+    cfg.active_db_profile = "local"
+    cfg.llm_profiles = {"openai": LLMConfig(provider="openai", model="gpt-4o")}
+    cfg.active_llm_profile = "openai"
+    cfg.llm = LLMConfig(provider="openai", model="gpt-4o")
+    return cfg
+
+
+def _real_settings_catalog() -> MagicMock:
+    """Build a catalog mock whose ``get_settings`` returns a real
+    dict — the agent reads ``settings.get("use_tool_agent", "true")``
+    and converts it via ``str().lower()``, so a default MagicMock
+    answer would coerce to a junk string and skip the tool-agent
+    dispatch we want to test.
+    """
+    catalog = MagicMock(name="SearchCatalog")
+    catalog.get_settings.return_value = {"use_tool_agent": "true"}
+    return catalog
+
+
+def test_search_agent_ask_passes_cancel_token_to_tool_agent(cfg_minimal) -> None:
+    """SearchAgent.ask threads its ``cancel_token`` kwarg into the
+    short-circuit tool-agent dispatch so the loop can poll it."""
+    catalog = _real_settings_catalog()
+    agent = SearchAgent(cfg_minimal, catalog, db_profiles=["local"])
+    token = threading.Event()
+    captured: dict[str, object] = {}
+
+    def fake_dispatch(*, cancel_token=None, **_):
+        captured["cancel_token"] = cancel_token
+        return SearchAnswer(
+            intent="tool_agent",
+            question="q",
+            rows=[],
+            confidence="high",
+            summary="ok",
+            provenance=[],
+            details={},
+        )
+
+    # Bypass the upstream short-circuit chain that doesn't take the
+    # token; the dispatch we care about is _answer_via_tool_agent.
+    with patch.object(agent, "_handle_chitchat", return_value=None):
+        with patch.object(agent, "_handle_meta_query", return_value=None):
+            with patch.object(agent, "_handle_followup_reaffirmation", return_value=None):
+                with patch.object(agent, "_llm_available", return_value=True):
+                    with patch.object(agent, "_answer_via_tool_agent", side_effect=fake_dispatch):
+                        with patch.object(agent, "_ensure_session_id", return_value=None):
+                            answer = agent.ask("test question", cancel_token=token)
+    assert captured["cancel_token"] is token
+    assert answer.intent == "tool_agent"
+
+
+def test_run_cancelled_returns_friendly_answer(cfg_minimal) -> None:
+    """When the tool agent raises RunCancelled (the user pressed
+    Ctrl-C and the cancel_token was set), SearchAgent.ask must turn
+    it into a clean cancelled SearchAnswer rather than letting the
+    exception escape into the REPL."""
+    catalog = _real_settings_catalog()
+    agent = SearchAgent(cfg_minimal, catalog, db_profiles=["local"])
+
+    def boom(**_):
+        raise RunCancelled("user cancel")
+
+    with patch.object(agent, "_handle_chitchat", return_value=None):
+        with patch.object(agent, "_handle_meta_query", return_value=None):
+            with patch.object(agent, "_handle_followup_reaffirmation", return_value=None):
+                with patch.object(agent, "_llm_available", return_value=True):
+                    with patch.object(agent, "_answer_via_tool_agent", side_effect=boom):
+                        with patch.object(agent, "_ensure_session_id", return_value=None):
+                            answer = agent.ask("test", cancel_token=threading.Event())
+    assert answer.intent == "cancelled"
+    assert "cancel" in answer.summary.lower()
+    assert answer.details.get("reason") == "cancelled_by_user"
+
+
+def test_run_cancelled_message_in_turkish_for_turkish_question(cfg_minimal) -> None:
+    """When the question was Turkish, the cancellation message
+    matches so the user gets a consistent locale."""
+    catalog = _real_settings_catalog()
+    agent = SearchAgent(cfg_minimal, catalog, db_profiles=["local"])
+
+    def boom(**_):
+        raise RunCancelled("user cancel")
+
+    with patch.object(agent, "_handle_chitchat", return_value=None):
+        with patch.object(agent, "_handle_meta_query", return_value=None):
+            with patch.object(agent, "_handle_followup_reaffirmation", return_value=None):
+                with patch.object(agent, "_llm_available", return_value=True):
+                    with patch.object(agent, "_answer_via_tool_agent", side_effect=boom):
+                        with patch.object(agent, "_ensure_session_id", return_value=None):
+                            answer = agent.ask(
+                                "satışları olan tabloları göster",
+                                cancel_token=threading.Event(),
+                            )
+    assert answer.intent == "cancelled"
+    assert "iptal" in answer.summary.lower()
+
+
+def test_search_agent_ask_works_without_cancel_token(cfg_minimal) -> None:
+    """Backwards-compat: callers that don't pass cancel_token still
+    work — the kwarg defaults to None and the agent skips the
+    cancel-token-aware path."""
+    catalog = _real_settings_catalog()
+    agent = SearchAgent(cfg_minimal, catalog, db_profiles=["local"])
+
+    def fake_dispatch(*, cancel_token=None, **_):
+        assert cancel_token is None  # default from signature
+        return SearchAnswer(
+            intent="tool_agent",
+            question="q",
+            rows=[],
+            confidence="high",
+            summary="ok",
+            provenance=[],
+            details={},
+        )
+
+    with patch.object(agent, "_handle_chitchat", return_value=None):
+        with patch.object(agent, "_handle_meta_query", return_value=None):
+            with patch.object(agent, "_handle_followup_reaffirmation", return_value=None):
+                with patch.object(agent, "_llm_available", return_value=True):
+                    with patch.object(agent, "_answer_via_tool_agent", side_effect=fake_dispatch):
+                        with patch.object(agent, "_ensure_session_id", return_value=None):
+                            answer = agent.ask("test")
+    assert answer.intent == "tool_agent"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -3085,7 +3085,7 @@ class RequestIdWiringTests(unittest.TestCase):
                 "show_confidence": "false",
             }
 
-            def ask(self, question_text: str):
+            def ask(self, question_text: str, **_kwargs):
                 # The whole point: at this exact moment, the request
                 # id must be set, so any log line emitted from inside
                 # SearchAgent / SearchCatalog / LLMProvider carries it.
@@ -3128,7 +3128,7 @@ class RequestIdWiringTests(unittest.TestCase):
         class FailingService:
             settings: dict[str, str] = {}
 
-            def ask(self, _q: str):
+            def ask(self, _q: str, **_kwargs):
                 raise RuntimeError("svc boom")
 
         cfg = AMXConfig()


### PR DESCRIPTION
## Summary
Reported: pressing Ctrl-C in CLI ask mode "doesn't terminate the session". Long-running LLM calls or chained tool dispatches held the GIL long enough that Python's default KeyboardInterrupt only fired after the question drained — the user's first Ctrl-C felt ignored, the chat seemed stuck.

- ``SearchAgent.ask`` / ``SearchService.ask`` accept ``cancel_token: threading.Event | None`` and forward to ``run_tool_agent`` (which polls the token between every tool dispatch and LLM iteration; the Studio side already had this plumbing from PR-D).
- ``_answer_via_tool_agent`` re-raises RunCancelled instead of swallowing into the legacy router (otherwise we'd re-ask the LLM after the user cancelled — exactly wrong).
- ``SearchAgent.ask`` catches RunCancelled and returns a clean ``intent='cancelled'`` SearchAnswer (Turkish summary when the question is Turkish).
- CLI ``_run_search_ask_body`` installs a temporary SIGINT handler: first press sets the token (graceful between-iteration exit), second press also raises KeyboardInterrupt so blocked socket I/O eventually terminates. Restored in ``finally``.

## Test plan
- [x] `pytest tests/` — 940 passing (4 new in `test_ask_cancel_token.py`, 2 fixtures widened in `test_regressions.py`)
- [x] Ruff format + check clean
- [ ] Manual CLI: `/search ask "very long question that triggers many tool calls"` → press Ctrl-C → "Cancelled by user." returns within 1 iteration; second Ctrl-C breaks out instantly even from a stuck HTTP socket
- [ ] Manual CLI: cancel mid-question, then ask another question — chat session continues normally, no leftover state