### PR TITLE
fix(llm): silence LiteLLM startup chatter on corp TLS proxies

### DIFF
--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -67,6 +67,24 @@ def _litellm() -> ModuleType:
         # so the underlying httpx client picks them up at construction time.
         _configure_ssl_environment()
 
+        # Silence LiteLLM's loggers BEFORE the import so the cost-map
+        # fetch warning ("Failed to fetch remote model cost map …
+        # SSL: CERTIFICATE_VERIFY_FAILED … falling back to local
+        # backup") doesn't leak through the CLI's clean prompt. The
+        # warning is informational — LiteLLM ships a local backup and
+        # uses it on fetch failure — but on corporate networks with
+        # MITM TLS proxies it fires every single import and clutters
+        # the chat. Setting LITELLM_LOCAL_MODEL_COST_MAP=True skips
+        # the network call entirely; pinning the loggers handles any
+        # other start-up chatter LiteLLM emits.
+        os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+        for logger_name in ("LiteLLM", "litellm"):
+            ext_logger = logging.getLogger(logger_name)
+            ext_logger.handlers.clear()
+            ext_logger.addHandler(logging.NullHandler())
+            ext_logger.propagate = False
+            ext_logger.setLevel(logging.CRITICAL + 1)
+
         import litellm as lm
 
         for logger_name in ("LiteLLM", "litellm"):

--- a/tests/test_litellm_silenced.py
+++ b/tests/test_litellm_silenced.py
@@ -1,0 +1,84 @@
+"""LiteLLM start-up chatter is silenced before the user sees it.
+
+Reported: on a corporate network with a MITM TLS proxy, LiteLLM's
+remote model-cost-map fetch fails the SSL handshake and emits a
+WARNING line every time the agent dispatches:
+
+    LiteLLM:WARNING: Failed to fetch remote model cost map from
+    https://raw.githubusercontent.com/.../model_prices_and_context_window.json:
+    [SSL: CERTIFICATE_VERIFY_FAILED] ... Falling back to local backup.
+
+The warning is informational — LiteLLM ships a local backup and uses
+it — but it clutters the otherwise-clean ``ask>`` prompt. Two fixes,
+both inside ``_litellm()``:
+
+1. Set ``LITELLM_LOCAL_MODEL_COST_MAP=True`` *before* importing the
+   library, so it skips the network call entirely.
+2. Pin the LiteLLM and litellm loggers to NullHandler with level
+   ``CRITICAL+1`` BEFORE the import (and again after, defensively)
+   so any other start-up chatter the library might add gets dropped.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import patch
+
+from amx.llm import provider as llm_provider
+
+
+def test_local_model_cost_map_env_set_before_import() -> None:
+    """``_litellm()`` must set ``LITELLM_LOCAL_MODEL_COST_MAP=True``
+    so litellm skips the GitHub fetch (which fires the SSL warning
+    on corp networks with TLS proxies).
+    """
+    # Reset module cache + env var, then call the bootstrap.
+    saved = os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+    try:
+        # The first call may already have configured the env var, so
+        # we check the post-condition rather than the boundary.
+        llm_provider._litellm()
+        assert os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP") == "True"
+    finally:
+        if saved is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = saved
+
+
+def test_litellm_loggers_silenced() -> None:
+    """The ``LiteLLM`` and ``litellm`` Python loggers should reach a
+    state where any WARNING-level record they emit is dropped — no
+    handler attached, no propagation to the root logger, level set
+    above WARNING.
+    """
+    llm_provider._litellm()
+    for name in ("LiteLLM", "litellm"):
+        ext = logging.getLogger(name)
+        # Level above WARNING — filter drops the cost-map warning.
+        assert ext.level >= logging.CRITICAL
+        # propagate disabled so the root handler doesn't print it.
+        assert ext.propagate is False
+        # Only NullHandler attached (or none).
+        non_null = [h for h in ext.handlers if not isinstance(h, logging.NullHandler)]
+        assert non_null == []
+
+
+def test_existing_env_var_is_respected() -> None:
+    """If the user has explicitly set ``LITELLM_LOCAL_MODEL_COST_MAP``
+    to a non-default value (e.g. False to opt back into remote
+    fetching for some reason), our setdefault must not clobber it.
+    """
+    saved = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    try:
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "False"
+        # Force re-init by stomping the cached module reference.
+        with patch.object(llm_provider, "_litellm_module", None):
+            llm_provider._litellm()
+        assert os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] == "False"
+    finally:
+        if saved is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = saved


### PR DESCRIPTION
## Summary
Reported: ``/search ask`` on a network with a MITM TLS proxy prints LiteLLM's "Failed to fetch remote model cost map ... CERTIFICATE_VERIFY_FAILED ... Falling back to local backup" warning every dispatch — informational only (LiteLLM ships the cost map locally) but clutters the chat prompt and worries the user.

- Set ``LITELLM_LOCAL_MODEL_COST_MAP=True`` BEFORE importing litellm so the GitHub fetch never fires. ``setdefault`` so an explicit user override (False, for local dev) is respected.
- Pin the ``LiteLLM`` and ``litellm`` Python loggers (NullHandler, propagate=False, CRITICAL+1) BEFORE the import too, so any other start-up chatter the library emits at module load gets dropped before the user sees it.

## Test plan
- [x] `pytest tests/` — 943 passing (3 new in `test_litellm_silenced.py`)
- [x] Ruff format + check clean
- [ ] Manual on a corp network: `/search ask "..."` → no LiteLLM warning lines printed; the cost-map fetch never hits GitHub