### PR TITLE
fix(cli): /session, /studio, /setup, /config dispatch from any tab

### DIFF
--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -934,6 +934,32 @@ def _handle_session_builtin(
     return False
 
 
+#: Top-level Click namespaces (the ``/db``, ``/llm``, … tabs) plus
+#: every command registered as a sibling Click subcommand at the same
+#: level. ``head`` matches against this set so a typed
+#: ``/<head> <subcmd>`` from any tab dispatches directly to the right
+#: namespace's Click group — no per-namespace whitelist drift. Tabs
+#: GROUP commands for discovery; this set keeps every command
+#: dispatchable from any tab.
+_CROSS_NAMESPACE_HEADS: frozenset[str] = frozenset(
+    {
+        "db",
+        "metadata",
+        "manual",  # alias → metadata
+        "docs",
+        "llm",
+        "code",
+        "analyze",
+        "search",
+        "history",
+        "session",
+        "setup",
+        "config",
+        "studio",
+    }
+)
+
+
 def session_to_click_args(namespace: str, parts: list[str]) -> list[str] | None:
     head = parts[0]
     shortcut_map = {
@@ -1012,7 +1038,11 @@ def session_to_click_args(namespace: str, parts: list[str]) -> list[str] | None:
         # of asking the LLM to "interpret" it as a question.
         if head in shortcut_map:
             return shortcut_map[head] + parts[1:]
-        if head in {"db", "metadata", "manual", "docs", "llm", "code", "analyze", "history"}:
+        # Single source of truth for cross-namespace dispatch — same
+        # set the non-search branch below uses, so every command stays
+        # reachable regardless of which tab the user is on. Tabs are
+        # for grouping/discovery; routing is global.
+        if head in _CROSS_NAMESPACE_HEADS:
             if head == "manual":
                 return ["metadata"] + parts[1:]
             return parts
@@ -1024,21 +1054,7 @@ def session_to_click_args(namespace: str, parts: list[str]) -> list[str] | None:
         # "Unknown command: /<x>" instead of silently routing the typo into
         # the search agent (e.g. ``/asl`` → ``search ask asl``).
         return None
-    if head in {
-        "db",
-        "metadata",
-        "manual",
-        "docs",
-        "llm",
-        "code",
-        "analyze",
-        "search",
-        "history",
-        "session",
-        "setup",
-        "config",
-        "studio",
-    }:
+    if head in _CROSS_NAMESPACE_HEADS:
         if head == "manual":
             return ["metadata"] + parts[1:]
         return parts

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -101,7 +101,6 @@ _ROOT_ENTRYPOINTS: tuple[SlashCommand, ...] = (
     SlashCommand("/analyze", "root", "Enter /analyze namespace"),
     SlashCommand("/search", "root", "Enter /search namespace"),
     SlashCommand("/history", "root", "Enter /history namespace"),
-    SlashCommand("/session", "root", "Manage /ask conversation sessions"),
     SlashCommand(
         "/studio",
         "root",
@@ -276,6 +275,25 @@ _SEARCH_COMMANDS: tuple[SlashCommand, ...] = (
         "/ask",
         "search",
         "Ask a metadata question; add --db-profile NAME (multi) for cross-DB scope; --actions for approved follow-up execution",
+    ),
+    # Sessions — manage `/ask` conversational threads. Dispatch is
+    # cross-namespace (works from any tab) like /doctor and /compare;
+    # listing here groups it next to /ask where it conceptually belongs.
+    SlashCommand(
+        "/session",
+        "search",
+        "Manage /ask conversation sessions (/session list|resume <id>|new|end|scope [profiles])",
+        long_desc=(
+            "Manage chat sessions for /ask. Subcommands:\n"
+            "  /session list                   — recent sessions (filter "
+            "with -n N or --all-profiles)\n"
+            "  /session resume <id>            — make ID the active session "
+            "for follow-up /ask turns\n"
+            "  /session new [--title TEXT]     — start a fresh session\n"
+            "  /session end                    — close the active session\n"
+            "  /session scope [profiles|clear] — sticky multi-profile scope "
+            "for the active session"
+        ),
     ),
     # Status
     SlashCommand("/status", "search", "Show catalog/index status"),

--- a/tests/test_session_command_global.py
+++ b/tests/test_session_command_global.py
@@ -1,0 +1,96 @@
+"""``/session`` works from any namespace + lives under /search.
+
+Reported: typing ``/session list`` while inside ``/search`` returned
+"Unknown command". The dispatcher's search-namespace branch had a
+narrow allowlist of cross-namespace heads that didn't include
+``"session"`` — every other tab fell through to the broader allow
+set further down, so the bug was specific to /search.
+
+Plus a presentation fix: the slash registry listed ``/session``
+under "root" so it didn't appear in /search's command help —
+inconsistent with where users naturally look (next to /ask).
+"""
+
+from __future__ import annotations
+
+from amx.cli_support.session import session_to_click_args
+from amx.cli_support.slash_commands import _ROOT_BUILTINS, _SEARCH_COMMANDS
+
+
+def test_session_dispatches_from_search_namespace() -> None:
+    """The bug-report path: ``/session list`` typed inside /search
+    must produce the Click args ``["session", "list"]`` so the
+    chat_session command group runs."""
+    assert session_to_click_args("search", ["session", "list"]) == ["session", "list"]
+    assert session_to_click_args("search", ["session", "resume", "42"]) == [
+        "session",
+        "resume",
+        "42",
+    ]
+    assert session_to_click_args("search", ["session", "new"]) == ["session", "new"]
+    assert session_to_click_args("search", ["session", "end"]) == ["session", "end"]
+    assert session_to_click_args("search", ["session", "scope", "a", "b"]) == [
+        "session",
+        "scope",
+        "a",
+        "b",
+    ]
+
+
+def test_session_still_works_from_other_tabs() -> None:
+    """Cross-namespace dispatch from every other tab — same as
+    /doctor, /compare, /history-store. Pin the contract so a future
+    refactor doesn't quietly break it."""
+    for namespace in ("", "db", "metadata", "docs", "llm", "code", "analyze", "history"):
+        assert session_to_click_args(namespace, ["session", "list"]) == [
+            "session",
+            "list",
+        ], f"failed from namespace={namespace!r}"
+
+
+def test_session_listed_under_search_group() -> None:
+    """The slash registry now lists /session under the search tab
+    so its help line appears next to /ask. Pin the move so it
+    doesn't drift back to root."""
+    search_names = {sc.command for sc in _SEARCH_COMMANDS}
+    root_names = {sc.command for sc in _ROOT_BUILTINS}
+    assert "/session" in search_names
+    assert "/session" not in root_names
+
+
+def test_studio_dispatches_from_every_tab() -> None:
+    """``/studio`` (open AMX Studio in browser) used to fail with
+    "Unknown command" inside /search because the search-namespace
+    dispatcher's allowed set didn't list it. Same fix as /session:
+    one cross-namespace head set, used by every dispatcher branch."""
+    for namespace in ("", "db", "metadata", "docs", "llm", "code", "analyze", "search", "history"):
+        out = session_to_click_args(namespace, ["studio"])
+        assert out == ["studio"], f"failed from namespace={namespace!r}: {out!r}"
+
+
+def test_config_dispatches_globally_except_inside_search() -> None:
+    """``/config`` is global — dispatches to the top-level config
+    Click subcommand from every tab — except /search, which has its
+    own search-config subcommand. Inside /search the head resolves
+    to ``["search", "config", ...]`` (search-config); everywhere else
+    it resolves to ``["config", ...]`` (root-config). Pin both so a
+    future allowed-set drift doesn't accidentally hide one of them."""
+    for namespace in ("", "db", "metadata", "docs", "llm", "code", "analyze", "history"):
+        assert session_to_click_args(namespace, ["config", "show"]) == [
+            "config",
+            "show",
+        ], f"failed from namespace={namespace!r}"
+    # /search has its own /config — keeps the existing precedence.
+    assert session_to_click_args("search", ["config", "show"]) == [
+        "search",
+        "config",
+        "show",
+    ]
+
+
+def test_setup_dispatches_from_every_tab() -> None:
+    """``/setup`` (interactive first-run wizard) reachable from every
+    tab including /search."""
+    for namespace in ("", "db", "metadata", "docs", "llm", "code", "analyze", "search", "history"):
+        out = session_to_click_args(namespace, ["setup"])
+        assert out == ["setup"], f"failed from namespace={namespace!r}: {out!r}"


### PR DESCRIPTION
## Summary
Reported: ``/session list`` typed inside /search returned "Unknown command", and the same problem applied to ``/studio`` and a couple of other root-level commands. Tabs are for grouping/discovery; every command should be reachable regardless of tab.

- Root cause: the dispatcher had two parallel allowed-sets — one for the search namespace, one for everyone else — that drifted apart. The search branch's set was narrower and missed several heads (session, studio, setup, config).
- Fix: introduced a single ``_CROSS_NAMESPACE_HEADS`` frozenset; both branches reference it. Adding a new top-level command in the future means adding it once and reaching every tab automatically.
- Intra-/search precedence preserved: ``/config`` typed inside /search still resolves to search-config (``["search", "config", ...]``); from any other tab it resolves to root-config.
- Bonus: moved ``/session`` from the root group to the search group in the registry so its help line appears next to ``/ask`` (its conceptual home). Added a long_desc subcommand quick-reference.

## Test plan
- [x] `pytest tests/` — 949 passing (6 new in `test_session_command_global.py`)
- [x] Ruff format + check clean
- [ ] Manual: `/search` → ``/session list`` works (regression check); same for ``/studio``, ``/setup``, ``/config show``