### PR TITLE
fix(ask): full-reach answers on unpinned 2-level profiles

### DIFF
--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -690,23 +690,54 @@ def _run_ask_repl(
         # on the first question.
         os.environ.pop("AMX_CHAT_SESSION_ID", None)
 
+    ask_kb = KeyBindings()
+
+    @ask_kb.add("escape", eager=True)
+    def _(event) -> None:  # type: ignore[no-untyped-def]
+        # Esc with text in the buffer clears the line; on an empty
+        # prompt it leaves ask mode (mirrors the main session's Esc-back
+        # convention so users don't have to remember /exit).
+        buf = event.app.current_buffer
+        if buf.text:
+            buf.reset()
+        else:
+            event.app.exit(result="__amx_ask_exit__")
+
+    @ask_kb.add("c-c")
+    def _(event) -> None:  # type: ignore[no-untyped-def]
+        # Ctrl-C with text clears the line; on an empty prompt it
+        # leaves ask mode rather than re-drawing a fresh ask> forever.
+        buf = event.app.current_buffer
+        if buf.text:
+            buf.reset()
+        else:
+            event.app.exit(result="__amx_ask_exit__")
+
     inner = PromptSession(
         message=HTML("<ansicyan><b>ask&gt;</b></ansicyan> "),
         mouse_support=False,
+        key_bindings=ask_kb,
     )
     while True:
         try:
-            line = inner.prompt().strip()
+            raw = inner.prompt()
         except EOFError:
             # Ctrl-D on an empty ask prompt drops back to the main session.
             console.print()
             success("Left ask mode.")
             return
         except KeyboardInterrupt:
-            # Ctrl-C resets the input line; /exit leaves ask mode.
+            # Defensive: the c-c binding above handles Ctrl-C, but if a
+            # nested context re-raises we still want to exit cleanly.
             console.print()
-            continue
+            success("Left ask mode.")
+            return
 
+        if raw == "__amx_ask_exit__":
+            success("Left ask mode.")
+            return
+
+        line = (raw or "").strip()
         if not line:
             continue
         # Allow the user to escape the REPL with familiar slash verbs without

--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import contextlib
 import json
 from collections.abc import Callable
+from dataclasses import replace as _dc_replace
 from difflib import SequenceMatcher
 from typing import Any
 
@@ -684,9 +685,33 @@ class ToolBox:
                         "profile's config. When composing the answer, list ALL entries "
                         "per profile, grouped by profile name; cite per-profile counts. "
                         "Profiles that errored / timed out are reported in "
-                        "``profiles_with_errors`` so the caveat is honest."
+                        "``profiles_with_errors`` so the caveat is honest.\n\n"
+                        "Set ``with_counts=true`` when the user asks 'which tables can "
+                        "we reach', 'how many tables / schemas do I have', or any "
+                        "coverage / rollup question — each database/catalog entry is "
+                        "then ``{name, schema_count, table_count}`` and the result "
+                        "gains per-profile ``total_schemas`` / ``total_tables`` plus "
+                        "grand totals ``grand_total_schemas`` / ``grand_total_tables``. "
+                        "Use these numbers DIRECTLY for the STATS-EXAMPLE-DRILL stats "
+                        "line — no follow-up tool call needed. Skip ``with_counts`` "
+                        "when the user only asks for names ('list my databases'); the "
+                        "count fan-out is per-database and adds latency."
                     ),
-                    "parameters": {"type": "object", "properties": {}, "required": []},
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "with_counts": {
+                                "type": "boolean",
+                                "description": (
+                                    "If true, enrich every database/catalog entry "
+                                    "with ``schema_count`` + ``table_count`` and "
+                                    "compute per-profile and grand totals. Default "
+                                    "false (names only)."
+                                ),
+                            },
+                        },
+                        "required": [],
+                    },
                 },
             },
             {
@@ -1435,6 +1460,32 @@ class ToolBox:
             return user_catalogs[0], user_catalogs, all_catalogs
         return "", user_catalogs, all_catalogs
 
+    # 3-level backends use a (catalog, schema, table) namespace; everything
+    # else is 2-level (database, schema, table). The /ask tool uses this to
+    # decide whether an unpinned profile is operating in "browse the server"
+    # mode (2-level, common) vs "auto-pick the only user catalog" (3-level).
+    _THREE_LEVEL_BACKENDS: frozenset[str] = frozenset({"databricks", "bigquery"})
+
+    def _profile_unpinned_two_level(self, profile: str) -> bool:
+        """``True`` when *profile* is a 2-level backend with no database pinned.
+
+        That state is fully supported (Studio's browse sidebar handles it
+        via per-database lazy loading), but the live-DB tools must NOT
+        silently fall through to the maintenance database — they would
+        list ``public`` from ``postgres`` (the bootstrap DB), which is
+        almost never what the user wants. Detected at metadata level so
+        we can refuse-with-hint before opening a connection on the wrong
+        database.
+        """
+        base = self.cfg.db_profiles.get(profile)
+        if base is None:
+            return False
+        backend = (str(getattr(base, "backend", "") or "")).lower()
+        if backend in self._THREE_LEVEL_BACKENDS:
+            return False
+        pinned_db = str(getattr(base, "database", "") or "").strip()
+        return not pinned_db
+
     def _list_schemas_on_profile(
         self,
         profile: str,
@@ -1447,19 +1498,45 @@ class ToolBox:
         ``db_profile=X``) and as the per-profile worker function for
         the multi-profile fan-out. Returns the same payload shape as
         the top-level tool with ``db_profile`` added.
+
+        Every payload carries ``pinned_database`` + ``pinned_catalog`` so
+        the LLM can see EACH profile's pinned scope independently — that
+        defends against cross-profile name bleed (one profile's pinned
+        catalog being applied to another profile's row).
         """
+        base = self.cfg.db_profiles.get(profile)
+        pinned_database = str(getattr(base, "database", "") or "").strip() if base else ""
+        pinned_catalog = str(getattr(base, "catalog", "") or "").strip() if base else ""
+        # 2-level profile with no DB pinned: refuse with a hint instead of
+        # falling through to the bootstrap DB. The LLM should call
+        # list_databases(with_counts=true) for the cross-DB rollup, or
+        # narrow with database= per call.
+        if self._profile_unpinned_two_level(profile):
+            return {
+                "db_profile": profile,
+                "pinned_database": pinned_database or None,
+                "pinned_catalog": pinned_catalog or None,
+                "unpinned": True,
+                "error": (
+                    "This 2-level profile has no database pinned. Call "
+                    "list_databases(with_counts=true) to enumerate every reachable "
+                    "database with schema/table rollups, or pass `database=` to scope "
+                    "this listing to one database."
+                ),
+                "schemas": [],
+                "count": 0,
+            }
         try:
             db = self._connector_for_profile(profile)
         except _ToolError as exc:
             return {
                 "db_profile": profile,
+                "pinned_database": pinned_database or None,
+                "pinned_catalog": pinned_catalog or None,
                 "error": str(exc),
                 "schemas": [],
                 "count": 0,
             }
-        # Catalog resolution honours the per-profile DBConfig.
-        base = self.cfg.db_profiles.get(profile)
-        pinned_catalog = str(getattr(base, "catalog", "") or "").strip() if base else ""
         explicit = (catalog or "").strip()
         cat_arg = explicit or pinned_catalog
         try:
@@ -1468,19 +1545,23 @@ class ToolBox:
         except Exception as exc:
             return {
                 "db_profile": profile,
+                "pinned_database": pinned_database or None,
+                "pinned_catalog": pinned_catalog or None,
                 "error": f"{exc.__class__.__name__}: {exc}",
                 "schemas": [],
                 "count": 0,
             }
         database = (
             cat_arg
-            or (getattr(base, "database", "") or "")
-            or (getattr(base, "catalog", "") or "")
+            or pinned_database
+            or pinned_catalog
             or (getattr(base, "project", "") or "")
             or "(no database pinned)"
         )
         payload: dict[str, Any] = {
             "db_profile": profile,
+            "pinned_database": pinned_database or None,
+            "pinned_catalog": pinned_catalog or None,
             "database": database,
             "schemas": schemas,
             "count": len(schemas),
@@ -1499,20 +1580,45 @@ class ToolBox:
         """Run ``list_tables(schema)`` (or ``list_assets``) against a
         named profile. Same payload shape as the top-level tool with
         ``db_profile`` added for cross-profile rendering.
+
+        Every payload carries ``pinned_database`` + ``pinned_catalog`` so
+        the LLM can see EACH profile's pinned scope independently and
+        won't bleed one profile's catalog onto another's row.
         """
+        base = self.cfg.db_profiles.get(profile)
+        pinned_database = str(getattr(base, "database", "") or "").strip() if base else ""
+        pinned_catalog = str(getattr(base, "catalog", "") or "").strip() if base else ""
+        # 2-level + unpinned: refuse-with-hint rather than silently
+        # listing the bootstrap DB's schemas.
+        if self._profile_unpinned_two_level(profile):
+            return {
+                "db_profile": profile,
+                "pinned_database": pinned_database or None,
+                "pinned_catalog": pinned_catalog or None,
+                "schema": schema,
+                "found": False,
+                "unpinned": True,
+                "error": (
+                    "This 2-level profile has no database pinned. Call "
+                    "list_databases(with_counts=true) to see what's reachable, "
+                    "or pass `database=` to scope this listing to one database."
+                ),
+                "tables": [],
+                "count": 0,
+            }
         try:
             db = self._connector_for_profile(profile)
         except _ToolError as exc:
             return {
                 "db_profile": profile,
+                "pinned_database": pinned_database or None,
+                "pinned_catalog": pinned_catalog or None,
                 "schema": schema,
                 "found": False,
                 "error": str(exc),
                 "tables": [],
                 "count": 0,
             }
-        base = self.cfg.db_profiles.get(profile)
-        pinned_catalog = str(getattr(base, "catalog", "") or "").strip() if base else ""
         cat_arg = (catalog or "").strip() or pinned_catalog
         try:
             with self._scoped_catalog(db, cat_arg):
@@ -1521,6 +1627,8 @@ class ToolBox:
                 if match is None:
                     return {
                         "db_profile": profile,
+                        "pinned_database": pinned_database or None,
+                        "pinned_catalog": pinned_catalog or None,
                         "schema": schema,
                         "catalog": cat_arg or None,
                         "found": False,
@@ -1536,6 +1644,8 @@ class ToolBox:
         except Exception as exc:
             return {
                 "db_profile": profile,
+                "pinned_database": pinned_database or None,
+                "pinned_catalog": pinned_catalog or None,
                 "schema": schema,
                 "found": False,
                 "error": f"{exc.__class__.__name__}: {exc}",
@@ -1544,6 +1654,8 @@ class ToolBox:
             }
         return {
             "db_profile": profile,
+            "pinned_database": pinned_database or None,
+            "pinned_catalog": pinned_catalog or None,
             "schema": match,
             "catalog": cat_arg or None,
             "found": True,
@@ -2567,7 +2679,97 @@ class ToolBox:
             "include_system": bool(include_system),
         }
 
-    def _tool_list_databases(self) -> dict[str, Any]:
+    def _count_database_assets(
+        self,
+        profile_name: str,
+        target: str,
+        supports_catalogs: bool,
+    ) -> dict[str, Any]:
+        """Return ``{"schema_count": N, "table_count": M}`` for *target*.
+
+        For 3-level backends (Databricks, BigQuery), the per-profile
+        connector is reused with ``_scoped_catalog`` to pin the catalog
+        — opening a fresh ``DatabaseConnector`` per catalog would
+        retrigger the SQL-warehouse cold-start (~2s per catalog on
+        Databricks) and easily blow the 8s per-profile fan-out budget.
+
+        For 2-level backends, the database lives in the connection
+        string, so a fresh connector is unavoidable; that's cheap on
+        PostgreSQL / Snowflake / MySQL.
+
+        ``list_assets_bulk`` is used when the adapter supports it
+        (single round trip); otherwise we sum ``list_tables(schema)``
+        per schema. Failures degrade gracefully: keys are omitted from
+        the returned dict when the count couldn't be computed, so the
+        caller can still surface the database name without numbers.
+        """
+        base = self.cfg.db_profiles.get(profile_name)
+        if base is None:
+            return {}
+
+        # 3-level: reuse the existing per-profile connector via
+        # _scoped_catalog. The connector's engine is already warm.
+        if supports_catalogs:
+            try:
+                conn = self._connector_for_profile(profile_name)
+            except _ToolError:
+                return {}
+            try:
+                with self._scoped_catalog(conn, target):
+                    try:
+                        schemas = [str(s) for s in conn.list_schemas()]
+                    except Exception:
+                        return {}
+                    out: dict[str, Any] = {"schema_count": len(schemas)}
+                    table_count: int | None = None
+                    try:
+                        bulk = conn.list_assets_bulk(target)
+                    except Exception:
+                        bulk = None
+                    if bulk is not None:
+                        table_count = len(bulk)
+                    if table_count is None:
+                        table_count = 0
+                        for s in schemas:
+                            try:
+                                table_count += len(conn.list_tables(s))
+                            except Exception:
+                                continue
+                    out["table_count"] = table_count
+                    return out
+            except Exception:
+                return {}
+
+        # 2-level: database lives in the connection string; open a fresh
+        # connector scoped to the target database.
+        try:
+            scoped_cfg = _dc_replace(base, database=target)
+        except TypeError:
+            return {}
+        scoped_conn: DatabaseConnector | None = None
+        try:
+            scoped_conn = DatabaseConnector(scoped_cfg)
+            try:
+                schemas = [str(s) for s in scoped_conn.list_schemas()]
+            except Exception:
+                return {}
+            out = {"schema_count": len(schemas)}
+            table_count = 0
+            for s in schemas:
+                try:
+                    table_count += len(scoped_conn.list_tables(s))
+                except Exception:
+                    continue
+            out["table_count"] = table_count
+            return out
+        except Exception:
+            return {}
+        finally:
+            if scoped_conn is not None:
+                with contextlib.suppress(Exception):
+                    scoped_conn.close()
+
+    def _tool_list_databases(self, *, with_counts: bool = False) -> dict[str, Any]:
         """List EVERY database (or catalog) reachable across the
         configured DB profiles — not just the one each profile has
         pinned.
@@ -2586,12 +2788,21 @@ class ToolBox:
         Per-profile fan-out runs through the same ThreadPoolExecutor
         the live-DB tools use (cap 8 workers, 8s per-profile timeout)
         so a slow / unreachable profile doesn't block the others.
+
+        ``with_counts``: when True, each database/catalog entry becomes
+        ``{name, schema_count, table_count}`` so the LLM can answer
+        "which tables can we reach" with the STATS-EXAMPLE-DRILL pattern
+        in one turn (no follow-up tool call to get totals). Bulk-listing
+        is preferred when the backend supports it; otherwise we fan
+        out ``list_tables`` per schema. The 8s per-profile timeout
+        still applies, so very large workspaces may surface partial
+        counts.
         """
         from concurrent.futures import ThreadPoolExecutor, wait
 
         targets = list(self.db_profiles)
         if not targets:
-            return {"profiles": {}, "count": 0, "scope": []}
+            return {"profiles": {}, "count": 0, "scope": [], "with_counts": with_counts}
 
         def _per_profile(profile_name: str) -> dict[str, Any]:
             base = self.cfg.db_profiles.get(profile_name)
@@ -2622,9 +2833,41 @@ class ToolBox:
             }
             try:
                 if supports_catalogs:
-                    payload["catalogs"] = [str(c) for c in conn.list_catalogs()]
+                    catalogs = [str(c) for c in conn.list_catalogs()]
+                    if with_counts:
+                        # System catalogs (system, samples, workspace,
+                        # hive_metastore, …) carry the workspace's own
+                        # tooling, NOT user data — skip count-enrichment
+                        # for them. Without this filter a Databricks
+                        # workspace with 4+ system catalogs blew through
+                        # the 8s per-profile timeout (each scoped
+                        # list_assets_bulk is ~1-2s on Databricks).
+                        # System catalogs are still surfaced (with no
+                        # counts) so the LLM knows the full reach.
+                        user_cats = set(self._user_catalogs(catalogs))
+                        enriched: list[dict[str, Any]] = []
+                        for c in catalogs:
+                            entry: dict[str, Any] = {"name": c}
+                            if c in user_cats:
+                                entry.update(self._count_database_assets(profile_name, c, True))
+                            else:
+                                entry["system_catalog"] = True
+                            enriched.append(entry)
+                        payload["catalogs"] = enriched
+                    else:
+                        payload["catalogs"] = catalogs
                 else:
-                    payload["databases"] = [str(d) for d in conn.list_databases()]
+                    databases = [str(d) for d in conn.list_databases()]
+                    if with_counts:
+                        payload["databases"] = [
+                            {
+                                "name": d,
+                                **self._count_database_assets(profile_name, d, False),
+                            }
+                            for d in databases
+                        ]
+                    else:
+                        payload["databases"] = databases
             except Exception as exc:
                 payload["error"] = f"{exc.__class__.__name__}: {exc}"
             return payload
@@ -2668,13 +2911,33 @@ class ToolBox:
             for name, payload in per_profile.items()
             if payload.get("error") or payload.get("timeout")
         ]
-        return {
+        result: dict[str, Any] = {
             "scope": targets,
             "profiles": per_profile,
             "total_reachable": total_dbs,
             "profiles_with_errors": with_errors,
             "count": len(per_profile),
+            "with_counts": with_counts,
         }
+        if with_counts:
+            # Per-profile and grand totals so the LLM can compose the
+            # STATS-EXAMPLE-DRILL line without re-summing dicts itself.
+            grand_schemas = 0
+            grand_tables = 0
+            for payload in per_profile.values():
+                p_schemas = 0
+                p_tables = 0
+                for entry in (payload.get("databases") or []) + (payload.get("catalogs") or []):
+                    if isinstance(entry, dict):
+                        p_schemas += int(entry.get("schema_count") or 0)
+                        p_tables += int(entry.get("table_count") or 0)
+                payload["total_schemas"] = p_schemas
+                payload["total_tables"] = p_tables
+                grand_schemas += p_schemas
+                grand_tables += p_tables
+            result["grand_total_schemas"] = grand_schemas
+            result["grand_total_tables"] = grand_tables
+        return result
 
     # ------------------------------------------------------------ dtype family
     # Map a user-supplied dtype token to a concrete SQL-LIKE pattern set so

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -123,9 +123,18 @@ def _agent_system_prompt(
             )
         elif backend:
             db_unpinned_hint = (
-                "  ⚠ No database is pinned for this profile. Call list_server_databases "
-                "to discover what's available, then ask the user to switch via /use-db or "
-                "pin one with /edit."
+                "  Note: this profile has no database pinned — that is a normal,\n"
+                "  fully-supported state. The user did NOT have to commit to a single\n"
+                "  database (Studio's multi-profile browse sidebar uses the same\n"
+                "  unpinned mode). NEVER ask the user to switch via /use-db or pin\n"
+                "  one with /edit; that's a blocker, not an answer. To answer\n"
+                "  reach / coverage questions ('which tables can we reach', 'what\n"
+                "  databases do I have'), call list_databases with `with_counts=true`\n"
+                "  — it fans out per profile and returns each reachable database\n"
+                "  with schema/table counts already aggregated. Then render the\n"
+                "  STATS-EXAMPLE-DRILL pattern (stats line, 5–8 examples, drill-in\n"
+                "  invitation). For schema/table tools that need a database to\n"
+                "  scope, pass `database=` explicitly per call."
             )
     schema_line = (
         ", ".join(schema_hint)
@@ -508,6 +517,40 @@ def _agent_system_prompt(
         "    blocker before answering. Always lead with stats + examples,\n"
         "    THEN invite drill-in. The user came with a question, not for\n"
         "    a multi-step picker.\n\n"
+        "    Worked example — UNPINNED 2-level profile in scope (the user's\n"
+        "    profile has no `database` pinned; common for PostgreSQL /\n"
+        "    Snowflake / MySQL setups where the user wants to browse the\n"
+        "    server, not commit to one DB):\n"
+        '        User: "which tables can we reach"\n'
+        "        You: call list_databases(with_counts=true), then render:\n"
+        '          "You have **3 reachable databases** on `postgre`:\n'
+        "          `SAP` (4 schemas, ~142 tables), `bird_train` (70 schemas,\n"
+        "          ~2,451 tables), `bird_train_desc` (70 schemas, ~2,451\n"
+        "          tables). Total: **~5,044 tables** across 3 databases on 1\n"
+        "          profile. Want me to drill into one — e.g. 'tables in\n"
+        "          `bird_train_desc`'?\"\n"
+        '        Do NOT say "please /use-db <database> first" or "pin a\n'
+        "        database with /edit\". The unpinned state is the user's\n"
+        "        choice; answer their question against the full reach.\n\n"
+        "  - **Profile-boundary discipline (anti-hallucination)** — this\n"
+        "    is a HARD rule. Each profile has its OWN pinned_database and\n"
+        "    pinned_catalog (or none). Tool result rows carry these\n"
+        "    per-profile fields explicitly (`pinned_database`,\n"
+        "    `pinned_catalog`). NEVER copy one profile's pinned name onto\n"
+        "    another profile's row. Concretely:\n"
+        "      * If profile `dbr` has `pinned_catalog: amx_test` and\n"
+        "        profile `postgre` has `pinned_database: null`, then\n"
+        "        `postgre`'s scope is the SERVER (3 reachable databases),\n"
+        "        NOT `amx_test.public`. Do not write\n"
+        '        "postgre (amx_test.public): 0 tables" — `amx_test` is\n'
+        "        not `postgre`'s catalog/database.\n"
+        "      * Read pinned_database / pinned_catalog from each row\n"
+        "        SEPARATELY. If a per-profile row says `unpinned: true`\n"
+        "        or carries `pinned_database: null`, treat that as\n"
+        '        "this profile spans the server" and use\n'
+        "        list_databases(with_counts=true) to enumerate the\n"
+        "        reach — never assume a sibling profile's catalog\n"
+        "        applies.\n\n"
         "  - **Multi-profile breakdowns** (per-profile counts, per-profile\n"
         "    errors). When the data set is small (≤ 10 items per profile)\n"
         "    use a bullet list with the profile name **bold** at the start.\n"

--- a/tests/test_answer_format_directives.py
+++ b/tests/test_answer_format_directives.py
@@ -115,3 +115,57 @@ def test_prompt_directs_single_paragraph_for_short_answers() -> None:
     prompt = _agent_system_prompt(cfg, ["public"])
     # The 'short answer' threshold is documented.
     assert "Short answer" in prompt or "short answer" in prompt
+
+
+def test_prompt_unpinned_2level_profile_is_normal_not_blocker() -> None:
+    """Regression guard: an unpinned 2-level profile (PostgreSQL etc.
+    without a pinned `database`) is a fully-supported state — Studio's
+    multi-profile browse already handles it. The prompt must NOT
+    instruct the LLM to ask the user to /use-db <db> or /edit. The
+    only mention of those phrases should be in the explicit
+    'NEVER ask the user to …' negation."""
+    from amx.config import DBConfig
+
+    cfg = AMXConfig()
+    cfg.db = DBConfig(backend="postgresql", host="pg.local", database="")
+    prompt = _agent_system_prompt(cfg, [])
+    # Every mention of the forbidden phrasing must be NEGATED — never
+    # surface as a positive instruction.
+    for phrase in ("switch via /use-db", "pin one with /edit"):
+        for occurrence in _find_all(prompt, phrase):
+            window = prompt[max(0, occurrence - 40) : occurrence]
+            assert "NEVER" in window or "not " in window.lower(), (
+                f"Phrase {phrase!r} appeared as a positive instruction: {window!r}"
+            )
+    # The new permissive phrasing must be present.
+    assert "no database pinned" in prompt
+    assert "with_counts=true" in prompt
+    assert "list_databases" in prompt
+    assert "blocker, not an answer" in prompt
+
+
+def _find_all(haystack: str, needle: str) -> list[int]:
+    out: list[int] = []
+    start = 0
+    while True:
+        idx = haystack.find(needle, start)
+        if idx == -1:
+            return out
+        out.append(idx)
+        start = idx + 1
+
+
+def test_prompt_anti_hallucination_profile_boundary_rule() -> None:
+    """Each profile has its OWN pinned_database / pinned_catalog (or
+    none). The Studio bug 'postgre (amx_test.public): 0 tables' came
+    from the LLM applying dbr's catalog name to postgre's row. The
+    prompt must explicitly forbid that name bleed."""
+    cfg = AMXConfig()
+    prompt = _agent_system_prompt(cfg, ["public"])
+    # The rule's keyword anchor.
+    assert "Profile-boundary discipline" in prompt
+    assert "pinned_database" in prompt
+    assert "pinned_catalog" in prompt
+    # Concrete forbidden case (one profile's catalog applied to another).
+    lower = prompt.lower()
+    assert "never copy" in lower or "do not write" in lower or "never apply" in lower

--- a/tests/test_list_databases_full_reach.py
+++ b/tests/test_list_databases_full_reach.py
@@ -158,3 +158,124 @@ def test_list_databases_single_profile_scope(cfg_two_profiles) -> None:
     assert result["scope"] == ["test-postgre"]
     assert result["count"] == 1
     assert result["profiles"]["test-postgre"]["databases"] == ["a", "b", "c"]
+
+
+def test_list_databases_with_counts_returns_schema_and_table_counts(
+    cfg_two_profiles, monkeypatch
+) -> None:
+    """``with_counts=True`` enriches each database/catalog entry with
+    ``schema_count`` + ``table_count``, plus per-profile and grand
+    totals so the LLM can compose the STATS-EXAMPLE-DRILL stats line
+    in one tool call. This is the answer to 'which tables can we
+    reach' on an unpinned 2-level profile — no follow-up tool needed.
+    """
+    # Stub the count helper so we don't open real connections.
+    counts: dict[tuple[str, str, bool], dict[str, int]] = {
+        ("test-postgre", "bird_train_desc", False): {"schema_count": 70, "table_count": 2451},
+        ("test-postgre", "postgres", False): {"schema_count": 1, "table_count": 0},
+        ("test-postgre", "analytics", False): {"schema_count": 4, "table_count": 142},
+        ("dbr", "amx_test", True): {"schema_count": 12, "table_count": 88},
+        ("dbr", "main", True): {"schema_count": 5, "table_count": 33},
+    }
+
+    def _fake_count_database_assets(self, profile_name, target, supports_catalogs):
+        return counts.get((profile_name, target, supports_catalogs), {})
+
+    monkeypatch.setattr(
+        ToolBox, "_count_database_assets", _fake_count_database_assets, raising=True
+    )
+
+    box = ToolBox(
+        cfg_two_profiles,
+        MagicMock(),
+        db_profiles=["dbr", "test-postgre"],
+        db_connectors={
+            "dbr": _stub_databricks_connector(["amx_test", "main"]),
+            "test-postgre": _stub_pg_connector(["bird_train_desc", "postgres", "analytics"]),
+        },
+    )
+    result = box._tool_list_databases(with_counts=True)
+
+    assert result["with_counts"] is True
+
+    pg = result["profiles"]["test-postgre"]
+    # The shape switches from list[str] to list[dict].
+    assert pg["databases"] == [
+        {"name": "bird_train_desc", "schema_count": 70, "table_count": 2451},
+        {"name": "postgres", "schema_count": 1, "table_count": 0},
+        {"name": "analytics", "schema_count": 4, "table_count": 142},
+    ]
+    # Per-profile rollup the LLM uses for the stats line.
+    assert pg["total_schemas"] == 70 + 1 + 4
+    assert pg["total_tables"] == 2451 + 0 + 142
+
+    dbr = result["profiles"]["dbr"]
+    assert dbr["catalogs"] == [
+        {"name": "amx_test", "schema_count": 12, "table_count": 88},
+        {"name": "main", "schema_count": 5, "table_count": 33},
+    ]
+    assert dbr["total_schemas"] == 12 + 5
+    assert dbr["total_tables"] == 88 + 33
+
+    # Grand totals across every profile in scope.
+    assert result["grand_total_schemas"] == 75 + 17
+    assert result["grand_total_tables"] == 2593 + 121
+
+
+def test_list_databases_with_counts_skips_system_catalogs(cfg_two_profiles, monkeypatch) -> None:
+    """Databricks workspaces have system catalogs (system, samples,
+    workspace, hive_metastore) alongside user catalogs. Each scoped
+    ``list_assets_bulk`` call is ~1-2s on Databricks, so enriching
+    every catalog including the system ones blew through the 8s
+    per-profile timeout in the user's bug report. The fix: skip
+    count-enrichment for system catalogs, but still surface them in
+    the names list with ``system_catalog: True`` so the LLM knows the
+    full reach. Reported: dbr profile timed out after 8s when it had
+    4 catalogs visible."""
+    counts_called: list[str] = []
+
+    def _fake_count(self, profile_name, target, supports_catalogs):
+        counts_called.append(target)
+        return {"schema_count": 1, "table_count": 1}
+
+    monkeypatch.setattr(ToolBox, "_count_database_assets", _fake_count, raising=True)
+
+    box = ToolBox(
+        cfg_two_profiles,
+        MagicMock(),
+        db_profiles=["dbr"],
+        db_connectors={
+            # The four-catalog scenario from the user's screenshot.
+            "dbr": _stub_databricks_connector(["amx_test", "samples", "system", "workspace"]),
+        },
+    )
+    result = box._tool_list_databases(with_counts=True)
+
+    # Counts were ONLY computed for the user catalog.
+    assert counts_called == ["amx_test"]
+
+    catalogs = result["profiles"]["dbr"]["catalogs"]
+    # User catalog: enriched.
+    assert {"name": "amx_test", "schema_count": 1, "table_count": 1} in catalogs
+    # System catalogs: surfaced without counts, marked.
+    for sys_cat in ("samples", "system", "workspace"):
+        assert {"name": sys_cat, "system_catalog": True} in catalogs
+
+
+def test_list_databases_with_counts_default_off(cfg_two_profiles) -> None:
+    """Default ``with_counts=False`` returns the legacy name-only
+    shape so callers that just want a quick name list don't pay the
+    per-database fan-out cost."""
+    box = ToolBox(
+        cfg_two_profiles,
+        MagicMock(),
+        db_profiles=["test-postgre"],
+        db_connectors={
+            "test-postgre": _stub_pg_connector(["a", "b"]),
+        },
+    )
+    result = box._tool_list_databases()
+    assert result["with_counts"] is False
+    assert result["profiles"]["test-postgre"]["databases"] == ["a", "b"]
+    assert "grand_total_schemas" not in result
+    assert "grand_total_tables" not in result

--- a/tests/test_unpinned_profile_listing.py
+++ b/tests/test_unpinned_profile_listing.py
@@ -1,0 +1,205 @@
+"""Live-DB tools must refuse-with-hint on unpinned 2-level profiles.
+
+Reported (CLI + Studio screenshots): with profile `postgre`
+(PostgreSQL, no `database` pinned) in scope, asking
+"which tables can we reach" replied with either a blocking
+"please /use-db <db> first" picker (CLI) or a wrong "0 tables in
+public" answer (Studio — the connector silently fell through to the
+`postgres` bootstrap maintenance database).
+
+Root cause: ``_list_schemas_on_profile`` and ``_list_tables_on_profile``
+opened a connection against the empty database, which the driver
+substituted for the bootstrap DB. The LLM then dutifully reported
+that wrong scope as if it were the truth.
+
+Fix: detect the 2-level + unpinned state at metadata level and
+return ``unpinned: True`` with a hint telling the LLM to call
+``list_databases(with_counts=True)`` (which fans out across every
+reachable database) or pass ``database=`` explicitly. This matches
+Studio's multi-profile browse model: an unpinned profile is normal,
+the user spans the server.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from amx.config import AMXConfig, DBConfig
+from amx.search.agent_tools import ToolBox
+
+
+@pytest.fixture()
+def cfg_unpinned_postgres() -> AMXConfig:
+    cfg = AMXConfig()
+    cfg.db_profiles = {
+        "postgre": DBConfig(
+            backend="postgresql",
+            host="pg.local",
+            database="",  # unpinned — the bug-report scenario
+        ),
+    }
+    cfg.active_db_profile = "postgre"
+    cfg.active_db_profiles = ["postgre"]
+    cfg.db = cfg.db_profiles["postgre"]
+    return cfg
+
+
+def _stub_connector_should_not_run() -> MagicMock:
+    """A connector whose live methods would explode if reached.
+
+    The point is to verify the unpinned-2-level branch refuses BEFORE
+    opening a live connection; if these methods get called the test
+    surfaces a clear "should not have been reached" failure.
+    """
+    conn = MagicMock()
+    conn.list_schemas = MagicMock(side_effect=AssertionError("must not run for unpinned 2-level"))
+    conn.list_tables = MagicMock(side_effect=AssertionError("must not run for unpinned 2-level"))
+    conn.list_assets = MagicMock(side_effect=AssertionError("must not run for unpinned 2-level"))
+    return conn
+
+
+def test_list_schemas_on_unpinned_2level_profile_refuses_with_hint(
+    cfg_unpinned_postgres,
+) -> None:
+    """``_list_schemas_on_profile`` on an unpinned PostgreSQL profile
+    returns ``unpinned: True`` with a hint, NOT a silent fall-through
+    to the bootstrap database."""
+    box = ToolBox(
+        cfg_unpinned_postgres,
+        MagicMock(),
+        db_profiles=["postgre"],
+        db_connectors={"postgre": _stub_connector_should_not_run()},
+    )
+    result = box._list_schemas_on_profile("postgre")
+    assert result["unpinned"] is True
+    assert result["pinned_database"] is None
+    assert result["schemas"] == []
+    assert result["count"] == 0
+    assert "list_databases" in result["error"]
+    assert "with_counts" in result["error"] or "database=" in result["error"]
+
+
+def test_list_tables_on_unpinned_2level_profile_refuses_with_hint(
+    cfg_unpinned_postgres,
+) -> None:
+    """Same defence for ``_list_tables_on_profile`` — refuses to
+    enumerate against the bootstrap DB."""
+    box = ToolBox(
+        cfg_unpinned_postgres,
+        MagicMock(),
+        db_profiles=["postgre"],
+        db_connectors={"postgre": _stub_connector_should_not_run()},
+    )
+    result = box._list_tables_on_profile("postgre", "public")
+    assert result["unpinned"] is True
+    assert result["found"] is False
+    assert result["pinned_database"] is None
+    assert result["tables"] == []
+    assert result["count"] == 0
+    assert "list_databases" in result["error"]
+
+
+def test_pinned_2level_profile_runs_live_query() -> None:
+    """A pinned 2-level profile is NOT refused — the existing live
+    path runs as before. The unpinned guard must not regress the
+    common pinned case."""
+    cfg = AMXConfig()
+    cfg.db_profiles = {
+        "pinned-pg": DBConfig(
+            backend="postgresql",
+            host="pg.local",
+            database="bird_train",
+        ),
+    }
+    cfg.active_db_profile = "pinned-pg"
+    cfg.active_db_profiles = ["pinned-pg"]
+    cfg.db = cfg.db_profiles["pinned-pg"]
+
+    conn = MagicMock()
+    conn.list_schemas = MagicMock(return_value=["public", "sales"])
+    conn.cfg = cfg.db_profiles["pinned-pg"]
+
+    box = ToolBox(
+        cfg,
+        MagicMock(),
+        db_profiles=["pinned-pg"],
+        db_connectors={"pinned-pg": conn},
+    )
+    result = box._list_schemas_on_profile("pinned-pg")
+    assert "unpinned" not in result
+    assert result["schemas"] == ["public", "sales"]
+    assert result["pinned_database"] == "bird_train"
+
+
+def test_unpinned_3level_profile_is_NOT_refused() -> None:
+    """3-level backends (Databricks UC, BigQuery) have their own
+    auto-pick path for unpinned catalogs (``_resolve_catalog_or_autopick``).
+    The 2-level unpinned guard must not catch them by mistake."""
+    cfg = AMXConfig()
+    cfg.db_profiles = {
+        "dbr": DBConfig(
+            backend="databricks",
+            host="dbc-xxx.databricks.com",
+            catalog="",  # unpinned 3-level
+        ),
+    }
+    cfg.active_db_profile = "dbr"
+    cfg.active_db_profiles = ["dbr"]
+    cfg.db = cfg.db_profiles["dbr"]
+
+    conn = MagicMock()
+    conn.list_schemas = MagicMock(return_value=["default"])
+    conn.cfg = cfg.db_profiles["dbr"]
+
+    box = ToolBox(
+        cfg,
+        MagicMock(),
+        db_profiles=["dbr"],
+        db_connectors={"dbr": conn},
+    )
+    result = box._list_schemas_on_profile("dbr")
+    # 3-level path stays as-is — no unpinned refusal.
+    assert "unpinned" not in result
+    assert result["schemas"] == ["default"]
+
+
+def test_per_profile_payload_carries_pinned_fields_for_anti_hallucination() -> None:
+    """Every per-profile payload must carry ``pinned_database`` and
+    ``pinned_catalog`` so the LLM sees each profile's pinned scope
+    independently. This is the defence against the Studio bug
+    'postgre (amx_test.public): 0 tables' — `amx_test` is `dbr`'s
+    catalog, not `postgre`'s, and the tool result must make that
+    boundary obvious."""
+    cfg = AMXConfig()
+    cfg.db_profiles = {
+        "pinned-pg": DBConfig(
+            backend="postgresql",
+            host="pg.local",
+            database="bird_train",
+        ),
+    }
+    cfg.active_db_profile = "pinned-pg"
+    cfg.active_db_profiles = ["pinned-pg"]
+    cfg.db = cfg.db_profiles["pinned-pg"]
+
+    conn = MagicMock()
+    conn.list_schemas = MagicMock(return_value=["public"])
+    conn.list_tables = MagicMock(return_value=["t1", "t2"])
+    conn.list_assets = MagicMock(side_effect=AttributeError)
+    conn.cfg = cfg.db_profiles["pinned-pg"]
+
+    box = ToolBox(
+        cfg,
+        MagicMock(),
+        db_profiles=["pinned-pg"],
+        db_connectors={"pinned-pg": conn},
+    )
+    schemas_result = box._list_schemas_on_profile("pinned-pg")
+    assert schemas_result["pinned_database"] == "bird_train"
+    assert schemas_result["pinned_catalog"] is None
+
+    tables_result = box._list_tables_on_profile("pinned-pg", "public")
+    assert tables_result["pinned_database"] == "bird_train"
+    assert tables_result["pinned_catalog"] is None


### PR DESCRIPTION
## Summary

- The /ask path mishandled an unpinned 2-level profile (PostgreSQL etc. with no `database` pinned) in two ways: the CLI replied with a blocking "please /use-db <db> first" picker, and Studio silently fell through to the bootstrap maintenance database and reported the wrong "0 tables in public" answer. This PR makes the unpinned state a first-class supported scope and gets the LLM to answer the question against the full reach of the server.
- New `list_databases(with_counts=true)` enriches each database/catalog with `schema_count` + `table_count`, plus per-profile `total_schemas` / `total_tables` and grand totals — so the LLM can compose the STATS-EXAMPLE-DRILL stats line in one tool call.
- `_list_schemas_on_profile` / `_list_tables_on_profile` carry per-payload `pinned_database` + `pinned_catalog` and refuse-with-hint when called against a 2-level unpinned profile, instead of silently dropping to the bootstrap database.
- New "Profile-boundary discipline" rule in the agent system prompt forbids copying one profile's pinned catalog onto another profile's row (the "postgre (amx_test.public): 0 tables" Studio bug).
- Ask REPL now exits cleanly on Esc / Ctrl-C from an empty prompt (matches the main session's Esc-back convention) instead of re-drawing ask> forever.
- Worked example added to the agent prompt for unpinned 2-level scope; `/use-db` and `/edit` are explicitly forbidden as redirects (a blocker is not an answer).
- Databricks system catalogs are surfaced without count enrichment so a workspace with several system catalogs does not blow the 8s per-profile timeout.

## Test plan

- [x] `pytest -ra tests/test_answer_format_directives.py tests/test_list_databases_full_reach.py tests/test_unpinned_profile_listing.py` — 22/22 pass locally
- [x] `ruff check amx tests` clean
- [x] `ruff format --check amx tests` clean
- [ ] CI: lint + format + mypy + test matrix (3.10 / 3.11 / 3.12) + web bundle freshness + build green
- [ ] Manual: Studio + CLI on the postgre (unpinned) profile — "which tables can we reach" must reply with the STATS-EXAMPLE-DRILL block, no /use-db redirect