### PR TITLE
ci: add pip-audit (advisory) and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+# Dependabot configuration.
+#
+# All updates open as PRs against main; merging is manual so a human
+# reviews any version bump before it lands. Commit-message prefixes
+# use ``build`` / ``ci`` — both are allowed by ``commit_parser_options``
+# in pyproject.toml but neither is in ``minor_tags`` or ``patch_tags``,
+# so dependabot PRs do not trigger a python-semantic-release version
+# bump on merge.
+
+version: 2
+updates:
+  # Python runtime + dev/test/perf extras (everything in pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Istanbul"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      python-deps:
+        patterns: ["*"]
+
+  # Studio SPA dependencies under frontend/
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Istanbul"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+    groups:
+      npm-deps:
+        patterns: ["*"]
+
+  # GitHub Actions used in .github/workflows/*
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Istanbul"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,29 @@ jobs:
             exit 1
           fi
 
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    # Advisory-only for now: surfaces CVEs in dependencies without
+    # blocking PRs. Drop ``continue-on-error`` once the baseline is
+    # clean and the team is ready to gate merges on advisories.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install project + pip-audit
+        run: |
+          python -m pip install --upgrade pip pip-audit
+          # Install the same surface the test job exercises so audit
+          # sees every transitive dep AMX actually pulls in.
+          python -m pip install -e ".[all,code-intel]"
+      - name: Run pip-audit
+        run: pip-audit --strict --progress-spinner off
+
   build:
     name: Build distribution
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Two supply-chain layers, both non-blocking initially:

- **Dependabot** (`.github/dependabot.yml`) — weekly PRs for:
  - `pip` (everything in `pyproject.toml`, all extras)
  - `npm` (`frontend/`)
  - `github-actions`
  Commit prefixes are `build:` / `ci:` — neither is in `minor_tags` or `patch_tags`, so dependabot merges do **not** trigger a `python-semantic-release` version bump.
- **pip-audit job** in `ci.yml` — runs against the editable install with `[all,code-intel]` extras (same surface the test job exercises). `continue-on-error: true` so any existing CVEs surface as advisories without blocking PRs. Flip the flag off once the baseline is clean.

The mypy pre-commit hook originally planned for this PR is **not** included — the existing CI mypy step is `continue-on-error: true` (untyped-defs in places), so adding a strict pre-commit hook today would fail every commit. It lands in a follow-up PR after the mypy baseline is cleaned up.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` validates both YAML files.
- [ ] CI shows the new `Dependency audit` job alongside existing checks. *(verify in this PR's CI run)*
- [ ] Dependabot's first scan opens grouped PRs Mon 06:00 Europe/Istanbul. *(verify in dependabot logs once merged to main)*