### PR TITLE
feat(observability): rotating log file + structured log_event helper

### DIFF
--- a/amx/utils/logging.py
+++ b/amx/utils/logging.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import json
 import logging
+import logging.handlers
+import os
 import sys
 import uuid
 from contextvars import ContextVar
@@ -25,6 +27,39 @@ from typing import Any
 
 LOG_DIR = Path.home() / ".amx" / "logs"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+# ── Log rotation ─────────────────────────────────────────────────────
+#
+# Long-running Studio sessions used to grow ``~/.amx/logs/amx.log``
+# without bound. The rotating handler caps the active file at
+# ``LOG_MAX_BYTES`` and keeps ``LOG_BACKUP_COUNT`` archives alongside
+# it, so the on-disk footprint is bounded at roughly
+# ``LOG_MAX_BYTES * (1 + LOG_BACKUP_COUNT)``.
+#
+# Defaults are conservative — 10 MB × 5 archives ≈ 60 MB ceiling — and
+# overridable per-environment via ``AMX_LOG_MAX_BYTES`` and
+# ``AMX_LOG_BACKUP_COUNT`` for users who want more retained history or
+# tighter caps. Rotation is on-write so the active file is always
+# ``amx.log``; archives become ``amx.log.1`` … ``amx.log.N``.
+
+_DEFAULT_LOG_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+_DEFAULT_LOG_BACKUP_COUNT = 5
+
+
+def _int_env(name: str, default: int, *, minimum: int = 0) -> int:
+    """Read a non-negative int from the environment, fall back on parse errors."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, value)
+
+
+LOG_MAX_BYTES = _int_env("AMX_LOG_MAX_BYTES", _DEFAULT_LOG_MAX_BYTES, minimum=1024)
+LOG_BACKUP_COUNT = _int_env("AMX_LOG_BACKUP_COUNT", _DEFAULT_LOG_BACKUP_COUNT, minimum=0)
 
 # Written when the profile agent cannot parse an LLM reply (debugging).
 LAST_PROFILE_RESPONSE_FILE = LOG_DIR / "last_profile_agent_response.txt"
@@ -140,7 +175,18 @@ def get_logger(name: str) -> logging.Logger:
         # (cp1252), and any log message containing →, —, … — including
         # ones produced by the human formatter itself — raises
         # UnicodeEncodeError on emit.
-        fh = logging.FileHandler(LOG_DIR / "amx.log", encoding="utf-8")
+        #
+        # ``RotatingFileHandler`` caps the active log at
+        # ``LOG_MAX_BYTES`` and keeps ``LOG_BACKUP_COUNT`` archives.
+        # Set ``LOG_BACKUP_COUNT=0`` to keep one bounded file with no
+        # rollovers (matches the legacy single-file behaviour while
+        # still capping disk usage).
+        fh = logging.handlers.RotatingFileHandler(
+            LOG_DIR / "amx.log",
+            maxBytes=LOG_MAX_BYTES,
+            backupCount=LOG_BACKUP_COUNT,
+            encoding="utf-8",
+        )
         fh.setLevel(logging.DEBUG)
         fh.setFormatter(JsonFormatter())
         logger.addHandler(fh)
@@ -149,3 +195,42 @@ def get_logger(name: str) -> logging.Logger:
         sh.setFormatter(_human_fmt)
         logger.addHandler(sh)
     return logger
+
+
+# ── Structured events ────────────────────────────────────────────────
+
+
+def log_event(event_type: str, /, **fields: Any) -> None:
+    """Write a structured event line to the rotating JSON log.
+
+    Each call emits one ``INFO``-level record on the ``amx.events``
+    logger. ``JsonFormatter`` already serialises ``ts``, ``level``,
+    ``logger``, ``request_id``, and the rendered message; the message
+    itself is the JSON-encoded ``{event, ...fields}`` payload so log
+    shippers can pivot on the event type without re-parsing the text.
+
+    This helper is intentionally thin and free of subscribers — it only
+    writes to the rotating file. Real-time fan-out for AMX Studio
+    continues to flow through :mod:`amx.web.progress_bus` (SSE).
+
+    Examples
+    --------
+    >>> log_event("run.start", profile="prod_pg", scope="public.transactions",
+    ...           backend="postgresql", model="claude-opus-4-7")
+    >>> log_event("run.cancellation.requested", run_id="abcd1234")
+    >>> log_event("run.agent.failed", run_id="abcd1234", agent="rag",
+    ...           reason="timeout")
+
+    Parameters
+    ----------
+    event_type:
+        Dot-separated event name (e.g. ``run.start``,
+        ``run.agent.failed``, ``run.cancellation.completed``).
+    fields:
+        JSON-serialisable key/value pairs describing the event.
+    """
+    logger = get_logger("events")
+    payload: dict[str, Any] = {"event": event_type}
+    if fields:
+        payload.update(fields)
+    logger.info(json.dumps(payload, ensure_ascii=False, default=str))

--- a/tests/test_logging_rotation_and_events.py
+++ b/tests/test_logging_rotation_and_events.py
@@ -1,0 +1,148 @@
+"""Tests for rotating file handler + ``log_event`` structured emitter.
+
+The handler change is invisible to log consumers (still ``amx.log``)
+but caps disk usage. The ``log_event`` helper is a new additive API
+that subsequent PRs (orchestrator cancellation, run lifecycle) will
+emit through.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+import pytest
+
+from amx.utils import logging as amx_logging
+from amx.utils.logging import LOG_BACKUP_COUNT, LOG_MAX_BYTES, get_logger, log_event
+
+
+def _clear_amx_loggers() -> None:
+    """Drop cached handlers so ``get_logger`` rebuilds against the
+    test's patched ``LOG_DIR``. ``get_logger`` short-circuits when
+    ``logger.handlers`` is non-empty, which would otherwise reuse the
+    pre-patch file handler from a prior test."""
+    for name in list(logging.Logger.manager.loggerDict):
+        if name.startswith("amx."):
+            logger = logging.getLogger(name)
+            for handler in list(logger.handlers):
+                logger.removeHandler(handler)
+                try:
+                    handler.close()
+                except Exception:  # pragma: no cover - cleanup best-effort
+                    pass
+
+
+@pytest.fixture
+def isolated_log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``LOG_DIR`` to a per-test temp dir and reset cached
+    handlers on entry and exit."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(amx_logging, "LOG_DIR", log_dir)
+    _clear_amx_loggers()
+    yield log_dir
+    _clear_amx_loggers()
+
+
+def test_get_logger_attaches_rotating_file_handler(isolated_log_dir: Path) -> None:
+    logger = get_logger("rotation_smoke")
+
+    rotating = [h for h in logger.handlers if isinstance(h, RotatingFileHandler)]
+    assert len(rotating) == 1, "expected exactly one RotatingFileHandler"
+
+    handler = rotating[0]
+    assert handler.maxBytes == LOG_MAX_BYTES
+    assert handler.backupCount == LOG_BACKUP_COUNT
+    # Active log path is ``<LOG_DIR>/amx.log`` so existing log shippers
+    # keep working after the rotation upgrade.
+    assert Path(handler.baseFilename).name == "amx.log"
+    assert Path(handler.baseFilename).parent == isolated_log_dir
+
+
+def test_log_event_writes_json_line_with_event_payload(isolated_log_dir: Path) -> None:
+    log_event(
+        "run.start",
+        run_id="abcd1234",
+        profile="prod_pg",
+        scope="public.transactions",
+    )
+
+    # Flush every amx.events handler so the on-disk file is up to date.
+    for handler in logging.getLogger("amx.events").handlers:
+        handler.flush()
+
+    log_path = isolated_log_dir / "amx.log"
+    raw = log_path.read_text(encoding="utf-8").splitlines()
+    records = [json.loads(line) for line in raw if line.strip()]
+
+    matching = [r for r in records if r.get("logger") == "amx.events"]
+    assert len(matching) == 1, "log_event should emit exactly one record"
+
+    record = matching[0]
+    assert record["level"] == "INFO"
+    payload = json.loads(record["message"])
+    assert payload == {
+        "event": "run.start",
+        "run_id": "abcd1234",
+        "profile": "prod_pg",
+        "scope": "public.transactions",
+    }
+
+
+def test_log_event_serialises_non_string_fields(isolated_log_dir: Path) -> None:
+    """Numeric / bool fields survive JSON round-trip — important so
+    downstream analytics can do arithmetic on duration_ms et al."""
+    log_event("run.cancellation.completed", drained_in_ms=1234, partial=True)
+
+    for handler in logging.getLogger("amx.events").handlers:
+        handler.flush()
+
+    raw = (isolated_log_dir / "amx.log").read_text(encoding="utf-8").splitlines()
+    matching = [
+        json.loads(line)
+        for line in raw
+        if line.strip() and json.loads(line).get("logger") == "amx.events"
+    ]
+    payload = json.loads(matching[0]["message"])
+    assert payload == {
+        "event": "run.cancellation.completed",
+        "drained_in_ms": 1234,
+        "partial": True,
+    }
+
+
+def test_log_event_carries_request_id(isolated_log_dir: Path) -> None:
+    """``request_id`` set via ``set_request_id`` propagates into the
+    structured event line — keeps run-scoped events groupable."""
+    amx_logging.set_request_id("rid-zzz")
+    try:
+        log_event("run.agent.failed", agent="rag", reason="timeout")
+    finally:
+        amx_logging.clear_request_id()
+
+    for handler in logging.getLogger("amx.events").handlers:
+        handler.flush()
+
+    raw = (isolated_log_dir / "amx.log").read_text(encoding="utf-8").splitlines()
+    matching = [
+        json.loads(line)
+        for line in raw
+        if line.strip() and json.loads(line).get("logger") == "amx.events"
+    ]
+    assert matching[0]["request_id"] == "rid-zzz"
+
+
+def test_int_env_helper_clamps_below_minimum(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``AMX_LOG_MAX_BYTES=0`` should not produce a zero-byte rotation
+    threshold — the helper enforces a minimum so a misconfiguration
+    can't disable rotation entirely."""
+    monkeypatch.setenv("AMX_LOG_MAX_BYTES", "0")
+    assert amx_logging._int_env("AMX_LOG_MAX_BYTES", 4096, minimum=1024) == 1024
+
+
+def test_int_env_helper_falls_back_on_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AMX_LOG_BACKUP_COUNT", "not-an-int")
+    assert amx_logging._int_env("AMX_LOG_BACKUP_COUNT", 5, minimum=0) == 5


### PR DESCRIPTION
## Summary

Two additive changes to `amx/utils/logging.py`. Nothing about existing log call sites, Studio SSE, or run history changes.

- **Rotating log file.** Replaces the single-file `FileHandler` with `RotatingFileHandler`. Active log path stays at `~/.amx/logs/amx.log` so existing log shippers keep working; archives become `amx.log.1` … `amx.log.N`. Defaults are 10 MB × 5 archives (~60 MB ceiling), overridable via `AMX_LOG_MAX_BYTES` and `AMX_LOG_BACKUP_COUNT` env vars. Closes the unbounded growth gap surfaced in the v0.12.9 audit.
- **`log_event(event_type, **fields)` helper.** Emits one `INFO` record on the `amx.events` logger with a JSON-encoded `{event, ...fields}` message. Follow-up PRs (orchestrator cancel plumbing, run lifecycle) will emit through this so log shippers can pivot on event type without re-parsing free-form text. `request_id` propagation continues to flow via the existing `ContextVar`.

## Why these two together

The `log_event` helper writes to the rotating file. Shipping rotation alone would leave the events helper landing in an unbounded log later; pairing them keeps the disk-footprint contract intact when telemetry events start firing.

## Test plan

- [x] `pytest tests/test_logging_rotation_and_events.py -v` — 6 new cases (handler config, env-var clamping, event payload shape, non-string field serialisation, request-id propagation, fallback parsing).
- [x] `pytest -q --ignore=tests/eval` — 953 tests pass, 19 deselected (integration/live), no regressions.
- [x] `ruff check` and `ruff format --check` clean on touched files.
- [ ] Smoke test in a real Studio session: confirm `amx.log` rotates after exceeding the cap. *(manual; not part of CI)*

## Release note

Uses `feat:` so this lands under the next **minor** bump when `python-semantic-release` is next run manually. No automatic release is triggered — `release.yml` only fires on `v*.*.*` tag pushes.