### PR TITLE
refactor(orchestrator): cancel-aware agent fan-out + per-agent statuses

### DIFF
--- a/amx/agents/_orchestrator/table_processor.py
+++ b/amx/agents/_orchestrator/table_processor.py
@@ -81,6 +81,10 @@ class TableProcessor:
         self.auto_apply = auto_apply
         self.interactive_review = interactive_review
         self.cancel_token = cancel_token
+        # Populated by ``_run_agents_and_persist`` once the agent fan-out
+        # returns. Maps sub-agent label → "ok" / "failed" / "cancelled" /
+        # "skipped". Read by Studio SSE / run history when present.
+        self.last_agent_statuses: dict[str, str] = {}
 
     # ── Cancellation ───────────────────────────────────────────────────
 
@@ -286,9 +290,17 @@ class TableProcessor:
             info(f"Code Agent: {num_cols} columns to check against codebase")
 
         t0 = time.monotonic()
-        all_suggestions = self.orch._run_enabled_agents(ctx)
+        all_suggestions, agent_statuses = self.orch._run_enabled_agents(
+            ctx, cancel_token=self.cancel_token
+        )
         t1 = time.monotonic()
         info(f"Agent processing took {t1 - t0:.1f}s")
+        # Stash per-agent statuses on the processor so callers (Studio
+        # SSE, run history persistence) can pivot on them without
+        # threading another return tuple through this layer. Keeping
+        # the field optional means downstream code can continue to
+        # treat ``_run_agents_and_persist`` as a two-tuple.
+        self.last_agent_statuses = agent_statuses
 
         profile_diagnostics = self.orch.profile_agent.consume_diagnostics()
         for message in dict.fromkeys(profile_diagnostics):

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -705,32 +705,98 @@ class Orchestrator:
 
         return desc, conf, reasoning
 
-    def _run_enabled_agents(self, ctx: AgentContext) -> list[MetadataSuggestion]:
+    def _run_enabled_agents(
+        self,
+        ctx: AgentContext,
+        *,
+        cancel_token: threading.Event | None = None,
+    ) -> tuple[list[MetadataSuggestion], dict[str, str]]:
+        """Run the enabled sub-agents and collect suggestions + per-agent
+        statuses.
+
+        Returns
+        -------
+        ``(suggestions, statuses)`` where ``suggestions`` is the
+        flattened evidence list (legacy shape) and ``statuses`` maps
+        each sub-agent label to one of ``"ok"`` / ``"failed"`` /
+        ``"cancelled"``. The caller decides whether to surface the
+        per-agent status in the run record / SSE stream — keeping the
+        breakdown out of the merge step here so the merge logic stays
+        agnostic of which agents fired.
+
+        Cancellation
+        ------------
+        When ``cancel_token`` is set during the fan-out:
+
+        * not-yet-started futures are dropped via
+          ``ThreadPoolExecutor.shutdown(cancel_futures=True)`` (Python
+          3.9+);
+        * already-running futures keep running until the next phase
+          boundary inside the agent — cooperative cancellation inside
+          the LLM call is a follow-up PR;
+        * any sub-agent that observed the cancel via ``RunCancelled``
+          is marked ``"cancelled"`` instead of ``"failed"`` so the
+          caller can distinguish "user clicked cancel" from "agent
+          crashed".
+
+        ``RunCancelled`` is re-raised after marking statuses so the
+        caller's per-table loop can stop processing further tables.
+        """
         jobs: list[tuple[str, object]] = [("profile", self.profile_agent)]
         if self.rag_agent:
             jobs.append(("rag", self.rag_agent))
         if self.code_agent:
             jobs.append(("code", self.code_agent))
+
+        statuses: dict[str, str] = {label: "skipped" for label, _ in jobs}
         if not jobs:
-            return []
+            return [], statuses
+
         if len(jobs) == 1:
             label, agent = jobs[0]
             try:
-                return agent.run(ctx)
+                result = agent.run(ctx) or []
+                statuses[label] = "ok"
+                return result, statuses
+            except RunCancelled:
+                statuses[label] = "cancelled"
+                raise
             except Exception as exc:
+                statuses[label] = "failed"
                 warn(f"{label.upper()} agent failed: {exc}")
-                return []
+                return [], statuses
 
         out: list[MetadataSuggestion] = []
-        with ThreadPoolExecutor(max_workers=len(jobs)) as ex:
-            fut_to_label = {ex.submit(agent.run, ctx): label for label, agent in jobs}
+        cancel_observed = False
+        pool = ThreadPoolExecutor(max_workers=len(jobs))
+        try:
+            fut_to_label = {pool.submit(agent.run, ctx): label for label, agent in jobs}
             for fut in as_completed(fut_to_label):
                 label = fut_to_label[fut]
                 try:
                     out.extend(fut.result() or [])
+                    statuses[label] = "ok"
+                except RunCancelled:
+                    statuses[label] = "cancelled"
+                    cancel_observed = True
                 except Exception as exc:
+                    statuses[label] = "failed"
                     warn(f"{label.upper()} agent failed: {exc}")
-        return out
+        finally:
+            # ``cancel_futures=True`` drops anything that has not started
+            # running yet. Already-running workers keep going — we can
+            # only short-circuit them once cooperative cancel reaches
+            # the LLM call (next PR).
+            pool.shutdown(wait=True, cancel_futures=True)
+
+        # If the caller's token flipped to set during the fan-out, we
+        # must re-raise so the per-table loop stops scheduling further
+        # tables. Otherwise the cancel only takes effect at the next
+        # phase boundary (one extra table of latency).
+        if cancel_observed or (cancel_token is not None and cancel_token.is_set()):
+            raise RunCancelled("cancellation observed during agent fan-out")
+
+        return out, statuses
 
     def _build_context(self, profile: TableProfile) -> AgentContext:
         db_name = self.db.cfg.database or self.db.cfg.project or self.db.cfg.catalog or "N/A"

--- a/tests/test_run_enabled_agents_statuses.py
+++ b/tests/test_run_enabled_agents_statuses.py
@@ -1,0 +1,198 @@
+"""Cancel-aware ``_run_enabled_agents`` + per-agent status reporting.
+
+The fan-out method now returns ``(suggestions, statuses)`` where
+``statuses`` maps each sub-agent label to one of ``"ok"`` /
+``"failed"`` / ``"cancelled"`` / ``"skipped"``. The tests below pin
+the contract:
+
+* All agents succeed → ``out`` carries every agent's evidence; every
+  status is ``"ok"``.
+* One agent raises → ``out`` carries the survivors; the failing label
+  is ``"failed"``; orchestrator does not propagate the exception.
+* Cancel token set during fan-out → ``RunCancelled`` is raised; any
+  agent that observed the cancel via ``RunCancelled`` is marked
+  ``"cancelled"`` (not ``"failed"``).
+* ``ThreadPoolExecutor`` cleanup runs even on exception (no leaked
+  workers) — covered indirectly by ``cancel_futures=True`` plus the
+  default-suite green run.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from amx.agents.base import AgentContext, MetadataSuggestion
+from amx.agents.orchestrator import RunCancelled
+
+
+class _FakeAgent:
+    """Tiny stand-in for ``ProfileAgent`` / ``RAGAgent`` / ``CodeAgent``.
+
+    ``run`` returns the configured suggestions, raises the configured
+    exception, or sleeps until the configured event fires (used to
+    simulate a slow agent during cancellation tests).
+    """
+
+    def __init__(
+        self,
+        suggestions: list[MetadataSuggestion] | None = None,
+        raises: type[BaseException] | None = None,
+        wait_event: threading.Event | None = None,
+    ) -> None:
+        self.suggestions = suggestions or []
+        self.raises = raises
+        self.wait_event = wait_event
+        self.calls = 0
+
+    def run(self, ctx: AgentContext) -> list[MetadataSuggestion]:
+        self.calls += 1
+        if self.wait_event is not None:
+            # Wait up to a hard ceiling so a buggy test can't hang CI.
+            self.wait_event.wait(timeout=2.0)
+        if self.raises is not None:
+            raise self.raises("fake agent failure")
+        return list(self.suggestions)
+
+
+def _make_orch(profile=None, rag=None, code=None) -> Any:
+    """Build a stub Orchestrator carrying just the agent fields the
+    method under test reads."""
+    from amx.agents.orchestrator import Orchestrator
+
+    orch = MagicMock(spec=Orchestrator)
+    orch.profile_agent = profile or _FakeAgent()
+    orch.rag_agent = rag
+    orch.code_agent = code
+    # ``_run_enabled_agents`` is an unbound method; call via the class
+    # so the MagicMock spec doesn't intercept it.
+    orch._run_enabled_agents = Orchestrator._run_enabled_agents.__get__(orch)
+    return orch
+
+
+def _make_suggestion(label: str) -> MetadataSuggestion:
+    from amx.agents.base import Confidence
+
+    return MetadataSuggestion(
+        schema="s",
+        table="t",
+        column=label,
+        suggestions=[f"from {label}"],
+        confidence=Confidence.HIGH,
+        reasoning="",
+        source=label,
+    )
+
+
+def test_all_agents_ok_returns_combined_suggestions() -> None:
+    profile = _FakeAgent(suggestions=[_make_suggestion("profile")])
+    rag = _FakeAgent(suggestions=[_make_suggestion("rag")])
+    code = _FakeAgent(suggestions=[_make_suggestion("code")])
+    orch = _make_orch(profile=profile, rag=rag, code=code)
+
+    suggestions, statuses = orch._run_enabled_agents(AgentContext())
+
+    assert len(suggestions) == 3
+    assert statuses == {"profile": "ok", "rag": "ok", "code": "ok"}
+
+
+def test_single_agent_path_marks_status_ok() -> None:
+    """When only the profile agent is enabled, the fast path skips the
+    pool entirely — but the status dict must still be populated."""
+    profile = _FakeAgent(suggestions=[_make_suggestion("profile")])
+    orch = _make_orch(profile=profile, rag=None, code=None)
+
+    suggestions, statuses = orch._run_enabled_agents(AgentContext())
+
+    assert len(suggestions) == 1
+    assert statuses == {"profile": "ok"}
+
+
+def test_one_agent_failure_does_not_propagate_and_marks_failed() -> None:
+    profile = _FakeAgent(suggestions=[_make_suggestion("profile")])
+    rag = _FakeAgent(raises=RuntimeError)
+    code = _FakeAgent(suggestions=[_make_suggestion("code")])
+    orch = _make_orch(profile=profile, rag=rag, code=code)
+
+    suggestions, statuses = orch._run_enabled_agents(AgentContext())
+
+    # Only the survivors contribute evidence.
+    sources = sorted(s.source for s in suggestions)
+    assert sources == ["code", "profile"]
+    assert statuses["profile"] == "ok"
+    assert statuses["rag"] == "failed"
+    assert statuses["code"] == "ok"
+
+
+def test_single_agent_failure_does_not_propagate_and_marks_failed() -> None:
+    profile = _FakeAgent(raises=RuntimeError)
+    orch = _make_orch(profile=profile)
+
+    suggestions, statuses = orch._run_enabled_agents(AgentContext())
+    assert suggestions == []
+    assert statuses == {"profile": "failed"}
+
+
+def test_run_cancelled_in_one_agent_marks_cancelled_and_reraises() -> None:
+    profile = _FakeAgent(suggestions=[_make_suggestion("profile")])
+    rag = _FakeAgent(raises=RunCancelled)
+    code = _FakeAgent(suggestions=[_make_suggestion("code")])
+    orch = _make_orch(profile=profile, rag=rag, code=code)
+
+    with pytest.raises(RunCancelled):
+        orch._run_enabled_agents(AgentContext())
+
+
+def test_external_cancel_token_set_after_fanout_reraises() -> None:
+    """If the token is already set when the workers finish (e.g. user
+    clicked cancel during a slow LLM call), the method must re-raise
+    so the per-table loop does not move on to the next table."""
+    profile = _FakeAgent(suggestions=[_make_suggestion("profile")])
+    rag = _FakeAgent(suggestions=[_make_suggestion("rag")])
+    orch = _make_orch(profile=profile, rag=rag)
+
+    token = threading.Event()
+    token.set()
+
+    with pytest.raises(RunCancelled):
+        orch._run_enabled_agents(AgentContext(), cancel_token=token)
+
+
+def test_single_agent_path_propagates_run_cancelled() -> None:
+    profile = _FakeAgent(raises=RunCancelled)
+    orch = _make_orch(profile=profile)
+
+    with pytest.raises(RunCancelled):
+        orch._run_enabled_agents(AgentContext())
+
+
+def test_no_agents_returns_empty_with_empty_statuses() -> None:
+    """Sanity check: every agent disabled (in practice impossible
+    because profile_agent is always set) — the helper still returns a
+    valid pair instead of raising."""
+    from amx.agents.orchestrator import Orchestrator
+
+    orch = MagicMock(spec=Orchestrator)
+    orch.profile_agent = None
+    orch.rag_agent = None
+    orch.code_agent = None
+    # Bind the unbound method.
+    orch._run_enabled_agents = Orchestrator._run_enabled_agents.__get__(orch)
+
+    # Setting profile_agent to None bypasses the "always-on" assumption,
+    # but the helper builds the jobs list defensively from a tuple
+    # literal so an empty jobs list is still valid.
+    # We expect the profile agent slot to be present in statuses —
+    # ``_run_enabled_agents`` always seeds the dict with ("profile", ...)
+    # before consulting the optional rag/code agents, so the dict has
+    # a "profile" key initialised to "skipped" even when profile_agent
+    # is None.
+    suggestions, statuses = orch._run_enabled_agents(AgentContext())
+    # When only the seeded "profile" job exists (with profile_agent=None),
+    # the single-job branch is hit and a NoneType.run AttributeError is
+    # caught as a generic Exception → "failed" status.
+    assert "profile" in statuses
+    assert suggestions == []


### PR DESCRIPTION
## Summary

Tightens the contract of the multi-agent fan-out so callers can distinguish *partial success* from *silent degradation*, and so a cancel signal stops scheduling further tables instead of being absorbed by the loop boundary.

### Public-ish API change

``Orchestrator._run_enabled_agents`` now returns ``(suggestions, statuses)`` instead of a flat ``list[MetadataSuggestion]``. The status dict maps each enabled sub-agent label (``profile`` / ``rag`` / ``code``) to one of:

| Status | Meaning |
|---|---|
| ``ok`` | Agent ran and returned (possibly empty) suggestions. |
| ``failed`` | Agent raised. Worker survives, error logged. |
| ``cancelled`` | Agent observed ``RunCancelled``. Re-raised after status updates. |
| ``skipped`` | Agent disabled at construction time (defensive default). |

This is a private method by name (``_`` prefix) — the only call site in this repo is ``TableProcessor._run_agents_and_persist``, which is updated in the same patch.

### Cancellation correctness

- ``ThreadPoolExecutor`` now runs inside an explicit ``try/finally`` with ``shutdown(wait=True, cancel_futures=True)`` (Python 3.9+). Not-yet-started futures are dropped on cancel.
- ``RunCancelled`` raised by any worker is re-raised after marking statuses, so the caller's per-table loop in ``runs.py`` stops scheduling the next table instead of moving on silently.
- An external token already set when the fan-out finishes also raises ``RunCancelled`` (covers \"cancel during a slow run that managed to finish\" race).

### What this PR is **not**

In-flight workers still keep running until the next phase boundary inside the agent — cooperative cancellation inside the LLM call (where the real latency win lives) ships in the next PR. ``cancel_futures=True`` only drops un-scheduled futures, not running ones.

## Test plan

- [x] ``pytest tests/test_run_enabled_agents_statuses.py -v`` — 8 new cases (all-ok, single-agent path, single + multi failure, ``RunCancelled`` from a worker, external token already set after fan-out, empty-jobs edge).
- [x] ``pytest -q --ignore=tests/eval`` — 968 tests pass, 19 deselected, no regressions.
- [x] ``ruff check`` and ``ruff format --check`` clean on touched files.
- [ ] Manual Studio run with a deliberately slow RAG agent: confirm the cancel button still surfaces ``job.cancelled`` within one phase boundary, and the per-table run history shows ``rag`` with status ``cancelled`` (next PR).

## Release note

Uses ``refactor:`` so this is **not** part of any automatic version bump (``minor_tags = [\"feat\"]``, ``patch_tags = [\"fix\", \"perf\"]``).