### PR TITLE
feat(web): add Content-Security-Policy + sibling response headers

### DIFF
--- a/amx/web/security_headers.py
+++ b/amx/web/security_headers.py
@@ -1,0 +1,91 @@
+"""Defence-in-depth response headers for AMX Studio.
+
+The Studio token + 127.0.0.1 binding already prevent cross-origin
+clients from reaching ``/api/*``. The headers added here are a
+secondary layer: they constrain what the SPA itself is allowed to
+do *if* an injected payload ever ends up in the DOM (LLM-rendered
+metadata, doc snippets, future user input).
+
+What we ship
+------------
+
+* **Content-Security-Policy** — restricts script / style / connect /
+  image sources to ``'self'`` (plus ``data:`` for inline assets used
+  by markdown render). Inline ``style`` is allowed because Tailwind
+  emits utility classes via ``style`` attributes; inline ``script``
+  is **not** allowed. ``frame-ancestors 'none'`` blocks clickjacking.
+* **Referrer-Policy: no-referrer** — Studio is on 127.0.0.1, never
+  send referrer when the user clicks a link to an external doc.
+* **X-Content-Type-Options: nosniff** — defence against MIME confusion
+  on the served SPA assets.
+* **X-Frame-Options: DENY** — legacy mirror of the CSP frame-ancestors
+  rule for browsers that ignore CSP.
+
+What we do **not** ship
+-----------------------
+
+* No HSTS — Studio runs over plain HTTP on 127.0.0.1. HSTS would
+  break the connection on browsers that have learned the loopback
+  origin.
+* No Permissions-Policy — Studio does not use camera / mic / geo /
+  payment APIs and the SPA bundle has no third-party iframes, so the
+  default-deny browser behaviour is already correct.
+
+The CSP allowlist is intentionally tight. If a future feature needs
+a relaxation (a CDN-hosted font, an external chart library), prefer
+adding a single explicit source over moving to ``'unsafe-inline'`` /
+``'unsafe-eval'``. The middleware is plain text on purpose so that
+diffing the policy between releases reads naturally in PR review.
+"""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+# Tight default. ``'self'`` covers everything the SPA loads in the
+# normal case (hashed assets under /assets/*, /api/* fetches, /api/*
+# SSE). ``data:`` for img-src lets ReactMarkdown render small inline
+# images embedded in doc snippets without falling through to a
+# blocked-src CSP report. ``'unsafe-inline'`` on style-src is the
+# Tailwind concession (utility-class style attrs); it does *not*
+# extend to script-src.
+_CSP = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "font-src 'self' data:; "
+    "frame-ancestors 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'"
+)
+
+_HEADERS: dict[str, str] = {
+    "Content-Security-Policy": _CSP,
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach the headers in :data:`_HEADERS` to every response.
+
+    The middleware writes through to *every* response — SPA shell,
+    /api/* JSON, SSE streams, error pages — so a future CSP
+    violation report covers them all.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        response = await call_next(request)
+        # We never overwrite a header a route has already set — if a
+        # specific endpoint needs a relaxed CSP (rare), it can set the
+        # header on its response and the middleware respects it.
+        for name, value in _HEADERS.items():
+            response.headers.setdefault(name, value)
+        return response

--- a/amx/web/security_headers.py
+++ b/amx/web/security_headers.py
@@ -79,9 +79,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     violation report covers them all.
     """
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
-    ) -> Response:
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)
         # We never overwrite a header a route has already set — if a
         # specific endpoint needs a relaxed CSP (rare), it can set the

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -35,6 +35,7 @@ from amx.web.routers import (
     system,
     system_ops,
 )
+from amx.web.security_headers import SecurityHeadersMiddleware
 
 
 def _static_root() -> Path:
@@ -87,6 +88,12 @@ def create_app(
     # Auth middleware runs before any router so unauthenticated /api/*
     # requests short-circuit with 401 — never reach the route handler.
     app.add_middleware(TokenAuthMiddleware)
+    # SecurityHeadersMiddleware sits in front of auth so the
+    # Content-Security-Policy + sibling headers ride along on the 401
+    # response too. Starlette runs middleware in the *reverse* of
+    # ``add_middleware`` order, so adding it after auth means it wraps
+    # the auth middleware — every response goes through it.
+    app.add_middleware(SecurityHeadersMiddleware)
 
     app.include_router(system.router)
     app.include_router(live_db.router)

--- a/tests/web/test_security_headers.py
+++ b/tests/web/test_security_headers.py
@@ -71,6 +71,4 @@ def test_route_set_header_is_not_overwritten(client, auth_headers) -> None:
     # the header (i.e. middleware did not corrupt headers across calls).
     r1 = client.get("/api/system", headers=auth_headers)
     r2 = client.get("/api/system", headers=auth_headers)
-    assert r1.headers.get("Content-Security-Policy") == r2.headers.get(
-        "Content-Security-Policy"
-    )
+    assert r1.headers.get("Content-Security-Policy") == r2.headers.get("Content-Security-Policy")

--- a/tests/web/test_security_headers.py
+++ b/tests/web/test_security_headers.py
@@ -1,0 +1,76 @@
+"""Defence-in-depth security headers ride along every response.
+
+The token + 127.0.0.1 binding still do the heavy lifting; these
+headers are a secondary layer that constrains what the SPA itself
+can do if a payload ever lands in the DOM. The tests here pin the
+contract so a future refactor of ``server.py`` can't silently drop
+the headers.
+"""
+
+from __future__ import annotations
+
+
+def test_csp_header_on_authenticated_api_response(client, auth_headers) -> None:
+    """``/api/system`` is a cheap, always-mounted JSON endpoint."""
+    r = client.get("/api/system", headers=auth_headers)
+    # We don't care which 2xx/4xx — only that the header rides along.
+    assert "Content-Security-Policy" in r.headers
+    csp = r.headers["Content-Security-Policy"]
+    # Tight defaults must survive any future refactor.
+    assert "default-src 'self'" in csp
+    assert "script-src 'self'" in csp
+    assert "frame-ancestors 'none'" in csp
+    # We deliberately allow inline style (Tailwind utility classes via
+    # ``style`` attributes) but never inline / eval'd script.
+    assert "'unsafe-inline'" in csp.split("style-src")[1].split(";")[0]
+    assert "'unsafe-eval'" not in csp
+
+
+def test_csp_header_on_401_unauthenticated_api(client) -> None:
+    """The headers must also ride a 401 — otherwise a stolen-token
+    error page would be the only response without CSP applied."""
+    r = client.get("/api/system")
+    assert r.status_code == 401
+    assert "Content-Security-Policy" in r.headers
+
+
+def test_referrer_policy_no_referrer(client, auth_headers) -> None:
+    r = client.get("/api/system", headers=auth_headers)
+    assert r.headers.get("Referrer-Policy") == "no-referrer"
+
+
+def test_x_content_type_options_nosniff(client, auth_headers) -> None:
+    r = client.get("/api/system", headers=auth_headers)
+    assert r.headers.get("X-Content-Type-Options") == "nosniff"
+
+
+def test_x_frame_options_deny(client, auth_headers) -> None:
+    """Mirror of CSP frame-ancestors for browsers that ignore CSP."""
+    r = client.get("/api/system", headers=auth_headers)
+    assert r.headers.get("X-Frame-Options") == "DENY"
+
+
+def test_headers_on_static_index(client) -> None:
+    """The SPA shell ``/`` returns the bundled ``index.html`` (or the
+    placeholder when the dist isn't on disk in test). Either way the
+    middleware must attach the headers."""
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "Content-Security-Policy" in r.headers
+    assert r.headers.get("X-Frame-Options") == "DENY"
+
+
+def test_route_set_header_is_not_overwritten(client, auth_headers) -> None:
+    """``setdefault`` semantics — if a future endpoint needs a relaxed
+    CSP it can set the header on its response and the middleware
+    respects it. We can't easily exercise this through the existing
+    routes (none override these headers today), so we assert the
+    middleware uses ``setdefault`` indirectly: setting the header twice
+    should be safe and idempotent."""
+    # Fire the same endpoint twice; second response must still carry
+    # the header (i.e. middleware did not corrupt headers across calls).
+    r1 = client.get("/api/system", headers=auth_headers)
+    r2 = client.get("/api/system", headers=auth_headers)
+    assert r1.headers.get("Content-Security-Policy") == r2.headers.get(
+        "Content-Security-Policy"
+    )


### PR DESCRIPTION
## Summary

Defence-in-depth layer on top of the existing token + 127.0.0.1 binding. A new ``SecurityHeadersMiddleware`` attaches a fixed header set to every response (SPA shell, ``/api/*`` JSON, SSE streams, 401/4xx error pages):

| Header | Value | Why |
|---|---|---|
| ``Content-Security-Policy`` | tight allowlist (see below) | Blocks injected ``<script>`` if a payload ever lands in the DOM |
| ``Referrer-Policy`` | ``no-referrer`` | Studio runs on 127.0.0.1; never leak referrer to external links |
| ``X-Content-Type-Options`` | ``nosniff`` | Defends served SPA assets from MIME confusion |
| ``X-Frame-Options`` | ``DENY`` | Legacy mirror of CSP frame-ancestors for browsers that ignore CSP |

CSP allowlist:
```
default-src 'self';
script-src 'self';                       (no inline, no eval)
style-src 'self' 'unsafe-inline';        (Tailwind utility-class style attrs)
img-src 'self' data:;                    (markdown render of inline images)
connect-src 'self';                      (SSE + /api/*)
font-src 'self' data:;
frame-ancestors 'none';
base-uri 'self';
form-action 'self';
```

## Implementation notes

- The middleware uses ``setdefault`` so a future endpoint that needs a relaxed policy can set the header on its response and the middleware respects it.
- ``add_middleware`` is called **after** the auth middleware so Starlette wraps it — auth runs first, then headers attach to whatever response auth produced (including the 401).
- No HSTS (Studio is plain HTTP on loopback; HSTS would break the connection).
- No Permissions-Policy (none of the gated APIs are used).

## What this PR is **not**

The frontend ErrorBoundary + SSE reconnect parts of the original \"PR-7\" are split into a follow-up PR so this one stays small. CSP needed no frontend changes — Tailwind utility classes work under ``style-src 'self' 'unsafe-inline'`` and the SPA loads no third-party scripts.

## Test plan

- [x] ``pytest tests/web/test_security_headers.py -v`` — 7 new cases (CSP shape, headers on 401, headers on SPA shell, header idempotency).
- [x] ``pytest -q --ignore=tests/eval`` — 975 tests pass, 19 deselected, no regressions.
- [x] ``ruff check`` and ``ruff format --check`` clean on touched files.
- [ ] Manual Studio session: open DevTools → Network tab, confirm 0 CSP violations during golden-path Run / Ask flows. *(local verification)*

## Release note

Uses ``feat:`` so this lands under the next **minor** bump when ``python-semantic-release`` is next run manually. No automatic release is triggered.