### PR TITLE
perf(db): batch FK target comments via adapter hook + Postgres impl

### DIFF
--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -278,6 +278,31 @@ class DatabaseAdapter(ABC):
     def get_database_comment(self, engine: Engine) -> str | None:
         return None
 
+    def batch_get_table_comments(
+        self,
+        engine: Engine,
+        pairs: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], str | None] | None:
+        """Fetch table comments for many ``(schema, table)`` pairs at once.
+
+        Default implementation returns ``None`` so callers fall back to
+        per-table ``get_table_comment`` queries — preserves current
+        behaviour for every adapter that has not overridden this hook.
+
+        Adapters that can answer all pairs in a single round-trip
+        (PostgreSQL, MySQL, etc.) should override and return a dict
+        mapping each requested pair to its comment text (or ``None``
+        when the table has no comment). Pairs not present in the dict
+        are treated as "no comment".
+
+        Implementation note: 200 outgoing/incoming FKs commonly hit
+        50+ unique target tables. The default code path issues 50+
+        round-trips through SQLAlchemy's inspector cache; the batch
+        override compresses that to one query against the catalog
+        view (e.g. ``pg_description`` on Postgres).
+        """
+        return None
+
     def column_comments_probe_query(self, schema: str, table: str) -> str:
         """Return the query or metadata operation used to inspect column comments."""
         return f"SQLAlchemy inspector get_columns(table={table!r}, schema={schema!r})"

--- a/amx/db/adapters/postgresql.py
+++ b/amx/db/adapters/postgresql.py
@@ -178,6 +178,56 @@ class PostgreSQLAdapter(DatabaseAdapter):
             ).fetchone()
         return row[0] if row else None
 
+    def batch_get_table_comments(
+        self,
+        engine: Engine,
+        pairs: list[tuple[str, str]],
+    ) -> dict[tuple[str, str], str | None] | None:
+        """Resolve all (schema, table) → comment pairs in one SQL round-trip.
+
+        Reads from ``pg_description`` joined to ``pg_class`` /
+        ``pg_namespace``, restricted to the exact pairs the caller
+        asked for. Tables without a comment are still present in the
+        return dict with a ``None`` value so the caller can
+        distinguish "no comment" from "table not found".
+
+        Replaces the per-table ``inspect(engine).get_table_comment``
+        fan-out used by ``Connector.get_related_table_comments``;
+        with ~50 unique FK targets the round-trip count drops from
+        ~50 to 1.
+        """
+        if not pairs:
+            return {}
+        # De-duplicate while preserving deterministic iteration so
+        # tests can pin a stable parameter expansion.
+        unique_pairs = sorted({(s, t) for s, t in pairs if s and t})
+        # Build (schema, table) tuple parameters using SQLAlchemy
+        # ``expanding`` semantics so the driver handles quoting and the
+        # number of placeholders varies safely with the input length.
+        # We fall back to a CTE join on a VALUES table because the
+        # PostgreSQL driver doesn't support tuple expansion for IN
+        # directly via SQLAlchemy's ``expanding`` flag.
+        values_sql = ", ".join(f"(:s{idx}, :t{idx})" for idx in range(len(unique_pairs)))
+        params: dict[str, str] = {}
+        for idx, (schema, table) in enumerate(unique_pairs):
+            params[f"s{idx}"] = schema
+            params[f"t{idx}"] = table
+        sql = (
+            "WITH wanted(schema_name, table_name) AS (VALUES "
+            f"{values_sql})\n"
+            "SELECT n.nspname AS schema_name, c.relname AS table_name, "
+            "obj_description(c.oid, 'pg_class') AS comment\n"
+            "FROM wanted w "
+            "JOIN pg_namespace n ON n.nspname = w.schema_name "
+            "JOIN pg_class c ON c.relnamespace = n.oid AND c.relname = w.table_name"
+        )
+        result: dict[tuple[str, str], str | None] = dict.fromkeys(unique_pairs)
+        with engine.connect() as conn:
+            for row in conn.execute(text(sql), params):
+                key = (str(row[0]), str(row[1]))
+                result[key] = row[2] if row[2] is not None else None
+        return result
+
     def column_comments_probe_query(self, schema: str, table: str) -> str:
         return (
             "SELECT a.attname AS column_name, col_description(c.oid, a.attnum) AS comment "

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -1118,7 +1118,15 @@ class DatabaseConnector:
         outgoing_fks: list[dict[str, Any]],
         incoming_fks: list[dict[str, Any]],
     ) -> list[dict[str, str]]:
-        """Fetch comments for tables connected through FK relationships."""
+        """Fetch comments for tables connected through FK relationships.
+
+        Uses :meth:`amx.db.adapters.base.BaseAdapter.batch_get_table_comments`
+        when the active adapter implements the hook (PostgreSQL today)
+        so a tabel with N foreign-key neighbours costs one round-trip
+        instead of N. Adapters that have not overridden the hook fall
+        back to the per-table ``get_table_comment`` path; behaviour is
+        unchanged for them.
+        """
         related: set[tuple[str, str]] = set()
         for fk in outgoing_fks:
             rs = str(fk.get("referred_schema") or "")
@@ -1131,9 +1139,34 @@ class DatabaseConnector:
             if rs and rt:
                 related.add((rs, rt))
 
+        if not related:
+            return []
+
+        ordered_pairs = sorted(related)
+
+        # Try the batch path first. ``batch_get_table_comments`` returns
+        # ``None`` on adapters that have not opted in; a dict (possibly
+        # empty) means the adapter handled the request and we should
+        # not fall back per-table.
+        comments_by_pair: dict[tuple[str, str], str | None] | None = None
+        try:
+            comments_by_pair = self._adapter.batch_get_table_comments(self.engine, ordered_pairs)
+        except Exception as exc:
+            # A misbehaving batch implementation must not break callers
+            # — log and fall back to the historical per-table path.
+            log.warning(
+                "Adapter %s batch_get_table_comments failed (%s); falling back to per-table fetch.",
+                type(self._adapter).__name__,
+                exc,
+            )
+            comments_by_pair = None
+
         out: list[dict[str, str]] = []
-        for rs, rt in sorted(related):
-            cmt = self.get_table_comment(rs, rt) or ""
+        for rs, rt in ordered_pairs:
+            if comments_by_pair is not None:
+                cmt = comments_by_pair.get((rs, rt)) or ""
+            else:
+                cmt = self.get_table_comment(rs, rt) or ""
             out.append({"schema": rs, "table": rt, "comment": cmt})
         return out
 

--- a/tests/test_get_related_table_comments_batch.py
+++ b/tests/test_get_related_table_comments_batch.py
@@ -1,0 +1,172 @@
+"""``Connector.get_related_table_comments`` batch fast-path + fallback.
+
+Most of the test surface here is structural — the heavy SQL behind
+the new ``BaseAdapter.batch_get_table_comments`` hook is exercised
+in live PostgreSQL integration tests, which are gated behind the
+``-m integration`` marker and do not run on the headless CI matrix.
+The unit tests below cover the connector's branching:
+
+* Adapter implements the hook → batch result is consulted; no
+  per-table ``get_table_comment`` fan-out.
+* Adapter returns ``None`` (default base impl) → legacy per-table
+  fan-out remains.
+* Adapter raises → caller logs and falls back per-table; no exception
+  surfaces to ``Connector.get_related_table_comments``.
+* No FK pairs → no adapter call at all (cheap empty-input shortcut).
+* Duplicate FK pairs → de-duped before the round-trip.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _make_connector(adapter=None) -> object:
+    """Build a stub Connector exposing only what
+    ``get_related_table_comments`` reads."""
+    from amx.db.connector import DatabaseConnector
+
+    conn = MagicMock(spec=DatabaseConnector)
+    conn._adapter = adapter or MagicMock()
+    conn.engine = MagicMock()
+    # ``get_table_comment`` is the per-table fallback path; tests below
+    # configure it to return a deterministic string.
+    conn.get_table_comment = MagicMock(side_effect=lambda s, t: f"cmt-{s}-{t}")
+    # Bind the unbound method so we can call it on the mock.
+    conn.get_related_table_comments = DatabaseConnector.get_related_table_comments.__get__(conn)
+    return conn
+
+
+def test_batch_path_used_when_adapter_returns_dict() -> None:
+    adapter = MagicMock()
+    adapter.batch_get_table_comments.return_value = {
+        ("public", "orders"): "Order header.",
+        ("public", "customers"): None,  # no comment is a valid result
+    }
+    conn = _make_connector(adapter=adapter)
+
+    out = conn.get_related_table_comments(
+        outgoing_fks=[{"referred_schema": "public", "referred_table": "orders"}],
+        incoming_fks=[{"source_schema": "public", "source_table": "customers"}],
+    )
+
+    # Adapter is consulted exactly once with the union of FK targets.
+    adapter.batch_get_table_comments.assert_called_once()
+    args, _ = adapter.batch_get_table_comments.call_args
+    pairs_arg = args[1]
+    assert sorted(pairs_arg) == [("public", "customers"), ("public", "orders")]
+
+    # No per-table fallback was used.
+    conn.get_table_comment.assert_not_called()
+
+    # Result preserves the comment text and stringifies missing comments.
+    assert out == [
+        {"schema": "public", "table": "customers", "comment": ""},
+        {"schema": "public", "table": "orders", "comment": "Order header."},
+    ]
+
+
+def test_legacy_path_used_when_adapter_returns_none() -> None:
+    """The default ``BaseAdapter`` impl returns ``None`` — the
+    connector must fall back to per-table ``get_table_comment``."""
+    adapter = MagicMock()
+    adapter.batch_get_table_comments.return_value = None
+    conn = _make_connector(adapter=adapter)
+
+    out = conn.get_related_table_comments(
+        outgoing_fks=[{"referred_schema": "public", "referred_table": "orders"}],
+        incoming_fks=[{"source_schema": "public", "source_table": "customers"}],
+    )
+
+    # Per-table fallback fired for each pair.
+    assert conn.get_table_comment.call_count == 2
+    assert {tuple(c.args) for c in conn.get_table_comment.call_args_list} == {
+        ("public", "customers"),
+        ("public", "orders"),
+    }
+    assert {row["comment"] for row in out} == {"cmt-public-orders", "cmt-public-customers"}
+
+
+def test_legacy_path_used_when_adapter_batch_raises() -> None:
+    """A misbehaving batch override must not break the caller — it
+    falls back to the legacy path and logs."""
+    adapter = MagicMock()
+    adapter.batch_get_table_comments.side_effect = RuntimeError("boom")
+    conn = _make_connector(adapter=adapter)
+
+    out = conn.get_related_table_comments(
+        outgoing_fks=[{"referred_schema": "public", "referred_table": "orders"}],
+        incoming_fks=[],
+    )
+    assert conn.get_table_comment.call_count == 1
+    assert out == [{"schema": "public", "table": "orders", "comment": "cmt-public-orders"}]
+
+
+def test_no_fk_pairs_returns_empty_list_and_skips_adapter() -> None:
+    adapter = MagicMock()
+    conn = _make_connector(adapter=adapter)
+
+    out = conn.get_related_table_comments(outgoing_fks=[], incoming_fks=[])
+    assert out == []
+    adapter.batch_get_table_comments.assert_not_called()
+
+
+def test_duplicate_fk_pairs_dedup_before_adapter_call() -> None:
+    adapter = MagicMock()
+    adapter.batch_get_table_comments.return_value = {("public", "orders"): "x"}
+    conn = _make_connector(adapter=adapter)
+
+    conn.get_related_table_comments(
+        outgoing_fks=[
+            {"referred_schema": "public", "referred_table": "orders"},
+            # Duplicate pair — same target.
+            {"referred_schema": "public", "referred_table": "orders"},
+        ],
+        incoming_fks=[
+            {"source_schema": "public", "source_table": "orders"},
+        ],
+    )
+
+    args, _ = adapter.batch_get_table_comments.call_args
+    pairs_arg = args[1]
+    # Three FK rows but only one unique pair reaches the adapter.
+    assert pairs_arg == [("public", "orders")]
+
+
+def test_empty_or_blank_fk_fields_are_filtered() -> None:
+    """FKs with empty schema or table strings are dropped before the
+    adapter call — matches existing legacy behaviour."""
+    adapter = MagicMock()
+    adapter.batch_get_table_comments.return_value = {("public", "orders"): None}
+    conn = _make_connector(adapter=adapter)
+
+    conn.get_related_table_comments(
+        outgoing_fks=[
+            {"referred_schema": "", "referred_table": "x"},
+            {"referred_schema": "public", "referred_table": ""},
+            {"referred_schema": "public", "referred_table": "orders"},
+        ],
+        incoming_fks=[],
+    )
+    args, _ = adapter.batch_get_table_comments.call_args
+    pairs_arg = args[1]
+    assert pairs_arg == [("public", "orders")]
+
+
+def test_base_adapter_default_returns_none() -> None:
+    """Pin the contract for adapters that have not opted in.
+
+    ``DatabaseAdapter.batch_get_table_comments`` is the new opt-in
+    hook — calling it on the unbound default impl with any arguments
+    must return ``None`` (signalling \"not handled, fall back\").
+    Calling unbound bypasses ``__init__`` so we don't need to fabricate
+    a config or engine just to assert the default contract.
+    """
+    from amx.db.adapters.base import DatabaseAdapter
+
+    # ``self`` is unused by the default impl, so a sentinel is fine.
+    sentinel_self = object()
+    result = DatabaseAdapter.batch_get_table_comments(
+        sentinel_self, engine=None, pairs=[("s", "t")]
+    )
+    assert result is None


### PR DESCRIPTION
## Summary

``Connector.get_related_table_comments`` used to fan out one ``inspect(engine).get_table_comment`` round-trip per unique FK target. A 200-FK schema commonly hits ~50 unique target tables, so the cost scaled linearly with neighbour count.

This PR adds an opt-in adapter hook so backends that can answer the lookup in a single SQL do so:

1. **``BaseAdapter.batch_get_table_comments(engine, pairs)``** — default returns ``None`` ⇒ adapters that have **not** opted in keep the legacy per-table path unchanged. No silent behavioural change for MySQL / Oracle / MSSQL / Snowflake / Databricks / BigQuery / Redshift / ClickHouse / DuckDB.
2. **PostgreSQL override** — single SQL against ``pg_description`` joined to ``pg_class`` / ``pg_namespace`` with a CTE/VALUES table of the requested pairs. 50+ round-trips collapse to one.
3. **Connector branching** — uses the batch result when the adapter returns a dict, falls back to the per-table path when it returns ``None``, and logs + falls back if the override raises (no exception surfaces to callers — matches the historical best-effort contract).

The dedup-before-call + empty-input shortcut + blank-field filter all stay where they were; the only behavioural change is the round-trip count on PostgreSQL.

## Why this hook shape

A single batch method on the adapter, opt-in, beats a generic SQL or schema-scoped reflection because:

- Each backend has its own catalog (``pg_description``, ``information_schema.TABLES``, Snowflake ``COMMENT`` column on ``INFORMATION_SCHEMA.TABLES``, etc.).
- Adapters have direct access to dialect-safe parameter binding (``text(...)`` + ``:param`` here), so we don't have to handcraft per-dialect quoting in connector code.
- Default ``None`` keeps the rollout safe — every adapter ships unchanged today and can be upgraded one PR at a time.

## Test plan

- [x] ``pytest tests/test_get_related_table_comments_batch.py -v`` — 7 new unit cases (batch fast-path, legacy fallback when override returns ``None``, legacy fallback when override raises, empty-input shortcut, dedup before round-trip, blank-field filter, default-impl contract).
- [x] ``pytest -q --ignore=tests/eval`` — 982 tests pass, 19 deselected, no regressions.
- [x] ``ruff check`` and ``ruff format --check`` clean on touched files.
- [ ] Live PostgreSQL ``-m integration`` run to confirm the SQL parameterisation works against a real ``pg_description`` view (covered by the existing integration suite next time it runs).

## Release note

Uses ``perf:`` so this lands under the next **patch** bump when ``python-semantic-release`` is next run manually. No automatic release is triggered.

## Follow-ups (not in this PR)

- ``profile_table()`` single-pass aggregation (``COUNT(*)`` + per-column ``DISTINCT`` collapses to one query).
- Per-backend SQLAlchemy pool config (``pool_size`` / ``max_overflow`` / ``pool_recycle``).
- MySQL + Snowflake + BigQuery overrides for ``batch_get_table_comments``.

Each lands as its own PR so the perf delta is attributable.