### PR TITLE
feat(storage): apply_events audit-log table + record/list helpers

### DIFF
--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -449,6 +449,51 @@ class SQLiteHistoryStore:
                 "CREATE INDEX IF NOT EXISTS idx_analysis_runs_shared_uuid "
                 "ON analysis_runs(shared_uuid)"
             )
+        # ── apply_events: audit trail of every COMMENT actually written ──
+        #
+        # ``run_results.applied_at`` already says "this row was applied"
+        # but cannot answer "what was the comment before we overwrote
+        # it" or "who applied it on which host". The apply_events table
+        # records one row per successful COMMENT write so /history
+        # rollback (PR-12b) and Studio's Recent Applies panel (PR-12c)
+        # have a stable replay log. Old comments are stored verbatim so
+        # rollback can restore them character-for-character.
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS apply_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                applied_at REAL NOT NULL,
+                run_id INTEGER,
+                result_id INTEGER,
+                profile_name TEXT NOT NULL DEFAULT '',
+                schema_name TEXT NOT NULL,
+                table_name TEXT NOT NULL DEFAULT '',
+                column_name TEXT,
+                asset_kind TEXT NOT NULL DEFAULT 'table',
+                old_comment TEXT,
+                new_comment TEXT NOT NULL,
+                applied_by TEXT NOT NULL DEFAULT '',
+                hostname TEXT NOT NULL DEFAULT '',
+                sql_template TEXT NOT NULL DEFAULT '',
+                FOREIGN KEY (run_id) REFERENCES analysis_runs(id),
+                FOREIGN KEY (result_id) REFERENCES run_results(id)
+            )
+            """
+        )
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_apply_events_applied_at "
+                "ON apply_events(applied_at DESC)"
+            )
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_apply_events_run_id ON apply_events(run_id)"
+            )
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_apply_events_asset "
+                "ON apply_events(profile_name, schema_name, table_name, column_name)"
+            )
 
     def create_run(
         self,
@@ -728,6 +773,113 @@ class SQLiteHistoryStore:
                 """,
                 (error_text, error_text, result_id),
             )
+
+    def record_apply_event(
+        self,
+        *,
+        schema_name: str,
+        new_comment: str,
+        run_id: int | None = None,
+        result_id: int | None = None,
+        profile_name: str = "",
+        table_name: str = "",
+        column_name: str | None = None,
+        asset_kind: str = "table",
+        old_comment: str | None = None,
+        applied_by: str = "",
+        hostname: str = "",
+        sql_template: str = "",
+    ) -> int:
+        """Append one ``apply_events`` row for a successful COMMENT write.
+
+        ``new_comment`` is the comment text actually written to the
+        database. ``old_comment`` (when supplied) lets a future
+        rollback step restore the prior state byte-for-byte. Every
+        other field is optional so callers that don't yet propagate
+        full attribution can still record a basic audit trail.
+
+        Returns the inserted row id so callers (e.g. Studio SSE) can
+        link a UI event back to the audit row.
+        """
+        now = time.time()
+        with self._lock, self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO apply_events (
+                    applied_at, run_id, result_id, profile_name,
+                    schema_name, table_name, column_name, asset_kind,
+                    old_comment, new_comment, applied_by, hostname,
+                    sql_template
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    now,
+                    run_id,
+                    result_id,
+                    profile_name,
+                    schema_name,
+                    table_name,
+                    column_name,
+                    asset_kind,
+                    old_comment,
+                    new_comment,
+                    applied_by,
+                    hostname,
+                    sql_template,
+                ),
+            )
+            return int(cursor.lastrowid or 0)
+
+    def list_apply_events(
+        self,
+        *,
+        run_id: int | None = None,
+        profile_name: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Return apply events newest-first, optionally filtered by run / profile.
+
+        Used by ``/history rollback`` (PR-12b) to find the events to
+        replay in reverse, and by Studio's Recent Applies panel
+        (PR-12c) to render the timeline.
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        if run_id is not None:
+            clauses.append("run_id = ?")
+            params.append(run_id)
+        if profile_name is not None:
+            clauses.append("profile_name = ?")
+            params.append(profile_name)
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = (
+            "SELECT id, applied_at, run_id, result_id, profile_name, "
+            "schema_name, table_name, column_name, asset_kind, "
+            "old_comment, new_comment, applied_by, hostname, sql_template "
+            "FROM apply_events" + where + " ORDER BY applied_at DESC LIMIT ?"
+        )
+        params.append(int(limit))
+        with self._lock, self._connect() as conn:
+            rows = conn.execute(sql, tuple(params)).fetchall()
+        return [
+            {
+                "id": int(r[0]),
+                "applied_at": float(r[1]),
+                "run_id": r[2],
+                "result_id": r[3],
+                "profile_name": str(r[4]),
+                "schema_name": str(r[5]),
+                "table_name": str(r[6]),
+                "column_name": r[7],
+                "asset_kind": str(r[8]),
+                "old_comment": r[9],
+                "new_comment": str(r[10]),
+                "applied_by": str(r[11]),
+                "hostname": str(r[12]),
+                "sql_template": str(r[13]),
+            }
+            for r in rows
+        ]
 
     def update_run_status(self, run_id: int, status: str, error_text: str = "") -> None:
         """Update run status without overwriting metrics/tokens/results payloads."""

--- a/tests/test_apply_events_audit.py
+++ b/tests/test_apply_events_audit.py
@@ -1,0 +1,165 @@
+"""``apply_events`` audit-log table + ``record_apply_event`` / ``list_apply_events``.
+
+The table records one row per successful COMMENT write so the
+upcoming ``/history rollback`` (PR-12b) and Studio's Recent Applies
+panel (PR-12c) have a stable replay log. The tests below pin:
+
+* ``init()`` creates the table + indexes idempotently (rerunning the
+  store on the same path is a no-op).
+* ``record_apply_event`` returns the inserted row id.
+* ``list_apply_events`` filters by run_id / profile_name and orders
+  newest-first.
+* ``old_comment`` is preserved verbatim — including ``None`` and
+  empty strings — so rollback can restore the prior state.
+
+We do not exercise the call-site integration here (apply.py still
+talks only to ``record_applied`` for now); that lands in PR-12b
+alongside the rollback command.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def test_init_creates_apply_events_table_idempotently(tmp_path: Path) -> None:
+    db_path = tmp_path / "history.db"
+    s1 = SQLiteHistoryStore(db_path)
+    s1.init()
+    # Running init again on the same DB must not raise — the schema
+    # creation is wrapped in IF NOT EXISTS.
+    s2 = SQLiteHistoryStore(db_path)
+    s2.init()
+    # Sanity: empty table after init.
+    assert s2.list_apply_events() == []
+
+
+def test_record_apply_event_persists_full_payload(store: SQLiteHistoryStore) -> None:
+    event_id = store.record_apply_event(
+        run_id=42,
+        result_id=7,
+        profile_name="prod_pg",
+        schema_name="public",
+        table_name="transactions",
+        column_name="posting",
+        asset_kind="table",
+        old_comment="Posting date.",
+        new_comment="Posting date encoded as YYYYMMDD.",
+        applied_by="omer",
+        hostname="laptop",
+        sql_template="COMMENT ON COLUMN public.transactions.posting IS :cmt",
+    )
+    assert event_id > 0
+
+    events = store.list_apply_events()
+    assert len(events) == 1
+    e = events[0]
+    assert e["id"] == event_id
+    assert e["run_id"] == 42
+    assert e["result_id"] == 7
+    assert e["profile_name"] == "prod_pg"
+    assert e["schema_name"] == "public"
+    assert e["table_name"] == "transactions"
+    assert e["column_name"] == "posting"
+    assert e["asset_kind"] == "table"
+    assert e["old_comment"] == "Posting date."
+    assert e["new_comment"] == "Posting date encoded as YYYYMMDD."
+    assert e["applied_by"] == "omer"
+    assert e["hostname"] == "laptop"
+    assert e["sql_template"].startswith("COMMENT ON COLUMN")
+    # Newest-first ordering — single row sits at the top.
+    assert e["applied_at"] <= time.time() + 1.0
+
+
+def test_record_apply_event_accepts_minimal_payload(store: SQLiteHistoryStore) -> None:
+    """Callers that don't yet propagate full attribution (early CLI
+    integration, tests) should still be able to record a basic event."""
+    event_id = store.record_apply_event(
+        schema_name="public",
+        new_comment="Minimal-payload comment.",
+    )
+    assert event_id > 0
+    events = store.list_apply_events()
+    assert len(events) == 1
+    e = events[0]
+    assert e["schema_name"] == "public"
+    assert e["new_comment"] == "Minimal-payload comment."
+    # Optional fields default to empty strings / None.
+    assert e["run_id"] is None
+    assert e["result_id"] is None
+    assert e["profile_name"] == ""
+    assert e["table_name"] == ""
+    assert e["column_name"] is None
+    assert e["old_comment"] is None
+    assert e["applied_by"] == ""
+    assert e["hostname"] == ""
+    assert e["sql_template"] == ""
+
+
+def test_old_comment_preserves_none_vs_empty_string(store: SQLiteHistoryStore) -> None:
+    """Distinct semantics: ``None`` = "we never read the prior comment"
+    vs ``""`` = "the prior comment was empty". Rollback needs both."""
+    store.record_apply_event(
+        schema_name="s",
+        new_comment="A",
+        old_comment=None,
+    )
+    store.record_apply_event(
+        schema_name="s",
+        new_comment="B",
+        old_comment="",
+    )
+    events = store.list_apply_events()
+    # Newest-first: B (with old="") then A (with old=None).
+    assert events[0]["new_comment"] == "B"
+    assert events[0]["old_comment"] == ""
+    assert events[1]["new_comment"] == "A"
+    assert events[1]["old_comment"] is None
+
+
+def test_list_apply_events_filters_by_run_id(store: SQLiteHistoryStore) -> None:
+    store.record_apply_event(schema_name="s", new_comment="A", run_id=1)
+    store.record_apply_event(schema_name="s", new_comment="B", run_id=2)
+    store.record_apply_event(schema_name="s", new_comment="C", run_id=1)
+
+    only_run_1 = store.list_apply_events(run_id=1)
+    assert {e["new_comment"] for e in only_run_1} == {"A", "C"}
+
+    only_run_2 = store.list_apply_events(run_id=2)
+    assert [e["new_comment"] for e in only_run_2] == ["B"]
+
+
+def test_list_apply_events_filters_by_profile_name(store: SQLiteHistoryStore) -> None:
+    store.record_apply_event(schema_name="s", new_comment="A", profile_name="prod_pg")
+    store.record_apply_event(schema_name="s", new_comment="B", profile_name="staging")
+    store.record_apply_event(schema_name="s", new_comment="C", profile_name="prod_pg")
+
+    only_prod = store.list_apply_events(profile_name="prod_pg")
+    assert {e["new_comment"] for e in only_prod} == {"A", "C"}
+
+
+def test_list_apply_events_orders_newest_first(store: SQLiteHistoryStore) -> None:
+    """Caller-friendly default — no need to ORDER BY in app code."""
+    ids = [store.record_apply_event(schema_name="s", new_comment=f"comment-{i}") for i in range(5)]
+    events = store.list_apply_events()
+    # Latest insertion first.
+    assert [e["id"] for e in events] == list(reversed(ids))
+
+
+def test_list_apply_events_respects_limit(store: SQLiteHistoryStore) -> None:
+    for i in range(10):
+        store.record_apply_event(schema_name="s", new_comment=f"c-{i}")
+    assert len(store.list_apply_events(limit=3)) == 3
+    assert len(store.list_apply_events(limit=100)) == 10


### PR DESCRIPTION
## Summary

Adds a new ``apply_events`` table in the SQLite history store that records one row per successful COMMENT write. Each row carries enough information for a future ``/history rollback`` to restore the prior state byte-for-byte and for Studio's Recent Applies panel to render a multi-user timeline.

### Schema

| Column | Purpose |
|---|---|
| ``applied_at``, ``run_id``, ``result_id`` | Run-grouped lookups |
| ``profile_name``, ``schema_name``, ``table_name``, ``column_name``, ``asset_kind`` | Asset identification |
| ``old_comment``, ``new_comment`` | Verbatim before/after — rollback restores ``old_comment`` literally |
| ``applied_by``, ``hostname`` | Multi-user attribution (matches existing 0.12.x ``run_results`` columns) |
| ``sql_template`` | COMMENT statement the adapter executed, with ``:cmt`` placeholder intact |

Three indexes cover the planned query patterns:
- ``applied_at DESC`` for the Studio panel timeline
- ``run_id`` for ``/history rollback <run-id>``
- ``(profile_name, schema_name, table_name, column_name)`` for asset-level history lookup

Migration is idempotent: ``CREATE TABLE IF NOT EXISTS`` + ``CREATE INDEX IF NOT EXISTS``. Re-running ``init()`` on an upgraded DB is a no-op.

### Two new methods

- ``record_apply_event(*, schema_name, new_comment, ...)`` — returns the inserted row id
- ``list_apply_events(run_id=, profile_name=, limit=100)`` — newest-first, optionally filtered

### What this PR is **not**

- ``apply_review_results_to_db`` does **not** yet call ``record_apply_event`` — wiring the call site lands in PR-12b alongside the ``/history rollback`` command.
- Studio's Recent Applies panel lands in PR-12c.

Splitting the stack keeps each PR small enough to review and revert independently. The audit-log payload landing first (with no caller-side change) is the lowest-risk slice — every existing call path keeps working.

## Test plan

- [x] ``pytest tests/test_apply_events_audit.py -v`` — 8 new cases (table creation idempotence, full + minimal payload persistence, None vs empty-string semantics for ``old_comment``, ``run_id`` / ``profile_name`` filtering, newest-first ordering, ``limit`` clause).
- [x] ``pytest -q --ignore=tests/eval`` — 997 tests pass, 19 deselected, no regressions.
- [x] ``ruff check`` and ``ruff format --check`` clean on touched files.
- [ ] Once PR-12b lands, manual ``amx /apply`` run + ``sqlite3 ~/.amx/history.db 'SELECT * FROM apply_events'`` to confirm rows accumulate. *(deferred to follow-up)*

## Release note

Uses ``feat:`` so this lands under the next **minor** bump when ``python-semantic-release`` is next run manually. No automatic release is triggered.