### PR TITLE
ci: cap dependabot auto-bumps at minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
     labels:
       - "dependencies"
       - "python"
+    # Major bumps need a planned migration (e.g. SQLAlchemy 2 → 3,
+    # Click 8 → 9). Auto-grouping them with minor/patch bumps in a
+    # single PR makes the PR un-reviewable and impossible to revert
+    # surgically. Security advisories still surface independently.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       python-deps:
         patterns: ["*"]
@@ -43,6 +50,13 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
+    # Same major-bump cap as the pip ecosystem. PR #191 was a 14-pkg
+    # major-grouped bundle (React 18→19, Router 6→7, Vite 5→8, …)
+    # that broke ``npm run build`` against the current SPA. Future
+    # major migrations land as one-off manual PRs.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-deps:
         patterns: ["*"]


### PR DESCRIPTION
## Summary

Closes the loop after PR #191 (14-pkg npm major bundle: React 18→19, Router 6→7, Vite 5→8, Tailwind 3→4, TypeScript 5→6) which failed ``npm run build`` and was un-reviewable as a single grouped PR.

Adds ``ignore: version-update:semver-major`` to both pip and npm ecosystems in ``.github/dependabot.yml``. Future major migrations land as one-off manual PRs; minor / patch bumps continue to flow as grouped weekly PRs.

Security advisories surface independently of this filter — Dependabot still creates a PR for any flagged CVE regardless of semver type.

## Test plan

- [x] ``python -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"`` — YAML parses.
- [ ] First weekly Dependabot scan after merge produces only minor/patch PRs (no React 19 etc). *(verifies the rule worked)*