### PR TITLE
feat(cli): amx /analyze apply --dry-run flag

### DIFF
--- a/amx/cli_support/commands/run.py
+++ b/amx/cli_support/commands/run.py
@@ -148,8 +148,19 @@ def register_analyze_commands(
         """Run metadata inference agents."""
 
     @analyze.command("apply")
+    @click.option(
+        "--dry-run",
+        is_flag=True,
+        default=False,
+        help=(
+            "Print the COMMENT statements that would run, without "
+            "touching the database. The pending file is left "
+            "unchanged so you can re-run /apply for real after "
+            "reviewing the preview."
+        ),
+    )
     @pass_config
-    def analyze_apply(cfg: AMXConfig) -> None:
+    def analyze_apply(cfg: AMXConfig, dry_run: bool) -> None:
         """Write pending approved descriptions to the database (COMMENT ON TABLE/COLUMN)."""
         from amx.agents.orchestrator import (
             apply_review_results_to_db,
@@ -172,7 +183,11 @@ def register_analyze_commands(
             )
             return
 
-        heading("Apply pending metadata to the database")
+        heading(
+            "Preview pending metadata writes (dry-run)"
+            if dry_run
+            else "Apply pending metadata to the database"
+        )
         render_table(
             "Pending comments",
             ["Asset", "Description"],
@@ -184,6 +199,65 @@ def register_analyze_commands(
                 for row in pending
             ],
         )
+        if dry_run:
+            # Dry-run path: short-circuit straight to the preview loop.
+            # No confirmation prompt — nothing will be written so there
+            # is nothing for the user to gate. Pending file is left
+            # untouched so the user can re-run /apply for real.
+            info(
+                f"Dry-run: showing the SQL templates for {len(pending)} pending comment(s). "
+                "No changes will be written."
+            )
+            db = DatabaseConnector(cfg.db)
+            if not db.test_connection():
+                log_event(
+                    event_type="analyze_apply",
+                    status="failed",
+                    command="analyze.apply",
+                    details={"reason": "db_connect_failed", "dry_run": True},
+                )
+                error("Cannot connect to database.")
+                sys.exit(1)
+
+            preview_count = 0
+            skipped_count = 0
+
+            def _on_preview(_r: Any, status: str, idx: int, total: int, detail: str) -> None:
+                nonlocal preview_count, skipped_count
+                if status == "preview":
+                    preview_count += 1
+                    if "unsupported" in detail.lower():
+                        skipped_count += 1
+                        info(f"  [{idx}/{total}] (skipped — backend cannot accept this asset kind)")
+                    else:
+                        info(f"  [{idx}/{total}] {detail}")
+                elif status == "preview_failed":
+                    skipped_count += 1
+                    error(f"  [{idx}/{total}] preview error: {detail}")
+
+            apply_review_results_to_db(
+                db,
+                pending,
+                on_progress=_on_preview,
+                dry_run=True,
+            )
+            success(
+                f"Dry-run complete: {preview_count} comment(s) previewed"
+                + (f", {skipped_count} unsupported/skipped." if skipped_count else ".")
+                + " Pending file unchanged. Re-run `/analyze apply` (without --dry-run) to write."
+            )
+            log_event(
+                event_type="analyze_apply",
+                status="preview",
+                command="analyze.apply",
+                details={
+                    "preview_count": preview_count,
+                    "skipped_count": skipped_count,
+                    "dry_run": True,
+                },
+            )
+            return
+
         if not confirm(f"Write {len(pending)} comment(s) to the database?", default=True):
             log_event(
                 event_type="analyze_apply",

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -101,6 +101,78 @@ class AnalyzeApplyIntegrationTests(unittest.TestCase):
         clear_pending.assert_called_once()
         fake_history.record_applied.assert_called_once_with(17)
 
+    def test_analyze_apply_dry_run_does_not_write(self) -> None:
+        """``--dry-run`` previews SQL templates without touching the
+        database. Pending file must stay intact, no record_applied
+        calls fire, and the live DB writeback path is bypassed."""
+        runner = CliRunner()
+        fake_history = Mock()
+        pending = [
+            SimpleNamespace(
+                table="orders",
+                column="id",
+                final_description="Order identifier",
+                result_id=17,
+            )
+        ]
+
+        class FakeDatabaseConnector:
+            def __init__(self, cfg):
+                self.cfg = cfg
+                self.backend = getattr(cfg, "backend", "unknown")
+
+            def test_connection(self) -> bool:
+                return True
+
+        previewed: list[tuple[str, str]] = []
+
+        def fake_apply_review_results_to_db(db, rows, **kwargs):
+            # Real implementation runs the preview loop; the test
+            # double simulates one ``preview`` callback per row so the
+            # CLI's ``Dry-run complete: N comment(s) previewed``
+            # message can be asserted.
+            assert kwargs.get("dry_run") is True, "dry_run flag must reach the orchestrator"
+            on_progress = kwargs.get("on_progress")
+            for idx, row in enumerate(rows, start=1):
+                previewed.append((row.table, row.column))
+                if on_progress is not None:
+                    on_progress(
+                        row,
+                        "preview",
+                        idx,
+                        len(rows),
+                        f"COMMENT ON COLUMN {row.table}.{row.column} IS :cmt",
+                    )
+            return 0
+
+        with (
+            patch("amx.pending_review.load_pending", return_value=pending),
+            patch("amx.pending_review.clear_pending") as clear_pending,
+            patch("amx.db.connector.DatabaseConnector", FakeDatabaseConnector),
+            patch(
+                "amx.agents.orchestrator.apply_review_results_to_db",
+                side_effect=fake_apply_review_results_to_db,
+            ),
+            patch("amx.cli_support.commands.run.history_store", return_value=fake_history),
+        ):
+            result = runner.invoke(
+                main,
+                ["--config", "test-config.yml", "analyze", "apply", "--dry-run"],
+                env={"AMX_SESSION_CHILD": "1"},
+                catch_exceptions=False,
+            )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("Preview pending metadata writes (dry-run)", result.output)
+        self.assertIn("Dry-run complete", result.output)
+        self.assertIn("COMMENT ON COLUMN orders.id IS :cmt", result.output)
+        # Pending file must NOT be cleared — dry-run is non-destructive.
+        clear_pending.assert_not_called()
+        # No record_applied calls — we never wrote anything.
+        fake_history.record_applied.assert_not_called()
+        # Adapter was consulted for every row in the pending list.
+        self.assertEqual(previewed, [("orders", "id")])
+
     def test_analyze_run_routes_through_cli_analyze_flow_module(self) -> None:
         runner = CliRunner()
 


### PR DESCRIPTION
## Summary

Wires the dry-run path added in PR #197 through to the user-facing CLI command.

\`amx /analyze apply --dry-run\` now:

- Skips the confirmation prompt (nothing will be written → nothing to gate).
- Lists pending comments in the same table as the live path.
- Calls \`apply_review_results_to_db(..., dry_run=True)\` with a progress handler that prints each rendered SQL template:  
  \`[N/total] COMMENT ON COLUMN x.y.z IS :cmt\`
- Surfaces unsupported / preview-failed rows separately.
- Emits \`analyze_apply\` event with status \`preview\` and a \`dry_run: True\` detail flag.
- Leaves the pending file untouched — re-run without the flag to write for real.

Default behaviour (no \`--dry-run\`) is byte-identical to the prior path.

## Test plan

- [x] \`pytest tests/test_cli_integration.py -v -k apply\` — 5 cases (4 existing + 1 new dry-run).
- [x] \`pytest -q --ignore=tests/eval\` — 998 tests pass, no regressions.
- [x] \`ruff check\` and \`ruff format --check\` clean.
- [ ] Manual \`amx /analyze apply --dry-run\` against a real schema. *(local verification)*