### PR TITLE
feat(apply): write apply_events audit row per successful COMMENT

### DIFF
--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from typing import Any
 
 from amx.agents.base import AgentContext, Confidence, MetadataSuggestion, apply_logprob_confidence
 from amx.agents.code_agent import CodeAgent
@@ -266,6 +267,42 @@ def is_placeholder_description(text: str | None) -> bool:
     return any(marker in sample for marker in _PLACEHOLDER_MARKERS)
 
 
+def _record_audit(
+    audit_log: Any,
+    r: ReviewResult,
+    *,
+    audit_profile: str,
+    audit_user: str,
+    audit_host: str,
+    audit_run_id: int | None,
+) -> None:
+    """Write one ``apply_events`` row for a successful COMMENT.
+
+    No-op when ``audit_log`` is ``None`` so the legacy code path stays
+    untouched. Failures are swallowed at debug level — the audit log
+    is best-effort and must never abort an otherwise-successful apply.
+    """
+    if audit_log is None:
+        return
+    try:
+        audit_log.record_apply_event(
+            run_id=audit_run_id,
+            result_id=getattr(r, "result_id", None),
+            profile_name=audit_profile,
+            schema_name=r.schema,
+            table_name=r.table or "",
+            column_name=r.column,
+            asset_kind=r.asset_kind or "table",
+            old_comment=None,
+            new_comment=r.final_description or "",
+            applied_by=audit_user,
+            hostname=audit_host,
+            sql_template="",
+        )
+    except Exception as exc:
+        log.debug("audit_log.record_apply_event failed for %s.%s: %s", r.schema, r.table, exc)
+
+
 def apply_review_results_to_db(
     db: DatabaseConnector,
     results: list[ReviewResult],
@@ -275,6 +312,11 @@ def apply_review_results_to_db(
     on_progress: Callable[[ReviewResult, str, int, int, str], None] | None = None,
     cancel_token: threading.Event | None = None,
     dry_run: bool = False,
+    audit_log: Any = None,
+    audit_profile: str = "",
+    audit_user: str = "",
+    audit_host: str = "",
+    audit_run_id: int | None = None,
 ) -> int:
     """Write approved descriptions as COMMENT ON TABLE/VIEW/COLUMN to the database.
 
@@ -402,6 +444,14 @@ def apply_review_results_to_db(
                                     )
                                 if on_applied is not None:
                                     on_applied(item)
+                                _record_audit(
+                                    audit_log,
+                                    item,
+                                    audit_profile=audit_profile,
+                                    audit_user=audit_user,
+                                    audit_host=audit_host,
+                                    audit_run_id=audit_run_id,
+                                )
                             index = next_index
                             continue
                     except Exception as batch_exc:
@@ -427,6 +477,14 @@ def apply_review_results_to_db(
                     on_progress(r, "applied", index + 1, total, "")
                 if on_applied is not None:
                     on_applied(r)
+                _record_audit(
+                    audit_log,
+                    r,
+                    audit_profile=audit_profile,
+                    audit_user=audit_user,
+                    audit_host=audit_host,
+                    audit_run_id=audit_run_id,
+                )
             except Exception as exc:
                 if on_progress is not None:
                     on_progress(r, "failed", index + 1, total, str(exc))

--- a/amx/cli_support/commands/run.py
+++ b/amx/cli_support/commands/run.py
@@ -222,6 +222,27 @@ def register_analyze_commands(
             backend=db.backend,
         )
 
+        # Build the audit context once so each successful COMMENT
+        # write lands in apply_events with the correct attribution.
+        # The history_store call is best-effort: if the store is
+        # disabled (private mode, init failed), audit_log stays None
+        # and apply_review_results_to_db treats the audit hooks as
+        # no-ops. Hostname and applied_by are read from the
+        # standard library so we don't need to depend on amx.config
+        # for what is essentially environment metadata.
+        import getpass
+        import socket
+
+        audit_log_handle = history_store()
+        try:
+            applied_by = getpass.getuser()
+        except Exception:
+            applied_by = ""
+        try:
+            hostname = socket.gethostname()
+        except Exception:
+            hostname = ""
+
         try:
             applied_count = apply_review_results_to_db(
                 db,
@@ -229,6 +250,10 @@ def register_analyze_commands(
                 on_applied=_on_applied,
                 on_failed=_on_failed,
                 on_progress=_on_progress if pending else None,
+                audit_log=audit_log_handle,
+                audit_profile=getattr(cfg.db, "name", "") or "",
+                audit_user=applied_by,
+                audit_host=hostname,
             )
         finally:
             if pending:

--- a/tests/test_apply_audit_integration.py
+++ b/tests/test_apply_audit_integration.py
@@ -1,0 +1,137 @@
+"""``apply_review_results_to_db`` records audit rows when audit_log given.
+
+Pins the contract that the new ``audit_log`` / ``audit_profile`` /
+``audit_user`` / ``audit_host`` / ``audit_run_id`` keyword arguments
+fan a successful COMMENT write into one ``apply_events`` row, and
+that the audit path is best-effort (a misbehaving store does not
+abort the apply).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from amx.agents.base import Confidence
+from amx.agents.orchestrator import ReviewResult, apply_review_results_to_db
+
+
+def _result(
+    schema: str,
+    table: str,
+    column: str | None,
+    *,
+    description: str = "Order header.",
+    asset_kind: str = "table",
+    applied: bool = True,
+    result_id: int | None = None,
+) -> ReviewResult:
+    return ReviewResult(
+        schema=schema,
+        table=table,
+        column=column,
+        final_description=description,
+        confidence=Confidence.HIGH,
+        source="combined",
+        applied=applied,
+        asset_kind=asset_kind,
+        result_id=result_id,
+    )
+
+
+def _make_db_mock() -> MagicMock:
+    """Build a DatabaseConnector double whose ``apply_comment`` is a
+    no-op. ``engine.begin`` returns a context manager so the
+    ``with db.engine.begin() as conn:`` block works."""
+    db = MagicMock()
+    db.apply_comment.return_value = None
+    db.apply_column_comments_batch.return_value = False  # force per-row path
+    return db
+
+
+def test_audit_log_receives_one_event_per_successful_apply() -> None:
+    db = _make_db_mock()
+    audit = MagicMock()
+
+    rows = [
+        _result("public", "orders", "id", result_id=10),
+        _result("public", "orders", "amount", result_id=11),
+    ]
+    applied = apply_review_results_to_db(
+        db,
+        rows,
+        audit_log=audit,
+        audit_profile="prod_pg",
+        audit_user="omer",
+        audit_host="laptop",
+        audit_run_id=42,
+    )
+
+    assert applied == 2
+    # Two successful applies → two audit rows.
+    assert audit.record_apply_event.call_count == 2
+    first_kwargs = audit.record_apply_event.call_args_list[0].kwargs
+    assert first_kwargs["schema_name"] == "public"
+    assert first_kwargs["table_name"] == "orders"
+    assert first_kwargs["column_name"] == "id"
+    assert first_kwargs["new_comment"] == "Order header."
+    assert first_kwargs["profile_name"] == "prod_pg"
+    assert first_kwargs["applied_by"] == "omer"
+    assert first_kwargs["hostname"] == "laptop"
+    assert first_kwargs["run_id"] == 42
+    assert first_kwargs["result_id"] == 10
+    assert first_kwargs["asset_kind"] == "table"
+    # Old-comment lookup deferred to PR-12b2 — the helper passes None
+    # for now so rollback knows "we never read it" rather than
+    # "it was empty".
+    assert first_kwargs["old_comment"] is None
+
+
+def test_audit_log_omitted_means_no_record_calls() -> None:
+    """Backward-compat: existing callers that don't pass audit_log
+    must not see any ``record_apply_event`` invocation (and the
+    function must keep working when the store is unavailable)."""
+    db = _make_db_mock()
+    rows = [_result("public", "orders", "id")]
+    applied = apply_review_results_to_db(db, rows)
+    assert applied == 1
+    # No mock to inspect — but the bare call must not raise.
+
+
+def test_audit_log_failure_does_not_abort_apply() -> None:
+    """A misbehaving store (raises on every record_apply_event) must
+    not cause apply_review_results_to_db to surface an exception or
+    skip the live DB write."""
+    db = _make_db_mock()
+    audit = MagicMock()
+    audit.record_apply_event.side_effect = RuntimeError("store down")
+
+    rows = [_result("public", "orders", "id")]
+    applied = apply_review_results_to_db(
+        db,
+        rows,
+        audit_log=audit,
+        audit_profile="prod_pg",
+    )
+    # Apply still reports success — best-effort audit doesn't gate it.
+    assert applied == 1
+    audit.record_apply_event.assert_called_once()
+    db.apply_comment.assert_called_once()
+
+
+def test_audit_log_skipped_in_dry_run() -> None:
+    """Dry-run never writes to the database, so it must not write
+    audit rows either — the audit log only records actual COMMENTs."""
+    db = _make_db_mock()
+    db.preview_comment_sql.return_value = "COMMENT ON COLUMN s.t.c IS :cmt"
+    audit = MagicMock()
+
+    rows = [_result("s", "t", "c")]
+    applied = apply_review_results_to_db(
+        db,
+        rows,
+        audit_log=audit,
+        audit_profile="prod_pg",
+        dry_run=True,
+    )
+    assert applied == 0
+    audit.record_apply_event.assert_not_called()

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -67,13 +67,16 @@ class AnalyzeApplyIntegrationTests(unittest.TestCase):
             def add_detail(self, idx: int, detail: str) -> None:
                 return None
 
-        def fake_apply_review_results_to_db(db, rows, on_applied, on_failed=None, on_progress=None):
+        def fake_apply_review_results_to_db(db, rows, **kwargs):
+            on_applied = kwargs.get("on_applied")
+            on_progress = kwargs.get("on_progress")
             for row in rows:
                 if on_progress is not None:
                     on_progress(row, "started", 1, len(rows), "")
                 if on_progress is not None:
                     on_progress(row, "applied", 1, len(rows), "")
-                on_applied(row)
+                if on_applied is not None:
+                    on_applied(row)
             return len(rows)
 
         with (


### PR DESCRIPTION
## Summary

Wires the ``apply_events`` audit log added in PR #198 into the live write-back path. Each successful COMMENT now lands in a corresponding ``apply_events`` row with full attribution.

### New keyword arguments on ``apply_review_results_to_db``

All optional, all defaulting in a way that preserves byte-identical legacy behaviour:

| Arg | Type | Purpose |
|---|---|---|
| ``audit_log`` | Any (``SQLiteHistoryStore``) | When None → every audit hook is a no-op |
| ``audit_profile`` | str | Active DB profile name |
| ``audit_user`` | str | ``getpass.getuser()`` from the CLI |
| ``audit_host`` | str | ``socket.gethostname()`` from the CLI |
| ``audit_run_id`` | int \| None | The history-store run id this apply belongs to |

A new helper ``_record_audit`` swallows any exception from ``record_apply_event`` at debug level — the audit log is best-effort and must never abort a successful apply. Audit rows are written from both the per-row path and the batched-column path, so adapters that emit a single multi-column COMMENT (Postgres ``set_multi_column_comments_sql``) still produce one ``apply_events`` row per affected column.

### CLI integration

``amx /analyze apply`` now passes the active ``history_store()`` plus user / hostname / db-profile name so a real apply populates ``apply_events`` without any user-visible flag flip. The dry-run path remains audit-free — the log only records COMMENTs that actually executed.

### What this PR is **not**

- No ``old_comment`` lookup yet — the helper passes ``None`` so rollback can distinguish "we never read it" from "it was empty". A pre-write read pass lands in PR-12b2 once the perf cost is measured.
- No ``/history rollback`` command — that's PR-12b3, building on these audit rows.
- No Studio Recent Applies panel — that's PR-12c.

## Test plan

- [x] ``pytest tests/test_apply_audit_integration.py -v`` — 4 new cases (one-event-per-apply, ``audit_log=None`` backward-compat, ``record_apply_event`` raise resilience, dry-run skip).
- [x] Existing ``test_analyze_apply_applies_pending_metadata`` updated to ``**kwargs``-capture (forward-compat for new keyword args).
- [x] ``pytest -q --ignore=tests/eval`` — 1001 tests pass.
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [ ] Manual ``amx /analyze apply`` against a real schema, then ``sqlite3 ~/.amx/history.db 'SELECT * FROM apply_events'`` to confirm rows accumulate. *(local verification)*