### PR TITLE
fix(docs): scanner respects .gitignore + skips binary files

### DIFF
--- a/amx/docs/scanner.py
+++ b/amx/docs/scanner.py
@@ -50,14 +50,73 @@ class DocInfo:
     cleanup_root: str = ""  # temporary source directory to remove after callers finish reading
 
 
+def _looks_binary(path: Path, *, sniff_bytes: int = 4096) -> bool:
+    """Best-effort binary file detector for the local-doc scanner.
+
+    The extension whitelist already excludes images / archives / etc.,
+    but extensionless files and ``.txt`` files that happen to hold
+    raw bytes still slip through. Read the first ``sniff_bytes``; if
+    a NUL byte is present we treat the file as binary and skip it
+    rather than feed garbage into the embedding model.
+
+    Read errors are swallowed and treated as "binary" so a transient
+    permission failure doesn't crash the whole scan.
+    """
+    try:
+        with path.open("rb") as fh:
+            chunk = fh.read(sniff_bytes)
+    except Exception:
+        return True
+    return b"\x00" in chunk
+
+
+def _load_gitignore_matcher(root: Path):
+    """Return a ``pathspec.PathSpec`` built from ``<root>/.gitignore``,
+    or ``None`` when the file is missing or pathspec is unavailable.
+
+    ``pathspec`` is an optional dep — we degrade gracefully to "no
+    filter" rather than fail the scan when it isn't installed.
+    """
+    candidate = root / ".gitignore"
+    if not candidate.is_file():
+        return None
+    try:
+        import pathspec  # type: ignore[import-untyped]
+    except Exception:
+        return None
+    try:
+        with candidate.open("r", encoding="utf-8", errors="ignore") as fh:
+            return pathspec.PathSpec.from_lines("gitwildmatch", fh)
+    except Exception:
+        return None
+
+
 def _resolve_local(path: str) -> Iterator[DocInfo]:
     p = Path(path).expanduser().resolve()
-    if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS:
-        yield DocInfo(str(p), p.stat().st_size, p.suffix.lower(), "local")
-    elif p.is_dir():
-        for f in sorted(p.rglob("*")):
-            if f.is_file() and f.suffix.lower() in SUPPORTED_EXTENSIONS:
-                yield DocInfo(str(f), f.stat().st_size, f.suffix.lower(), "local")
+    if p.is_file():
+        if p.suffix.lower() in SUPPORTED_EXTENSIONS and not _looks_binary(p):
+            yield DocInfo(str(p), p.stat().st_size, p.suffix.lower(), "local")
+        return
+    if not p.is_dir():
+        return
+
+    matcher = _load_gitignore_matcher(p)
+    for f in sorted(p.rglob("*")):
+        if not f.is_file():
+            continue
+        if f.suffix.lower() not in SUPPORTED_EXTENSIONS:
+            continue
+        # ``.gitignore`` matchers want repo-relative posix paths.
+        if matcher is not None:
+            try:
+                rel = f.relative_to(p).as_posix()
+            except ValueError:
+                rel = ""
+            if rel and matcher.match_file(rel):
+                continue
+        if _looks_binary(f):
+            continue
+        yield DocInfo(str(f), f.stat().st_size, f.suffix.lower(), "local")
 
 
 def normalize_github_url(url: str) -> str:

--- a/tests/test_docs_scanner_safety.py
+++ b/tests/test_docs_scanner_safety.py
@@ -1,0 +1,103 @@
+"""Local doc scanner safety: ``.gitignore`` respect + binary detection.
+
+The scanner used to ``rglob("*")`` and trust the extension whitelist
+alone. Two gaps we close here:
+
+1. ``.gitignore`` was ignored, so a user pointing AMX at a working
+   git repo could accidentally feed ``node_modules/**`` or
+   ``.venv/**`` into the embedding store.
+2. Extensionless files and ``.txt`` files that hold raw bytes still
+   slipped through the whitelist and produced garbage embeddings.
+
+Both gaps are best-effort: ``pathspec`` is optional (falls back to
+"no filter" when missing) and the binary sniff is the simplest
+possible heuristic (``NUL`` byte in the first 4 KB).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from amx.docs.scanner import _resolve_local
+
+
+def _scan(path: Path) -> list[str]:
+    """Helper — return scanned paths as plain strings, sorted for assert."""
+    return sorted(d.path for d in _resolve_local(str(path)))
+
+
+def test_resolve_local_picks_up_supported_extensions(tmp_path: Path) -> None:
+    (tmp_path / "good.md").write_text("docs", encoding="utf-8")
+    (tmp_path / "good.txt").write_text("plain", encoding="utf-8")
+    # Unsupported extension — must be filtered out.
+    (tmp_path / "skip.bin").write_bytes(b"raw")
+    paths = _scan(tmp_path)
+    names = [Path(p).name for p in paths]
+    assert "good.md" in names
+    assert "good.txt" in names
+    assert "skip.bin" not in names
+
+
+def test_resolve_local_skips_binary_files_with_supported_extension(tmp_path: Path) -> None:
+    """A ``.txt`` carrying raw bytes (NUL in first 4 KB) is rejected
+    so the embedding store doesn't end up indexing garbage."""
+    bad = tmp_path / "binary.txt"
+    bad.write_bytes(b"hello\x00world")
+    good = tmp_path / "real.txt"
+    good.write_text("hello world", encoding="utf-8")
+    paths = _scan(tmp_path)
+    names = [Path(p).name for p in paths]
+    assert "real.txt" in names
+    assert "binary.txt" not in names
+
+
+def test_resolve_local_respects_gitignore_when_pathspec_available(tmp_path: Path) -> None:
+    """When ``pathspec`` is installed (and a ``.gitignore`` is present),
+    matching files are skipped. We use a deliberately-broad pattern
+    (``ignored/``) so the test runs whether or not ``pathspec`` is
+    present — when it isn't, the file is still picked up; when it is,
+    it isn't. Both paths are valid behaviour for the scanner."""
+    (tmp_path / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+    keep = tmp_path / "keep.md"
+    keep.write_text("kept", encoding="utf-8")
+    nested = tmp_path / "ignored"
+    nested.mkdir()
+    (nested / "drop.md").write_text("dropped", encoding="utf-8")
+
+    try:
+        import pathspec  # noqa: F401  # only used to detect availability
+    except Exception:
+        pathspec_available = False
+    else:
+        pathspec_available = True
+
+    paths = _scan(tmp_path)
+    names = [Path(p).name for p in paths]
+    assert "keep.md" in names
+    if pathspec_available:
+        assert "drop.md" not in names
+    # If pathspec isn't installed, drop.md is still seen — that's the
+    # documented graceful-degradation behaviour.
+
+
+def test_resolve_local_single_file_path(tmp_path: Path) -> None:
+    """Pointing the scanner at a single file (not a directory) works
+    too — historic CLI behaviour the new branching must preserve."""
+    f = tmp_path / "doc.md"
+    f.write_text("hi", encoding="utf-8")
+    paths = _scan(f)
+    assert paths == [str(f)]
+
+
+def test_resolve_local_single_binary_file_is_skipped(tmp_path: Path) -> None:
+    f = tmp_path / "weird.txt"
+    f.write_bytes(b"\x00binary")
+    paths = _scan(f)
+    assert paths == []
+
+
+def test_resolve_local_unknown_path_returns_nothing(tmp_path: Path) -> None:
+    """Non-existent paths short-circuit cleanly; no exception."""
+    missing = tmp_path / "does-not-exist"
+    paths = _scan(missing)
+    assert paths == []


### PR DESCRIPTION
## Summary

Two safety gaps in ``_resolve_local`` (the local-doc ingestion path ``/docs`` uses) flagged in the v0.12.9 audit.

| Gap | Fix |
|---|---|
| ``.gitignore`` ignored — pointing at a working repo fed ``node_modules`` / ``.venv`` into embeddings | New ``_load_gitignore_matcher`` builds a ``pathspec.PathSpec`` (graceful degradation when pathspec absent) |
| Extension whitelist trusted the suffix alone — ``.txt`` files holding raw bytes produced garbage embeddings | New ``_looks_binary`` reads 4 KB and skips on ``NUL`` byte |

Both filters are best-effort: ``pathspec`` stays optional so the doc cluster's existing extras don't grow; the binary sniff is the simplest heuristic that catches the audit's reported cases.

## Test plan

- [x] ``pytest tests/test_docs_scanner_safety.py -v`` — 6 cases (supported picks, binary skip with supported extension, ``.gitignore`` respect when pathspec installed + graceful degradation, single file + single binary, non-existent path).
- [x] ``pytest -q --ignore=tests/eval`` — 1013 tests pass.
- [x] ``ruff check`` and ``ruff format --check`` clean.

## What this PR is **not**

Embedding stale-entity cleanup (the original PR-6's "incremental" piece). ``upsert_entities`` is already id-based incremental; the gap is "delete rows when the source asset disappears", which needs a ``Connector.list_entities`` call-site refactor and lands as PR-6b.