### PR TITLE
refactor(search): extract pure helpers from agent_tools.py

### DIFF
--- a/amx/search/_agent_tools_helpers.py
+++ b/amx/search/_agent_tools_helpers.py
@@ -1,0 +1,136 @@
+"""Pure helpers extracted from ``amx.search.agent_tools``.
+
+The historical ``agent_tools.py`` is a 5,000+ line god module that
+mixes a 50-method ``ToolBox`` class with a handful of small utility
+functions. Pulling the utilities out so:
+
+- the public ``agent_tools`` import surface stays unchanged (this
+  module is private — call sites still ``from amx.search.agent_tools
+  import _name_overlap_score`` or use the re-exports below);
+- a future PR can split the ``ToolBox`` class itself into mixins
+  without entangling the helpers in the same diff;
+- `_safe_json` and the scoring heuristics become independently
+  testable without spinning up the full ToolBox + connector chain.
+
+Nothing here depends on the ``ToolBox`` instance. Every function is
+pure (modulo a ``re`` import and ``json.dumps``); the only "state"
+is the ``families`` table baked into ``_dtype_compat_score``.
+"""
+
+from __future__ import annotations
+
+import json
+import re as _re
+from difflib import SequenceMatcher
+from typing import Any
+
+
+class _ToolError(RuntimeError):
+    """Raised by a tool when it can't fulfil the request — surfaced verbatim
+    to the LLM so it can adjust and try a different tool."""
+
+
+def _name_overlap_score(left: str, right: str) -> float:
+    """Score column-name similarity in [0, 1].
+
+    Combines token-level Jaccard overlap with character-level
+    SequenceMatcher ratio so ``customer_id`` and ``cust_id`` score high
+    (token "id" matches), while ``customer_id`` and ``payment_status``
+    score 0. Used by the cross-profile JOIN finder.
+    """
+    a = (left or "").strip().lower()
+    b = (right or "").strip().lower()
+    if not a or not b:
+        return 0.0
+    if a == b:
+        return 1.0
+
+    def _tok(s: str) -> set[str]:
+        parts = _re.split(r"[_\W]+|(?=[A-Z])", s)
+        return {p.lower() for p in parts if p and len(p) >= 2}
+
+    tokens_a = _tok(a)
+    tokens_b = _tok(b)
+    jaccard = 0.0
+    if tokens_a and tokens_b:
+        intersect = tokens_a & tokens_b
+        union = tokens_a | tokens_b
+        jaccard = len(intersect) / max(1, len(union))
+    char = SequenceMatcher(None, a, b).ratio()
+    return max(jaccard, char if char >= 0.7 else 0.0)
+
+
+def _dtype_compat_score(left: str, right: str) -> float:
+    """Score dtype compatibility for join purposes.
+
+    Returns 1.0 for same-family (INT↔BIGINT, VARCHAR↔TEXT), 0.5 for
+    weakly compatible (INT↔NUMERIC), 0.0 for incompatible
+    (VARCHAR↔INT). Coarse buckets are sufficient — joins on
+    incompatible dtypes won't actually work in SQL anyway.
+    """
+    families = {
+        "int": ("int", "bigint", "smallint", "tinyint", "int2", "int4", "int8"),
+        "float": (
+            "float",
+            "double",
+            "real",
+            "numeric",
+            "decimal",
+            "float8",
+            "float4",
+        ),
+        "string": ("char", "varchar", "text", "string", "nvarchar", "nchar"),
+        "bool": ("bool", "boolean", "bit"),
+        "date": ("date",),
+        "timestamp": ("timestamp", "datetime", "timestamptz"),
+        "uuid": ("uuid",),
+        "binary": ("bytea", "blob", "binary", "varbinary"),
+    }
+    canon = lambda s: (s or "").strip().lower().split("(", 1)[0]  # noqa: E731
+    a = canon(left)
+    b = canon(right)
+    if not a or not b:
+        return 0.0
+    if a == b:
+        return 1.0
+
+    def _family(name: str) -> str | None:
+        for fam, members in families.items():
+            if name in members:
+                return fam
+            for member in members:
+                if name.startswith(member):
+                    return fam
+        return None
+
+    fa = _family(a)
+    fb = _family(b)
+    if fa and fa == fb:
+        return 1.0
+    if {fa, fb} == {"int", "float"}:
+        return 0.5
+    return 0.0
+
+
+def _description_proximity(left: str, right: str) -> float:
+    """Cheap text-similarity proxy for the vector signal in the
+    cross-profile JOIN finder. Returns 0.0 when either side has no
+    description (we don't silently inflate the score on undocumented
+    columns).
+    """
+    a = (left or "").strip().lower()
+    b = (right or "").strip().lower()
+    if not a or not b:
+        return 0.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _safe_json(value: Any, *, max_len: int = 6000) -> str:
+    """Serialize a tool result; truncate so the prompt stays manageable."""
+    try:
+        text = json.dumps(value, ensure_ascii=False, default=str)
+    except Exception:  # pragma: no cover - JSON of catalog rows always works
+        text = str(value)
+    if len(text) > max_len:
+        text = text[: max_len - 18] + "...<truncated>"
+    return text

--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -26,127 +26,31 @@ from typing import Any
 
 from amx.config import AMXConfig
 from amx.db.connector import DatabaseConnector, ProfilingError
+from amx.search._agent_tools_helpers import (
+    _description_proximity,
+    _dtype_compat_score,
+    _name_overlap_score,
+    _safe_json,
+    _ToolError,
+)
 from amx.search.catalog import SearchCatalog
 
-
-class _ToolError(RuntimeError):
-    """Raised by a tool when it can't fulfil the request — surfaced verbatim
-    to the LLM so it can adjust and try a different tool."""
-
-
-def _name_overlap_score(left: str, right: str) -> float:
-    """Score column-name similarity in [0, 1].
-
-    Combines token-level Jaccard overlap with character-level
-    SequenceMatcher ratio so ``customer_id`` and ``cust_id`` score high
-    (token "id" matches), while ``customer_id`` and ``payment_status``
-    score 0. Used by the cross-profile JOIN finder.
-    """
-    a = (left or "").strip().lower()
-    b = (right or "").strip().lower()
-    if not a or not b:
-        return 0.0
-    if a == b:
-        return 1.0
-    # Token Jaccard (split on _ + camelCase boundaries).
-    import re as _re
-
-    def _tok(s: str) -> set[str]:
-        parts = _re.split(r"[_\W]+|(?=[A-Z])", s)
-        return {p.lower() for p in parts if p and len(p) >= 2}
-
-    tokens_a = _tok(a)
-    tokens_b = _tok(b)
-    jaccard = 0.0
-    if tokens_a and tokens_b:
-        intersect = tokens_a & tokens_b
-        union = tokens_a | tokens_b
-        jaccard = len(intersect) / max(1, len(union))
-    # Character similarity for short names where token matching misses.
-    char = SequenceMatcher(None, a, b).ratio()
-    # Take the max so either signal can carry a strong match.
-    return max(jaccard, char if char >= 0.7 else 0.0)
-
-
-def _dtype_compat_score(left: str, right: str) -> float:
-    """Score dtype compatibility for join purposes.
-
-    Returns 1.0 for same-family (INT↔BIGINT, VARCHAR↔TEXT), 0.5 for
-    weakly compatible (INT↔NUMERIC), 0.0 for incompatible
-    (VARCHAR↔INT). Coarse buckets are sufficient — joins on
-    incompatible dtypes won't actually work in SQL anyway.
-    """
-    families = {
-        "int": ("int", "bigint", "smallint", "tinyint", "int2", "int4", "int8"),
-        "float": (
-            "float",
-            "double",
-            "real",
-            "numeric",
-            "decimal",
-            "float8",
-            "float4",
-        ),
-        "string": ("char", "varchar", "text", "string", "nvarchar", "nchar"),
-        "bool": ("bool", "boolean", "bit"),
-        "date": ("date",),
-        "timestamp": ("timestamp", "datetime", "timestamptz"),
-        "uuid": ("uuid",),
-        "binary": ("bytea", "blob", "binary", "varbinary"),
-    }
-    canon = lambda s: (s or "").strip().lower().split("(", 1)[0]  # noqa: E731
-    a = canon(left)
-    b = canon(right)
-    if not a or not b:
-        return 0.0
-    if a == b:
-        return 1.0
-
-    def _family(name: str) -> str | None:
-        for fam, members in families.items():
-            if name in members:
-                return fam
-            for member in members:
-                if name.startswith(member):
-                    return fam
-        return None
-
-    fa = _family(a)
-    fb = _family(b)
-    if fa and fa == fb:
-        return 1.0
-    # int↔float weak compatibility (e.g. id columns stored as numeric)
-    if {fa, fb} == {"int", "float"}:
-        return 0.5
-    return 0.0
-
-
-def _description_proximity(left: str, right: str) -> float:
-    """Cheap text-similarity proxy for the vector signal in the
-    cross-profile JOIN finder. PR-D swaps this for a real
-    SearchIndex query — for now a SequenceMatcher ratio over the
-    cleaned description text gives recall comparable to a small
-    embedding model on short identifiers/descriptions.
-
-    Returns 0.0 when either side has no description (we don't want to
-    silently inflate the score on undocumented columns).
-    """
-    a = (left or "").strip().lower()
-    b = (right or "").strip().lower()
-    if not a or not b:
-        return 0.0
-    return SequenceMatcher(None, a, b).ratio()
-
-
-def _safe_json(value: Any, *, max_len: int = 6000) -> str:
-    """Serialize a tool result; truncate so the prompt stays manageable."""
-    try:
-        text = json.dumps(value, ensure_ascii=False, default=str)
-    except Exception:  # pragma: no cover - JSON of catalog rows always works
-        text = str(value)
-    if len(text) > max_len:
-        text = text[: max_len - 18] + "...<truncated>"
-    return text
+# ``json`` and ``SequenceMatcher`` stay imported above because the
+# ``ToolBox`` methods below still reach for them directly. The pure
+# helpers (``_name_overlap_score``, ``_dtype_compat_score``,
+# ``_description_proximity``, ``_safe_json``, and the ``_ToolError``
+# sentinel) live in ``_agent_tools_helpers`` and are re-exported here
+# so historical imports — ``from amx.search.agent_tools import
+# _name_overlap_score`` — keep working without forcing every caller
+# to chase the internal split.
+__all__ = (
+    "_ToolError",
+    "_description_proximity",
+    "_dtype_compat_score",
+    "_name_overlap_score",
+    "_safe_json",
+    "ToolBox",
+)
 
 
 class ToolBox:

--- a/tests/test_agent_tools_helpers.py
+++ b/tests/test_agent_tools_helpers.py
@@ -1,0 +1,112 @@
+"""Pure helpers extracted from ``amx.search.agent_tools``.
+
+Pinning the contracts here so a future ``ToolBox`` mixin split can't
+silently change a scoring heuristic. Both the new direct module and
+the legacy re-export through ``agent_tools`` are tested so historical
+imports keep working.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_helpers_are_re_exported_from_agent_tools_module() -> None:
+    """The legacy import path must keep working for any external
+    caller that grabbed a private helper before this PR landed."""
+    from amx.search import _agent_tools_helpers as helpers
+    from amx.search import agent_tools
+
+    for name in (
+        "_ToolError",
+        "_name_overlap_score",
+        "_dtype_compat_score",
+        "_description_proximity",
+        "_safe_json",
+    ):
+        assert getattr(agent_tools, name) is getattr(helpers, name), (
+            f"{name} re-export drifted from the canonical helpers module"
+        )
+
+
+def test_name_overlap_identical_strings_score_one() -> None:
+    from amx.search._agent_tools_helpers import _name_overlap_score
+
+    assert _name_overlap_score("customer_id", "customer_id") == 1.0
+
+
+def test_name_overlap_token_match_scores_high() -> None:
+    from amx.search._agent_tools_helpers import _name_overlap_score
+
+    score = _name_overlap_score("customer_id", "cust_id")
+    assert 0.3 < score <= 1.0  # token "id" matches; jaccard or char ratio carries it
+
+
+def test_name_overlap_unrelated_scores_zero() -> None:
+    from amx.search._agent_tools_helpers import _name_overlap_score
+
+    assert _name_overlap_score("customer_id", "payment_status") == 0.0
+
+
+def test_name_overlap_empty_input_returns_zero() -> None:
+    from amx.search._agent_tools_helpers import _name_overlap_score
+
+    assert _name_overlap_score("", "anything") == 0.0
+    assert _name_overlap_score("anything", "") == 0.0
+
+
+def test_dtype_compat_same_family_returns_one() -> None:
+    from amx.search._agent_tools_helpers import _dtype_compat_score
+
+    assert _dtype_compat_score("INT", "BIGINT") == 1.0
+    assert _dtype_compat_score("VARCHAR(64)", "TEXT") == 1.0
+
+
+def test_dtype_compat_int_vs_numeric_is_weak() -> None:
+    from amx.search._agent_tools_helpers import _dtype_compat_score
+
+    assert _dtype_compat_score("INT", "NUMERIC") == 0.5
+
+
+def test_dtype_compat_incompatible_returns_zero() -> None:
+    from amx.search._agent_tools_helpers import _dtype_compat_score
+
+    assert _dtype_compat_score("VARCHAR", "INT") == 0.0
+    assert _dtype_compat_score("UUID", "INT") == 0.0
+
+
+def test_description_proximity_zero_when_either_side_blank() -> None:
+    from amx.search._agent_tools_helpers import _description_proximity
+
+    assert _description_proximity("", "Order header.") == 0.0
+    assert _description_proximity("Order header.", "") == 0.0
+
+
+def test_safe_json_truncates_long_payloads() -> None:
+    from amx.search._agent_tools_helpers import _safe_json
+
+    big = {"rows": ["x" * 100 for _ in range(200)]}
+    out = _safe_json(big, max_len=200)
+    assert len(out) <= 200
+    assert out.endswith("...<truncated>")
+
+
+def test_safe_json_returns_str_for_unserialisable() -> None:
+    from amx.search._agent_tools_helpers import _safe_json
+
+    class _Funny:
+        def __repr__(self) -> str:
+            return "<funny>"
+
+    out = _safe_json(_Funny())
+    assert "<funny>" in out
+
+
+def test_tool_error_is_runtime_error_subclass() -> None:
+    """``ToolBox.invoke`` distinguishes ``_ToolError`` from arbitrary
+    exceptions; the inheritance chain must not regress."""
+    from amx.search._agent_tools_helpers import _ToolError
+
+    assert issubclass(_ToolError, RuntimeError)
+    with pytest.raises(_ToolError):
+        raise _ToolError("smoke")


### PR DESCRIPTION
## Summary

First slice of the original PR-10 (5,000-line god module split). Pulls five small pure utilities out of ``amx/search/agent_tools.py`` into a new private module ``amx/search/_agent_tools_helpers``:

- ``_ToolError`` (sentinel)
- ``_name_overlap_score`` (column-name similarity in [0, 1])
- ``_dtype_compat_score`` (join compatibility bucket)
- ``_description_proximity`` (text similarity proxy)
- ``_safe_json`` (LLM payload serialiser with truncation)

The helpers are re-exported from ``agent_tools`` (``__all__`` declared) so historical imports keep working without forcing every caller to chase the internal split.

## Why this slice

These functions are **pure** — no ``self``, no DB access, no mutation. Splitting them out:
- frees up a future ``ToolBox``-class split into mixins from "everything in one diff" pressure;
- makes the scoring heuristics independently testable (12 new unit cases);
- reduces ``agent_tools.py`` by ~120 lines and lifts the ``re``/``json``/``SequenceMatcher`` import noise into the canonical helpers module.

## What this PR is **not**

The bigger ``ToolBox`` split into per-category mixins (db / catalog / search / review / runs) lands as a follow-up PR-10b once the design is reviewed — that touches every method on the class and needs its own dedicated review.

## Test plan

- [x] ``pytest tests/test_agent_tools_helpers.py -v`` — 12 new cases (all five helpers + the legacy re-export contract).
- [x] ``pytest -q --ignore=tests/eval`` — 1028 tests pass.
- [x] ``ruff check`` and ``ruff format --check`` clean.