### PR TITLE
feat(apply): pre-write old_comment lookup populates apply_events.old_comment

### DIFF
--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -275,12 +275,19 @@ def _record_audit(
     audit_user: str,
     audit_host: str,
     audit_run_id: int | None,
+    old_comment: str | None = None,
 ) -> None:
     """Write one ``apply_events`` row for a successful COMMENT.
 
     No-op when ``audit_log`` is ``None`` so the legacy code path stays
     untouched. Failures are swallowed at debug level — the audit log
     is best-effort and must never abort an otherwise-successful apply.
+
+    ``old_comment`` is the verbatim comment text that was on the
+    asset *before* this apply overwrote it. ``None`` means we
+    couldn't read it (adapter doesn't expose a read API, or the
+    pre-write read raised); ``/history rollback`` treats ``None``
+    as "original state unknown — skip this row".
     """
     if audit_log is None:
         return
@@ -293,7 +300,7 @@ def _record_audit(
             table_name=r.table or "",
             column_name=r.column,
             asset_kind=r.asset_kind or "table",
-            old_comment=None,
+            old_comment=old_comment,
             new_comment=r.final_description or "",
             applied_by=audit_user,
             hostname=audit_host,
@@ -301,6 +308,57 @@ def _record_audit(
         )
     except Exception as exc:
         log.debug("audit_log.record_apply_event failed for %s.%s: %s", r.schema, r.table, exc)
+
+
+class _OldCommentReader:
+    """Read prior COMMENT values from the live DB before they are
+    overwritten, with a per-(schema, table) column-comment cache so
+    a 200-row apply against one table costs one
+    ``get_column_comments`` call rather than 200.
+
+    Misses (adapter without a read API, query failure, asset kind
+    AMX cannot read) return ``None`` — the audit row records that
+    as "original unknown" and ``/history rollback`` skips that
+    row instead of synthesising garbage.
+    """
+
+    def __init__(self, db: DatabaseConnector) -> None:
+        self.db = db
+        self._column_cache: dict[tuple[str, str], dict[str, str | None]] = {}
+
+    def read(self, r: ReviewResult, kind: AssetKind) -> str | None:
+        try:
+            if kind == AssetKind.SCHEMA:
+                return self.db.get_schema_comment(r.schema)
+            if kind == AssetKind.DATABASE:
+                return self.db.get_database_comment()
+            if r.column is None:
+                return self.db.get_table_comment(r.schema, r.table)
+            key = (r.schema, r.table)
+            cached = self._column_cache.get(key)
+            if cached is None:
+                try:
+                    cached = self.db.get_column_comments(r.schema, r.table) or {}
+                except Exception as exc:
+                    log.debug(
+                        "get_column_comments failed for %s.%s (%s); "
+                        "audit will record old_comment=None",
+                        r.schema,
+                        r.table,
+                        exc,
+                    )
+                    cached = {}
+                self._column_cache[key] = cached
+            return cached.get(r.column)
+        except Exception as exc:
+            log.debug(
+                "old-comment read failed for %s.%s.%s (%s); audit will record old_comment=None",
+                r.schema,
+                r.table,
+                r.column or "",
+                exc,
+            )
+            return None
 
 
 def apply_review_results_to_db(
@@ -383,6 +441,13 @@ def apply_review_results_to_db(
         # callback to count "would-apply" rows when needed.
         return 0
 
+    # Build the old-comment reader once per apply call. Cache scope is
+    # the call so concurrent apply runs (multi-user shared store) get
+    # independent caches; nothing escapes this function. The reader is
+    # only consulted when ``audit_log`` is set — saves a round-trip on
+    # every legacy caller that doesn't audit.
+    old_reader = _OldCommentReader(db) if audit_log is not None else None
+
     with db.engine.begin() as conn:
         total = len(pending)
         index = 0
@@ -424,6 +489,15 @@ def apply_review_results_to_db(
                     batched_comments = [
                         (item.column or "", item.final_description) for item in group
                     ]
+                    # Pre-fetch the prior comment for every item in the
+                    # group BEFORE the batch overwrite — once committed,
+                    # the original text is gone and rollback can't
+                    # recover it. The reader caches at (schema, table)
+                    # level, so this is one ``get_column_comments``
+                    # call per table regardless of group size.
+                    pre_old: list[str | None] = []
+                    if old_reader is not None:
+                        pre_old = [old_reader.read(item, kind) for item in group]
                     try:
                         if on_progress is not None:
                             on_progress(
@@ -451,6 +525,7 @@ def apply_review_results_to_db(
                                     audit_user=audit_user,
                                     audit_host=audit_host,
                                     audit_run_id=audit_run_id,
+                                    old_comment=(pre_old[offset - 1] if pre_old else None),
                                 )
                             index = next_index
                             continue
@@ -461,6 +536,12 @@ def apply_review_results_to_db(
                             r.table,
                             batch_exc,
                         )
+            # Pre-fetch the prior comment for this row before the
+            # overwrite. ``read`` swallows its own errors and returns
+            # None on failure, so a misbehaving adapter doesn't break
+            # the apply itself — the audit row just lands with
+            # old_comment=None and rollback skips it.
+            pre_old_value = old_reader.read(r, kind) if old_reader is not None else None
             try:
                 if on_progress is not None:
                     on_progress(r, "started", index + 1, total, "")
@@ -484,6 +565,7 @@ def apply_review_results_to_db(
                     audit_user=audit_user,
                     audit_host=audit_host,
                     audit_run_id=audit_run_id,
+                    old_comment=pre_old_value,
                 )
             except Exception as exc:
                 if on_progress is not None:

--- a/tests/test_apply_audit_integration.py
+++ b/tests/test_apply_audit_integration.py
@@ -50,6 +50,13 @@ def _make_db_mock() -> MagicMock:
 
 def test_audit_log_receives_one_event_per_successful_apply() -> None:
     db = _make_db_mock()
+    # Pre-write reader (added in PR-12b2) consults ``get_column_comments``
+    # before each overwrite so audit rows can carry the prior text.
+    # Stub returns the originals AMX is about to replace.
+    db.get_column_comments.return_value = {
+        "id": "Order id (DBA-written).",
+        "amount": "Total amount in cents.",
+    }
     audit = MagicMock()
 
     rows = [
@@ -80,10 +87,16 @@ def test_audit_log_receives_one_event_per_successful_apply() -> None:
     assert first_kwargs["run_id"] == 42
     assert first_kwargs["result_id"] == 10
     assert first_kwargs["asset_kind"] == "table"
-    # Old-comment lookup deferred to PR-12b2 — the helper passes None
-    # for now so rollback knows "we never read it" rather than
-    # "it was empty".
-    assert first_kwargs["old_comment"] is None
+    # PR-12b2: ``old_comment`` carries the pre-write value the reader
+    # captured. ``/history rollback`` uses this to restore the
+    # originals — DBA-written or otherwise — byte-for-byte.
+    assert first_kwargs["old_comment"] == "Order id (DBA-written)."
+
+    second_kwargs = audit.record_apply_event.call_args_list[1].kwargs
+    assert second_kwargs["old_comment"] == "Total amount in cents."
+
+    # Reader caches per-table; both rows share one round-trip.
+    db.get_column_comments.assert_called_once_with("public", "orders")
 
 
 def test_audit_log_omitted_means_no_record_calls() -> None:

--- a/tests/test_apply_audit_old_comment.py
+++ b/tests/test_apply_audit_old_comment.py
@@ -1,0 +1,189 @@
+"""Pre-write ``old_comment`` lookup → ``apply_events.old_comment`` populated.
+
+PR-12 + PR-12b shipped audit-log writes with ``old_comment=None``.
+This PR closes the loop: ``apply_review_results_to_db`` now reads
+the prior COMMENT before the overwrite via ``_OldCommentReader`` and
+threads it into ``record_apply_event`` so ``/history rollback`` can
+restore the original state byte-for-byte — including DBA-written
+comments AMX never authored.
+
+We pin the contract here without spinning up a real connector:
+
+* Column comment: reader caches ``get_column_comments`` per
+  (schema, table); a 200-row apply against one table fans out to
+  one read, not 200.
+* Single-table comment: ``get_table_comment`` is consulted.
+* Schema comment: ``get_schema_comment`` is consulted.
+* Reader failure → ``old_comment=None``; the apply path proceeds
+  normally and the audit row records "original unknown".
+* ``audit_log=None`` short-circuits the reader entirely (legacy
+  callers stay on the historical hot path with no extra DB round
+  trips).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from amx.agents.base import Confidence
+from amx.agents.orchestrator import (
+    ReviewResult,
+    _OldCommentReader,
+    apply_review_results_to_db,
+)
+from amx.db.connector import AssetKind
+
+
+def _result(
+    schema: str,
+    table: str,
+    column: str | None,
+    *,
+    description: str = "Order header.",
+    asset_kind: str = "table",
+    applied: bool = True,
+    result_id: int | None = None,
+) -> ReviewResult:
+    return ReviewResult(
+        schema=schema,
+        table=table,
+        column=column,
+        final_description=description,
+        confidence=Confidence.HIGH,
+        source="combined",
+        applied=applied,
+        asset_kind=asset_kind,
+        result_id=result_id,
+    )
+
+
+def _make_db_mock() -> MagicMock:
+    db = MagicMock()
+    db.apply_comment.return_value = None
+    db.apply_column_comments_batch.return_value = False
+    return db
+
+
+# ── _OldCommentReader unit ──────────────────────────────────────────
+
+
+def test_reader_returns_table_comment_when_column_is_none() -> None:
+    db = MagicMock()
+    db.get_table_comment.return_value = "Order header (DBA)."
+    reader = _OldCommentReader(db)
+
+    rr = _result("public", "orders", None)
+    assert reader.read(rr, AssetKind.TABLE) == "Order header (DBA)."
+    db.get_table_comment.assert_called_once_with("public", "orders")
+
+
+def test_reader_caches_column_comments_per_table() -> None:
+    """200-row apply against one table → exactly one
+    get_column_comments call."""
+    db = MagicMock()
+    db.get_column_comments.return_value = {
+        "id": "Customer id (DBA).",
+        "name": "Customer name.",
+    }
+    reader = _OldCommentReader(db)
+
+    rr_id = _result("public", "customers", "id")
+    rr_name = _result("public", "customers", "name")
+
+    assert reader.read(rr_id, AssetKind.TABLE) == "Customer id (DBA)."
+    assert reader.read(rr_name, AssetKind.TABLE) == "Customer name."
+    # Single bulk read served both column lookups.
+    db.get_column_comments.assert_called_once_with("public", "customers")
+
+
+def test_reader_returns_none_for_unknown_column() -> None:
+    db = MagicMock()
+    db.get_column_comments.return_value = {"id": "known"}
+    reader = _OldCommentReader(db)
+    rr = _result("s", "t", "missing")
+    assert reader.read(rr, AssetKind.TABLE) is None
+
+
+def test_reader_swallows_get_column_comments_failure() -> None:
+    """A misbehaving adapter must not break apply — return None and
+    let the audit row record 'original unknown'."""
+    db = MagicMock()
+    db.get_column_comments.side_effect = RuntimeError("driver blew up")
+    reader = _OldCommentReader(db)
+    assert reader.read(_result("s", "t", "c"), AssetKind.TABLE) is None
+
+
+def test_reader_consults_schema_comment_for_schema_kind() -> None:
+    db = MagicMock()
+    db.get_schema_comment.return_value = "Sales schema."
+    reader = _OldCommentReader(db)
+    rr = _result("sales", "", None, asset_kind="schema")
+    assert reader.read(rr, AssetKind.SCHEMA) == "Sales schema."
+    db.get_schema_comment.assert_called_once_with("sales")
+
+
+# ── apply_review_results_to_db integration ───────────────────────────
+
+
+def test_apply_threads_old_comment_into_audit_record() -> None:
+    """Per-row path: read happens before overwrite, audit gets the
+    prior text — DBA-written or otherwise."""
+    db = _make_db_mock()
+    db.get_column_comments.return_value = {"id": "DBA-written id comment."}
+    audit = MagicMock()
+
+    apply_review_results_to_db(
+        db,
+        [_result("public", "orders", "id", description="LLM rewrite.")],
+        audit_log=audit,
+        audit_profile="prod_pg",
+    )
+
+    audit.record_apply_event.assert_called_once()
+    kwargs = audit.record_apply_event.call_args.kwargs
+    assert kwargs["old_comment"] == "DBA-written id comment."
+    assert kwargs["new_comment"] == "LLM rewrite."
+
+
+def test_apply_records_none_when_no_prior_comment() -> None:
+    """Column with no comment in the DB → audit records None
+    (distinct from 'we couldn't read it')."""
+    db = _make_db_mock()
+    db.get_column_comments.return_value = {"id": None}
+    audit = MagicMock()
+
+    apply_review_results_to_db(
+        db,
+        [_result("public", "orders", "id")],
+        audit_log=audit,
+    )
+
+    kwargs = audit.record_apply_event.call_args.kwargs
+    assert kwargs["old_comment"] is None
+
+
+def test_apply_skips_old_comment_read_when_audit_log_none() -> None:
+    """Legacy callers (no audit) must not pay the get_*_comments
+    round-trip cost."""
+    db = _make_db_mock()
+    apply_review_results_to_db(db, [_result("public", "orders", "id")])
+    db.get_column_comments.assert_not_called()
+    db.get_table_comment.assert_not_called()
+
+
+def test_apply_continues_when_pre_read_raises() -> None:
+    """A bug in get_column_comments must not abort the apply — the
+    audit row just lands with old_comment=None."""
+    db = _make_db_mock()
+    db.get_column_comments.side_effect = RuntimeError("read failed")
+    audit = MagicMock()
+
+    n_applied = apply_review_results_to_db(
+        db,
+        [_result("public", "orders", "id")],
+        audit_log=audit,
+    )
+    assert n_applied == 1
+    db.apply_comment.assert_called_once()
+    kwargs = audit.record_apply_event.call_args.kwargs
+    assert kwargs["old_comment"] is None


### PR DESCRIPTION
## Summary

Closes the missing half of the audit log shipped in PR #198 + PR #201. ``apply_events.old_comment`` was always ``None`` because the audit row was written *after* the COMMENT was overwritten — once committed, the original text is gone.

This PR adds ``_OldCommentReader``: when the caller passes ``audit_log=...``, the reader fetches the prior COMMENT from the live DB **before** the overwrite and threads it into ``record_apply_event(old_comment=...)``. Cache scope is per ``(schema, table)`` so a 200-row apply against one table issues **one** ``get_column_comments`` call instead of 200.

Reader is only constructed when ``audit_log`` is set, so legacy callers (CLI without history store, programmatic apply, every existing test that doesn't pass audit_log) keep paying zero overhead.

## Why it matters

The user-asked scenario in the audit walkthrough: a DBA had hand-written comments (``\"Posting date (manual; legacy)\"``), the user runs ``amx /run`` + ``/apply``, the LLM rewrites take over. With this PR, ``apply_events.old_comment`` carries the DBA's verbatim text. The upcoming ``amx /history rollback <run_id>`` (PR-12b3) restores it byte-for-byte — independent of who originally wrote it.

## Failure modes

| Situation | ``old_comment`` value |
|---|---|
| Adapter has no read API | ``None`` |
| ``get_column_comments`` raises | ``None`` (logged at debug) |
| Column not in DB / never had a comment | ``None`` |
| Empty string in DB | ``\"\"`` (distinct — rollback restores empty literal) |

``/history rollback`` (PR-12b3) treats ``None`` as ""original unknown — skip this row"" rather than synthesising garbage.

## Test plan

- [x] ``pytest tests/test_apply_audit_old_comment.py -v`` — 9 new cases (reader: table / column-cache / missing / raise / schema; apply integration: threaded through / ``None`` for empty / skipped when no audit_log / continues on read failure).
- [x] Existing ``test_audit_log_receives_one_event_per_successful_apply`` updated — the prior ``old_comment is None`` assertion is now ``old_comment == \"DBA-written\"`` matching the new contract.
- [x] ``pytest -q --ignore=tests/eval`` — 1037 tests pass.
- [x] ``ruff check`` and ``ruff format --check`` clean.

## Release note

Uses ``feat:`` so this lands under the next **minor** bump when ``python-semantic-release`` is next run manually. No automatic release is triggered.