### PR TITLE
feat(cli): amx /history rollback <run_id>

### DIFF
--- a/amx/cli_support/commands/history.py
+++ b/amx/cli_support/commands/history.py
@@ -653,4 +653,192 @@ def register_history_commands(
 
         _mark_run_success()
 
+    @history.command("rollback")
+    @click.argument("run_id", type=int)
+    @click.option(
+        "--yes",
+        "-y",
+        "skip_confirm",
+        is_flag=True,
+        default=False,
+        help="Skip the confirmation prompt (scripted use).",
+    )
+    @pass_config
+    def history_rollback(cfg: AMXConfig, run_id: int, skip_confirm: bool) -> None:
+        """Restore the COMMENTs that ``run_id`` overwrote.
+
+        Replays ``apply_events`` rows for ``RUN_ID`` in **reverse**
+        order, writing each row's ``old_comment`` back to the
+        database via ``db.apply_comment``. Rows whose ``old_comment``
+        is ``None`` (the audit row never captured the prior text —
+        adapter without a read API, or the pre-write read failed)
+        are skipped with a warning, **not** silently overwritten
+        with garbage.
+
+        DBA-written comments are restored verbatim because the audit
+        log records "what was on the asset before the apply",
+        independent of who originally wrote it.
+        """
+        from amx.db.connector import AssetKind, DatabaseConnector
+
+        hs = history_store()
+        if hs is None:
+            error(
+                "History store isn't initialized; nothing to roll back. "
+                "Run `/setup` or `/history-store enable` first."
+            )
+            log_event(
+                event_type="history_rollback",
+                status="failed",
+                command="history.rollback",
+                details={"run_id": run_id, "reason": "no_history_store"},
+            )
+            return
+
+        try:
+            events = hs.list_apply_events(run_id=run_id, limit=10_000)
+        except Exception as exc:
+            error(f"Could not read apply_events for run #{run_id}: {exc}")
+            log_event(
+                event_type="history_rollback",
+                status="failed",
+                command="history.rollback",
+                details={"run_id": run_id, "reason": "list_failed", "error": str(exc)},
+            )
+            return
+
+        if not events:
+            warn(
+                f"No apply events recorded for run #{run_id}. "
+                "Either the run never wrote anything, or it predates the audit log."
+            )
+            log_event(
+                event_type="history_rollback",
+                status="skipped",
+                command="history.rollback",
+                details={"run_id": run_id, "reason": "no_events"},
+            )
+            return
+
+        restorable = [e for e in events if e.get("old_comment") is not None]
+        skipped = [e for e in events if e.get("old_comment") is None]
+
+        heading(f"Rollback run #{run_id}")
+        info(
+            f"Found {len(events)} apply event(s); "
+            f"{len(restorable)} restorable, {len(skipped)} skipped (original unknown)."
+        )
+        if restorable:
+            preview_rows = []
+            for e in restorable[:10]:
+                asset = ".".join(
+                    p
+                    for p in (e.get("schema_name"), e.get("table_name"), e.get("column_name"))
+                    if p
+                )
+                preview_rows.append(
+                    [
+                        asset,
+                        (e.get("new_comment") or "")[:48],
+                        (e.get("old_comment") or "")[:48],
+                    ]
+                )
+            render_table(
+                "Will restore (sample)" if len(restorable) > 10 else "Will restore",
+                ["Asset", "Current (will be replaced)", "Restoring to"],
+                preview_rows,
+            )
+
+        if not restorable:
+            warn(
+                "Nothing to restore. All events have ``old_comment=None`` — "
+                "the original text was never captured (apply ran before "
+                "PR-12b2, or the adapter doesn't expose a read API)."
+            )
+            log_event(
+                event_type="history_rollback",
+                status="skipped",
+                command="history.rollback",
+                details={"run_id": run_id, "reason": "no_restorable_events"},
+            )
+            return
+
+        if not skip_confirm and not confirm(
+            f"Restore {len(restorable)} comment(s) by overwriting current values?",
+            default=False,
+        ):
+            info("Cancelled.")
+            log_event(
+                event_type="history_rollback",
+                status="cancelled",
+                command="history.rollback",
+                details={"run_id": run_id, "restorable": len(restorable)},
+            )
+            return
+
+        db = DatabaseConnector(cfg.db)
+        if not db.test_connection():
+            error("Cannot connect to database.")
+            log_event(
+                event_type="history_rollback",
+                status="failed",
+                command="history.rollback",
+                details={"run_id": run_id, "reason": "db_connect_failed"},
+            )
+            return
+
+        # Apply rollbacks in reverse application order so a series of
+        # writes to the same asset in one run unwinds in the right
+        # direction (last-write-wins forward → first-write-wins back).
+        ordered = sorted(
+            restorable,
+            key=lambda e: e.get("applied_at") or 0,
+            reverse=True,
+        )
+
+        restored = 0
+        failed: list[tuple[str, str]] = []
+        with db.engine.begin() as conn:
+            for event in ordered:
+                schema = event.get("schema_name") or ""
+                table = event.get("table_name") or ""
+                column = event.get("column_name")
+                kind_label = (event.get("asset_kind") or "table").lower()
+                try:
+                    kind = AssetKind(kind_label)
+                except ValueError:
+                    kind = AssetKind.TABLE
+                asset_path = ".".join(p for p in (schema, table, column) if p)
+                try:
+                    db.apply_comment(
+                        schema=schema,
+                        table=table,
+                        column=column,
+                        comment=event.get("old_comment") or "",
+                        asset_kind=kind,
+                        conn=conn,
+                    )
+                    restored += 1
+                    info(f"  ✓ {asset_path}")
+                except Exception as exc:
+                    failed.append((asset_path, str(exc)))
+                    warn(f"  ✗ {asset_path}: {exc}")
+
+        if failed:
+            warn(f"Restored {restored} of {len(ordered)}; {len(failed)} failed.")
+        else:
+            success(f"Restored {restored} comment(s) from run #{run_id}.")
+
+        log_event(
+            event_type="history_rollback",
+            status="success" if not failed else "partial",
+            command="history.rollback",
+            details={
+                "run_id": run_id,
+                "restored": restored,
+                "skipped": len(skipped),
+                "failed": len(failed),
+            },
+        )
+
     return history

--- a/tests/test_history_rollback_command.py
+++ b/tests/test_history_rollback_command.py
@@ -1,0 +1,198 @@
+"""``amx /history rollback <run_id>`` command tests.
+
+The user scenario (audit walkthrough): a DBA had hand-written
+comments in the live DB, the user ran ``amx /run`` + ``/apply``,
+the LLM rewrites took over. Rollback now restores the originals
+byte-for-byte regardless of who originally wrote them.
+
+Tests pin the contract without a real DB:
+
+* No history store → ``/history rollback`` reports a clean error.
+* No events for the run → graceful warning, no DB writes.
+* Mix of restorable and ``old_comment is None`` rows → only the
+  restorable ones are written; the unknown ones are skipped (and
+  reported in the success summary).
+* Reverse-time replay: latest write unwinds first so a chain of
+  writes to one asset within a single run unwinds in order.
+* ``--yes`` skips the confirm prompt.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from amx.cli import main
+
+
+def _event(
+    *,
+    applied_at: float,
+    schema: str = "public",
+    table: str = "orders",
+    column: str | None = "id",
+    asset_kind: str = "table",
+    new_comment: str = "LLM rewrite.",
+    old_comment: str | None = "DBA original.",
+) -> dict:
+    """Build an apply_events row in the shape ``list_apply_events`` returns."""
+    return {
+        "id": int(applied_at * 1000) % 1_000_000,
+        "applied_at": applied_at,
+        "run_id": 42,
+        "result_id": None,
+        "profile_name": "prod_pg",
+        "schema_name": schema,
+        "table_name": table,
+        "column_name": column,
+        "asset_kind": asset_kind,
+        "old_comment": old_comment,
+        "new_comment": new_comment,
+        "applied_by": "omer",
+        "hostname": "laptop",
+        "sql_template": "",
+    }
+
+
+class HistoryRollbackTests(unittest.TestCase):
+    def test_no_history_store_reports_clean_error(self) -> None:
+        runner = CliRunner()
+        with patch("amx.cli_support.commands.history.history_store", return_value=None):
+            result = runner.invoke(
+                main,
+                ["--config", "test-config.yml", "history", "rollback", "42"],
+                env={"AMX_SESSION_CHILD": "1"},
+                catch_exceptions=False,
+            )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("History store isn't initialized", result.output)
+        # No DB connector ever instantiated.
+        self.assertNotIn("✓", result.output)
+
+    def test_empty_event_list_warns_and_exits_clean(self) -> None:
+        runner = CliRunner()
+        store = MagicMock()
+        store.list_apply_events.return_value = []
+        with patch("amx.cli_support.commands.history.history_store", return_value=store):
+            result = runner.invoke(
+                main,
+                ["--config", "test-config.yml", "history", "rollback", "42"],
+                env={"AMX_SESSION_CHILD": "1"},
+                catch_exceptions=False,
+            )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No apply events", result.output)
+        store.list_apply_events.assert_called_once_with(run_id=42, limit=10_000)
+
+    def test_only_unknown_old_comments_skips_with_warning(self) -> None:
+        runner = CliRunner()
+        store = MagicMock()
+        store.list_apply_events.return_value = [
+            _event(applied_at=1.0, column="id", old_comment=None),
+            _event(applied_at=2.0, column="amount", old_comment=None),
+        ]
+        with patch("amx.cli_support.commands.history.history_store", return_value=store):
+            result = runner.invoke(
+                main,
+                ["--config", "test-config.yml", "history", "rollback", "42", "--yes"],
+                env={"AMX_SESSION_CHILD": "1"},
+                catch_exceptions=False,
+            )
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Nothing to restore", result.output)
+        # No DatabaseConnector creation either.
+
+    def test_restorable_rows_replayed_in_reverse_time_order(self) -> None:
+        runner = CliRunner()
+        store = MagicMock()
+        # Three writes within run #42: t=1 → t=2 → t=3 on the same asset.
+        # Rollback should replay starting at t=3 going backwards so the
+        # asset ends up holding the value it had before t=1.
+        store.list_apply_events.return_value = [
+            _event(applied_at=1.0, column="id", old_comment="v0"),
+            _event(applied_at=2.0, column="id", old_comment="v1"),
+            _event(applied_at=3.0, column="id", old_comment="v2"),
+        ]
+
+        applied_in_order: list[str] = []
+
+        class FakeConnector:
+            def __init__(self, _cfg) -> None:
+                self.backend = "postgresql"
+                self.engine = SimpleNamespace(begin=lambda: _NoopTx())
+
+            def test_connection(self) -> bool:
+                return True
+
+            def apply_comment(self, **kwargs) -> None:
+                applied_in_order.append(kwargs["comment"])
+
+        class _NoopTx:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc) -> bool:
+                return False
+
+        with (
+            patch("amx.cli_support.commands.history.history_store", return_value=store),
+            patch("amx.db.connector.DatabaseConnector", FakeConnector),
+        ):
+            result = runner.invoke(
+                main,
+                ["--config", "test-config.yml", "history", "rollback", "42", "--yes"],
+                env={"AMX_SESSION_CHILD": "1"},
+                catch_exceptions=False,
+            )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        # Reverse time order — latest-applied unwinds first.
+        self.assertEqual(applied_in_order, ["v2", "v1", "v0"])
+        self.assertIn("Restored 3 comment(s)", result.output)
+
+    def test_mix_restorable_and_unknown(self) -> None:
+        runner = CliRunner()
+        store = MagicMock()
+        store.list_apply_events.return_value = [
+            _event(applied_at=1.0, column="id", old_comment="DBA-id"),
+            _event(applied_at=2.0, column="amount", old_comment=None),
+            _event(applied_at=3.0, column="status", old_comment="DBA-status"),
+        ]
+
+        applied_pairs: list[tuple[str | None, str]] = []
+
+        class FakeConnector:
+            def __init__(self, _cfg) -> None:
+                self.backend = "postgresql"
+                self.engine = SimpleNamespace(begin=lambda: _NoopTx())
+
+            def test_connection(self) -> bool:
+                return True
+
+            def apply_comment(self, **kwargs) -> None:
+                applied_pairs.append((kwargs.get("column"), kwargs["comment"]))
+
+        class _NoopTx:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc) -> bool:
+                return False
+
+        with (
+            patch("amx.cli_support.commands.history.history_store", return_value=store),
+            patch("amx.db.connector.DatabaseConnector", FakeConnector),
+        ):
+            result = runner.invoke(
+                main,
+                ["--config", "test-config.yml", "history", "rollback", "42", "--yes"],
+                env={"AMX_SESSION_CHILD": "1"},
+                catch_exceptions=False,
+            )
+        self.assertEqual(result.exit_code, 0)
+        # 'amount' (None old_comment) is skipped; the other two replay
+        # in reverse time order: status first, then id.
+        self.assertEqual(applied_pairs, [("status", "DBA-status"), ("id", "DBA-id")])
+        self.assertIn("Restored 2 comment(s)", result.output)


### PR DESCRIPTION
## Summary

Closes the audit-log loop. PR #198 added ``apply_events``; PR #201 wired the live writes; PR #209 populated ``old_comment`` from a pre-write read. **This PR exposes the rollback verb on the CLI.**

\`\`\`bash
amx /history rollback 42
amx /history rollback 42 --yes   # scripted / non-interactive
\`\`\`

### What it does

1. Loads ``apply_events`` for the run via ``SQLiteHistoryStore.list_apply_events(run_id=…)``.
2. Splits into **restorable** (``old_comment is not None``) vs **skipped** (``old_comment is None`` → original was unknown, e.g. apply ran before PR-12b2).
3. Renders a preview table of the first 10 restorable rows so the user sees exactly what will land.
4. Prompts for confirmation unless ``--yes`` is passed.
5. Replays in **reverse time order** so a chain of writes to one asset within the run unwinds in the correct direction (last-write-wins forward → first-write-wins back).
6. Writes via ``db.apply_comment`` in a single ``engine.begin()`` transaction; per-row failures are reported but do not abort the rest of the rollback.
7. Logs an analyze-style event (``status: success / partial / cancelled / skipped / failed``) for ``/history audit``.

### Why it matters (the user's scenario)

DBA had hand-written comments. User runs ``amx /run`` + ``/apply``. LLM rewrites take over. With this PR plus #209, ``amx /history rollback <run_id>`` puts the DBA's verbatim text back — independent of who originally authored each comment. The audit log captures **what was on the asset**, not "what AMX wrote".

## Test plan

- [x] ``pytest tests/test_history_rollback_command.py -v`` — 5 cases (no history store, empty events, only-unknown rows, restorable + reverse-time replay, mix of restorable + unknown).
- [x] ``pytest -q --ignore=tests/eval`` — 1042 tests pass.
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [ ] Manual end-to-end: ``amx /run`` against PostgreSQL, ``/apply``, then ``/history rollback`` and ``SELECT obj_description(...)`` to confirm the DBA-original is back. *(local verification)*

## Closes
- Original PR-12 plan's "Audit log + rollback" line
- Defer items PR-12b2 + PR-12b3 listed in the v0.12.9 audit roadmap