### PR TITLE
ci(perf): wire ask cold-path bench guard into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,36 @@ jobs:
       - name: Run pip-audit
         run: pip-audit --strict --progress-spinner off
 
+  perf-cold-path:
+    name: Ask cold-path bench
+    runs-on: ubuntu-latest
+    # Advisory by default — the run still surfaces regressions in the
+    # log without blocking merges. Flip ``continue-on-error`` to false
+    # once the baseline is stable and the team wants the gate hard.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[all,code-intel,perf]"
+      - name: Run cold-path benchmarks
+        # ``-m perf`` flips the marker filter from the default exclude
+        # to include. Bench file is ``bench_*.py`` so default test
+        # collection doesn't pick it up — ``--rootdir`` keeps pytest
+        # honest about discovery.
+        run: |
+          pytest tests/perf/bench_ask_no_context.py \
+            -m perf \
+            --benchmark-only \
+            --benchmark-min-rounds=5 \
+            --benchmark-disable-gc
+
   build:
     name: Build distribution
     runs-on: ubuntu-latest

--- a/tests/perf/bench_ask_no_context.py
+++ b/tests/perf/bench_ask_no_context.py
@@ -1,0 +1,95 @@
+"""Cold-path latency guards for the /ask doc/code RAG plumbing.
+
+The PR-1..4 series wired ``search_docs`` and ``search_code`` into the
+LLM tool list. The contract was:
+
+  * No doc/code profile in scope → tool short-circuits with
+    ``reason: no_*_for_scope`` and never opens a Chroma client.
+  * The scope resolver is pure-Python over a couple of dicts, well
+    under a millisecond.
+  * The static ``ToolBox.schemas()`` listing is constant work — the
+    LLM tool registry building should not balloon per question.
+
+These benchmarks pin those guarantees. They run under
+``pytest tests/perf -m perf`` and are intentionally cheap so the
+nightly perf job can keep them under a second total.
+
+Hot-path /ask benchmarks that need a live LLM live in their own
+file — these here assert the cold path stays cold.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amx.config import AMXConfig, DBConfig
+from amx.search._agent.scope import (
+    resolve_code_profiles_for_scope,
+    resolve_doc_profiles_for_scope,
+)
+from amx.search.agent_tools import ToolBox
+from amx.search.catalog import SearchCatalog
+
+
+@pytest.fixture
+def cold_toolbox(tmp_path):
+    """ToolBox with one DB profile and no docs/code — the no-context path."""
+    cfg = AMXConfig.load(str(tmp_path / "config.yml"))
+    cfg.db_profiles["prod_pg"] = DBConfig(backend="postgresql", host="x")
+    cfg.active_db_profile = "prod_pg"
+    cfg.active_db_profiles = ["prod_pg"]
+    catalog = SearchCatalog(db_path=tmp_path / "search.db")
+    box = ToolBox(cfg, catalog, db_profiles=["prod_pg"])
+    yield box
+    box.close()
+
+
+@pytest.mark.perf
+def test_toolbox_schemas_static(benchmark):
+    """``ToolBox.schemas()`` is a constant LLM tool registry. Should be
+    free — guarding against a careless caller adding a per-call DB
+    lookup or schema introspection inside the static."""
+    schemas = benchmark(ToolBox.schemas)
+    names = {s["function"]["name"] for s in schemas}
+    assert "search_docs" in names
+    assert "search_code" in names
+
+
+@pytest.mark.perf
+def test_search_docs_no_context_short_circuit(benchmark, cold_toolbox):
+    """No doc profile → must not open Chroma; payload reports the
+    skip reason. Guard against an accidental eager-init regression."""
+    payload = benchmark(lambda: cold_toolbox._tool_search_docs(query="hello"))
+    assert payload["count"] == 0
+    assert payload["reason"] == "no_docs_for_scope"
+
+
+@pytest.mark.perf
+def test_search_code_no_context_short_circuit(benchmark, cold_toolbox):
+    """Same guarantee for ``search_code`` — empty scope, fast return."""
+    payload = benchmark(lambda: cold_toolbox._tool_search_code(query="hello"))
+    assert payload["count"] == 0
+    assert payload["reason"] == "no_code_for_scope"
+
+
+@pytest.mark.perf
+def test_scope_resolver_pure_python(benchmark, tmp_path):
+    """Resolver is dict comprehension over small lists. Should be in
+    the microseconds; guards against someone reaching for I/O later."""
+    cfg = AMXConfig.load(str(tmp_path / "config.yml"))
+    cfg.db_profiles["prod_pg"] = DBConfig(backend="postgresql", host="x")
+    cfg.db_profiles["analytics_bq"] = DBConfig(backend="bigquery", host="bq")
+    cfg.doc_profiles["contracts"] = ["/abs/contracts"]
+    cfg.doc_profiles["handbook"] = ["/abs/handbook"]
+    cfg.code_profiles["etl"] = "/abs/etl"
+    cfg.set_doc_profile_linked_dbs("contracts", ["prod_pg"])
+
+    def _resolve_both() -> tuple[list[str], list[str]]:
+        return (
+            resolve_doc_profiles_for_scope(cfg, ["prod_pg"]),
+            resolve_code_profiles_for_scope(cfg, ["prod_pg"]),
+        )
+
+    docs, code = benchmark(_resolve_both)
+    assert "contracts" in docs
+    assert code == ["etl"]


### PR DESCRIPTION
## Summary

Final PR of the doc/code-RAG-into-`/ask` series (PR-1=#212, PR-2=#213,
PR-3=#214, PR-4=#215).

Pins the cold-path guarantees the earlier PRs introduced. Four
benchmarks under ``tests/perf/bench_ask_no_context.py``:

1. ``search_docs`` short-circuits to ``no_docs_for_scope`` without
   opening Chroma when nothing is configured.
2. ``search_code`` short-circuits to ``no_code_for_scope`` likewise.
3. The scope resolver is dict-comprehension-fast (no I/O).
4. ``ToolBox.schemas()`` stays a constant-time LLM tool registry.

A new CI job runs them with ``-m perf --benchmark-only`` on every
PR. Advisory by default — surfaces regressions in the log without
blocking merges; flip ``continue-on-error`` when ready to gate.

## Test plan

- [ ] Local: ``pytest tests/perf/bench_ask_no_context.py -m perf
  --benchmark-only`` all four green.
- [ ] CI: the new ``Ask cold-path bench`` job appears on the PR
  status checks and runs to completion.
- [ ] Cold-path numbers: search_docs / search_code no-context call
  under 5μs each on CI runner.