### PR TITLE
build: support Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Added
 
+- **Python 3.13 and 3.14 support.** CI now exercises the full
+  3.10–3.14 matrix on every PR, and PyPI classifiers advertise the
+  expanded support surface. `requires-python` stays at `>=3.10`.
 - **`amx /history rollback <run_id>`** — undo a past `/apply` by restoring the
   COMMENTs each affected asset had immediately before the run. Backed by the
   new `apply_events` audit table; replays in reverse time order inside a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Database",
     "Topic :: Software Development :: Documentation",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
## Summary
- Add Python 3.13 and 3.14 to CI test matrix as required (hard) versions
- Add `Programming Language :: Python :: 3.13` and `:: 3.14` classifiers
- Update CHANGELOG

`requires-python` stays at `>=3.10`. Tool target versions (ruff `py310`, mypy `3.10`) are unchanged — they target the minimum supported version, not the maximum.

## Test plan
- [ ] CI green on 3.10, 3.11, 3.12, 3.13, 3.14
- [ ] `pip install -e ".[all,code-intel]"` succeeds on 3.13 and 3.14 in CI
- [ ] `pytest -ra` passes on 3.13 and 3.14