### PR TITLE
fix(apply): isolate per-row writeback failures behind a SAVEPOINT

### DIFF
--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import re
 import threading
 from collections import defaultdict
@@ -361,6 +362,46 @@ class _OldCommentReader:
             return None
 
 
+@contextlib.contextmanager
+def _savepoint_or_passthrough(conn: Any):
+    """Per-row SAVEPOINT context.
+
+    PostgreSQL aborts the entire transaction when one statement
+    fails; without a savepoint, every subsequent COMMENT in the same
+    apply batch fails with ``InFailedSqlTransaction``. SQLAlchemy's
+    ``conn.begin_nested()`` issues ``SAVEPOINT`` and rolls just that
+    savepoint back on exception, leaving the outer tx alive.
+
+    Some adapters / test fakes don't implement ``begin_nested``; fall
+    back to a passthrough so they keep working as they did before
+    (Postgres is the only common backend with the cascade behaviour).
+    """
+    nested = getattr(conn, "begin_nested", None)
+    if not callable(nested):
+        yield None
+        return
+    try:
+        cm = nested()
+    except Exception:
+        # Some fakes raise on construction — be conservative and skip
+        # the savepoint, falling back to the legacy single-tx path.
+        yield None
+        return
+    enter = getattr(cm, "__enter__", None)
+    exit_ = getattr(cm, "__exit__", None)
+    if not callable(enter) or not callable(exit_):
+        yield None
+        return
+    enter()
+    try:
+        yield cm
+    except BaseException as exc:
+        if not exit_(type(exc), exc, exc.__traceback__):
+            raise
+    else:
+        exit_(None, None, None)
+
+
 def apply_review_results_to_db(
     db: DatabaseConnector,
     results: list[ReviewResult],
@@ -498,14 +539,23 @@ def apply_review_results_to_db(
                     pre_old: list[str | None] = []
                     if old_reader is not None:
                         pre_old = [old_reader.read(item, kind) for item in group]
+                    # Wrap the batch in a SAVEPOINT so a failed batch
+                    # (or a failed individual statement inside the
+                    # batch on PostgreSQL, which would otherwise abort
+                    # the outer tx and cascade-fail every subsequent
+                    # row with ``InFailedSqlTransaction``) only rolls
+                    # back its own savepoint and leaves the per-row
+                    # fallback path usable.
                     try:
                         if on_progress is not None:
                             on_progress(
                                 group[0], "started", index + 1, total, f"batch:{len(group)}"
                             )
-                        if db.apply_column_comments_batch(
-                            r.schema, r.table, batched_comments, conn=conn
-                        ):
+                        with _savepoint_or_passthrough(conn):
+                            applied_batch = db.apply_column_comments_batch(
+                                r.schema, r.table, batched_comments, conn=conn
+                            )
+                        if applied_batch:
                             for offset, item in enumerate(group, start=1):
                                 applied += 1
                                 if on_progress is not None:
@@ -545,14 +595,21 @@ def apply_review_results_to_db(
             try:
                 if on_progress is not None:
                     on_progress(r, "started", index + 1, total, "")
-                db.apply_comment(
-                    schema=r.schema,
-                    table=r.table,
-                    column=r.column,
-                    comment=r.final_description,
-                    asset_kind=kind,
-                    conn=conn,
-                )
+                # Per-row SAVEPOINT: keeps a single failed COMMENT (eg.
+                # "schema does not exist" on Postgres) from poisoning
+                # the rest of the batch with InFailedSqlTransaction.
+                # The savepoint auto-rolls back on exception when used
+                # as a context manager, so the outer tx stays alive
+                # for the next row.
+                with _savepoint_or_passthrough(conn):
+                    db.apply_comment(
+                        schema=r.schema,
+                        table=r.table,
+                        column=r.column,
+                        comment=r.final_description,
+                        asset_kind=kind,
+                        conn=conn,
+                    )
                 applied += 1
                 if on_progress is not None:
                     on_progress(r, "applied", index + 1, total, "")
@@ -572,6 +629,12 @@ def apply_review_results_to_db(
                     on_progress(r, "failed", index + 1, total, str(exc))
                 if on_failed is not None:
                     on_failed(r, exc)
+                # Surface the proximate cause (eg. schema/table not
+                # found) instead of the cascade noise. Postgres
+                # ``InFailedSqlTransaction`` errors used to dominate
+                # the log when one row failed inside a single tx;
+                # SAVEPOINTs above kill that cascade, but we still
+                # render the original error message cleanly.
                 error(
                     f"Failed to apply comment on {r.schema}.{r.table or ''}.{r.column or ''} ({r.asset_kind}): {exc}"
                 )

--- a/tests/test_apply_savepoint_isolation.py
+++ b/tests/test_apply_savepoint_isolation.py
@@ -1,0 +1,121 @@
+"""SAVEPOINT-per-row isolation in ``apply_review_results_to_db``.
+
+PostgreSQL aborts the entire transaction when a single statement
+fails (``InFailedSqlTransaction`` cascade). Without per-row savepoints,
+one bad asset (e.g. wrong schema name) used to fail every subsequent
+row in the same apply batch with a misleading "transaction aborted"
+error — even though every other asset was perfectly valid.
+
+These tests pin the contract that a row-level error stays contained:
+the rest of the batch still applies and the user sees the original
+error on just the failing row.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+from amx.agents.base import Confidence
+from amx.agents.orchestrator import ReviewResult, apply_review_results_to_db
+
+
+def _result(schema: str, table: str, column: str | None) -> ReviewResult:
+    return ReviewResult(
+        schema=schema,
+        table=table,
+        column=column,
+        final_description=f"desc for {schema}.{table}.{column or '(table)'}",
+        confidence=Confidence.HIGH,
+        source="combined",
+        applied=True,
+        asset_kind="table",
+    )
+
+
+def _make_db(apply_side_effect):
+    """Build a connector mock whose ``apply_comment`` is the supplied
+    callable. ``engine.begin()`` and ``conn.begin_nested()`` both
+    return real context-manager mocks so the SAVEPOINT path under
+    test executes without hitting a database."""
+    db = MagicMock()
+    conn = MagicMock()
+
+    @contextmanager
+    def _begin_nested():
+        try:
+            yield MagicMock()
+        except Exception:
+            # Mirror SQLAlchemy: nested context manager swallows the
+            # exception only if you call ``.commit()`` explicitly.
+            # Here we want the raise to propagate so the outer
+            # try/except sees it — same as production.
+            raise
+
+    conn.begin_nested.side_effect = _begin_nested
+
+    @contextmanager
+    def _begin_outer():
+        yield conn
+
+    db.engine.begin.side_effect = _begin_outer
+    db.apply_comment.side_effect = apply_side_effect
+    return db, conn
+
+
+def test_first_row_failure_does_not_cascade_into_others() -> None:
+    """One bad row (schema not found) should not poison the rest."""
+    # Distinct (schema, table) tuples so each row goes through the
+    # per-row writeback (the batched path is exercised in the
+    # ``test_savepoint_used_per_row`` companion).
+    rows = [
+        _result("missing_schema", "offices", "officeCode"),
+        _result("public", "orders", "id"),
+        _result("public", "products", "total"),
+    ]
+
+    calls: list[str] = []
+
+    def _apply_comment(*, schema, table, column, comment, asset_kind, conn):
+        calls.append(f"{schema}.{table}.{column}")
+        if schema == "missing_schema":
+            raise RuntimeError('schema "missing_schema" does not exist')
+
+    db, _conn = _make_db(_apply_comment)
+
+    failures: list[tuple[str, str]] = []
+    successes: list[str] = []
+
+    applied = apply_review_results_to_db(
+        db,
+        rows,
+        on_applied=lambda r: successes.append(f"{r.schema}.{r.table}.{r.column}"),
+        on_failed=lambda r, exc: failures.append((f"{r.schema}.{r.table}.{r.column}", str(exc))),
+    )
+
+    # Every row was attempted (no cascade truncation).
+    assert len(calls) == 3, f"expected 3 attempts, got {len(calls)}: {calls}"
+    # The two valid rows applied; the bad one did not.
+    assert applied == 2
+    assert successes == ["public.orders.id", "public.products.total"]
+    # The bad row reported the original cause, not "transaction aborted".
+    assert len(failures) == 1
+    assert failures[0][0] == "missing_schema.offices.officeCode"
+    assert "missing_schema" in failures[0][1]
+    assert "does not exist" in failures[0][1]
+
+
+def test_savepoint_used_per_row() -> None:
+    """The connection's ``begin_nested`` is called once per row (not
+    just once for the whole batch) — that's the actual mechanism that
+    prevents PostgreSQL's transaction-abort cascade."""
+    rows = [
+        _result("public", "a", "x"),
+        _result("public", "b", "y"),
+    ]
+
+    db, conn = _make_db(lambda **_: None)
+
+    apply_review_results_to_db(db, rows)
+
+    assert conn.begin_nested.call_count == len(rows)


### PR DESCRIPTION
## Summary

Reported: a Postgres apply hit ``schema \"car_retails\" does not exist``
on the first COMMENT, then every following row failed with
``InFailedSqlTransaction`` — the cascade you get when you keep
issuing statements on a Postgres connection whose tx has already
been aborted. The user-facing error noise made the real cause
(wrong schema name) hard to spot.

Root cause: ``apply_review_results_to_db`` ran the whole loop inside
a single ``db.engine.begin()`` transaction. One failed statement
poisoned every following one.

Fix: per-row and per-batch SAVEPOINTs via ``conn.begin_nested()`` so
a row-level error rolls back only its own savepoint and the outer
transaction stays usable for the next row. A small
``_savepoint_or_passthrough`` helper makes the orchestrator robust
to adapters/test fakes that don't expose ``begin_nested`` (the
existing legacy ``FakeConnection`` test fixtures).

## Test plan

- [ ] ``tests/test_apply_savepoint_isolation.py`` (new) — first-row
  failure leaves the rest applied, ``begin_nested`` is taken once
  per row.
- [ ] Existing 1106 tests (incl. ``test_apply_flow_*`` regressions)
  still green.
- [ ] Manual: re-run the failing scenario in Studio — expect only
  the offending row to fail with the original Postgres message,
  every other row applies cleanly.