### PR TITLE
fix(pending): mark restored rows applied=True so save_pending keeps them

### DIFF
--- a/amx/web/routers/pending.py
+++ b/amx/web/routers/pending.py
@@ -232,6 +232,12 @@ def restore(body: RestoreRequest) -> dict[str, Any]:
         confidence=confidence,
         source=body.source,
         asset_kind=body.asset_kind,
+        # ReviewResult.applied defaults to False, but save_pending() drops
+        # any row with applied=False on the way out — without this the
+        # restore looked successful (200 OK + "Restored" toast) yet the
+        # pending file silently lost the new row, so the SPA's "Apply
+        # pending queue" button stayed at "Nothing to apply".
+        applied=True,
         result_id=body.result_id,
         alternatives=list(body.alternatives or []),
         logprob_score=body.logprob_score,

--- a/tests/web/test_pending.py
+++ b/tests/web/test_pending.py
@@ -38,8 +38,16 @@ def stub_pending(monkeypatch, tmp_path):
         return list(state)
 
     def fake_save_pending(results) -> None:
+        # Mirror the real ``save_pending`` filter — only ``applied=True``
+        # rows with non-empty descriptions land on disk. Without this
+        # the stub silently masks bugs where a caller forgets to set
+        # ``applied=True`` (caught by the restore-persists test below).
         state.clear()
-        state.extend(results)
+        state.extend(
+            r
+            for r in results
+            if getattr(r, "applied", False) and (getattr(r, "final_description", "") or "").strip()
+        )
 
     def fake_clear_pending() -> None:
         state.clear()
@@ -315,6 +323,65 @@ def test_pending_preview_empty_queue(client, auth_headers, stub_pending) -> None
     response = client.post("/api/pending/preview", headers=auth_headers)
     assert response.status_code == 200
     assert response.json() == {"events": [], "count": 0}
+
+
+def test_pending_restore_persists_row(client, auth_headers, stub_pending) -> None:
+    """``POST /api/pending/restore`` must actually land the row in the
+    queue. The bug it pins: ReviewResult.applied defaults to False and
+    ``save_pending`` drops applied=False rows, so an early version of
+    this endpoint silently 200 OK'd the request without persisting the
+    row — the SPA's "Apply pending queue (N)" stayed at zero.
+    """
+    response = client.post(
+        "/api/pending/restore",
+        headers=auth_headers,
+        json={
+            "schema": "public",
+            "table": "orders",
+            "column": "id",
+            "result_id": 4242,
+            "final_description": "Order primary key.",
+            "confidence": "high",
+            "asset_kind": "table",
+            "alternatives": ["Order primary key.", "Unique order id."],
+            "logprob_score": 0.95,
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["already_present"] is False
+    assert body["count"] == 1
+
+    listing = client.get("/api/pending", headers=auth_headers).json()
+    assert listing["count"] == 1
+    saved = listing["pending"][0]
+    assert saved["result_id"] == 4242
+    assert saved["final_description"] == "Order primary key."
+    assert saved["applied"] is True
+
+
+def test_pending_restore_idempotent_by_result_id(client, auth_headers, stub_pending) -> None:
+    """A second restore for the same result_id must report
+    ``already_present`` and not duplicate the row."""
+    body = {
+        "schema": "public",
+        "table": "orders",
+        "column": "id",
+        "result_id": 9001,
+        "final_description": "Order primary key.",
+        "confidence": "high",
+        "asset_kind": "table",
+        "alternatives": [],
+        "logprob_score": None,
+    }
+    first = client.post("/api/pending/restore", headers=auth_headers, json=body)
+    second = client.post("/api/pending/restore", headers=auth_headers, json=body)
+    assert first.status_code == 200
+    assert first.json()["already_present"] is False
+    assert second.status_code == 200
+    assert second.json()["already_present"] is True
+    listing = client.get("/api/pending", headers=auth_headers).json()
+    assert listing["count"] == 1
 
 
 def _drain_sse(client, path: str, auth_headers, timeout: float = 3.0):


### PR DESCRIPTION
## Summary

Reported: picking an alternative on a previously-skipped row produced a
\"Restored\" toast and a 200 OK from ``POST /api/pending/restore``, but
the \"Apply pending queue\" button stayed at \"Nothing to apply\" and the
queued count never moved off zero.

Root cause: ``ReviewResult.applied`` defaults to ``False``, and
``save_pending`` explicitly drops every ``applied=False`` row before
writing to disk. The restore endpoint built a ReviewResult without
setting ``applied=True``, so ``save_pending`` silently dropped the
new row. The HTTP response and toast both reported success because
the file write itself didn't fail — it just persisted the same rows
it had loaded a moment earlier.

Fix: pass ``applied=True`` when constructing the restored ReviewResult.
Also tighten the test fake ``fake_save_pending`` stub to mirror the
real filter so future regressions of this shape can't pass tests.

## Test plan

- [ ] ``tests/web/test_pending.py::test_pending_restore_persists_row``
  green (without the fix it fails on ``count == 1``).
- [ ] ``tests/web/test_pending.py::test_pending_restore_idempotent_by_result_id``
  green — second restore returns ``already_present=True`` and keeps
  one row in the queue.
- [ ] Manual: skip a row, click an alternative on it → button flips
  to ``Apply pending queue (1)`` once the pending refetch lands.