### PR TITLE
fix(secrets): preserve keyring reference when backend is offline

### DIFF
--- a/amx/config.py
+++ b/amx/config.py
@@ -174,6 +174,17 @@ def _externalise_secrets_in_data(
 
 
 def _resolve_secret_field(mapping: dict[str, Any], field_name: str, store: SecretStore) -> None:
+    """Replace one ``keyring:...`` reference with its plaintext value.
+
+    When the keyring backend is unavailable (eg. macOS denied access
+    after a Python reinstall) or the entry no longer exists, the
+    reference STAYS in the mapping unchanged. The previous behaviour
+    overwrote the field with ``""`` which then became permanent on the
+    next ``cfg.save()`` — externalise skips empty values, so the YAML
+    lost the keyring pointer and the user had to re-enter the secret
+    even after fixing the backend. Leaving the reference in place lets
+    a subsequent process resolve it once the backend recovers.
+    """
     value = mapping.get(field_name, "")
     if not is_secret_reference(value):
         return
@@ -182,14 +193,20 @@ def _resolve_secret_field(mapping: dict[str, Any], field_name: str, store: Secre
         resolved = store.get(keyring_key)
     except Exception:
         resolved = None
-    mapping[field_name] = resolved or ""
+    if resolved:
+        mapping[field_name] = resolved
+    # else: keep the reference intact so cfg.save() can still
+    # round-trip it to YAML when the backend is healthy again.
 
 
 def _resolve_secrets_in_data(data: dict[str, Any], store: SecretStore) -> dict[str, Any]:
     """Replace ``keyring:...`` references in ``data`` with plaintext values from the store.
 
-    Mutates ``data`` in place. References that cannot be resolved (keyring
-    unavailable, or key removed) are replaced with empty strings.
+    Mutates ``data`` in place. References that cannot be resolved
+    (keyring unavailable, or key removed) are LEFT AS REFERENCES so a
+    subsequent run can recover once the backend is healthy — overwriting
+    them with ``""`` would silently destroy the YAML pointer on the
+    next save.
     """
     db_profiles = data.get("db_profiles") or {}
     if isinstance(db_profiles, dict):

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -198,7 +198,35 @@ class DatabaseConnector:
     """Unified database connector that delegates backend-specific work to adapters."""
 
     def __init__(self, cfg: DBConfig):
-        self.cfg = cfg
+        # Sanitize unresolved keyring references on a COPY so the
+        # adapter never tries to use ``keyring:db_profiles/<x>/password``
+        # as a real secret (which would produce a confusing
+        # backend-specific auth error). Mutating the caller's cfg
+        # would propagate through ``AMXConfig.save()`` and erase the
+        # YAML reference — keep the original intact so the next
+        # process with a healthy keyring backend (any platform:
+        # macOS Keychain, Linux Secret Service, Windows Credential
+        # Manager) can resolve it.
+        from dataclasses import replace as _replace
+
+        from amx.storage.secrets import is_secret_reference
+
+        sanitized: dict[str, str] = {}
+        for fld in ("password", "access_token"):
+            current = getattr(cfg, fld, "") or ""
+            if is_secret_reference(current):
+                sanitized[fld] = ""
+                log.warning(
+                    "DB profile %s field is an unresolved keyring "
+                    "reference — backend keyring may be unavailable. "
+                    "Connection attempts will fail until the backend "
+                    "recovers or the credential is re-entered via /db.",
+                    fld,
+                )
+        if sanitized:
+            self.cfg = _replace(cfg, **sanitized)
+        else:
+            self.cfg = cfg
         self._engine: Engine | None = None
 
         # Auto-install the backend's driver(s) before constructing the
@@ -213,7 +241,7 @@ class DatabaseConnector:
 
         from amx.db.adapters import get_adapter
 
-        self._adapter = get_adapter(cfg)
+        self._adapter = get_adapter(self.cfg)
 
     @property
     def engine(self) -> Engine:

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -970,6 +970,31 @@ class LLMProvider:
 
     def __init__(self, cfg: LLMConfig):
         self.cfg = cfg
+        # When the keyring backend is unreachable (Keychain ACL miss
+        # after a binary path change on macOS, gnome-keyring /
+        # KWallet not running on Linux, Credential Manager access
+        # denied on Windows, …), the YAML's
+        # ``keyring:llm_profiles/<name>/api_key`` reference falls
+        # through to ``cfg.api_key`` unresolved. Compute an effective
+        # key for outgoing auth without mutating the dataclass —
+        # mutating would propagate through ``cfg.save()`` and erase
+        # the YAML reference for future runs that have a healthy
+        # backend.
+        from amx.storage.secrets import is_secret_reference
+
+        if is_secret_reference(cfg.api_key):
+            env_fallback = os.getenv("AMX_LLM_API_KEY", "")
+            log.warning(
+                "%s api_key is an unresolved keyring reference (backend unavailable?). %s",
+                cfg.provider or "(provider)",
+                "Using AMX_LLM_API_KEY env fallback."
+                if env_fallback
+                else "No AMX_LLM_API_KEY env fallback set; calls will fail until "
+                "the keyring backend recovers or you run /llm to re-enter the key.",
+            )
+            self._effective_api_key = env_fallback
+        else:
+            self._effective_api_key = cfg.api_key or ""
         normalized_model = normalize_llm_model(cfg.provider, cfg.model)
         if normalized_model and normalized_model != cfg.model:
             log.info(
@@ -1004,9 +1029,14 @@ class LLMProvider:
         return get_batch_provider(self.cfg) is not None
 
     def _configure_env(self) -> None:
+        # ``_effective_api_key`` is the resolved key we should auth with —
+        # ``cfg.api_key`` may still be a ``keyring:`` reference when the
+        # backend was offline at config-load time, and we don't want to
+        # leak the reference into upstream Authorization headers.
+        api_key = self._effective_api_key
         env_key = PROVIDER_ENV_KEY.get(self.cfg.provider)
-        if env_key and self.cfg.api_key:
-            os.environ[env_key] = self.cfg.api_key
+        if env_key and api_key:
+            os.environ[env_key] = api_key
 
         normalized_base = _normalized_api_base(self.cfg.provider, self.cfg.api_base)
         if normalized_base != self.cfg.api_base:
@@ -1024,21 +1054,21 @@ class LLMProvider:
             # Databricks Serving rejects an empty bearer; fall back to a
             # placeholder so LiteLLM doesn't strip the Authorization header,
             # but the real PAT (when supplied) wins.
-            os.environ.setdefault("OPENAI_API_KEY", self.cfg.api_key or "local")
+            os.environ.setdefault("OPENAI_API_KEY", api_key or "local")
         elif self.cfg.provider == "openrouter":
             if self.cfg.api_base:
                 os.environ["OPENAI_API_BASE"] = self.cfg.api_base
             # LiteLLM OpenRouter path expects OpenAI-style key wiring.
-            if self.cfg.api_key:
-                os.environ["OPENROUTER_API_KEY"] = self.cfg.api_key
-                os.environ["OPENAI_API_KEY"] = self.cfg.api_key
+            if api_key:
+                os.environ["OPENROUTER_API_KEY"] = api_key
+                os.environ["OPENAI_API_KEY"] = api_key
             else:
                 os.environ.setdefault("OPENROUTER_API_KEY", "")
         elif self.cfg.provider == "ollama":
             if self.cfg.api_base:
                 os.environ["OLLAMA_API_BASE"] = self.cfg.api_base
             # Some LiteLLM versions still check for a key even if unused
-            os.environ.setdefault("OLLAMA_API_KEY", self.cfg.api_key or "ollama")
+            os.environ.setdefault("OLLAMA_API_KEY", api_key or "ollama")
 
         lm = _litellm()
         lm.drop_params = True
@@ -1224,7 +1254,9 @@ class LLMProvider:
             extra["timeout"] = _llm_timeout_sec()
 
         def _do_completion(api_base_override: str | None) -> Any:
-            explicit_api_key = self.cfg.api_key if self.cfg.provider == "openrouter" else None
+            explicit_api_key = (
+                self._effective_api_key if self.cfg.provider == "openrouter" else None
+            )
             kwargs_for_call = dict(extra)
             if use_streaming:
                 kwargs_for_call["stream"] = True

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -2138,10 +2138,14 @@ class SecretKeychainTests(unittest.TestCase):
             yaml_text = cfg_path.read_text()
             self.assertNotIn("legacy-plain", yaml_text)
 
-    def test_missing_keyring_entry_resolves_to_empty_string(self) -> None:
-        """A reference whose key has been deleted from the keyring should not
-        crash the loader; the field becomes empty so the user can be prompted
-        to re-enter the secret."""
+    def test_missing_keyring_entry_preserves_reference_string(self) -> None:
+        """A reference whose backend lookup fails (key deleted, keyring
+        unavailable, ACL denied) MUST stay a reference in the in-memory
+        dataclass — the previous "fall back to empty" behaviour caused
+        the YAML pointer to be wiped on the next ``cfg.save()``,
+        permanently losing the credential after a transient backend
+        outage. ``DatabaseConnector`` strips it before any adapter sees
+        it; the YAML round-trip is what we pin here."""
         with tempfile.TemporaryDirectory() as td:
             cfg_path = Path(td) / "config.yml"
             cfg_path.write_text(
@@ -2156,7 +2160,9 @@ class SecretKeychainTests(unittest.TestCase):
                 "    password: keyring:db_profiles/ghost/password\n"
             )
             cfg = AMXConfig.load(str(cfg_path))
-            self.assertEqual(cfg.db_profiles["ghost"].password, "")
+            self.assertTrue(
+                cfg.db_profiles["ghost"].password.startswith("keyring:")
+            )
 
     def test_llm_api_key_externalised_separately_from_db(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_secrets_unresolved_reference.py
+++ b/tests/test_secrets_unresolved_reference.py
@@ -1,0 +1,172 @@
+"""Unresolved ``keyring:`` references must survive load → save round-trips.
+
+Reported regression: after a Python reinstall (``pip install -e .``) the
+keyring backend can briefly become unreachable on any platform —
+macOS Keychain ACL miss, gnome-keyring / KWallet not running on
+Linux, Credential Manager access denied on Windows. Without the fix
+in this PR, that transient failure was *permanent*: the load step
+overwrote the YAML's ``keyring:...`` reference with ``""`` in memory,
+and the next ``cfg.save()`` then wrote the empty string to disk and
+deleted the pointer for good. Users had to re-enter every secret.
+
+These tests pin the new contract: the YAML reference is preserved
+even when the backend is offline, so the very next process with a
+healthy backend can resolve it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amx.config import AMXConfig
+from amx.storage.secrets import (
+    InMemorySecretStore,
+    NullSecretStore,
+    SecretStore,
+    set_default_store,
+)
+
+
+@pytest.fixture
+def healthy_store() -> InMemorySecretStore:
+    """Backend that has the secret (the happy path)."""
+    store = InMemorySecretStore()
+    store.set("llm_profiles/default/api_key", "sk-real-key")
+    set_default_store(store)
+    yield store
+    set_default_store(None)
+
+
+@pytest.fixture
+def offline_store() -> SecretStore:
+    """Backend that's reachable but doesn't know the secret — the
+    macOS-Keychain-after-binary-rebuild / gnome-keyring-not-running
+    shape."""
+    store = NullSecretStore()
+    set_default_store(store)
+    yield store
+    set_default_store(None)
+
+
+def _seed_yaml_with_reference(path: Path) -> None:
+    path.write_text(
+        """\
+db_profiles:
+  prod:
+    backend: postgresql
+    host: db.example.com
+    database: prod
+llm_profiles:
+  default:
+    provider: openai
+    model: gpt-4o
+    api_key: keyring:llm_profiles/default/api_key
+active_db_profile: prod
+active_llm_profile: default
+""",
+        encoding="utf-8",
+    )
+
+
+def test_offline_keyring_does_not_overwrite_reference_on_save(tmp_path, offline_store) -> None:
+    """When the keyring is unavailable on load, the YAML must keep the
+    original ``keyring:...`` pointer through every subsequent save —
+    that's the only way a recovered backend can resolve the secret
+    on the next run."""
+    yaml_path = tmp_path / "config.yml"
+    _seed_yaml_with_reference(yaml_path)
+
+    cfg = AMXConfig.load(str(yaml_path))
+    # In-memory the reference falls through unresolved (no plaintext).
+    assert cfg.llm.api_key.startswith("keyring:")
+
+    # Trigger every save path: explicit save() and an autosave via
+    # mutating a tracked field. Both used to wipe the reference.
+    cfg.save()
+    cfg.active_llm_profile = "default"
+
+    reloaded = yaml_path.read_text(encoding="utf-8")
+    assert "keyring:llm_profiles/default/api_key" in reloaded, (
+        "save() destroyed the keyring reference; the user would lose the "
+        "credential permanently after a transient backend outage."
+    )
+
+
+def test_healthy_keyring_resolves_to_plaintext(tmp_path, healthy_store) -> None:
+    """The happy path still works — load resolves the reference, save
+    re-externalises it back to a reference."""
+    yaml_path = tmp_path / "config.yml"
+    _seed_yaml_with_reference(yaml_path)
+
+    cfg = AMXConfig.load(str(yaml_path))
+    assert cfg.llm.api_key == "sk-real-key"
+    cfg.save()
+
+    reloaded = yaml_path.read_text(encoding="utf-8")
+    assert "keyring:llm_profiles/default/api_key" in reloaded
+    assert "sk-real-key" not in reloaded
+
+
+def test_provider_does_not_send_reference_as_bearer(monkeypatch) -> None:
+    """``LLMProvider`` must never let a ``keyring:`` reference reach
+    upstream. When the cfg arrives unresolved, the provider falls back
+    to the ``AMX_LLM_API_KEY`` env var (or empty) for outgoing calls
+    while leaving the cfg dataclass — and therefore the YAML — intact.
+    """
+    from amx.config import LLMConfig
+    from amx.llm.provider import LLMProvider
+
+    monkeypatch.setenv("AMX_LLM_API_KEY", "sk-env-fallback")
+    cfg = LLMConfig(
+        provider="openai",
+        model="gpt-4o",
+        api_key="keyring:llm_profiles/default/api_key",
+    )
+    provider = LLMProvider(cfg)
+
+    # The dataclass must be untouched so save() preserves the YAML
+    # pointer.
+    assert cfg.api_key == "keyring:llm_profiles/default/api_key"
+    # The provider's effective key is the env fallback.
+    assert provider._effective_api_key == "sk-env-fallback"
+
+
+def test_db_connector_does_not_send_reference_password(monkeypatch) -> None:
+    """``DatabaseConnector`` must replace unresolved references with
+    empty strings on a copy so an adapter never tries to use
+    ``keyring:db_profiles/<x>/password`` as a real secret."""
+    from dataclasses import dataclass
+
+    from amx.config import DBConfig
+    from amx.db.connector import DatabaseConnector
+
+    @dataclass
+    class _StubAdapter:
+        name: str = "stub"
+        capabilities: object = None
+
+    monkeypatch.setattr(
+        "amx.db.adapters.get_adapter",
+        lambda cfg: _StubAdapter(),
+    )
+    monkeypatch.setattr(
+        "amx.db.drivers.ensure_backend_driver",
+        lambda backend: None,
+    )
+
+    original = DBConfig(
+        backend="postgresql",
+        host="x",
+        database="d",
+        password="keyring:db_profiles/prod/password",
+    )
+    db = DatabaseConnector(original)
+
+    # The connector holds a copy with the reference scrubbed.
+    assert db.cfg.password == ""
+    # The original cfg dataclass — the one stored on the
+    # AMXConfig.db_profiles map — is untouched, so a save() round-trip
+    # still preserves the YAML pointer.
+    assert original.password == "keyring:db_profiles/prod/password"


### PR DESCRIPTION
## Summary

Reported: after ``pip install -e .`` the LLM profile's API key
\"becomes invalid\" — every call returns *The API key configured for
this LLM profile is invalid*. Re-entering the key via /llm fixes it,
but the same trap fires again after the next reinstall.

Root cause: every platform's keyring backend can briefly return
``None`` for an existing entry — macOS Keychain ACL miss after the
binary path changes, gnome-keyring / KWallet not running on Linux,
Credential Manager access denied on Windows.
``_resolve_secret_field`` overwrote the in-memory value with ``\"\"``
whenever the lookup failed; the next ``cfg.save()`` then wrote that
empty string to disk, dropping the YAML's ``keyring:`` pointer for
good. **One transient outage → permanent secret loss.**

Fixes (platform-agnostic — applies to every OS that uses keyring):

1. ``_resolve_secret_field`` leaves the reference string in the
   dataclass when resolution fails. The YAML round-trip preserves
   the pointer because ``_externalise_secret`` already short-circuits
   on already-reference values — the next process with a healthy
   backend resolves it automatically.
2. ``LLMProvider`` substitutes ``AMX_LLM_API_KEY`` for outgoing auth
   when ``cfg.api_key`` is an unresolved reference, never leaking the
   pointer into Authorization headers. The dataclass stays intact so
   ``cfg.save()`` keeps the YAML pointer.
3. ``DatabaseConnector`` does the same for ``password`` /
   ``access_token`` on a ``replace()`` copy. Adapters never see the
   reference; the original ``DBConfig`` on ``AMXConfig.db_profiles``
   keeps its YAML pointer.

## Test plan

- [ ] Simulate offline backend on each OS (set ``KEYRING_PROPERTY_…``
  to nullkeyring, or mock it) → ``AMXConfig.load(...).save()`` →
  YAML still contains ``keyring:llm_profiles/<x>/api_key``.
- [ ] Real macOS run: revoke Keychain access for python, restart
  AMX → log warns about unresolved reference, ``AMX_LLM_API_KEY``
  env fallback (when set) still authenticates. Re-grant Keychain
  access → next process resolves automatically.
- [ ] ``pytest tests/test_secrets_unresolved_reference.py`` green.
- [ ] Full suite (1114 tests) green.