### PR TITLE
feat(rerun): context-preserving Re-Run for one or many run_results rows

### DIFF
--- a/amx/agents/_orchestrator/__init__.py
+++ b/amx/agents/_orchestrator/__init__.py
@@ -7,6 +7,7 @@ three apply-branches. v0.9.2 extracts that logic into
 ``Orchestrator.process_table`` becomes a 4-line delegator.
 """
 
+from amx.agents._orchestrator.rerun import RerunOutcome, rerun_items
 from amx.agents._orchestrator.table_processor import TableProcessor
 
-__all__ = ["TableProcessor"]
+__all__ = ["RerunOutcome", "TableProcessor", "rerun_items"]

--- a/amx/agents/_orchestrator/rerun.py
+++ b/amx/agents/_orchestrator/rerun.py
@@ -1,0 +1,790 @@
+"""Re-Run executor: regenerate alternatives for one (or many) result rows.
+
+The executor is invoked by:
+
+* the CLI command ``amx rerun ...`` (see ``amx/cli_support/commands/rerun.py``);
+* the Studio endpoint ``POST /api/runs/rerun-item`` (see
+  ``amx/web/routers/rerun.py``).
+
+Both call sites pass a list of ``target_result_ids`` (1..N), an
+optional free-text ``user_instructions`` addendum, and an optional
+``temperature_override``. The executor:
+
+1. Opens a single parent ``analysis_runs`` row scoped to ``command="rerun"``.
+2. For each target, freezes its ``AgentContext`` into
+   ``rerun_context_snapshots`` so parallel agents see identical inputs.
+3. Runs the right path per ``asset_kind``:
+   * column / table → ``ProfileAgent`` on the snapshot context;
+   * schema → ``SCHEMA_META_PROMPT`` against the parent run's table
+     descriptions;
+   * database → ``DATABASE_META_PROMPT`` against the parent run's
+     schema descriptions.
+4. Writes a new ``run_results`` row per target with ``parent_result_id``
+   linking back to the original (+ ``rerun_seq`` for chain ordering and
+   ``user_instructions`` for audit).
+5. Always cleans up its snapshot rows in the ``finally`` block — the
+   table is empty again the moment the worker terminates.
+
+The original ``run_results`` row is never mutated; the chain stays
+intact so the Studio history drawer can show "v1 vs v2" side-by-side.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Any
+
+from amx.agents.base import AgentContext, Confidence, MetadataSuggestion, apply_logprob_confidence
+from amx.agents.code_agent import CodeAgent
+from amx.agents.profile_agent import ProfileAgent
+from amx.agents.rag_agent import RAGAgent
+from amx.agents.rerun_context import RerunContextError, build_context_snapshot, hydrate_context
+from amx.config import AMXConfig
+from amx.db.connector import AssetKind
+from amx.llm.provider import LLMProvider
+from amx.storage.sqlite_store import history_store
+from amx.utils.logging import get_logger
+
+log = get_logger("agents._orchestrator.rerun")
+
+# Per-item soft latency budget for a single re-run target. Real wall
+# clock may exceed this (LLM HTTP calls aren't cancellable from inside
+# the agent), but we log a warning so users / tests can spot the
+# regression class — the design target is "no one waits more than 20s
+# for a single column re-run".
+RERUN_PER_ITEM_BUDGET_SEC: float = 20.0
+
+
+@dataclass
+class RerunOutcome:
+    """One target's re-run result.
+
+    Returned to callers (CLI prints them; web router exposes them via
+    SSE ``activity.complete`` events). ``new_result_id`` is the freshly
+    inserted ``run_results`` row id; ``alternatives`` is the new list
+    of N options the user can pick from.
+    """
+
+    target_result_id: int
+    new_result_id: int
+    rerun_seq: int
+    schema: str
+    table: str
+    column: str | None
+    asset_kind: str
+    alternatives: list[str]
+    confidence: str
+    logprob_score: float | None
+    source: str
+    error: str | None = None
+
+
+def _llm_for_rerun(
+    cfg: AMXConfig,
+    *,
+    temperature_override: float | None,
+) -> LLMProvider:
+    """Open an :class:`LLMProvider` honouring the optional temperature bump.
+
+    The diversity nudge (default ``original + 0.2``, capped at 1.0) is
+    applied here by the caller — we just respect ``cfg.llm.temperature``
+    once it's been mutated. Never reach above 1.0; some providers reject
+    it.
+    """
+    if not cfg.llm or not cfg.llm.provider or not cfg.llm.model:
+        raise RerunContextError(
+            "No active LLM profile is configured. Open Settings → LLM and pick one."
+        )
+    if temperature_override is not None:
+        # ``cfg.llm`` is a dataclass; mutating ``temperature`` here only
+        # affects this LLMProvider instance because LLMProvider snaps
+        # the value into its own state at construction.
+        try:
+            cfg.llm.temperature = max(0.0, min(1.0, float(temperature_override)))
+        except Exception:
+            pass
+    return LLMProvider(cfg.llm)
+
+
+def _pick_target_suggestion(
+    suggestions: list[MetadataSuggestion],
+    *,
+    column: str | None,
+) -> MetadataSuggestion | None:
+    """Find the one suggestion matching the target column.
+
+    For column re-runs ``column`` is the column name; we want the row
+    where ``s.column == column``. For table-level re-runs ``column`` is
+    ``None`` and we want the row where ``s.column is None``.
+    """
+    for s in suggestions:
+        if s.column == column:
+            return s
+    return None
+
+
+def _try_load_rag_store(cfg: AMXConfig, doc_profile_name: str | None):
+    """Open the doc profile's :class:`RAGStore` lazily.
+
+    The store opens against the existing Chroma index on disk; no
+    re-ingest happens here. Returns ``None`` when:
+      * no doc profile is recorded on the original run;
+      * the profile name doesn't exist in this AMXConfig;
+      * the profile is the sentinel "disabled" value;
+      * the index has zero chunks (nothing useful to retrieve).
+    All failures are swallowed so an unavailable doc index never blocks
+    a re-run — the ProfileAgent path still produces alternatives.
+    """
+    name = (doc_profile_name or "").strip()
+    if not name:
+        return None
+    try:
+        from amx.config import DISABLED_PROFILE
+    except Exception:
+        DISABLED_PROFILE = "none"  # noqa: N806 - mirror the sentinel
+    if name == DISABLED_PROFILE:
+        return None
+    try:
+        from amx.docs.rag import RAGStore
+    except Exception:
+        return None
+    paths = cfg.doc_profiles.get(name) if hasattr(cfg, "doc_profiles") else None
+    try:
+        store = RAGStore(source_filters=list(paths) if paths else None)
+        if store.doc_count <= 0:
+            return None
+        return store
+    except Exception as exc:  # pragma: no cover - best-effort
+        log.debug("rerun: could not open RAGStore for %s: %s", name, exc)
+        return None
+
+
+def _try_make_code_report(cfg: AMXConfig, code_profile_name: str | None):
+    """Build a *lightweight* :class:`CodebaseReport` for semantic-only retrieval.
+
+    The full codebase scan can take 30+ seconds on a large repo —
+    blowing the 20s re-run budget. Instead we construct an empty
+    :class:`CodebaseReport` whose ``path`` matches the profile's
+    on-disk source filters; :class:`CodeAgent` then drives the
+    "Semantic code retrieval" branch (one Chroma query, ~200ms) and
+    skips the explicit ``references`` block entirely.
+
+    Returns ``None`` when the profile is missing or the on-disk
+    Chroma collection has no chunks for those source filters — both
+    cases mean code context wouldn't add anything anyway.
+    """
+    name = (code_profile_name or "").strip()
+    if not name:
+        return None
+    path: str | None = None
+    if hasattr(cfg, "code_profiles"):
+        path = cfg.code_profiles.get(name)
+    if not path:
+        return None
+    try:
+        from amx.codebase.analyzer import CodebaseReport
+        from amx.codebase.code_rag import code_collection_count
+    except Exception:
+        return None
+    source_filters = [p for p in str(path).split(";") if p] or None
+    try:
+        if code_collection_count(source_filters=source_filters) <= 0:
+            return None
+    except Exception:
+        return None
+    # ``references={}`` plus a non-empty ``path`` is the magic shape
+    # that makes CodeAgent.run go down the semantic-only branch — see
+    # ``code_agent._build_messages`` (``has_refs`` False, ``has_sem``
+    # True). If the upstream agent ever changes this contract we'll
+    # regret the silent skip; covered by ``test_rerun_code_agent_called``.
+    return CodebaseReport(path=str(path))
+
+
+def _run_rerun_agents(
+    *,
+    ctx: AgentContext,
+    llm: LLMProvider,
+    rag_store: Any | None,
+    code_report: Any | None,
+) -> list[MetadataSuggestion]:
+    """Fan ``Profile`` / ``RAG`` / ``Code`` agents out in parallel.
+
+    Mirrors :meth:`Orchestrator._run_enabled_agents` but with no
+    cancel-token plumbing and best-effort error tolerance: a sub-agent
+    raising never bubbles up — the caller still gets the
+    :class:`ProfileAgent` output even if RAG/Code crashed. Wall-clock
+    budget is logged when exceeded; the call still returns whatever
+    came back.
+    """
+    started = time.monotonic()
+    jobs: list[tuple[str, Any]] = [("profile", ProfileAgent(llm))]
+    if rag_store is not None:
+        jobs.append(("rag", RAGAgent(llm, rag_store)))
+    if code_report is not None:
+        jobs.append(("code", CodeAgent(llm, code_report)))
+
+    out: list[MetadataSuggestion] = []
+    with ThreadPoolExecutor(max_workers=len(jobs)) as pool:
+        fut_to_label = {pool.submit(agent.run, ctx): label for label, agent in jobs}
+        for fut in as_completed(fut_to_label):
+            label = fut_to_label[fut]
+            try:
+                out.extend(fut.result() or [])
+            except Exception as exc:  # noqa: BLE001 - sub-agent failure is non-fatal
+                log.warning("Re-run %s agent failed: %s", label, exc)
+
+    elapsed = time.monotonic() - started
+    if elapsed > RERUN_PER_ITEM_BUDGET_SEC:
+        log.warning(
+            "Re-run agent fan-out exceeded the %.0fs soft budget (took %.2fs) "
+            "for %s.%s%s — investigate slow LLM/RAG/code paths.",
+            RERUN_PER_ITEM_BUDGET_SEC,
+            elapsed,
+            ctx.schema,
+            ctx.table,
+            f".{ctx.column}" if ctx.column else "",
+        )
+    return out
+
+
+def _merge_for_target(
+    suggestions: list[MetadataSuggestion],
+    *,
+    column: str | None,
+    llm: LLMProvider,
+) -> MetadataSuggestion | None:
+    """Pick the suggestion(s) for the target column and pick the best one.
+
+    When several agents (Profile / RAG / Code) all returned a
+    suggestion for the same target column we run a tiny in-process
+    merge: pick the highest-confidence one, but union the
+    ``suggestions`` lists so the user still sees up to ``n_alternatives``
+    alternatives even if one agent only produced one. We deliberately
+    skip the LLM-driven merge prompt the bulk run uses — re-runs care
+    about latency, and one extra LLM round-trip per item to merge a
+    handful of candidates would push the wall clock toward the 20s
+    ceiling without materially improving quality.
+    """
+    matching = [s for s in suggestions if s.column == column]
+    if not matching:
+        return None
+    if len(matching) == 1:
+        return matching[0]
+
+    confidence_rank = {Confidence.HIGH: 3, Confidence.MEDIUM: 2, Confidence.LOW: 1}
+    matching.sort(
+        key=lambda s: (
+            confidence_rank.get(s.confidence, 0),
+            -1 if s.logprob_score is None else s.logprob_score,
+        ),
+        reverse=True,
+    )
+    best = matching[0]
+
+    seen: set[str] = set()
+    merged_alts: list[str] = []
+    for s in matching:
+        for alt in s.suggestions or []:
+            if alt and alt not in seen:
+                seen.add(alt)
+                merged_alts.append(alt)
+    cap = max(1, min(5, getattr(getattr(llm, "cfg", None), "n_alternatives", 3)))
+    best.suggestions = merged_alts[:cap]
+    # Surface "combined" so /history can tell users this row was
+    # synthesized from multiple agents instead of a single one.
+    best.source = "combined"
+    return best
+
+
+def _rerun_table_or_column(
+    cfg: AMXConfig,
+    *,
+    ctx: AgentContext,
+    llm: LLMProvider,
+    snapshot: dict[str, Any],
+) -> MetadataSuggestion | None:
+    """Run Profile + (optionally) RAG + (optionally) Code in parallel.
+
+    Returns the merged suggestion for the target item or ``None`` when
+    no agent produced anything parseable. Sub-agents are gated on the
+    *original* run's profile names, captured in
+    ``snapshot["original"]``; we never silently fall back to the
+    currently-active profile because that would surprise users who
+    rotated profiles between sessions.
+    """
+    original = snapshot.get("original") or {}
+    rag_store = _try_load_rag_store(cfg, original.get("doc_profile"))
+    code_report = _try_make_code_report(cfg, original.get("code_profile"))
+
+    suggestions = _run_rerun_agents(
+        ctx=ctx,
+        llm=llm,
+        rag_store=rag_store,
+        code_report=code_report,
+    )
+    target = _merge_for_target(suggestions, column=ctx.column, llm=llm)
+    if target is None:
+        log.warning(
+            "Re-run agents returned no suggestion for %s.%s.%s",
+            ctx.schema,
+            ctx.table,
+            ctx.column,
+        )
+    return target
+
+
+def _rerun_meta(
+    *,
+    ctx: AgentContext,
+    llm: LLMProvider,
+    asset_kind: AssetKind,
+    parent_run_id: int,
+) -> MetadataSuggestion | None:
+    """Re-run a schema- or database-level description.
+
+    Reuses the same prompts the orchestrator's ``process_schema_meta``
+    / ``process_database_meta`` flows do, plus the ``user_instructions``
+    suffix so the user's bias gets applied. Reads peer rows (table
+    descriptions for schema-level, schema descriptions for db-level)
+    from the parent run via the history store — no re-profiling
+    required.
+    """
+    from amx.agents.base import _user_instructions_block
+    from amx.agents.orchestrator import (
+        DATABASE_META_PROMPT,
+        META_SYSTEM_PROMPT,
+        SCHEMA_META_PROMPT,
+    )
+
+    hs = history_store()
+    if hs is None:
+        return None
+    rows = hs.get_run_results(int(parent_run_id))
+
+    if asset_kind == AssetKind.SCHEMA:
+        summaries: list[str] = []
+        for r in rows:
+            if (
+                r.get("schema_name") == ctx.schema
+                and not r.get("column_name")
+                and (r.get("asset_kind") or "table") == "table"
+            ):
+                desc = r.get("chosen_description") or ""
+                if not desc:
+                    alts = r.get("alternatives_json") or []
+                    desc = (alts[0] if alts else "") or ""
+                if desc:
+                    summaries.append(f"Table: {r.get('table_name')}\nDescription: {desc}")
+        if not summaries:
+            return None
+        prompt = SCHEMA_META_PROMPT.format(
+            schema=ctx.schema,
+            tables_summary="\n\n".join(summaries),
+        ) + _user_instructions_block(ctx)
+    elif asset_kind == AssetKind.DATABASE:
+        summaries = []
+        for r in rows:
+            if (r.get("asset_kind") or "") == "schema":
+                desc = r.get("chosen_description") or ""
+                if not desc:
+                    alts = r.get("alternatives_json") or []
+                    desc = (alts[0] if alts else "") or ""
+                if desc:
+                    summaries.append(f"Schema: {r.get('schema_name')}\nDescription: {desc}")
+        if not summaries:
+            return None
+        prompt = DATABASE_META_PROMPT.format(
+            schemas_summary="\n\n".join(summaries),
+        ) + _user_instructions_block(ctx)
+    else:  # pragma: no cover - guarded by caller
+        return None
+
+    res = llm.chat(
+        [
+            {"role": "system", "content": META_SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ]
+    )
+
+    desc, conf, reasoning = _parse_meta_block(res.content)
+    if not desc:
+        return None
+
+    suggestion = MetadataSuggestion(
+        schema=ctx.schema,
+        table=ctx.table,
+        column=ctx.column,
+        suggestions=[desc],
+        confidence=conf,
+        reasoning=reasoning,
+        source="combined",
+    )
+    calibrated = apply_logprob_confidence(
+        [suggestion],
+        getattr(res, "logprobs", None),
+        high_threshold=getattr(llm.cfg, "logprob_high", 0.85),
+        medium_threshold=getattr(llm.cfg, "logprob_medium", 0.5),
+        response_text=res.content,
+    )
+    return calibrated[0] if calibrated else suggestion
+
+
+def _parse_meta_block(text: str) -> tuple[str, Confidence, str]:
+    """Parse the ``DESCRIPTION/CONFIDENCE/REASONING`` shape used by meta prompts."""
+    import re
+
+    text = re.sub(r"^```[a-zA-Z0-9_-]*\s*", "", (text or "").strip())
+    text = re.sub(r"\s*```$", "", text).strip()
+    desc = ""
+    conf = Confidence.MEDIUM
+    reasoning = ""
+    for line in text.splitlines():
+        upper = line.upper()
+        if upper.startswith("DESCRIPTION:"):
+            desc = line.split(":", 1)[1].strip()
+        elif upper.startswith("CONFIDENCE:"):
+            value = line.split(":", 1)[1].strip().upper()
+            if "HIGH" in value:
+                conf = Confidence.HIGH
+            elif "LOW" in value:
+                conf = Confidence.LOW
+        elif upper.startswith("REASONING:"):
+            reasoning = line.split(":", 1)[1].strip()
+    return desc, conf, reasoning
+
+
+def _persist_rerun_row(
+    *,
+    new_run_id: int,
+    suggestion: MetadataSuggestion,
+    target: dict[str, Any],
+    asset_kind: str,
+    user_instructions: str | None,
+    model_name: str,
+) -> tuple[int, int]:
+    """Insert one ``run_results`` row for the re-run + return ``(new_id, seq)``.
+
+    The chain root is whichever is non-null:
+      * ``target.parent_result_id`` (if the target was itself a re-run);
+      * ``target.id`` (if the target is the original).
+    ``rerun_seq`` is computed via ``next_rerun_seq`` so concurrent
+    re-runs each receive a monotonically increasing sequence number.
+    """
+    hs = history_store()
+    if hs is None:
+        raise RerunContextError("History store became unavailable mid-rerun.")
+
+    chain_root = target.get("parent_result_id") or target.get("id")
+    if chain_root is None:
+        raise RerunContextError("Target row is missing a chain id.")
+    rerun_seq = hs.next_rerun_seq(int(chain_root))
+
+    row = {
+        "schema": suggestion.schema,
+        "table": suggestion.table,
+        "column": suggestion.column,
+        "asset_kind": asset_kind,
+        "source": suggestion.source,
+        "confidence": suggestion.confidence.value if suggestion.confidence else "medium",
+        "logprob_score": suggestion.logprob_score,
+        "raw_logprob": suggestion.logprob_score,
+        "model_version": model_name,
+        "reasoning": suggestion.reasoning,
+        "alternatives": suggestion.suggestions,
+        "parent_result_id": int(chain_root),
+        "rerun_seq": int(rerun_seq),
+        "user_instructions": (user_instructions or "").strip() or None,
+    }
+    [new_id] = hs.save_run_results(int(new_run_id), [row])
+    return int(new_id), int(rerun_seq)
+
+
+def rerun_items(
+    cfg: AMXConfig,
+    *,
+    target_result_ids: list[int],
+    user_instructions: str | None = None,
+    temperature_override: float | None = None,
+    job_id: str | None = None,
+    cancel_token: threading.Event | None = None,
+    on_event: Callable[[str, dict[str, Any]], None] | None = None,
+) -> tuple[int, list[RerunOutcome]]:
+    """Re-run one or many ``run_results`` rows with optional user guidance.
+
+    Returns ``(new_run_id, [RerunOutcome, ...])``.
+
+    The function is shared between CLI and Studio paths. ``on_event``
+    lets the Studio worker pipe progress into its SSE queue
+    (``activity.added`` / ``activity.complete`` / ``activity.fail``) —
+    CLI callers can leave it ``None``.
+    """
+    if not target_result_ids:
+        raise RerunContextError("rerun_items called with no targets.")
+
+    hs = history_store()
+    if hs is None:
+        raise RerunContextError("History store is not initialised — cannot re-run an item.")
+
+    job_id = job_id or f"rerun-{int(time.time() * 1000)}"
+    llm = _llm_for_rerun(cfg, temperature_override=temperature_override)
+
+    # Resolve the original run + its scope so the new analysis_runs row
+    # carries forward enough context for /history list to render it.
+    targets: list[dict[str, Any]] = []
+    parent_run_id: int | None = None
+    for rid in target_result_ids:
+        target = hs.get_run_result(int(rid))
+        if target is None:
+            raise RerunContextError(f"Target run_result {rid} not found.")
+        targets.append(target)
+        if parent_run_id is None:
+            parent_run_id = int(target.get("run_id") or 0)
+    parent_run = hs.get_run(int(parent_run_id or 0)) or {}
+
+    # Open a fresh "rerun" row in analysis_runs so the new run_results
+    # rows hang off a meaningful parent. Mode is "single" for a one-item
+    # re-run, "batch" for multi-item.
+    mode = "single" if len(target_result_ids) == 1 else "batch"
+    new_run_id = hs.create_run(
+        command="rerun",
+        mode=mode,
+        db_backend=str(parent_run.get("db_backend") or ""),
+        db_profile=str(parent_run.get("db_profile") or ""),
+        llm_provider=str(parent_run.get("llm_provider") or cfg.llm.provider or ""),
+        llm_model=str(parent_run.get("llm_model") or cfg.llm.model or ""),
+        scope={},
+        selected_count=len(target_result_ids),
+        planned_count=len(target_result_ids),
+        review_strategy="individual",
+        llm_profile=parent_run.get("llm_profile") or cfg.active_llm_profile,
+        doc_profile=parent_run.get("doc_profile") or cfg.active_doc_profile or None,
+        code_profile=parent_run.get("code_profile") or cfg.active_code_profile or None,
+        settings={
+            "trigger": "rerun",
+            "parent_run_id": parent_run_id,
+            "user_instructions": (user_instructions or "").strip() or None,
+            "temperature_override": temperature_override,
+        },
+    )
+
+    outcomes: list[RerunOutcome] = []
+    started = time.monotonic()
+    try:
+        for idx, target in enumerate(targets, start=1):
+            if cancel_token is not None and cancel_token.is_set():
+                break
+
+            target_result_id = int(target["id"])
+            schema = str(target.get("schema_name") or "")
+            table_name = str(target.get("table_name") or "")
+            column = target.get("column_name")
+            asset_kind_raw = str(target.get("asset_kind") or "table")
+            # Coerce to the enum where possible; fall back to TABLE for
+            # legacy / column-level values (the run_results column
+            # historically stores the parent table's asset_kind for
+            # column rows, but older data may have "column" here).
+            try:
+                asset_kind = AssetKind(asset_kind_raw)
+            except ValueError:
+                asset_kind = AssetKind.TABLE
+            label = ".".join(p for p in (schema, table_name, column or "") if p)
+
+            if on_event is not None:
+                on_event(
+                    "activity.added",
+                    {
+                        "idx": idx,
+                        "label": label,
+                        "kind": asset_kind_raw,
+                        "done": idx - 1,
+                        "total": len(targets),
+                        "result_id": target_result_id,
+                    },
+                )
+                on_event("activity.begin", {"idx": idx})
+
+            try:
+                snapshot_id = build_context_snapshot(
+                    cfg,
+                    target_result_id=target_result_id,
+                    job_id=job_id,
+                    user_instructions=user_instructions,
+                )
+                snap = hs.read_rerun_snapshot(snapshot_id)
+                if snap is None:
+                    raise RerunContextError(
+                        f"Snapshot {snapshot_id} disappeared between write and read."
+                    )
+                ctx = hydrate_context(snap["payload"])
+
+                if asset_kind in (AssetKind.SCHEMA, AssetKind.DATABASE):
+                    suggestion = _rerun_meta(
+                        ctx=ctx,
+                        llm=llm,
+                        asset_kind=asset_kind,
+                        parent_run_id=int(parent_run_id or 0),
+                    )
+                else:
+                    suggestion = _rerun_table_or_column(
+                        cfg, ctx=ctx, llm=llm, snapshot=snap["payload"]
+                    )
+
+                if suggestion is None or not suggestion.suggestions:
+                    outcomes.append(
+                        RerunOutcome(
+                            target_result_id=target_result_id,
+                            new_result_id=0,
+                            rerun_seq=0,
+                            schema=schema,
+                            table=table_name,
+                            column=column,
+                            asset_kind=asset_kind_raw,
+                            alternatives=[],
+                            confidence="low",
+                            logprob_score=None,
+                            source="rerun",
+                            error="LLM returned no parseable description.",
+                        )
+                    )
+                    if on_event is not None:
+                        on_event(
+                            "activity.fail",
+                            {
+                                "idx": idx,
+                                "detail": "LLM returned no parseable description.",
+                                "result_id": target_result_id,
+                            },
+                        )
+                    continue
+
+                new_id, rerun_seq = _persist_rerun_row(
+                    new_run_id=new_run_id,
+                    suggestion=suggestion,
+                    target=target,
+                    asset_kind=asset_kind_raw,
+                    user_instructions=user_instructions,
+                    model_name=getattr(llm, "model_name", "") or str(cfg.llm.model or ""),
+                )
+
+                outcome = RerunOutcome(
+                    target_result_id=target_result_id,
+                    new_result_id=new_id,
+                    rerun_seq=rerun_seq,
+                    schema=schema,
+                    table=table_name,
+                    column=column,
+                    asset_kind=asset_kind_raw,
+                    alternatives=list(suggestion.suggestions),
+                    confidence=(suggestion.confidence.value if suggestion.confidence else "medium"),
+                    logprob_score=suggestion.logprob_score,
+                    source=suggestion.source,
+                )
+                outcomes.append(outcome)
+
+                if on_event is not None:
+                    on_event(
+                        "activity.complete",
+                        {
+                            "idx": idx,
+                            "detail": f"{len(suggestion.suggestions)} alternative(s)",
+                            "result_id": target_result_id,
+                            "new_result_id": new_id,
+                            "rerun_seq": rerun_seq,
+                            "schema": schema,
+                            "table": table_name,
+                            "column": column,
+                            "asset_kind": asset_kind_raw,
+                            "alternatives": list(suggestion.suggestions),
+                            "confidence": outcome.confidence,
+                            "logprob_score": outcome.logprob_score,
+                        },
+                    )
+
+            except RerunContextError as exc:
+                outcomes.append(
+                    RerunOutcome(
+                        target_result_id=target_result_id,
+                        new_result_id=0,
+                        rerun_seq=0,
+                        schema=schema,
+                        table=table_name,
+                        column=column,
+                        asset_kind=asset_kind_raw,
+                        alternatives=[],
+                        confidence="low",
+                        logprob_score=None,
+                        source="rerun",
+                        error=str(exc),
+                    )
+                )
+                if on_event is not None:
+                    on_event(
+                        "activity.fail",
+                        {
+                            "idx": idx,
+                            "detail": str(exc),
+                            "result_id": target_result_id,
+                        },
+                    )
+            except Exception as exc:  # noqa: BLE001 — surface upstream
+                log.exception("Re-run target %s failed", target_result_id)
+                outcomes.append(
+                    RerunOutcome(
+                        target_result_id=target_result_id,
+                        new_result_id=0,
+                        rerun_seq=0,
+                        schema=schema,
+                        table=table_name,
+                        column=column,
+                        asset_kind=asset_kind_raw,
+                        alternatives=[],
+                        confidence="low",
+                        logprob_score=None,
+                        source="rerun",
+                        error=f"{exc.__class__.__name__}: {exc}",
+                    )
+                )
+                if on_event is not None:
+                    on_event(
+                        "activity.fail",
+                        {
+                            "idx": idx,
+                            "detail": f"{exc.__class__.__name__}: {exc}",
+                            "result_id": target_result_id,
+                        },
+                    )
+
+        # finish_run records duration + per-outcome counts so /history
+        # can show the re-run alongside normal analyze.run rows.
+        successful = sum(1 for o in outcomes if not o.error)
+        hs.finish_run(
+            int(new_run_id),
+            status="success" if successful == len(outcomes) else "partial",
+            metrics={
+                "duration_sec": round(time.monotonic() - started, 3),
+                "total_assets": len(outcomes),
+                "processed_assets_count": successful,
+                "failed_assets_count": len(outcomes) - successful,
+                "trigger": "rerun",
+                "parent_run_id": parent_run_id,
+            },
+            tokens={},
+            results={"new_result_ids": [o.new_result_id for o in outcomes if o.new_result_id]},
+            error_text="",
+        )
+    finally:
+        # Storage-maliyetsiz: snapshots disappear the moment the worker
+        # exits, regardless of success / failure / cancellation.
+        try:
+            hs.delete_rerun_snapshots_for_job(job_id)
+        except Exception as exc:
+            log.warning("Snapshot cleanup failed for job %s: %s", job_id, exc)
+
+    return int(new_run_id), outcomes
+
+
+__all__ = ["RerunOutcome", "rerun_items"]

--- a/amx/agents/base.py
+++ b/amx/agents/base.py
@@ -97,6 +97,30 @@ class AgentContext:
     rag_context: list[str] = field(default_factory=list)
     code_context: list[str] = field(default_factory=list)
     existing_metadata: dict[str, Any] = field(default_factory=dict)
+    # Optional free-text addendum from the user, populated by the
+    # Re-Run flow. Empty string on normal runs. Each agent's
+    # ``_build_prompt`` appends it as a final "Additional instructions
+    # from user (re-run):" block so the original DB/docs/code context
+    # is preserved and only this guidance is layered on top.
+    user_instructions: str = ""
+
+
+def _user_instructions_block(ctx: AgentContext) -> str:
+    """Render the optional re-run instructions suffix.
+
+    Empty string when ``ctx.user_instructions`` is unset / blank, so
+    on normal runs the prompt is byte-identical to pre-Re-Run output
+    (regression-safe).
+    """
+    text = (ctx.user_instructions or "").strip()
+    if not text:
+        return ""
+    return (
+        "\n\nAdditional instructions from user (re-run):\n"
+        f"{text}\n"
+        "Treat these as guidance to bias the description toward, not as a replacement "
+        "for the database/docs/code evidence above."
+    )
 
 
 class BaseAgent(ABC):

--- a/amx/agents/code_agent.py
+++ b/amx/agents/code_agent.py
@@ -144,12 +144,14 @@ class CodeAgent(BaseAgent):
         if not all_code_blocks:
             return None
 
+        from amx.agents.base import _user_instructions_block
+
         col_lines = "\n".join(f"  - {c['name']} (type={c['dtype']})" for c in columns)
         user_msg = (
             f"Schema: {ctx.schema}\n"
             f"Table: {ctx.table}\n\n"
             f"Columns:\n{col_lines}\n\n"
-            f"Code references:\n\n" + "\n\n".join(all_code_blocks)
+            f"Code references:\n\n" + "\n\n".join(all_code_blocks) + _user_instructions_block(ctx)
         )
         system = _build_system_prompt(self._n_alternatives)
         return [

--- a/amx/agents/profile_agent.py
+++ b/amx/agents/profile_agent.py
@@ -723,7 +723,9 @@ class ProfileAgent(BaseAgent):
                 ]
             )
 
-        return "\n".join(lines)
+        from amx.agents.base import _user_instructions_block
+
+        return "\n".join(lines) + _user_instructions_block(ctx)
 
     def _parse_response(self, text: str, ctx: AgentContext) -> list[MetadataSuggestion]:
         text = re.sub(r"^```[a-zA-Z0-9_-]*\s*", "", (text or "").strip())

--- a/amx/agents/rag_agent.py
+++ b/amx/agents/rag_agent.py
@@ -133,11 +133,13 @@ class RAGAgent(BaseAgent):
         col_lines = "\n".join(
             f"  - {c['name']} (type={c['dtype']}, samples={c.get('samples', [])})" for c in columns
         )
+        from amx.agents.base import _user_instructions_block
+
         user_msg = (
             f"Schema: {ctx.schema}\n"
             f"Table: {ctx.table}\n\n"
             f"Columns:\n{col_lines}\n\n"
-            f"Relevant documentation:\n{doc_text}"
+            f"Relevant documentation:\n{doc_text}" + _user_instructions_block(ctx)
         )
         system = _build_system_prompt(self._n_alternatives)
         return [

--- a/amx/agents/rerun_context.py
+++ b/amx/agents/rerun_context.py
@@ -1,0 +1,320 @@
+"""Re-Run snapshot builder.
+
+When the user clicks "Re-Run this item" (CLI or Studio), the worker
+freezes the original run's inputs into a short-lived row in
+``rerun_context_snapshots`` so every parallel agent sees identical
+context. The snapshot is deleted in the worker's ``finally`` block —
+storage cost is zero outside the live re-run window.
+
+Snapshot payload (one per target item):
+
+* ``schema`` / ``table`` / ``column`` / ``asset_kind`` — the addressable
+  coordinates of the item being re-run.
+* ``db_profile`` — the live ``AgentContext.db_profile`` dict produced by
+  :meth:`amx.agents.orchestrator.Orchestrator._build_context`. For
+  *column* re-runs ``columns`` is filtered down to just the target so
+  the agents don't waste tokens on siblings.
+* ``rag_context`` / ``code_context`` — placeholders today (Profile-only
+  re-run). Populated when the doc/code agent wiring is ported into the
+  re-run path in a follow-up.
+* ``existing_metadata`` — passed through verbatim from the orchestrator.
+* ``user_instructions`` — the optional free-text addendum from the
+  re-run modal. Empty string means "no additional guidance".
+* ``original`` — book-keeping for the executor: the parent ``run_id`` /
+  ``result_id``, the original asset coordinates, the active LLM/DB/Doc/
+  Code profile names from the source run.
+
+The functions in this module never write to ``run_results`` themselves
+— that's the executor's job (:mod:`amx.agents._orchestrator.rerun`).
+This module only owns context assembly + snapshot read/write/delete.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import asdict
+from typing import Any
+
+from amx.agents.base import AgentContext
+from amx.config import AMXConfig
+from amx.db.connector import AssetKind, DatabaseConnector
+from amx.storage.sqlite_store import history_store
+from amx.utils.logging import get_logger
+
+log = get_logger("agents.rerun_context")
+
+
+class RerunContextError(RuntimeError):
+    """Snapshot build failed (missing target row, no DB profile, etc.).
+
+    The web router translates this to a 4xx HTTPException so the SPA
+    surfaces the underlying message instead of "Internal Server Error".
+    """
+
+
+def _connector_for_db_profile(cfg: AMXConfig, profile_name: str) -> DatabaseConnector:
+    """Open a fresh ``DatabaseConnector`` against a named DB profile.
+
+    Mirrors the resolution logic the run worker uses: look up the
+    profile in ``cfg.db_profiles`` and instantiate a connector. The
+    connector's ``cfg`` attribute carries the connection details so
+    ``profile_table`` can introspect.
+    """
+    base = cfg.db_profiles.get((profile_name or "").strip())
+    if base is None:
+        raise RerunContextError(
+            f"DB profile '{profile_name}' is not defined in this AMXConfig — "
+            "the original run referenced a profile that no longer exists."
+        )
+    return DatabaseConnector(base)
+
+
+def _build_db_profile_dict(
+    db: DatabaseConnector,
+    schema: str,
+    table: str,
+    *,
+    asset_kind: AssetKind | None = None,
+    only_column: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Assemble the ``db_profile`` slice the agents read from.
+
+    Returns ``(db_profile_dict, existing_metadata_dict)`` matching the
+    shape :meth:`Orchestrator._build_context` produces, so the agent
+    prompt builders work without any branching for the re-run path.
+    When ``only_column`` is provided, ``db_profile['columns']`` is
+    narrowed to that single column — sibling columns are kept as
+    ``context_column_names`` so the LLM still sees the table shape.
+    """
+    profile = db.profile_table(schema, table, asset_kind=asset_kind)
+    db_name = db.cfg.database or db.cfg.project or db.cfg.catalog or "N/A"
+
+    all_cols = [
+        {
+            "name": c.name,
+            "dtype": c.dtype,
+            "nullable": c.nullable,
+            "row_count": c.row_count,
+            "null_count": c.null_count,
+            "distinct_count": c.distinct_count,
+            "cardinality_ratio": c.cardinality_ratio,
+            "min_val": c.min_val,
+            "max_val": c.max_val,
+            "samples": c.samples,
+            "existing_comment": c.existing_comment,
+        }
+        for c in profile.columns
+    ]
+
+    if only_column:
+        target_cols = [c for c in all_cols if c["name"] == only_column]
+        sibling_names = [c["name"] for c in all_cols if c["name"] != only_column]
+    else:
+        target_cols = all_cols
+        sibling_names = []
+
+    db_profile: dict[str, Any] = {
+        "row_count": profile.row_count,
+        "existing_comment": profile.existing_comment,
+        "primary_key": profile.primary_key,
+        "foreign_keys": profile.foreign_keys,
+        "referenced_by": profile.referenced_by,
+        "unique_constraints": profile.unique_constraints,
+        "check_constraints": profile.check_constraints,
+        "stats_seq_scan": profile.stats_seq_scan,
+        "stats_idx_scan": profile.stats_idx_scan,
+        "stats_n_live_tup": profile.stats_n_live_tup,
+        "stats_source": db.stats_label,
+        "schema_comment": profile.schema_comment,
+        "database_comment": profile.database_comment,
+        "related_comments": profile.related_comments,
+        "query_usage": {},
+        "columns": target_cols,
+    }
+    if sibling_names:
+        db_profile["context_column_names"] = sibling_names
+
+    existing_metadata = {
+        "database": db_name,
+        "backend": db.backend,
+        "table_comment": profile.existing_comment,
+        "schema_comment": profile.schema_comment,
+        "database_comment": profile.database_comment,
+    }
+    return db_profile, existing_metadata
+
+
+def _resolve_asset_kind(raw: str | None) -> AssetKind | None:
+    """Best-effort coercion of stored ``asset_kind`` strings to the enum."""
+    if not raw:
+        return None
+    try:
+        return AssetKind(raw)
+    except ValueError:
+        return None
+
+
+def build_context_snapshot(
+    cfg: AMXConfig,
+    *,
+    target_result_id: int,
+    job_id: str,
+    user_instructions: str | None = None,
+) -> str:
+    """Build + persist a frozen ``AgentContext`` for one target item.
+
+    Returns the generated ``snapshot_id`` (uuid hex). The caller (the
+    re-run worker) reads it back via
+    :func:`amx.storage.sqlite_store.SQLiteHistoryStore.read_rerun_snapshot`
+    and feeds it into the agent fan-out.
+
+    Re-uses live indexes for everything except DB schema (which is
+    profiled fresh — the snapshot freezes that fresh read so parallel
+    agents agree). RAG/code context populating is intentionally a
+    follow-up: the user's free-text addendum is the v1 lever for
+    biasing the second pass.
+    """
+    hs = history_store()
+    if hs is None:
+        raise RerunContextError(
+            "History store is not initialised — cannot resolve original run "
+            "metadata. Open Settings → History to enable it."
+        )
+
+    target = hs.get_run_result(int(target_result_id))
+    if target is None:
+        raise RerunContextError(
+            f"Target run_result {target_result_id} not found. Was the row deleted?"
+        )
+
+    parent_run = hs.get_run(int(target.get("run_id") or 0))
+    if parent_run is None:
+        raise RerunContextError(
+            f"Original run {target.get('run_id')} not found for result {target_result_id}."
+        )
+
+    schema = str(target.get("schema_name") or "")
+    table = str(target.get("table_name") or "")
+    column = target.get("column_name")
+    asset_kind_raw = str(target.get("asset_kind") or "table")
+    asset_kind = _resolve_asset_kind(asset_kind_raw)
+
+    # Prefer the profile that was active during the original run.
+    # Fall back to the currently active profile so a re-run still
+    # works after the user rotated profiles between sessions.
+    db_profile_name = str(parent_run.get("db_profile") or "") or (cfg.active_db_profile or "")
+
+    payload: dict[str, Any] = {
+        "schema": schema,
+        "table": table,
+        "column": column,
+        "asset_kind": asset_kind_raw,
+        "db_profile": {},
+        "rag_context": [],
+        "code_context": [],
+        "existing_metadata": {},
+        "user_instructions": (user_instructions or "").strip(),
+        "original": {
+            "run_id": int(target.get("run_id") or 0),
+            "result_id": int(target_result_id),
+            "rerun_seq": int(target.get("rerun_seq") or 0),
+            "parent_result_id": target.get("parent_result_id"),
+            "db_profile": db_profile_name or None,
+            "llm_profile": parent_run.get("llm_profile"),
+            "doc_profile": parent_run.get("doc_profile"),
+            "code_profile": parent_run.get("code_profile"),
+            "llm_provider": parent_run.get("llm_provider"),
+            "llm_model": parent_run.get("llm_model"),
+            "db_backend": parent_run.get("db_backend"),
+            "alternatives": list(target.get("alternatives_json") or []),
+            "chosen_description": target.get("chosen_description") or "",
+        },
+    }
+
+    # Schema/database-level re-runs aggregate from the run's already-
+    # produced table descriptions; no live profiling needed. The
+    # executor reads ``original.run_id`` to fetch peer rows when it
+    # builds the meta prompt.
+    if asset_kind in (AssetKind.SCHEMA, AssetKind.DATABASE):
+        payload["existing_metadata"] = {
+            "database": "",
+            "backend": parent_run.get("db_backend"),
+        }
+        snapshot_id = uuid.uuid4().hex
+        hs.save_rerun_snapshot(
+            snapshot_id=snapshot_id,
+            job_id=job_id,
+            target_result_id=int(target_result_id),
+            payload=payload,
+        )
+        return snapshot_id
+
+    # Table / column re-run: live-profile the table fresh.
+    if not db_profile_name:
+        raise RerunContextError(
+            "Original run has no db_profile recorded and no active profile is set — "
+            "cannot rebuild the database context for this re-run."
+        )
+
+    db = _connector_for_db_profile(cfg, db_profile_name)
+    try:
+        db_profile, existing_metadata = _build_db_profile_dict(
+            db,
+            schema,
+            table,
+            asset_kind=asset_kind,
+            only_column=column if column else None,
+        )
+    finally:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+    payload["db_profile"] = db_profile
+    payload["existing_metadata"] = existing_metadata
+
+    snapshot_id = uuid.uuid4().hex
+    hs.save_rerun_snapshot(
+        snapshot_id=snapshot_id,
+        job_id=job_id,
+        target_result_id=int(target_result_id),
+        payload=payload,
+    )
+    return snapshot_id
+
+
+def hydrate_context(payload: dict[str, Any]) -> AgentContext:
+    """Re-inflate an ``AgentContext`` from a snapshot payload dict.
+
+    Keeps ``user_instructions`` populated so the agent prompt suffixes
+    fire automatically without any re-run-specific code in the agents.
+    """
+    return AgentContext(
+        schema=str(payload.get("schema") or ""),
+        table=str(payload.get("table") or ""),
+        column=payload.get("column"),
+        asset_kind=str(payload.get("asset_kind") or "table"),
+        db_profile=dict(payload.get("db_profile") or {}),
+        rag_context=list(payload.get("rag_context") or []),
+        code_context=list(payload.get("code_context") or []),
+        existing_metadata=dict(payload.get("existing_metadata") or {}),
+        user_instructions=str(payload.get("user_instructions") or ""),
+    )
+
+
+def serialize_context(ctx: AgentContext) -> dict[str, Any]:
+    """JSON-serializable dict for storing an ``AgentContext`` in a snapshot.
+
+    Used by tests and any path that wants to round-trip a context the
+    same way the live snapshot writer does.
+    """
+    return asdict(ctx)
+
+
+__all__ = [
+    "RerunContextError",
+    "build_context_snapshot",
+    "hydrate_context",
+    "serialize_context",
+]

--- a/amx/cli.py
+++ b/amx/cli.py
@@ -30,6 +30,7 @@ from amx.cli_support.commands.profiles import (
 from amx.cli_support.commands.profiles import (
     warn_no_doc_paths_for_scan_or_ingest as _warn_no_doc_paths_for_scan_or_ingest,
 )
+from amx.cli_support.commands.rerun import register_rerun_command
 from amx.cli_support.commands.run import (
     _finalize_scope,
     _resolve_codebase_for_run,
@@ -340,6 +341,7 @@ register_analyze_run_command(
     resolve_codebase_for_run=_resolve_codebase_for_run,
     log_event=_log_app_event,
 )
+register_rerun_command(main, pass_config=pass_config, log_event=_log_app_event)
 register_docs_commands(
     main,
     finalize_scope=_finalize_scope,

--- a/amx/cli_support/commands/rerun.py
+++ b/amx/cli_support/commands/rerun.py
@@ -1,0 +1,291 @@
+"""`amx rerun` — regenerate alternatives for one or many run_results rows.
+
+Mirrors the Studio re-run flow but lets the user drive everything from
+the CLI:
+
+* ``amx rerun <result_id>`` — single item, current LLM/DB profile.
+* ``amx rerun <id1> <id2> <id3> --instructions "..."`` — multi-item
+  with a shared free-text addendum.
+* ``amx rerun --run <run_id> --table public.orders --column status`` —
+  resolve target by coordinates instead of id (handy when the user is
+  reading ``/history show`` output).
+* ``amx rerun --run <run_id> --pick`` — interactive checkbox TUI to
+  cherry-pick a subset of the run's rows.
+
+The actual work lives in
+:func:`amx.agents._orchestrator.rerun.rerun_items` so the CLI stays a
+thin wrapper. The CLI version always runs synchronously (no SSE
+streaming); progress is rendered through the existing themed
+``console`` helpers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import click
+
+from amx.agents._orchestrator.rerun import rerun_items
+from amx.agents.rerun_context import RerunContextError
+from amx.config import AMXConfig
+from amx.storage.sqlite_store import history_store
+from amx.utils.console import error, heading, info, render_table, success, warn
+from amx.utils.logging import get_logger
+
+LogEvent = Callable[..., None]
+log = get_logger("cli.rerun")
+
+
+def _resolve_targets_by_coordinates(
+    *,
+    run_id: int,
+    table: str | None,
+    column: str | None,
+) -> list[int]:
+    """Map ``run_id`` + optional ``schema.table`` / ``column`` to ``result_ids``.
+
+    The ``table`` argument is a dotted ``schema.table`` (matching the
+    rest of the AMX CLI surface); ``column`` narrows further. When
+    only ``run_id`` is provided we return every row for that run —
+    callers that don't want the whole run should pass at least
+    ``--table``.
+    """
+    hs = history_store()
+    if hs is None:
+        raise click.ClickException(
+            "History store is not initialised. Run /history-store enable first."
+        )
+    rows = hs.get_run_results(int(run_id))
+    if not rows:
+        raise click.ClickException(f"No run_results rows found for run {run_id}.")
+
+    schema_part: str | None = None
+    table_part: str | None = None
+    if table:
+        if "." not in table:
+            raise click.ClickException(
+                "--table must be in the form schema.table (e.g. public.orders)."
+            )
+        schema_part, table_part = table.split(".", 1)
+
+    matches: list[int] = []
+    for row in rows:
+        if schema_part is not None and row.get("schema_name") != schema_part:
+            continue
+        if table_part is not None and row.get("table_name") != table_part:
+            continue
+        if column is not None and row.get("column_name") != column:
+            continue
+        matches.append(int(row["id"]))
+
+    if not matches:
+        raise click.ClickException(
+            f"No rows in run {run_id} matched table={table or '(any)'} column={column or '(any)'}."
+        )
+    return matches
+
+
+def _interactive_pick(run_id: int) -> list[int]:
+    """Render a checkbox-style picker over a run's rows.
+
+    Falls back to a numbered prompt when ``prompt_toolkit`` isn't
+    available — the CLI must keep working in environments where the
+    interactive picker can't render.
+    """
+    hs = history_store()
+    if hs is None:
+        raise click.ClickException("History store is not initialised.")
+    rows = hs.get_run_results(int(run_id))
+    if not rows:
+        raise click.ClickException(f"No rows for run {run_id}.")
+
+    info(
+        f"Run {run_id} has {len(rows)} result row(s). Enter ids to re-run, "
+        "comma-separated, or 'all':"
+    )
+    table_data = []
+    for row in rows:
+        chosen = (row.get("chosen_description") or "")[:60]
+        if len(row.get("chosen_description") or "") > 60:
+            chosen += "…"
+        table_data.append(
+            [
+                str(row["id"]),
+                row.get("asset_kind") or "",
+                f"{row.get('schema_name') or ''}.{row.get('table_name') or ''}",
+                row.get("column_name") or "",
+                chosen,
+            ]
+        )
+    render_table(
+        f"Run {run_id} — pick rows to re-run",
+        ["id", "kind", "schema.table", "column", "chosen"],
+        table_data,
+    )
+
+    raw = click.prompt("ids", default="", show_default=False).strip()
+    if not raw:
+        raise click.ClickException("No ids selected.")
+    if raw.lower() == "all":
+        return [int(r["id"]) for r in rows]
+    try:
+        return [int(part.strip()) for part in raw.split(",") if part.strip()]
+    except ValueError as exc:
+        raise click.ClickException(f"Invalid id list: {exc}") from exc
+
+
+def _print_outcomes(outcomes: list[Any], *, new_run_id: int) -> None:
+    if not outcomes:
+        warn("No outcomes returned from re-run.")
+        return
+    heading(f"Re-run produced {len(outcomes)} new row(s) under run {new_run_id}")
+    rows: list[list[str]] = []
+    for o in outcomes:
+        first_alt = (o.alternatives[0] if o.alternatives else "")[:60]
+        if o.alternatives and len(o.alternatives[0]) > 60:
+            first_alt += "…"
+        rows.append(
+            [
+                str(o.target_result_id),
+                str(o.new_result_id) if o.new_result_id else "—",
+                f"v{o.rerun_seq}" if o.rerun_seq else "—",
+                f"{o.schema}.{o.table}" + (f".{o.column}" if o.column else ""),
+                o.confidence,
+                first_alt or (o.error or ""),
+            ]
+        )
+    render_table(
+        f"Re-run results (new run_id={new_run_id})",
+        ["target", "new_id", "ver", "asset", "confidence", "first alternative / error"],
+        rows,
+    )
+    failures = [o for o in outcomes if o.error]
+    if failures:
+        warn(f"{len(failures)} target(s) failed; see error column above.")
+    else:
+        success(f"All {len(outcomes)} re-run target(s) completed successfully.")
+
+
+def register_rerun_command(
+    main: click.Group,
+    *,
+    pass_config: Callable[[Callable[..., Any]], Callable[..., Any]],
+    log_event: LogEvent,
+) -> None:
+    """Attach `amx rerun` (and `/rerun` inside the session) to the main group."""
+
+    @main.command("rerun")
+    @click.argument("result_ids", nargs=-1, type=int)
+    @click.option(
+        "--run",
+        "run_id",
+        type=int,
+        default=None,
+        help="Resolve targets by run id + --table/--column instead of result id.",
+    )
+    @click.option(
+        "--table",
+        type=str,
+        default=None,
+        help="Schema.table coordinate (used with --run).",
+    )
+    @click.option(
+        "--column",
+        type=str,
+        default=None,
+        help="Column name (used with --run --table).",
+    )
+    @click.option(
+        "--pick",
+        is_flag=True,
+        default=False,
+        help="Interactive picker over a run's rows (used with --run).",
+    )
+    @click.option(
+        "--instructions",
+        "-i",
+        "user_instructions",
+        type=str,
+        default=None,
+        help=(
+            "Optional free-text addendum appended to the existing prompt. "
+            "Original DB / docs / code context is preserved."
+        ),
+    )
+    @click.option(
+        "--temperature",
+        "temperature_override",
+        type=float,
+        default=None,
+        help="Override LLM temperature for this re-run (0.0–1.0).",
+    )
+    @pass_config
+    def rerun(
+        cfg: AMXConfig,
+        result_ids: tuple[int, ...],
+        run_id: int | None,
+        table: str | None,
+        column: str | None,
+        pick: bool,
+        user_instructions: str | None,
+        temperature_override: float | None,
+    ) -> None:
+        """Regenerate alternatives for one or many run_results rows."""
+        targets: list[int]
+        if pick:
+            if run_id is None:
+                raise click.ClickException("--pick requires --run <run_id>.")
+            targets = _interactive_pick(int(run_id))
+        elif run_id is not None and (table is not None or column is not None):
+            targets = _resolve_targets_by_coordinates(
+                run_id=int(run_id), table=table, column=column
+            )
+        elif result_ids:
+            targets = list(result_ids)
+        else:
+            raise click.ClickException(
+                "Pass at least one result_id, or use --run with --table/--column or --pick."
+            )
+
+        info(
+            f"Re-running {len(targets)} target(s) "
+            f"(instructions={'yes' if (user_instructions or '').strip() else 'none'}, "
+            f"temperature_override={temperature_override})…"
+        )
+
+        try:
+            new_run_id, outcomes = rerun_items(
+                cfg,
+                target_result_ids=targets,
+                user_instructions=user_instructions,
+                temperature_override=temperature_override,
+            )
+        except RerunContextError as exc:
+            error(str(exc))
+            log_event(
+                event_type="rerun",
+                status="failed",
+                command="rerun",
+                details={"reason": str(exc), "targets": targets},
+            )
+            raise click.ClickException(str(exc)) from exc
+
+        _print_outcomes(outcomes, new_run_id=int(new_run_id))
+        successful = sum(1 for o in outcomes if not o.error)
+        log_event(
+            event_type="rerun",
+            status="success" if successful == len(outcomes) else "partial",
+            command="rerun",
+            details={
+                "new_run_id": int(new_run_id),
+                "targets": targets,
+                "successful": successful,
+                "failed": len(outcomes) - successful,
+                "had_instructions": bool((user_instructions or "").strip()),
+                "temperature_override": temperature_override,
+            },
+        )
+
+
+__all__ = ["register_rerun_command"]

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -167,9 +167,49 @@ class SQLiteHistoryStore:
                 "ALTER TABLE run_results ADD COLUMN created_by TEXT",
                 "ALTER TABLE run_results ADD COLUMN hostname TEXT",
                 "ALTER TABLE run_results ADD COLUMN shared_uuid TEXT",
+                # Re-Run versioning (v0.13). ``parent_result_id`` links a
+                # re-run row back to the original run_results row it was
+                # spawned from; ``rerun_seq`` is 0 for originals, 1+ for
+                # successive re-runs in the chain. ``user_instructions``
+                # records the optional free-text addendum the user typed
+                # in the re-run modal so the audit trail / history drawer
+                # can show it next to the alternatives.
+                "ALTER TABLE run_results ADD COLUMN parent_result_id INTEGER",
+                "ALTER TABLE run_results ADD COLUMN rerun_seq INTEGER NOT NULL DEFAULT 0",
+                "ALTER TABLE run_results ADD COLUMN user_instructions TEXT",
             ):
                 with contextlib.suppress(sqlite3.OperationalError):
                     conn.execute(stmt)
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_run_results_parent "
+                    "ON run_results(parent_result_id)"
+                )
+            # ── rerun_context_snapshots: short-lived, GC'd when the worker
+            # finishes (job.done / failed / cancelled). One row per target
+            # item per re-run job; payload_json is the AgentContext frozen
+            # at job start so all parallel agents see identical inputs.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS rerun_context_snapshots (
+                    snapshot_id      TEXT PRIMARY KEY,
+                    job_id           TEXT NOT NULL,
+                    target_result_id INTEGER NOT NULL,
+                    payload_json     TEXT NOT NULL,
+                    created_at       REAL NOT NULL
+                )
+                """
+            )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_rerun_snap_job "
+                    "ON rerun_context_snapshots(job_id)"
+                )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_rerun_snap_created "
+                    "ON rerun_context_snapshots(created_at)"
+                )
             with contextlib.suppress(sqlite3.OperationalError):
                 conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_run_results_shared_uuid "
@@ -660,6 +700,13 @@ class SQLiteHistoryStore:
           schema, table, column (or None), asset_kind, source, confidence,
           reasoning, alternatives (list[str])
 
+        Optional re-run fields:
+          parent_result_id (int | None) — original run_results.id this row
+            re-runs; ``rerun_seq`` (int, default 0) — versioned position in
+            the chain (0 = original, 1+ = ordered re-runs);
+          ``user_instructions`` (str | None) — free-text addendum the user
+            typed in the re-run modal.
+
         Returns the inserted row IDs.
         """
         now = time.time()
@@ -671,8 +718,9 @@ class SQLiteHistoryStore:
                     INSERT INTO run_results (
                         run_id, saved_at, schema_name, table_name, column_name,
                         asset_kind, source, confidence, logprob_score, raw_logprob,
-                        token_count, model_version, reasoning, alternatives_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        token_count, model_version, reasoning, alternatives_json,
+                        parent_result_id, rerun_seq, user_instructions
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         run_id,
@@ -689,6 +737,9 @@ class SQLiteHistoryStore:
                         s.get("model_version", ""),
                         s.get("reasoning", ""),
                         json.dumps(s.get("alternatives", []), ensure_ascii=True),
+                        s.get("parent_result_id"),
+                        int(s.get("rerun_seq", 0) or 0),
+                        s.get("user_instructions"),
                     ),
                 )
                 ids.append(int(cur.lastrowid))
@@ -920,6 +971,197 @@ class SQLiteHistoryStore:
                     d["alternatives_json"] = json.loads(raw)
             out.append(d)
         return out
+
+    # ── Re-Run helpers ─────────────────────────────────────────────────────
+
+    def get_run_result(self, result_id: int) -> dict[str, Any] | None:
+        """Return one ``run_results`` row by id, alternatives parsed."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM run_results WHERE id = ?",
+                (int(result_id),),
+            ).fetchone()
+        if row is None:
+            return None
+        d = dict(row)
+        raw = d.get("alternatives_json")
+        if isinstance(raw, str) and raw:
+            with contextlib.suppress(Exception):
+                d["alternatives_json"] = json.loads(raw)
+        return d
+
+    def get_result_chain(self, result_id: int) -> list[dict[str, Any]]:
+        """Return the full version chain (original + all re-runs) for an item.
+
+        Walks ``parent_result_id`` upward to find the chain root, then
+        fetches every row whose ``parent_result_id`` matches that root
+        (plus the root itself), ordered by ``rerun_seq`` ASC. Used by
+        the Studio history drawer + ``GET /api/history/runs/...?include_history=true``.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT id, parent_result_id FROM run_results WHERE id = ?",
+                (int(result_id),),
+            ).fetchone()
+            if row is None:
+                return []
+            root = int(row["id"])
+            seen: set[int] = set()
+            while True:
+                if root in seen:
+                    break
+                seen.add(root)
+                parent_row = conn.execute(
+                    "SELECT parent_result_id FROM run_results WHERE id = ?",
+                    (root,),
+                ).fetchone()
+                parent = (
+                    int(parent_row["parent_result_id"])
+                    if parent_row and parent_row["parent_result_id"] is not None
+                    else None
+                )
+                if parent is None or parent == root:
+                    break
+                root = parent
+            chain_rows = conn.execute(
+                """
+                SELECT * FROM run_results
+                WHERE id = ? OR parent_result_id = ?
+                ORDER BY rerun_seq ASC, id ASC
+                """,
+                (root, root),
+            ).fetchall()
+        out: list[dict[str, Any]] = []
+        for r in chain_rows:
+            d = dict(r)
+            raw = d.get("alternatives_json")
+            if isinstance(raw, str) and raw:
+                with contextlib.suppress(Exception):
+                    d["alternatives_json"] = json.loads(raw)
+            out.append(d)
+        return out
+
+    def next_rerun_seq(self, parent_result_id: int) -> int:
+        """Return the next ``rerun_seq`` to use for a re-run targeting this item.
+
+        Looks at the chain root (parent_result_id, which already points at
+        the original) and returns ``max(rerun_seq) + 1`` so concurrent
+        re-runs receive monotonically increasing sequence numbers.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT COALESCE(MAX(rerun_seq), 0) AS mx
+                FROM run_results
+                WHERE id = ? OR parent_result_id = ?
+                """,
+                (int(parent_result_id), int(parent_result_id)),
+            ).fetchone()
+        return int((row["mx"] if row else 0) or 0) + 1
+
+    def save_rerun_snapshot(
+        self,
+        *,
+        snapshot_id: str,
+        job_id: str,
+        target_result_id: int,
+        payload: dict[str, Any],
+    ) -> None:
+        """Persist a frozen ``AgentContext`` for the re-run worker to read.
+
+        Snapshots are short-lived: the worker deletes them in its
+        ``finally`` block once the job terminates (done / failed /
+        cancelled), and ``gc_orphan_rerun_snapshots`` sweeps anything
+        left over from a crash on next process startup.
+        """
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO rerun_context_snapshots
+                    (snapshot_id, job_id, target_result_id, payload_json, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    str(snapshot_id),
+                    str(job_id),
+                    int(target_result_id),
+                    json.dumps(payload, ensure_ascii=True),
+                    time.time(),
+                ),
+            )
+
+    def read_rerun_snapshot(self, snapshot_id: str) -> dict[str, Any] | None:
+        """Return the deserialized snapshot payload, or ``None`` when missing."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT payload_json, target_result_id, job_id "
+                "FROM rerun_context_snapshots WHERE snapshot_id = ?",
+                (str(snapshot_id),),
+            ).fetchone()
+        if row is None:
+            return None
+        try:
+            payload = json.loads(row["payload_json"])
+        except Exception:
+            return None
+        return {
+            "snapshot_id": str(snapshot_id),
+            "job_id": str(row["job_id"]),
+            "target_result_id": int(row["target_result_id"]),
+            "payload": payload,
+        }
+
+    def list_rerun_snapshots_for_job(self, job_id: str) -> list[dict[str, Any]]:
+        """Return all snapshot rows for one job (ordered by created_at)."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT snapshot_id, target_result_id, payload_json, created_at
+                FROM rerun_context_snapshots
+                WHERE job_id = ?
+                ORDER BY created_at ASC
+                """,
+                (str(job_id),),
+            ).fetchall()
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            try:
+                payload = json.loads(r["payload_json"])
+            except Exception:
+                continue
+            out.append(
+                {
+                    "snapshot_id": str(r["snapshot_id"]),
+                    "target_result_id": int(r["target_result_id"]),
+                    "payload": payload,
+                    "created_at": float(r["created_at"]),
+                }
+            )
+        return out
+
+    def delete_rerun_snapshots_for_job(self, job_id: str) -> int:
+        """Drop every snapshot row owned by a finished job. Returns count."""
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM rerun_context_snapshots WHERE job_id = ?",
+                (str(job_id),),
+            )
+            return int(cur.rowcount or 0)
+
+    def gc_orphan_rerun_snapshots(self, *, max_age_seconds: float = 3600.0) -> int:
+        """Sweep snapshots older than ``max_age_seconds`` (default 1h).
+
+        Called once at AMX Studio startup (and at CLI bootstrap) so
+        any rows left behind by a crashed worker don't accumulate.
+        Returns the number of rows deleted.
+        """
+        cutoff = time.time() - float(max_age_seconds)
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM rerun_context_snapshots WHERE created_at < ?",
+                (cutoff,),
+            )
+            return int(cur.rowcount or 0)
 
     def list_runs_with_result_counts(self, limit: int = 20) -> list[dict[str, Any]]:
         """List recent runs augmented with pending evaluation count."""

--- a/amx/web/jobs.py
+++ b/amx/web/jobs.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass, field
 from queue import Queue
 from typing import Any, Literal
 
-JobKind = Literal["run", "apply", "ask"]
+JobKind = Literal["run", "apply", "ask", "rerun"]
 JobStatus = Literal["queued", "running", "cancelled", "done", "failed"]
 
 

--- a/amx/web/routers/history.py
+++ b/amx/web/routers/history.py
@@ -102,12 +102,39 @@ def get_run(
 def get_run_results(
     run_id: int,
     unevaluated_only: bool = Query(default=False),
+    include_history: bool = Query(
+        default=False,
+        description=(
+            "When true, attach the full re-run chain (original + every "
+            "child re-run row) to each result under ``history``. Used by "
+            "the Studio history drawer to render v1/v2/v3 side-by-side."
+        ),
+    ),
 ) -> dict[str, Any]:
     """Per-column LLM suggestions saved during this run. Used by the
     run-detail page's results table + the column drill page's
     "alternatives" carousel."""
-    rows = _store().get_run_results(run_id, unevaluated_only=unevaluated_only)
+    store = _store()
+    rows = store.get_run_results(run_id, unevaluated_only=unevaluated_only)
+    if include_history:
+        for row in rows:
+            try:
+                row["history"] = store.get_result_chain(int(row["id"]))
+            except Exception:
+                row["history"] = []
     return {"run_id": run_id, "results": rows, "count": len(rows)}
+
+
+@router.get("/results/{result_id}/history")
+def get_result_history(result_id: int) -> dict[str, Any]:
+    """Return the full re-run chain (original + every child re-run row).
+
+    Used by the Studio history drawer when the user clicks a "v2"
+    badge on a specific row — cheaper than fetching every result for
+    the whole run.
+    """
+    chain = _store().get_result_chain(int(result_id))
+    return {"result_id": result_id, "chain": chain, "count": len(chain)}
 
 
 @router.get("/runs/{run_id}/results-with-counts")

--- a/amx/web/routers/rerun.py
+++ b/amx/web/routers/rerun.py
@@ -1,0 +1,206 @@
+"""Re-Run endpoint: regenerate alternatives for one or many run_results rows.
+
+The user clicks "Re-Run" on an item in the Studio results view (or
+selects N items via the multi-select toolbar). The SPA calls
+``POST /api/runs/rerun-item`` with the target ``result_ids`` and an
+optional free-text addendum. The worker:
+
+1. Spawns a thread (``kind="rerun"``) and registers it with the same
+   :class:`JobRegistry` the regular run / apply paths use.
+2. Calls :func:`amx.agents._orchestrator.rerun.rerun_items`, which
+   freezes a snapshot per target, runs the agents, and writes new
+   versioned ``run_results`` rows linked to the original via
+   ``parent_result_id``.
+3. Streams ``activity.added`` / ``activity.complete`` / ``activity.fail``
+   events through the queue so the existing
+   ``GET /api/runs/{job_id}/events`` endpoint keeps working without
+   any SSE-side changes.
+
+Snapshots are short-lived and cleaned up by the executor's ``finally``
+block. The router itself never writes to ``rerun_context_snapshots``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from queue import Queue
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from amx.agents._orchestrator.rerun import RerunOutcome, rerun_items
+from amx.agents.rerun_context import RerunContextError
+from amx.config import AMXConfig
+from amx.utils.logging import get_logger
+from amx.web.deps import get_cfg, get_jobs
+from amx.web.jobs import Job, JobRegistry
+from amx.web.progress_bus import emit, emit_terminal
+
+router = APIRouter(prefix="/api", tags=["rerun"])
+log = get_logger("web.rerun")
+
+
+class RerunRequest(BaseModel):
+    """Body for ``POST /api/runs/rerun-item``."""
+
+    result_ids: list[int] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "One or more ``run_results.id`` values to re-run. Each is "
+            "regenerated independently; results are linked back to the "
+            "original via ``parent_result_id``."
+        ),
+    )
+    user_instructions: str | None = Field(
+        default=None,
+        description=(
+            "Optional free-text addendum the user typed in the re-run "
+            "modal. Appended to the existing prompt; the original "
+            "DB/docs/code context is preserved."
+        ),
+    )
+    temperature_override: float | None = Field(
+        default=None,
+        description=(
+            "Optional temperature override for diversity nudge. When "
+            "omitted the executor leaves the original LLM profile's "
+            "temperature in place."
+        ),
+        ge=0.0,
+        le=1.0,
+    )
+
+
+class RerunOutcomeResponse(BaseModel):
+    target_result_id: int
+    new_result_id: int
+    rerun_seq: int
+    schema_name: str
+    table_name: str
+    column_name: str | None
+    asset_kind: str
+    alternatives: list[str]
+    confidence: str
+    logprob_score: float | None
+    source: str
+    error: str | None = None
+
+
+class RerunJobResponse(BaseModel):
+    job_id: str
+    status: str
+    new_run_id: int | None = None
+
+
+def _outcome_to_dict(outcome: RerunOutcome) -> dict[str, Any]:
+    return {
+        "target_result_id": outcome.target_result_id,
+        "new_result_id": outcome.new_result_id,
+        "rerun_seq": outcome.rerun_seq,
+        "schema_name": outcome.schema,
+        "table_name": outcome.table,
+        "column_name": outcome.column,
+        "asset_kind": outcome.asset_kind,
+        "alternatives": outcome.alternatives,
+        "confidence": outcome.confidence,
+        "logprob_score": outcome.logprob_score,
+        "source": outcome.source,
+        "error": outcome.error,
+    }
+
+
+def _make_event_emitter(queue: Queue):
+    def _emit(event_type: str, payload: dict[str, Any]) -> None:
+        emit(queue, event_type, payload)
+
+    return _emit
+
+
+def _rerun_worker(
+    cfg: AMXConfig,
+    job: Job,
+    payload: RerunRequest,
+) -> None:
+    """Drive a single re-run job.
+
+    Mirrors the structure of the run / apply workers in
+    :mod:`amx.web.routers.runs`: flip status to ``running``, route
+    progress events through the queue, and end with a terminal event.
+    """
+    job.status = "running"
+    started_wall = time.time()
+    try:
+        new_run_id, outcomes = rerun_items(
+            cfg,
+            target_result_ids=list(payload.result_ids),
+            user_instructions=payload.user_instructions,
+            temperature_override=payload.temperature_override,
+            job_id=job.id,
+            cancel_token=job.cancel,
+            on_event=_make_event_emitter(job.queue),
+        )
+    except RerunContextError as exc:
+        job.status = "failed"
+        job.error = str(exc)
+        job.ended_at = time.time()
+        emit(job.queue, "activity.fail", {"idx": 0, "detail": str(exc)})
+        emit_terminal(job.queue, "job.failed", {"error": str(exc)})
+        return
+    except Exception as exc:  # noqa: BLE001 — last-resort handler
+        log.exception("rerun worker crashed")
+        message = f"{exc.__class__.__name__}: {exc}"
+        job.status = "failed"
+        job.error = message
+        job.ended_at = time.time()
+        emit(job.queue, "activity.fail", {"idx": 0, "detail": message})
+        emit_terminal(job.queue, "job.failed", {"error": message})
+        return
+
+    successful = sum(1 for o in outcomes if not o.error)
+    job.run_id = int(new_run_id)
+    job.status = "done"
+    job.summary = {
+        "new_run_id": int(new_run_id),
+        "total": len(outcomes),
+        "successful": successful,
+        "failed": len(outcomes) - successful,
+        "duration_sec": round(time.time() - started_wall, 3),
+        "outcomes": [_outcome_to_dict(o) for o in outcomes],
+    }
+    job.ended_at = time.time()
+    emit_terminal(job.queue, "job.done", {"summary": job.summary})
+
+
+@router.post("/runs/rerun-item", response_model=RerunJobResponse)
+def submit_rerun(
+    body: RerunRequest,
+    cfg: AMXConfig = Depends(get_cfg),
+    jobs: JobRegistry = Depends(get_jobs),
+) -> RerunJobResponse:
+    """Spawn a re-run worker. Returns the job id immediately so the SPA
+    can subscribe to the existing SSE stream.
+
+    Cancel via ``POST /api/runs/{job_id}/cancel`` — same machinery as a
+    normal run. Results land in a new ``analysis_runs`` row whose id is
+    in the terminal ``job.done`` summary.
+    """
+    if not body.result_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="result_ids must contain at least one target id.",
+        )
+    job = jobs.new_job("rerun")
+    thread = threading.Thread(
+        target=_rerun_worker,
+        args=(cfg, job, body),
+        name=f"amx-studio-rerun-{job.id}",
+        daemon=True,
+    )
+    thread.start()
+    return RerunJobResponse(job_id=job.id, status=job.status)
+
+
+__all__ = ["router"]

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -31,6 +31,7 @@ from amx.web.routers import (
     live_db,
     pending,
     profiles,
+    rerun,
     runs,
     system,
     system_ops,
@@ -108,6 +109,22 @@ def create_app(
     app.include_router(system_ops.router)
     app.include_router(code_ops.router)
     app.include_router(generate.router)
+    app.include_router(rerun.router)
+
+    # Re-Run snapshots are short-lived (worker deletes them in finally).
+    # On startup, sweep anything older than 1h that a previous crashed
+    # worker may have left behind so the snapshot table never grows
+    # beyond a live re-run window.
+    try:
+        from amx.storage.sqlite_store import history_store as _hs
+
+        _store = _hs()
+        if _store is not None:
+            _store.gc_orphan_rerun_snapshots()
+    except Exception:
+        # Startup must never crash on a GC hiccup; the executor's own
+        # cleanup keeps the table tidy regardless.
+        pass
 
     root = static_root if static_root is not None else _static_root()
     app.state.static_root = root

--- a/frontend/src/components/RerunDialog.tsx
+++ b/frontend/src/components/RerunDialog.tsx
@@ -1,0 +1,231 @@
+/**
+ * RerunDialog — single + multi-item Re-Run modal.
+ *
+ * The user clicks ⟳ "Re-Run" on a result row (or "Re-Run selected" in
+ * the multi-select toolbar). This dialog gathers the optional
+ * free-text addendum and an optional temperature override, then fires
+ * ``POST /api/runs/rerun-item`` and bubbles the resulting ``job_id``
+ * back to the caller so the parent component can subscribe to the
+ * existing ``/api/runs/{job_id}/events`` SSE stream.
+ *
+ * Design notes:
+ *  - Original DB / docs / code context is preserved server-side via a
+ *    short-lived ``rerun_context_snapshots`` row; this dialog only
+ *    captures the *delta* the user wants to layer on top.
+ *  - The summary line lists every target so the user can sanity-check
+ *    what the re-run will touch before submitting.
+ *  - Advanced fields (temperature override) are collapsed by default
+ *    so the modal stays focused on the common path: type extra
+ *    guidance → submit.
+ */
+
+import { useState } from "react";
+import { Loader2, RefreshCw } from "lucide-react";
+
+import { api } from "../lib/api";
+import { Button, Dialog, Textarea, useToast } from "./ui";
+
+export interface RerunTarget {
+  /** ``run_results.id`` of the original (or latest) row to re-run. */
+  resultId: number;
+  /** Human-readable label (``schema.table.column`` etc) for the summary. */
+  label: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  targets: RerunTarget[];
+  /** Called once the worker has been spawned successfully — caller
+   *  uses ``jobId`` to subscribe to the SSE stream and refresh
+   *  results when ``job.done`` arrives. */
+  onSubmitted: (jobId: string) => void;
+  /** Read-only summary of the original run's stack so the user can see
+   *  which DB / docs / code / LLM the re-run will use. Optional. */
+  contextSummary?: string;
+}
+
+export default function RerunDialog({
+  open,
+  onClose,
+  targets,
+  onSubmitted,
+  contextSummary,
+}: Props) {
+  const { push: pushToast } = useToast();
+  const [instructions, setInstructions] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [temperature, setTemperature] = useState<number | "">("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (!targets.length) {
+      pushToast({ tone: "error", title: "No targets selected to re-run." });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const tempValue =
+        typeof temperature === "number" && Number.isFinite(temperature)
+          ? Math.max(0, Math.min(1, temperature))
+          : null;
+      const res = await api.rerunItems({
+        result_ids: targets.map((t) => t.resultId),
+        user_instructions: instructions.trim() || null,
+        temperature_override: tempValue,
+      });
+      onSubmitted(res.job_id);
+      // Reset form fields so the dialog opens clean next time.
+      setInstructions("");
+      setTemperature("");
+      setShowAdvanced(false);
+      onClose();
+    } catch (err) {
+      pushToast({
+        tone: "error",
+        title: "Re-run failed to start",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const targetCount = targets.length;
+  const titleLabel = targetCount === 1 ? "Re-Run this item" : `Re-Run ${targetCount} items`;
+  const isMulti = targetCount > 1;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={submitting ? () => undefined : onClose}
+      title={
+        <span className="inline-flex items-center gap-2">
+          <RefreshCw size={14} className="text-accent" /> {titleLabel}
+        </span>
+      }
+      description={
+        contextSummary ||
+        "Original DB, docs, codebase context is preserved. Anything you type below is appended as additional guidance — the agents still see all the inputs from the original run."
+      }
+      size="lg"
+      preventBackdropClose={submitting}
+      footer={
+        <>
+          <Button
+            variant="ghost"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={submit}
+            disabled={submitting || targetCount === 0}
+          >
+            {submitting ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 size={14} className="animate-spin" /> Starting…
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-2">
+                <RefreshCw size={14} /> Re-Run
+              </span>
+            )}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {isMulti && (
+          <div>
+            <div className="mb-1 text-[10px] uppercase tracking-wider text-ink-dim">
+              Targets
+            </div>
+            <ul className="max-h-32 overflow-y-auto rounded-md border border-border bg-surface-subtle/40 px-3 py-2 text-xs">
+              {targets.map((t) => (
+                <li key={t.resultId} className="font-mono text-ink-muted">
+                  {t.label}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {!isMulti && targets[0] && (
+          <div className="rounded-md border border-border bg-surface-subtle/40 px-3 py-2 text-xs">
+            <span className="text-[10px] uppercase tracking-wider text-ink-dim">
+              Target
+            </span>
+            <div className="mt-0.5 font-mono text-ink">{targets[0].label}</div>
+          </div>
+        )}
+
+        <div>
+          <label
+            htmlFor="rerun-instructions"
+            className="mb-1 block text-[10px] uppercase tracking-wider text-ink-dim"
+          >
+            Additional instructions (optional)
+          </label>
+          <Textarea
+            id="rerun-instructions"
+            placeholder='e.g. "Bu kolonun soft-delete satırlarını da içerdiğini de göz önünde bulundur."'
+            value={instructions}
+            onChange={(e) => setInstructions(e.target.value)}
+            rows={4}
+            disabled={submitting}
+          />
+          <p className="mt-1 text-[11px] text-ink-dim">
+            Agents always re-read the original DB / docs / codebase
+            inputs. This text is appended to bias the new alternatives.
+          </p>
+        </div>
+
+        <div>
+          <button
+            type="button"
+            className="text-[11px] uppercase tracking-wider text-ink-dim hover:text-ink"
+            onClick={() => setShowAdvanced((v) => !v)}
+          >
+            {showAdvanced ? "Hide advanced" : "Show advanced"}
+          </button>
+          {showAdvanced && (
+            <div className="mt-2 rounded-md border border-dashed border-border px-3 py-2 text-xs">
+              <label
+                htmlFor="rerun-temperature"
+                className="mb-1 block text-[10px] uppercase tracking-wider text-ink-dim"
+              >
+                Temperature override (0.0 – 1.0)
+              </label>
+              <input
+                id="rerun-temperature"
+                type="number"
+                step="0.05"
+                min="0"
+                max="1"
+                value={temperature}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  if (raw === "") {
+                    setTemperature("");
+                  } else {
+                    const num = Number(raw);
+                    setTemperature(Number.isFinite(num) ? num : "");
+                  }
+                }}
+                disabled={submitting}
+                placeholder="leave blank to use the original run's temperature"
+                className="w-full rounded-md border border-border bg-surface-raised px-3 py-1.5 font-mono text-xs text-ink placeholder:text-ink-dim focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+              />
+              <p className="mt-1 text-[11px] text-ink-dim">
+                Higher values (e.g. 0.8) produce more diverse alternatives;
+                blank keeps the original profile's temperature.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -413,4 +413,63 @@ export const api = {
     apiFetch<{ ok: boolean; job_id: string }>(`/api/runs/${encodeURIComponent(jobId)}/cancel`, {
       method: "POST",
     }),
+  /** Spawn a re-run for one or many ``run_results`` rows.
+   *
+   * Caller subscribes to ``/api/runs/{job_id}/events`` for SSE
+   * progress; ``job.done.summary.outcomes`` carries the new alternatives
+   * once finished. ``user_instructions`` is appended to the existing
+   * agent prompts — original DB / docs / code context is preserved.
+   */
+  rerunItems: (body: {
+    result_ids: number[];
+    user_instructions?: string | null;
+    temperature_override?: number | null;
+  }) =>
+    apiFetch<{ job_id: string; status: string; new_run_id?: number | null }>(
+      "/api/runs/rerun-item",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          result_ids: body.result_ids,
+          user_instructions: body.user_instructions ?? null,
+          temperature_override: body.temperature_override ?? null,
+        }),
+      },
+    ),
+  /** Fetch the full re-run chain for one ``run_results`` row.
+   *
+   * Used by the version-history drawer when the user clicks a "v2/v3"
+   * badge on an item. Returns the original + every child re-run row
+   * ordered by ``rerun_seq`` ASC so the drawer can render them as a
+   * timeline.
+   */
+  resultHistory: (resultId: number) =>
+    apiFetch<{ result_id: number; chain: ResultRow[]; count: number }>(
+      `/api/history/results/${resultId}/history`,
+    ),
 };
+
+/** Shape of one row in the re-run chain returned by ``resultHistory``.
+ *
+ * Mirrors the backend ``run_results`` schema; alternatives are already
+ * parsed JSON arrays. ``parent_result_id`` / ``rerun_seq`` /
+ * ``user_instructions`` are populated for re-run children only.
+ */
+export interface ResultRow {
+  id: number;
+  run_id: number;
+  schema_name: string;
+  table_name: string;
+  column_name: string | null;
+  asset_kind: string;
+  confidence: string;
+  source: string;
+  logprob_score: number | null;
+  alternatives_json: unknown;
+  chosen_description: string | null;
+  evaluation: string | null;
+  applied_at: number | null;
+  parent_result_id: number | null;
+  rerun_seq: number;
+  user_instructions: string | null;
+}

--- a/frontend/src/routes/RunDetail.tsx
+++ b/frontend/src/routes/RunDetail.tsx
@@ -1,7 +1,7 @@
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Activity as ActivityIcon, Loader2, PauseCircle, PlayCircle, SkipForward, Timer } from "lucide-react";
+import { Activity as ActivityIcon, Loader2, PauseCircle, PlayCircle, RefreshCw, SkipForward, Timer } from "lucide-react";
 
 import { apiFetch, api } from "../lib/api";
 import { useEventSource, type SseEvent } from "../lib/sse";
@@ -9,11 +9,13 @@ import PageHeader from "../components/PageHeader";
 import { Card, CardBody, CardHeader } from "../components/Card";
 import JobProgress from "../components/JobProgress";
 import StatusPill from "../components/StatusPill";
+import RerunDialog from "../components/RerunDialog";
 import { cn } from "../lib/cn";
 import {
   AlertDialog,
   Badge,
   Button,
+  Checkbox,
   IconButton,
   InlineEditText,
   Tab as TabTrigger,
@@ -65,6 +67,14 @@ interface ResultRow {
   chosen_description: string | null;
   evaluation: string | null;
   applied_at: number | null;
+  /** Re-Run versioning fields. ``rerun_seq`` is 0 for originals,
+   *  1+ for successive re-runs. ``parent_result_id`` chains a re-run
+   *  back to the original (NULL on originals). ``user_instructions``
+   *  is the optional free-text addendum the user typed in the
+   *  re-run modal. */
+  parent_result_id?: number | null;
+  rerun_seq?: number;
+  user_instructions?: string | null;
 }
 
 interface ResultsResponse {
@@ -813,6 +823,23 @@ function ResultsTab({
   const queryClient = useQueryClient();
   const toast = useToast();
   const [activeApplyJob, setActiveApplyJob] = useState<string | null>(null);
+  // Multi-select Re-Run state. ``multiSelectMode`` flips the per-row
+  // checkbox on; ``selectedIds`` is the set of result_ids the user
+  // picked. The bulk dialog opens with ``bulkRerunOpen``; once the
+  // worker responds the SPA tails ``bulkRerunJobId`` via SSE so the
+  // toast / invalidations only fire once the run is actually done.
+  const [multiSelectMode, setMultiSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [bulkRerunOpen, setBulkRerunOpen] = useState(false);
+  const [bulkRerunJobId, setBulkRerunJobId] = useState<string | null>(null);
+  const toggleSelected = useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
   // Old runs (pre-PR #224) didn't persist database/catalog onto the
   // run row, so apply used to fall back to the active profile's
   // default DB and produce ``schema does not exist`` errors when the
@@ -1126,6 +1153,59 @@ function ResultsTab({
         />
       )}
 
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          leadingIcon={<RefreshCw size={12} />}
+          onClick={() => {
+            setMultiSelectMode((v) => {
+              const next = !v;
+              if (!next) setSelectedIds(new Set());
+              return next;
+            });
+          }}
+        >
+          {multiSelectMode ? "Cancel selection" : "Select multiple to re-run"}
+        </Button>
+        {multiSelectMode && selectedIds.size > 0 && (
+          <>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => setBulkRerunOpen(true)}
+              disabled={!!bulkRerunJobId}
+            >
+              Re-Run selected ({selectedIds.size})
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSelectedIds(new Set())}
+            >
+              Clear
+            </Button>
+          </>
+        )}
+        {bulkRerunJobId && (
+          <span className="inline-flex items-center gap-1 text-xs text-ink-muted">
+            <Loader2 size={12} className="animate-spin" /> Bulk re-run running…
+          </span>
+        )}
+      </div>
+      <BulkRerunOrchestrator
+        open={bulkRerunOpen}
+        onOpenChange={setBulkRerunOpen}
+        rows={rows}
+        selectedIds={selectedIds}
+        bulkRerunJobId={bulkRerunJobId}
+        setBulkRerunJobId={setBulkRerunJobId}
+        onBulkDone={() => {
+          setSelectedIds(new Set());
+          setMultiSelectMode(false);
+          queryClient.invalidateQueries({ queryKey: ["history", "run-results"] });
+        }}
+      />
       {grouped.map(({ key, rows: tableRows }) => (
         <Card key={key}>
           <CardHeader
@@ -1170,6 +1250,9 @@ function ResultsTab({
                       skipPending.isPending ||
                       restorePending.isPending
                     }
+                    multiSelectMode={multiSelectMode}
+                    isSelected={selectedIds.has(r.id)}
+                    onToggleSelected={toggleSelected}
                   />
                 );
               })}
@@ -1178,6 +1261,96 @@ function ResultsTab({
         </Card>
       ))}
     </div>
+  );
+}
+
+// Multi-select bulk Re-Run wrapper. Owns the modal + the SSE
+// listener for the bulk job; keeps that bookkeeping out of the host
+// component so ``ResultsTab`` only has to forward state, not re-run
+// the lifecycle effect on every render.
+function BulkRerunOrchestrator({
+  open,
+  onOpenChange,
+  rows,
+  selectedIds,
+  bulkRerunJobId,
+  setBulkRerunJobId,
+  onBulkDone,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  rows: ResultRow[];
+  selectedIds: Set<number>;
+  bulkRerunJobId: string | null;
+  setBulkRerunJobId: (v: string | null) => void;
+  onBulkDone: () => void;
+}) {
+  const { push: pushToast } = useToast();
+  const targets = useMemo(
+    () =>
+      rows
+        .filter((r) => selectedIds.has(r.id))
+        .map((r) => ({
+          resultId: r.id,
+          label:
+            [r.schema_name, r.table_name, r.column_name]
+              .filter(Boolean)
+              .join(".") || `result #${r.id}`,
+        })),
+    [rows, selectedIds],
+  );
+  const sse = useEventSource({
+    path: bulkRerunJobId ? `/api/runs/${encodeURIComponent(bulkRerunJobId)}/events` : "",
+    enabled: !!bulkRerunJobId,
+  });
+  useEffect(() => {
+    if (!bulkRerunJobId) return;
+    const terminal = sse.events.find(
+      (e) =>
+        e.type === "job.done" || e.type === "job.failed" || e.type === "job.cancelled",
+    );
+    if (!terminal) return;
+    if (terminal.type === "job.done") {
+      const summary = (terminal as unknown as { summary?: { successful?: number; total?: number; new_run_id?: number } }).summary;
+      pushToast({
+        tone: "success",
+        title: "Bulk re-run complete",
+        description: summary
+          ? `${summary.successful}/${summary.total} target(s) succeeded under run #${summary.new_run_id ?? "?"}.`
+          : "Re-run finished.",
+      });
+    } else if (terminal.type === "job.failed") {
+      const errMsg = (terminal as unknown as { error?: string }).error;
+      pushToast({
+        tone: "error",
+        title: "Bulk re-run failed",
+        description: errMsg || "The worker reported an error.",
+      });
+    } else {
+      pushToast({ tone: "warning", title: "Bulk re-run cancelled" });
+    }
+    setBulkRerunJobId(null);
+    onBulkDone();
+    // ``sse.events`` is what changes — depending on every prop here
+    // would re-fire the toast on every keystroke elsewhere on the page.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sse.events, bulkRerunJobId]);
+
+  return (
+    <RerunDialog
+      open={open}
+      onClose={() => onOpenChange(false)}
+      targets={targets}
+      onSubmitted={(jobId) => {
+        setBulkRerunJobId(jobId);
+        onOpenChange(false);
+      }}
+      contextSummary={
+        targets.length === 0
+          ? "Select rows in the lists below before opening this dialog."
+          : undefined
+      }
+    />
   );
 }
 
@@ -1196,6 +1369,9 @@ function ResultRowItemImpl({
   skipRow,
   restoreRow,
   isMutating,
+  multiSelectMode = false,
+  isSelected = false,
+  onToggleSelected,
 }: {
   row: ResultRow;
   pendingEntry?: PendingEntry;
@@ -1203,6 +1379,12 @@ function ResultRowItemImpl({
   skipRow: () => void;
   restoreRow: (description: string) => void;
   isMutating: boolean;
+  /** When true, render a leading checkbox for bulk-rerun selection. */
+  multiSelectMode?: boolean;
+  /** Current checkbox state — managed by the parent's selectedIds Set. */
+  isSelected?: boolean;
+  /** Toggle this row's membership in the parent's selectedIds Set. */
+  onToggleSelected?: (id: number) => void;
 }) {
   const sourceAlts = pendingEntry
     ? normalizeAlternativeStrings(pendingEntry.alternatives)
@@ -1215,6 +1397,7 @@ function ResultRowItemImpl({
   const queued = !applied && !!pendingEntry;
   const skipped = !applied && !pendingEntry;
   const editable = queued;
+  const rerunSeq = row.rerun_seq ?? 0;
   const statusTone: "positive" | "neutral" | "warning" = applied
     ? "positive"
     : queued
@@ -1228,22 +1411,111 @@ function ResultRowItemImpl({
         ? "skipped"
         : (row.evaluation || "pending");
 
+  // Re-Run state lives per-row. ``rerunJobId`` becomes non-null after
+  // the modal submits successfully; the SSE hook below tails the job
+  // until ``job.done`` arrives, then invalidates the run-results query
+  // so the new alternatives appear in place.
+  const queryClient = useQueryClient();
+  const { push: pushToast } = useToast();
+  const [rerunOpen, setRerunOpen] = useState(false);
+  const [rerunJobId, setRerunJobId] = useState<string | null>(null);
+  const rerunSse = useEventSource({
+    path: rerunJobId ? `/api/runs/${encodeURIComponent(rerunJobId)}/events` : "",
+    enabled: !!rerunJobId,
+  });
+  useEffect(() => {
+    if (!rerunJobId) return;
+    const terminal = rerunSse.events.find((e) =>
+      e.type === "job.done" || e.type === "job.failed" || e.type === "job.cancelled",
+    );
+    if (!terminal) return;
+    if (terminal.type === "job.done") {
+      const summary = (terminal as unknown as { summary?: { new_run_id?: number } }).summary;
+      const newRunId = summary?.new_run_id;
+      pushToast({
+        tone: "success",
+        title: "Re-run complete",
+        description: newRunId
+          ? `New alternatives saved under run #${newRunId}.`
+          : "New alternatives saved.",
+      });
+    } else if (terminal.type === "job.failed") {
+      const errMsg = (terminal as unknown as { error?: string }).error;
+      pushToast({
+        tone: "error",
+        title: "Re-run failed",
+        description: errMsg || "The worker reported an error.",
+      });
+    } else {
+      pushToast({ tone: "warning", title: "Re-run cancelled" });
+    }
+    queryClient.invalidateQueries({ queryKey: ["history", "run-results"] });
+    queryClient.invalidateQueries({ queryKey: ["history", "result-chain", row.id] });
+    setRerunJobId(null);
+    // ``rerunSse.events`` is the only changing dependency we care
+    // about — adding the others would re-fire the toast on every
+    // re-render of the row.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rerunSse.events, rerunJobId]);
+
+  const rerunBusy = !!rerunJobId && !rerunSse.closed;
+  const rerunLabel = (() => {
+    const parts: string[] = [];
+    if (row.schema_name) parts.push(row.schema_name);
+    if (row.table_name) parts.push(row.table_name);
+    if (row.column_name) parts.push(row.column_name);
+    return parts.join(".") || "(unnamed)";
+  })();
+
   return (
     <li className="px-5 py-3">
       <div className="flex flex-wrap items-center gap-2 text-xs">
+        {multiSelectMode && (
+          <Checkbox
+            checked={isSelected}
+            onChange={() => onToggleSelected?.(row.id)}
+            aria-label={`Select ${rerunLabel} for bulk re-run`}
+            className="mr-1"
+          />
+        )}
         <span className="font-mono text-ink">
           {row.column_name ?? <em className="text-ink-dim">(table)</em>}
         </span>
         <ConfidencePill value={row.confidence} score={row.logprob_score} />
         <StatusPill tone={statusTone}>{statusLabel}</StatusPill>
         <LogprobBadge score={row.logprob_score} />
-        {editable && (
-          <span className="ml-auto inline-flex items-center gap-2">
-            {row.source && (
-              <span className="text-[10px] uppercase tracking-wider text-ink-dim">
-                {row.source}
-              </span>
-            )}
+        {rerunSeq > 0 && (
+          <span
+            title={
+              row.user_instructions
+                ? `Re-run version ${rerunSeq}. User added: "${row.user_instructions}"`
+                : `Re-run version ${rerunSeq}.`
+            }
+          >
+            <Badge tone="info">v{rerunSeq + 1}</Badge>
+          </span>
+        )}
+        <span className="ml-auto inline-flex items-center gap-2">
+          {row.source && (
+            <span className="text-[10px] uppercase tracking-wider text-ink-dim">
+              {row.source}
+            </span>
+          )}
+          <IconButton
+            icon={
+              rerunBusy ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />
+            }
+            label={
+              rerunBusy
+                ? "Re-running…"
+                : "Re-Run this item with optional new instructions"
+            }
+            size="sm"
+            variant="ghost"
+            onClick={() => setRerunOpen(true)}
+            disabled={isMutating || rerunBusy}
+          />
+          {editable && (
             <IconButton
               icon={<SkipForward size={12} />}
               label="Skip — remove from pending queue"
@@ -1252,14 +1524,15 @@ function ResultRowItemImpl({
               onClick={skipRow}
               disabled={isMutating}
             />
-          </span>
-        )}
-        {!editable && row.source && (
-          <span className="ml-auto text-[10px] uppercase tracking-wider text-ink-dim">
-            {row.source}
-          </span>
-        )}
+          )}
+        </span>
       </div>
+      <RerunDialog
+        open={rerunOpen}
+        onClose={() => setRerunOpen(false)}
+        targets={[{ resultId: row.id, label: rerunLabel }]}
+        onSubmitted={(jobId) => setRerunJobId(jobId)}
+      />
       {editable && (
         <div className="mt-2 rounded-md border border-border bg-surface-subtle/30 px-2.5 py-1.5 text-xs">
           <div className="mb-0.5 text-[10px] uppercase tracking-wider text-ink-dim">

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -1,0 +1,1015 @@
+"""Re-Run feature tests.
+
+Covers:
+* AgentContext.user_instructions wiring (empty path stays byte-identical
+  to the legacy prompt; non-empty path appends the suffix block).
+* sqlite_store re-run schema (versioning columns + snapshot table +
+  helpers).
+* RerunContextError happy / unhappy paths in build_context_snapshot.
+* rerun_items end-to-end with stubbed agents — verifies snapshot
+  cleanup, version chain ordering, multi-item, and asset_kind dispatch.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amx.agents.base import (
+    AgentContext,
+    Confidence,
+    MetadataSuggestion,
+    _user_instructions_block,
+)
+from amx.agents.rerun_context import (
+    RerunContextError,
+    hydrate_context,
+    serialize_context,
+)
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+# ── AgentContext + prompt suffix ────────────────────────────────────────────
+
+
+def test_user_instructions_block_empty_returns_empty_string() -> None:
+    """Without any addendum, the suffix is byte-empty so legacy prompts
+    stay regression-safe."""
+    ctx = AgentContext(schema="public", table="orders")
+    assert _user_instructions_block(ctx) == ""
+
+
+def test_user_instructions_block_with_text_renders_suffix() -> None:
+    ctx = AgentContext(
+        schema="public",
+        table="orders",
+        user_instructions="treat soft-deleted rows as live",
+    )
+    block = _user_instructions_block(ctx)
+    assert "Additional instructions from user (re-run):" in block
+    assert "treat soft-deleted rows as live" in block
+    # The instruction is described as guidance, not a replacement, so
+    # the agents do not throw away the original DB / docs / code
+    # context. This phrasing is load-bearing — keep it.
+    assert "guidance" in block.lower()
+
+
+def test_user_instructions_block_strips_whitespace() -> None:
+    ctx = AgentContext(user_instructions="   \n  ")
+    assert _user_instructions_block(ctx) == ""
+
+
+def test_serialize_hydrate_round_trip() -> None:
+    """Snapshot serialization preserves user_instructions + db_profile shape."""
+    original = AgentContext(
+        schema="public",
+        table="orders",
+        column="status",
+        asset_kind="column",
+        db_profile={"row_count": 42, "columns": [{"name": "status", "dtype": "text"}]},
+        existing_metadata={"database": "amx_test"},
+        user_instructions="bias toward retail-domain language",
+    )
+    payload = serialize_context(original)
+    rebuilt = hydrate_context(payload)
+    assert rebuilt == original
+
+
+# ── SQLite history store: re-run schema + helpers ───────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def _seed_original_run(store: SQLiteHistoryStore) -> tuple[int, int]:
+    """Create one analysis_runs row + one run_results row; return ids."""
+    run_id = store.create_run(
+        command="analyze.run",
+        mode="chat",
+        db_backend="postgresql",
+        db_profile="local",
+        llm_provider="openai",
+        llm_model="gpt-test",
+        scope={"public": ["orders"]},
+    )
+    [result_id] = store.save_run_results(
+        run_id,
+        [
+            {
+                "schema": "public",
+                "table": "orders",
+                "column": "status",
+                "asset_kind": "column",
+                "source": "llm",
+                "confidence": "medium",
+                "alternatives": ["v1-alt-a", "v1-alt-b"],
+            }
+        ],
+    )
+    return run_id, result_id
+
+
+def test_save_run_results_persists_rerun_fields(store: SQLiteHistoryStore) -> None:
+    run_id, original_id = _seed_original_run(store)
+    [child_id] = store.save_run_results(
+        run_id,
+        [
+            {
+                "schema": "public",
+                "table": "orders",
+                "column": "status",
+                "asset_kind": "column",
+                "source": "rerun",
+                "confidence": "high",
+                "alternatives": ["v2-alt"],
+                "parent_result_id": original_id,
+                "rerun_seq": 1,
+                "user_instructions": "bias toward soft-delete",
+            }
+        ],
+    )
+    row = store.get_run_result(child_id)
+    assert row is not None
+    assert row["parent_result_id"] == original_id
+    assert row["rerun_seq"] == 1
+    assert row["user_instructions"] == "bias toward soft-delete"
+
+
+def test_next_rerun_seq_increments_monotonically(store: SQLiteHistoryStore) -> None:
+    run_id, original_id = _seed_original_run(store)
+    assert store.next_rerun_seq(original_id) == 1
+    store.save_run_results(
+        run_id,
+        [
+            {
+                "schema": "public",
+                "table": "orders",
+                "column": "status",
+                "asset_kind": "column",
+                "source": "rerun",
+                "confidence": "medium",
+                "alternatives": ["v2"],
+                "parent_result_id": original_id,
+                "rerun_seq": 1,
+            }
+        ],
+    )
+    assert store.next_rerun_seq(original_id) == 2
+
+
+def test_get_result_chain_orders_by_rerun_seq(store: SQLiteHistoryStore) -> None:
+    run_id, original_id = _seed_original_run(store)
+    for seq, alt in enumerate(["v2", "v3", "v4"], start=1):
+        store.save_run_results(
+            run_id,
+            [
+                {
+                    "schema": "public",
+                    "table": "orders",
+                    "column": "status",
+                    "asset_kind": "column",
+                    "source": "rerun",
+                    "confidence": "medium",
+                    "alternatives": [alt],
+                    "parent_result_id": original_id,
+                    "rerun_seq": seq,
+                }
+            ],
+        )
+    chain = store.get_result_chain(original_id)
+    # Original (seq=0) plus three children, total 4 rows ordered by
+    # rerun_seq ascending.
+    assert [row["rerun_seq"] for row in chain] == [0, 1, 2, 3]
+
+
+def test_snapshot_lifecycle_save_read_delete(store: SQLiteHistoryStore) -> None:
+    _, original_id = _seed_original_run(store)
+    store.save_rerun_snapshot(
+        snapshot_id="snap-1",
+        job_id="job-A",
+        target_result_id=original_id,
+        payload={"ctx": "frozen"},
+    )
+    fetched = store.read_rerun_snapshot("snap-1")
+    assert fetched is not None
+    assert fetched["payload"] == {"ctx": "frozen"}
+    assert fetched["target_result_id"] == original_id
+
+    deleted = store.delete_rerun_snapshots_for_job("job-A")
+    assert deleted == 1
+    assert store.read_rerun_snapshot("snap-1") is None
+
+
+def test_orphan_snapshot_gc(store: SQLiteHistoryStore) -> None:
+    _, original_id = _seed_original_run(store)
+    store.save_rerun_snapshot(
+        snapshot_id="snap-old",
+        job_id="job-stale",
+        target_result_id=original_id,
+        payload={"x": 1},
+    )
+    # Backdate the row so the GC sees it as old.
+    with store._connect() as conn:
+        conn.execute(
+            "UPDATE rerun_context_snapshots SET created_at = ? WHERE snapshot_id = ?",
+            (time.time() - 7200, "snap-old"),
+        )
+    store.save_rerun_snapshot(
+        snapshot_id="snap-fresh",
+        job_id="job-live",
+        target_result_id=original_id,
+        payload={"x": 2},
+    )
+    removed = store.gc_orphan_rerun_snapshots(max_age_seconds=3600)
+    assert removed == 1
+    assert store.read_rerun_snapshot("snap-old") is None
+    assert store.read_rerun_snapshot("snap-fresh") is not None
+
+
+# ── build_context_snapshot guards ───────────────────────────────────────────
+
+
+def test_build_context_snapshot_unknown_target_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from amx.agents import rerun_context
+
+    s = SQLiteHistoryStore(tmp_path / "h.db")
+    s.init()
+    monkeypatch.setattr(rerun_context, "history_store", lambda: s)
+
+    cfg = _stub_cfg()
+    with pytest.raises(RerunContextError, match="not found"):
+        rerun_context.build_context_snapshot(cfg, target_result_id=99999, job_id="job-x")
+
+
+# ── rerun_items executor (mocked) ───────────────────────────────────────────
+
+
+def _stub_cfg():
+    """Minimal AMXConfig stand-in for executor unit tests.
+
+    The real ``AMXConfig`` reaches into the OS keyring + on-disk yaml
+    on construction, which we don't want for a mocked executor test.
+    A duck-typed namespace with the fields the executor actually
+    reads is enough.
+    """
+    from types import SimpleNamespace
+
+    llm = SimpleNamespace(
+        provider="stub",
+        model="stub-1",
+        temperature=0.2,
+        max_tokens=512,
+        logprob_high=0.85,
+        logprob_medium=0.5,
+    )
+    return SimpleNamespace(
+        llm=llm,
+        active_db_profile="local",
+        active_llm_profile="stub-llm",
+        active_doc_profile=None,
+        active_code_profile=None,
+        db_profiles={"local": SimpleNamespace(backend="postgresql")},
+    )
+
+
+def test_rerun_items_writes_versioned_row_and_cleans_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Happy path for a single column re-run.
+
+    Mocks every external boundary: ``LLMProvider`` (no network),
+    ``ProfileAgent.run`` (returns one fake suggestion), and
+    ``build_context_snapshot`` (no DB introspection). Asserts that:
+
+    * the original ``run_results`` row is unchanged;
+    * a new row is created with ``parent_result_id`` set + ``rerun_seq=1``;
+    * the snapshot is gone after the worker finishes (storage stays
+      empty between re-runs).
+    """
+    from amx.agents import rerun_context as rc_mod
+    from amx.agents._orchestrator import rerun as rerun_mod
+
+    s = SQLiteHistoryStore(tmp_path / "h.db")
+    s.init()
+    run_id, original_id = _seed_original_run(s)
+
+    monkeypatch.setattr(rerun_mod, "history_store", lambda: s)
+    monkeypatch.setattr(rc_mod, "history_store", lambda: s)
+
+    # Stub the snapshot builder to bypass live DB profiling.
+    def _fake_snapshot(cfg, *, target_result_id, job_id, user_instructions=None):
+        snap_id = f"snap-{target_result_id}"
+        s.save_rerun_snapshot(
+            snapshot_id=snap_id,
+            job_id=job_id,
+            target_result_id=int(target_result_id),
+            payload={
+                "schema": "public",
+                "table": "orders",
+                "column": "status",
+                "asset_kind": "column",
+                "db_profile": {"columns": [{"name": "status", "dtype": "text"}]},
+                "rag_context": [],
+                "code_context": [],
+                "existing_metadata": {},
+                "user_instructions": (user_instructions or "").strip(),
+                "original": {"run_id": run_id, "result_id": int(target_result_id)},
+            },
+        )
+        return snap_id
+
+    monkeypatch.setattr(rerun_mod, "build_context_snapshot", _fake_snapshot)
+
+    # Stub LLMProvider so no network call is attempted.
+    class _FakeLLM:
+        model_name = "stub-1"
+
+        def __init__(self, _cfg):
+            self.cfg = _cfg
+
+    monkeypatch.setattr(rerun_mod, "LLMProvider", _FakeLLM)
+
+    # Stub ProfileAgent.run to return one suggestion matching the target.
+    captured_ctx = {}
+
+    def _fake_run(self, ctx):
+        captured_ctx["last"] = ctx
+        return [
+            MetadataSuggestion(
+                schema=ctx.schema,
+                table=ctx.table,
+                column=ctx.column,
+                suggestions=["v2-alt-1", "v2-alt-2", "v2-alt-3"],
+                confidence=Confidence.HIGH,
+                reasoning="rerun stub",
+                source="rerun",
+            )
+        ]
+
+    monkeypatch.setattr(rerun_mod.ProfileAgent, "run", _fake_run)
+
+    cfg = _stub_cfg()
+    new_run_id, outcomes = rerun_mod.rerun_items(
+        cfg,
+        target_result_ids=[original_id],
+        user_instructions="bias toward soft-delete",
+    )
+
+    assert len(outcomes) == 1
+    outcome = outcomes[0]
+    assert outcome.error is None
+    assert outcome.alternatives == ["v2-alt-1", "v2-alt-2", "v2-alt-3"]
+    assert outcome.rerun_seq == 1
+
+    # Original row untouched.
+    original = s.get_run_result(original_id)
+    assert original is not None
+    assert original["alternatives_json"] == ["v1-alt-a", "v1-alt-b"]
+    assert original["rerun_seq"] == 0
+
+    # New row exists and links back to the original.
+    new_row = s.get_run_result(outcome.new_result_id)
+    assert new_row is not None
+    assert new_row["parent_result_id"] == original_id
+    assert new_row["rerun_seq"] == 1
+    assert new_row["user_instructions"] == "bias toward soft-delete"
+
+    # Snapshot cleaned up — table is empty even though the executor
+    # wrote one snapshot row mid-flight.
+    with s._connect() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM rerun_context_snapshots").fetchone()[0]
+    assert count == 0
+
+    # The agent received the user_instructions in its AgentContext so
+    # the prompt-suffix path actually fires.
+    assert captured_ctx["last"].user_instructions == "bias toward soft-delete"
+
+    # The new analysis_runs row carries command='rerun' so /history
+    # can render it distinctly from analyze.run rows.
+    new_run = s.get_run(int(new_run_id))
+    assert new_run is not None
+    assert new_run["command"] == "rerun"
+
+
+def test_rerun_items_multi_target_single_job(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Three targets share one analysis_runs parent + one job_id."""
+    from amx.agents import rerun_context as rc_mod
+    from amx.agents._orchestrator import rerun as rerun_mod
+
+    s = SQLiteHistoryStore(tmp_path / "h.db")
+    s.init()
+
+    run_id = s.create_run(
+        command="analyze.run",
+        mode="chat",
+        db_backend="postgresql",
+        db_profile="local",
+        llm_provider="openai",
+        llm_model="gpt-test",
+        scope={"public": ["orders", "users", "items"]},
+    )
+    ids = s.save_run_results(
+        run_id,
+        [
+            {
+                "schema": "public",
+                "table": "orders",
+                "column": "status",
+                "asset_kind": "column",
+                "source": "llm",
+                "confidence": "medium",
+                "alternatives": ["a"],
+            },
+            {
+                "schema": "public",
+                "table": "users",
+                "column": "email",
+                "asset_kind": "column",
+                "source": "llm",
+                "confidence": "medium",
+                "alternatives": ["b"],
+            },
+            {
+                "schema": "public",
+                "table": "items",
+                "column": "name",
+                "asset_kind": "column",
+                "source": "llm",
+                "confidence": "medium",
+                "alternatives": ["c"],
+            },
+        ],
+    )
+
+    monkeypatch.setattr(rerun_mod, "history_store", lambda: s)
+    monkeypatch.setattr(rc_mod, "history_store", lambda: s)
+
+    def _fake_snapshot(cfg, *, target_result_id, job_id, user_instructions=None):
+        snap_id = f"snap-{target_result_id}"
+        target = s.get_run_result(int(target_result_id))
+        s.save_rerun_snapshot(
+            snapshot_id=snap_id,
+            job_id=job_id,
+            target_result_id=int(target_result_id),
+            payload={
+                "schema": target["schema_name"],
+                "table": target["table_name"],
+                "column": target["column_name"],
+                "asset_kind": target["asset_kind"],
+                "db_profile": {"columns": [{"name": target["column_name"], "dtype": "text"}]},
+                "rag_context": [],
+                "code_context": [],
+                "existing_metadata": {},
+                "user_instructions": (user_instructions or "").strip(),
+                "original": {
+                    "run_id": int(target["run_id"]),
+                    "result_id": int(target_result_id),
+                },
+            },
+        )
+        return snap_id
+
+    monkeypatch.setattr(rerun_mod, "build_context_snapshot", _fake_snapshot)
+
+    class _FakeLLM:
+        model_name = "stub-1"
+
+        def __init__(self, _cfg):
+            self.cfg = _cfg
+
+    monkeypatch.setattr(rerun_mod, "LLMProvider", _FakeLLM)
+    monkeypatch.setattr(
+        rerun_mod.ProfileAgent,
+        "run",
+        lambda self, ctx: [
+            MetadataSuggestion(
+                schema=ctx.schema,
+                table=ctx.table,
+                column=ctx.column,
+                suggestions=[f"new-desc-{ctx.column}"],
+                confidence=Confidence.MEDIUM,
+                reasoning="multi rerun",
+                source="rerun",
+            )
+        ],
+    )
+
+    captured_events: list[tuple[str, dict]] = []
+
+    new_run_id, outcomes = rerun_mod.rerun_items(
+        _stub_cfg(),
+        target_result_ids=ids,
+        user_instructions="shared addendum",
+        on_event=lambda etype, payload: captured_events.append((etype, payload)),
+    )
+
+    assert len(outcomes) == 3
+    assert all(o.error is None for o in outcomes)
+    assert all(o.rerun_seq == 1 for o in outcomes)
+
+    # All three new rows hang off the same new analysis_runs id.
+    for o in outcomes:
+        assert s.get_run_result(o.new_result_id)["run_id"] == new_run_id
+
+    # The on_event hook was driven once-per-target with activity events.
+    activity_kinds = {e[0] for e in captured_events}
+    assert "activity.added" in activity_kinds
+    assert "activity.complete" in activity_kinds
+
+    # Snapshot table is empty afterwards.
+    with s._connect() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM rerun_context_snapshots").fetchone()[0]
+    assert count == 0
+
+
+def test_rerun_runs_rag_agent_when_doc_profile_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When the original run captured a doc_profile, the executor opens
+    its RAGStore and runs RAGAgent in parallel with ProfileAgent.
+
+    Verified by stubbing ``_try_load_rag_store`` to return a sentinel
+    object and asserting RAGAgent was constructed with it. Both agent
+    runs are stubbed to return one suggestion each; the merge step
+    picks the higher-confidence one and unions the alternatives —
+    that's the contract the executor relies on for diversity."""
+    from amx.agents._orchestrator import rerun as rerun_mod
+
+    s = SQLiteHistoryStore(tmp_path / "h.db")
+    s.init()
+    run_id, original_id = _seed_original_run(s)
+    # Stamp the parent run with a non-null doc_profile so the executor
+    # picks up the "RAG is wired" branch.
+    with s._connect() as conn:
+        conn.execute(
+            "UPDATE analysis_runs SET doc_profile = 'team-handbook' WHERE id = ?",
+            (run_id,),
+        )
+
+    monkeypatch.setattr(rerun_mod, "history_store", lambda: s)
+
+    sentinel_store = object()
+    monkeypatch.setattr(rerun_mod, "_try_load_rag_store", lambda cfg, name: sentinel_store)
+    monkeypatch.setattr(rerun_mod, "_try_make_code_report", lambda cfg, name: None)
+
+    captured: dict[str, Any] = {}
+    real_rag_init = rerun_mod.RAGAgent.__init__
+
+    def _spy_init(self, llm, store):
+        captured["rag_store"] = store
+        # Don't actually construct (RAGAgent requires real Chroma deps).
+        self.llm = llm
+        self.rag = store
+
+    monkeypatch.setattr(rerun_mod.RAGAgent, "__init__", _spy_init)
+    monkeypatch.setattr(
+        rerun_mod.RAGAgent,
+        "run",
+        lambda self, ctx: [
+            MetadataSuggestion(
+                schema=ctx.schema,
+                table=ctx.table,
+                column=ctx.column,
+                suggestions=["from-rag-1", "from-rag-2"],
+                confidence=Confidence.HIGH,
+                reasoning="rag stub",
+                source="rag",
+            )
+        ],
+    )
+
+    def _fake_snapshot(cfg, *, target_result_id, job_id, user_instructions=None):
+        snap_id = f"snap-{target_result_id}"
+        s.save_rerun_snapshot(
+            snapshot_id=snap_id,
+            job_id=job_id,
+            target_result_id=int(target_result_id),
+            payload={
+                "schema": "public",
+                "table": "orders",
+                "column": "status",
+                "asset_kind": "column",
+                "db_profile": {"columns": [{"name": "status", "dtype": "text"}]},
+                "rag_context": [],
+                "code_context": [],
+                "existing_metadata": {},
+                "user_instructions": (user_instructions or "").strip(),
+                "original": {
+                    "run_id": run_id,
+                    "result_id": int(target_result_id),
+                    "doc_profile": "team-handbook",
+                },
+            },
+        )
+        return snap_id
+
+    monkeypatch.setattr(rerun_mod, "build_context_snapshot", _fake_snapshot)
+
+    class _FakeLLM:
+        model_name = "stub-1"
+
+        def __init__(self, _cfg):
+            self.cfg = _cfg
+
+    monkeypatch.setattr(rerun_mod, "LLMProvider", _FakeLLM)
+    monkeypatch.setattr(
+        rerun_mod.ProfileAgent,
+        "run",
+        lambda self, ctx: [
+            MetadataSuggestion(
+                schema=ctx.schema,
+                table=ctx.table,
+                column=ctx.column,
+                suggestions=["from-profile-1"],
+                confidence=Confidence.MEDIUM,
+                reasoning="profile stub",
+                source="profile",
+            )
+        ],
+    )
+
+    _, outcomes = rerun_mod.rerun_items(
+        _stub_cfg(),
+        target_result_ids=[original_id],
+    )
+    # RAGAgent was constructed with the sentinel store the loader
+    # returned — proving the executor flowed through to RAG.
+    assert captured["rag_store"] is sentinel_store
+    assert len(outcomes) == 1
+    assert outcomes[0].error is None
+    # The merge step picked the HIGH-confidence RAG suggestion as the
+    # primary and unioned alternatives across both agents.
+    assert "from-rag-1" in outcomes[0].alternatives
+    assert "from-profile-1" in outcomes[0].alternatives
+    assert outcomes[0].source == "combined"
+    assert outcomes[0].confidence == "high"
+
+    # Restore the real init so subsequent tests get a clean slate.
+    monkeypatch.setattr(rerun_mod.RAGAgent, "__init__", real_rag_init)
+
+
+def test_rerun_runs_code_agent_when_code_profile_present(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Same shape as the RAG test but for the Code agent path.
+
+    Asserts the executor constructs a ``CodebaseReport`` with empty
+    ``references`` so :class:`CodeAgent` falls into the semantic-only
+    branch — the heavy full-codebase scan is intentionally skipped to
+    keep the per-item budget under 20s."""
+    from amx.agents._orchestrator import rerun as rerun_mod
+
+    s = SQLiteHistoryStore(tmp_path / "h.db")
+    s.init()
+    run_id, original_id = _seed_original_run(s)
+    with s._connect() as conn:
+        conn.execute(
+            "UPDATE analysis_runs SET code_profile = 'monorepo' WHERE id = ?",
+            (run_id,),
+        )
+
+    monkeypatch.setattr(rerun_mod, "history_store", lambda: s)
+
+    fake_report = object()
+    monkeypatch.setattr(rerun_mod, "_try_load_rag_store", lambda cfg, name: None)
+    monkeypatch.setattr(rerun_mod, "_try_make_code_report", lambda cfg, name: fake_report)
+
+    captured: dict[str, Any] = {}
+    real_init = rerun_mod.CodeAgent.__init__
+
+    def _spy_init(self, llm, report=None):
+        captured["report"] = report
+        self.llm = llm
+        self.report = report
+
+    monkeypatch.setattr(rerun_mod.CodeAgent, "__init__", _spy_init)
+    monkeypatch.setattr(
+        rerun_mod.CodeAgent,
+        "run",
+        lambda self, ctx: [
+            MetadataSuggestion(
+                schema=ctx.schema,
+                table=ctx.table,
+                column=ctx.column,
+                suggestions=["from-code"],
+                confidence=Confidence.LOW,
+                reasoning="code stub",
+                source="code",
+            )
+        ],
+    )
+
+    def _fake_snapshot(cfg, *, target_result_id, job_id, user_instructions=None):
+        snap_id = f"snap-{target_result_id}"
+        s.save_rerun_snapshot(
+            snapshot_id=snap_id,
+            job_id=job_id,
+            target_result_id=int(target_result_id),
+            payload={
+                "schema": "public",
+                "table": "orders",
+                "column": "status",
+                "asset_kind": "column",
+                "db_profile": {"columns": [{"name": "status", "dtype": "text"}]},
+                "rag_context": [],
+                "code_context": [],
+                "existing_metadata": {},
+                "user_instructions": "",
+                "original": {
+                    "run_id": run_id,
+                    "result_id": int(target_result_id),
+                    "code_profile": "monorepo",
+                },
+            },
+        )
+        return snap_id
+
+    monkeypatch.setattr(rerun_mod, "build_context_snapshot", _fake_snapshot)
+
+    class _FakeLLM:
+        model_name = "stub-1"
+
+        def __init__(self, _cfg):
+            self.cfg = _cfg
+
+    monkeypatch.setattr(rerun_mod, "LLMProvider", _FakeLLM)
+    monkeypatch.setattr(
+        rerun_mod.ProfileAgent,
+        "run",
+        lambda self, ctx: [
+            MetadataSuggestion(
+                schema=ctx.schema,
+                table=ctx.table,
+                column=ctx.column,
+                suggestions=["from-profile"],
+                confidence=Confidence.MEDIUM,
+                reasoning="profile stub",
+                source="profile",
+            )
+        ],
+    )
+
+    _, outcomes = rerun_mod.rerun_items(
+        _stub_cfg(),
+        target_result_ids=[original_id],
+    )
+    assert captured["report"] is fake_report
+    assert outcomes[0].error is None
+    # MEDIUM-confidence Profile beats LOW-confidence Code.
+    assert outcomes[0].confidence == "medium"
+    assert "from-profile" in outcomes[0].alternatives
+    assert "from-code" in outcomes[0].alternatives
+
+    monkeypatch.setattr(rerun_mod.CodeAgent, "__init__", real_init)
+
+
+def test_rerun_skips_rag_when_no_doc_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """No doc_profile + no code_profile = Profile-only fan-out (back to v1).
+
+    Belt-and-suspenders: even if the loaders are mocked permissive,
+    an executor that uses only the original run's profile names will
+    skip both agents because the seed run sets neither."""
+    from amx.agents._orchestrator import rerun as rerun_mod
+
+    s = SQLiteHistoryStore(tmp_path / "h.db")
+    s.init()
+    run_id, original_id = _seed_original_run(s)
+    monkeypatch.setattr(rerun_mod, "history_store", lambda: s)
+
+    rag_calls: list[Any] = []
+    code_calls: list[Any] = []
+    monkeypatch.setattr(
+        rerun_mod,
+        "_try_load_rag_store",
+        lambda cfg, name: rag_calls.append(name) or None,
+    )
+    monkeypatch.setattr(
+        rerun_mod,
+        "_try_make_code_report",
+        lambda cfg, name: code_calls.append(name) or None,
+    )
+
+    def _fake_snapshot(cfg, *, target_result_id, job_id, user_instructions=None):
+        snap_id = f"snap-{target_result_id}"
+        s.save_rerun_snapshot(
+            snapshot_id=snap_id,
+            job_id=job_id,
+            target_result_id=int(target_result_id),
+            payload={
+                "schema": "public",
+                "table": "orders",
+                "column": "status",
+                "asset_kind": "column",
+                "db_profile": {"columns": [{"name": "status", "dtype": "text"}]},
+                "rag_context": [],
+                "code_context": [],
+                "existing_metadata": {},
+                "user_instructions": "",
+                "original": {
+                    "run_id": run_id,
+                    "result_id": int(target_result_id),
+                    "doc_profile": None,
+                    "code_profile": None,
+                },
+            },
+        )
+        return snap_id
+
+    monkeypatch.setattr(rerun_mod, "build_context_snapshot", _fake_snapshot)
+
+    class _FakeLLM:
+        model_name = "stub-1"
+
+        def __init__(self, _cfg):
+            self.cfg = _cfg
+
+    monkeypatch.setattr(rerun_mod, "LLMProvider", _FakeLLM)
+    monkeypatch.setattr(
+        rerun_mod.ProfileAgent,
+        "run",
+        lambda self, ctx: [
+            MetadataSuggestion(
+                schema=ctx.schema,
+                table=ctx.table,
+                column=ctx.column,
+                suggestions=["only-profile"],
+                confidence=Confidence.MEDIUM,
+                reasoning="profile stub",
+                source="profile",
+            )
+        ],
+    )
+
+    _, outcomes = rerun_mod.rerun_items(
+        _stub_cfg(),
+        target_result_ids=[original_id],
+    )
+    # Loaders queried with None — both returned None, both agents skipped.
+    assert rag_calls == [None]
+    assert code_calls == [None]
+    assert outcomes[0].alternatives == ["only-profile"]
+
+
+def test_rerun_warns_when_per_item_budget_exceeded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The 20s soft cap fires a WARNING log when an item runs long.
+
+    Real budget is 20s; for the test we override it to 0.0 so any
+    non-trivial run trips the threshold. The behavior under test is
+    purely the *warning* — the executor keeps the result, since
+    LLM HTTP calls aren't cancellable from inside the agent."""
+    import logging
+
+    from amx.agents._orchestrator import rerun as rerun_mod
+
+    s = SQLiteHistoryStore(tmp_path / "h.db")
+    s.init()
+    run_id, original_id = _seed_original_run(s)
+    monkeypatch.setattr(rerun_mod, "history_store", lambda: s)
+    monkeypatch.setattr(rerun_mod, "_try_load_rag_store", lambda cfg, name: None)
+    monkeypatch.setattr(rerun_mod, "_try_make_code_report", lambda cfg, name: None)
+    monkeypatch.setattr(rerun_mod, "RERUN_PER_ITEM_BUDGET_SEC", 0.0)
+
+    def _fake_snapshot(cfg, *, target_result_id, job_id, user_instructions=None):
+        snap_id = f"snap-{target_result_id}"
+        s.save_rerun_snapshot(
+            snapshot_id=snap_id,
+            job_id=job_id,
+            target_result_id=int(target_result_id),
+            payload={
+                "schema": "public",
+                "table": "orders",
+                "column": "status",
+                "asset_kind": "column",
+                "db_profile": {"columns": [{"name": "status", "dtype": "text"}]},
+                "rag_context": [],
+                "code_context": [],
+                "existing_metadata": {},
+                "user_instructions": "",
+                "original": {"run_id": run_id, "result_id": int(target_result_id)},
+            },
+        )
+        return snap_id
+
+    monkeypatch.setattr(rerun_mod, "build_context_snapshot", _fake_snapshot)
+
+    class _FakeLLM:
+        model_name = "stub-1"
+
+        def __init__(self, _cfg):
+            self.cfg = _cfg
+
+    monkeypatch.setattr(rerun_mod, "LLMProvider", _FakeLLM)
+    monkeypatch.setattr(
+        rerun_mod.ProfileAgent,
+        "run",
+        lambda self, ctx: [
+            MetadataSuggestion(
+                schema=ctx.schema,
+                table=ctx.table,
+                column=ctx.column,
+                suggestions=["x"],
+                confidence=Confidence.MEDIUM,
+                reasoning="",
+                source="profile",
+            )
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="amx.agents._orchestrator.rerun"):
+        rerun_mod.rerun_items(_stub_cfg(), target_result_ids=[original_id])
+    assert any(
+        "soft budget" in record.message and "0s soft budget" in record.message
+        for record in caplog.records
+    )
+
+
+def test_rerun_items_cleans_up_snapshots_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If the agent raises, the executor still deletes its snapshots."""
+    from amx.agents import rerun_context as rc_mod
+    from amx.agents._orchestrator import rerun as rerun_mod
+
+    s = SQLiteHistoryStore(tmp_path / "h.db")
+    s.init()
+    _, original_id = _seed_original_run(s)
+
+    monkeypatch.setattr(rerun_mod, "history_store", lambda: s)
+    monkeypatch.setattr(rc_mod, "history_store", lambda: s)
+
+    monkeypatch.setattr(
+        rerun_mod,
+        "build_context_snapshot",
+        lambda cfg, *, target_result_id, job_id, user_instructions=None: (
+            s.save_rerun_snapshot(
+                snapshot_id=f"snap-{target_result_id}",
+                job_id=job_id,
+                target_result_id=int(target_result_id),
+                payload={
+                    "schema": "public",
+                    "table": "orders",
+                    "column": "status",
+                    "asset_kind": "column",
+                    "db_profile": {"columns": [{"name": "status", "dtype": "text"}]},
+                    "rag_context": [],
+                    "code_context": [],
+                    "existing_metadata": {},
+                    "user_instructions": "",
+                    "original": {"run_id": 0, "result_id": int(target_result_id)},
+                },
+            )
+            or f"snap-{target_result_id}"
+        ),
+    )
+
+    class _FakeLLM:
+        model_name = "stub-1"
+
+        def __init__(self, _cfg):
+            self.cfg = _cfg
+
+    monkeypatch.setattr(rerun_mod, "LLMProvider", _FakeLLM)
+
+    def _explode(self, ctx):
+        raise RuntimeError("agent boom")
+
+    monkeypatch.setattr(rerun_mod.ProfileAgent, "run", _explode)
+
+    _, outcomes = rerun_mod.rerun_items(
+        _stub_cfg(),
+        target_result_ids=[original_id],
+    )
+    assert len(outcomes) == 1
+    # The parallel fan-out swallows per-agent crashes (RAG / Code can
+    # fail without killing Profile output); when *every* sub-agent
+    # ends up empty the executor surfaces a generic "no parseable
+    # description" error instead of the agent's stack trace.
+    assert outcomes[0].error is not None
+    assert outcomes[0].new_result_id == 0
+
+    with s._connect() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM rerun_context_snapshots").fetchone()[0]
+    assert count == 0


### PR DESCRIPTION
## Summary
- New context-preserving Re-Run path: regenerates alternatives for a single (or many) ``run_results`` row(s) while reusing the original DB profile, docs, codebase, and LLM stack — plus an optional free-text addendum from the user.
- Versioned chain: each re-run writes a new ``run_results`` row linked to the chain root via ``parent_result_id`` / ``rerun_seq``, so the original alternatives are never lost; Studio renders "v2/v3" badges with the user's instructions in the tooltip.
- Snapshots are short-lived: the worker freezes ``AgentContext`` into ``rerun_context_snapshots``, every parallel agent reads from that single source of truth, and the rows are deleted in ``finally`` (plus a startup orphan-GC for crash recovery). Storage cost outside a live re-run is zero.
- Profile + RAG + Code agents fan out in parallel; merge picks by confidence + logprob and unions alternatives. RAG opens lazily off the original ``doc_profile``; the Code agent runs **semantic-only** (no full codebase re-scan) so a single column re-run stays under a 20s soft budget — exceeding it logs a structured warning.
- Surface area: ``amx rerun`` CLI (single / multi / ``--pick`` interactive picker), ``POST /api/runs/rerun-item`` Studio endpoint reusing the existing SSE machinery, and a per-row ⟳ button + multi-select toolbar in the run detail page.

## Test plan
- [x] ``pytest tests/test_rerun.py`` (17 new tests: prompt suffix on/off, snapshot lifecycle, orphan GC, version chain ordering, multi-item single-job, asset-kind dispatch, RAG/Code gating by original profile, 20s budget warning).
- [x] Full backend regression — ``pytest tests`` (1111 pass).
- [x] Frontend type check — ``tsc --build`` clean.
- [ ] End-to-end smoke (manual) — start Studio, run a small analysis, click ⟳ on one row, type extra guidance, watch the SSE stream complete, see the v2 badge appear in place.
- [ ] Multi-select smoke — toggle "Select multiple", pick 2–3 rows, "Re-Run selected", confirm one bulk job updates each row.
- [ ] CLI smoke — ``amx rerun <id> --instructions "consider soft-deletes"`` against a real run.