### PR TITLE
fix(console): stop Rich markup tags leaking in info() output

### DIFF
--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -18,6 +18,7 @@ from amx.utils.console import (
     error,
     heading,
     info,
+    info_styled,
     render_table,
     step_spinner,
     warn,
@@ -145,7 +146,7 @@ def _maybe_modify_profiles_before_run(
     if db_names:
         db_choice = ask_choice("Select DB profile", db_names, default=cfg.active_db_profile)
         cfg.set_active_db_profile(db_choice)
-        info(f"Active DB: [bold #fb923c]{db_choice}[/]")
+        info_styled("Active DB", db_choice)
         db = DatabaseConnector(cfg.db)
         with step_spinner("Testing new database connection..."):
             if not db.test_connection():
@@ -156,7 +157,7 @@ def _maybe_modify_profiles_before_run(
     if llm_names:
         llm_choice = ask_choice("Select LLM profile", llm_names, default=cfg.active_llm_profile)
         cfg.set_active_llm_profile(llm_choice)
-        info(f"Active LLM: [bold #fb923c]{llm_choice}[/]")
+        info_styled("Active LLM", llm_choice)
         llm = LLMProvider(cfg.llm)
 
     doc_names = list(cfg.doc_profiles.keys())
@@ -168,7 +169,7 @@ def _maybe_modify_profiles_before_run(
             default=cfg.active_doc_profile or DISABLED_PROFILE,
         )
         cfg.active_doc_profile = doc_choice
-        info(f"Active Docs: [bold #fb923c]{doc_choice}[/]")
+        info_styled("Active Docs", doc_choice)
 
     code_names = list(cfg.code_profiles.keys())
     if code_names:
@@ -179,7 +180,7 @@ def _maybe_modify_profiles_before_run(
             default=cfg.active_code_profile or DISABLED_PROFILE,
         )
         cfg.active_code_profile = code_choice
-        info(f"Active Code: [bold #fb923c]{code_choice}[/]")
+        info_styled("Active Code", code_choice)
 
     cfg.save()
     info("Profile selections saved to config.yml.")

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -24,6 +24,7 @@ from amx.utils.console import (
     error,
     heading,
     info,
+    info_styled,
     render_table,
     success,
     warn,
@@ -1306,7 +1307,7 @@ def cmd_inspect(cfg: AMXConfig, rest: list[str]) -> None:
 
     profile = cfg.db_profiles[profile_name]
     heading(f"DB profile: {profile_name}")
-    info(f"  Backend:    [#22d3ee]{profile.backend}[/#22d3ee]")
+    info_styled("  Backend", profile.backend, value_style="#22d3ee")
     info(f"  Connection: {profile.display_summary}")
 
     # Print non-secret connection fields per backend so users can sanity-

--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -19,6 +19,7 @@ from amx.utils.console import (
     error,
     heading,
     info,
+    info_styled,
     render_table,
     success,
     warn,
@@ -218,8 +219,8 @@ def cmd_temperature(cfg: AMXConfig, rest: list[str]) -> None:
     """Show or set the LLM sampling temperature for the active profile."""
     if not rest:
         current = getattr(cfg.llm, "temperature", 0.2)
-        info(f"Current LLM temperature: [bold]{current:.2f}[/]")
-        info("Run [#22d3ee]/temperature <value>[/#22d3ee] to change (e.g. 0.7). Range: 0.0-2.0.")
+        info_styled("Current LLM temperature", f"{current:.2f}", value_style="bold")
+        info("Run /temperature <value> to change (e.g. 0.7). Range: 0.0-2.0.")
         return
 
     try:

--- a/amx/cli_support/commands/search.py
+++ b/amx/cli_support/commands/search.py
@@ -33,6 +33,7 @@ from amx.utils.console import (
     error,
     info,
     info_markdown,
+    info_styled,
     render_table,
     success,
     warn,
@@ -815,7 +816,7 @@ def _interactive_sync_scope(
             default=cfg.active_db_profile or sorted(cfg.db_profiles.keys())[0],
         )
         cfg.set_active_db_profile(selected)
-        info(f"Active DB: [bold #fb923c]{selected}[/]")
+        info_styled("Active DB", selected)
     db = DatabaseConnector(cfg.db)
     scope = _finalize_scope(
         cfg,

--- a/amx/utils/console.py
+++ b/amx/utils/console.py
@@ -180,6 +180,25 @@ def info(text: str) -> None:
     console.print(f"[info]ℹ  {_markup_escape(text)}[/info]")
 
 
+def info_styled(label: str, value: str, *, value_style: str = "bold #fb923c") -> None:
+    """``info()`` with the *value* visually emphasized.
+
+    Renders ``ℹ  <label>: <styled value>``. Both ``label`` and ``value``
+    are :func:`escape`'d so user-controlled substrings (profile names,
+    DB identifiers, etc.) cannot inject Rich markup.
+
+    Use this instead of ``info(f"... [bold]{x}[/]")`` — the plain
+    :func:`info` helper escapes the whole string and turns those tags
+    into literal text that leaks to the terminal.
+    """
+    if is_quiet():
+        return
+    console.print(
+        f"[info]ℹ  {_markup_escape(label)}: "
+        f"[{value_style}]{_markup_escape(value)}[/{value_style}][/info]"
+    )
+
+
 def info_markdown(text: str) -> None:
     """Render an LLM-style answer with markdown (bold, code, tables, lists).
 


### PR DESCRIPTION
## Summary
- ``info()`` escapes its whole argument (defence against substrings like ``[databricks]`` getting swallowed as Rich tags), so callers passing literal ``[bold #fb923c]…[/]`` markup saw the tags rendered verbatim in the terminal — e.g. ``ℹ  Active DB: [bold #fb923c]postgre[/]`` instead of the intended bold-orange ``postgre``.
- Add ``info_styled(label, value, value_style="bold #fb923c")`` for the common "label: <emphasized value>" pattern; both label and value are escaped before splicing so the safety contract is preserved.
- Convert every leaking call site found by grep: ``analyze_flow`` (Active DB / LLM / Docs / Code in the pre-run picker), ``search`` (/ask scope picker), ``profiles`` (/temperature current-value), ``db`` (/db show Backend row).
- No behaviour change for unaffected callers — plain ``info()`` semantics (escape everything) stay intact.

## Test plan
- [x] Existing suite green — ``pytest tests/ --ignore=tests/eval --ignore=tests/perf`` (1111 pass).
- [x] Smoke render via ``Console(file=StringIO)`` confirms no literal ``[bold`` / ``[/]`` in the output and the variables (``postgre``, ``or-kimi2.6``, ``postgresql``) render through.
- [ ] Manual smoke (interactive) — start the CLI, run /run, hit ``y`` at "Do you want to modify profiles before run?", verify the four ``Active …`` lines render with orange-bold values and no markup leak.