### PR TITLE
feat(pricing): live LLM cost tracking with user override + frozen+live audit

### DIFF
--- a/amx/agents/code_agent.py
+++ b/amx/agents/code_agent.py
@@ -190,7 +190,7 @@ class CodeAgent(BaseAgent):
         est = estimate_tokens(messages)
         with step_spinner(f"Code Agent: {len(columns)} columns", token_estimate=est):
             result = self.llm.chat(messages)
-        tracker.record("code_agent", est, result.usage)
+        tracker.record_for("code_agent", est, self.llm, result.usage)
 
         suggestions = self._parse_response(result.content, ctx)
         return apply_logprob_confidence(

--- a/amx/agents/equivalence_agent.py
+++ b/amx/agents/equivalence_agent.py
@@ -238,7 +238,7 @@ def run_equivalence_pass(
             continue
 
         with contextlib.suppress(Exception):
-            tracker.record("equivalence_agent", 0, result.usage)
+            tracker.record_for("equivalence_agent", 0, llm, result.usage)
 
         raw = (result.content or "").strip()
         if not raw:

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -1187,7 +1187,7 @@ class Orchestrator:
         est = estimate_tokens(messages)
         with step_spinner(f"Merging suggestions: {len(needs_merge)} columns", token_estimate=est):
             result = self.llm.chat(messages)
-        tracker.record("merge", est, result.usage)
+        tracker.record_for("merge", est, self.llm, result.usage)
 
         parsed = self._parse_merge_response(result.content)
 
@@ -1772,7 +1772,7 @@ class Orchestrator:
                         for c in cols_slice
                     ]
                     batch_ctx = self.profile_agent._ctx_with_columns(ctx, col_dicts)
-                    tracker.record("profile_agent(batch)", 0, chat_result.usage)
+                    tracker.record_for("profile_agent(batch)", 0, self.llm, chat_result.usage)
                     parsed = self.profile_agent.parse_batch_result(chat_result.content, batch_ctx)
                     all_suggestions.extend(
                         apply_logprob_confidence(
@@ -1788,7 +1788,7 @@ class Orchestrator:
                 cid = f"rag:{schema}:{table}"
                 chat_result = batch_results.get(cid)
                 if chat_result and chat_result.content:
-                    tracker.record("rag_agent(batch)", 0, chat_result.usage)
+                    tracker.record_for("rag_agent(batch)", 0, self.llm, chat_result.usage)
                     parsed = self.rag_agent.parse_batch_result(chat_result.content, ctx)
                     all_suggestions.extend(
                         apply_logprob_confidence(
@@ -1804,7 +1804,7 @@ class Orchestrator:
                 cid = f"code:{schema}:{table}"
                 chat_result = batch_results.get(cid)
                 if chat_result and chat_result.content:
-                    tracker.record("code_agent(batch)", 0, chat_result.usage)
+                    tracker.record_for("code_agent(batch)", 0, self.llm, chat_result.usage)
                     parsed = self.code_agent.parse_batch_result(chat_result.content, ctx)
                     all_suggestions.extend(
                         apply_logprob_confidence(

--- a/amx/agents/profile_agent.py
+++ b/amx/agents/profile_agent.py
@@ -390,7 +390,7 @@ class ProfileAgent(BaseAgent):
             log.error("LLM call failed in profile agent: %s", exc)
             return []
 
-        tracker.record("profile_agent", est, result.usage)
+        tracker.record_for("profile_agent", est, self.llm, result.usage)
         response = result.content
         _logprobs = result.logprobs
 

--- a/amx/agents/rag_agent.py
+++ b/amx/agents/rag_agent.py
@@ -178,7 +178,7 @@ class RAGAgent(BaseAgent):
         est = estimate_tokens(messages)
         with step_spinner(f"RAG Agent: {len(columns)} columns", token_estimate=est):
             result = self.llm.chat(messages)
-        tracker.record("rag_agent", est, result.usage)
+        tracker.record_for("rag_agent", est, self.llm, result.usage)
 
         suggestions = self._parse_response(result.content, ctx)
         return apply_logprob_confidence(

--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -436,6 +436,7 @@ def _finalize_history_run(
             },
             tokens={
                 "total_tokens": token_tracker.total_tokens,
+                "total_cost_usd": round(token_tracker.total_cost_usd, 8),
                 "summary": token_tracker.summary(),
                 "records": token_tracker.records(),
             },

--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -246,6 +246,125 @@ def cmd_temperature(cfg: AMXConfig, rest: list[str]) -> None:
 # heads-up before silently committing it to config.yml.
 _MAX_TOKENS_SOFT_CAP = 262_144
 
+_RESET_TOKENS = {"reset", "clear", "default", "auto", "none", "-"}
+
+
+def cmd_cost(cfg: AMXConfig, rest: list[str]) -> None:
+    """Show or set per-1M-token cost overrides for the active LLM profile.
+
+    Usage::
+
+        /cost                           # show effective price + source
+        /cost <input> <output>          # set custom override (USD / Mtok)
+        /cost reset                     # remove the override
+
+    Resolution order is documented in ``amx/llm/pricing.py:lookup_price``;
+    a custom override always wins over LiteLLM / OpenRouter / fallback.
+    Both rates are required when setting — a half-override is treated
+    as no override to avoid the "set output, forgot input" footgun.
+    """
+    from amx.llm.pricing import cache_age_seconds, lookup_price
+
+    profile = cfg.active_llm_profile or ""
+    if not profile or profile not in cfg.llm_profiles:
+        warn("No active LLM profile. Run /add-llm-profile or /use-llm first.")
+        return
+
+    if not rest:
+        price = lookup_price(
+            cfg, provider=cfg.llm.provider, model=cfg.llm.model, profile_name=profile
+        )
+        info_styled(
+            f"Cost for '{profile}' [input  $/Mtok]",
+            f"{price.input_per_mtok:.4f}",
+            value_style="bold",
+        )
+        info_styled(
+            f"Cost for '{profile}' [output $/Mtok]",
+            f"{price.output_per_mtok:.4f}",
+            value_style="bold",
+        )
+        info_styled("Source", price.source)
+        if price.source != "user_override":
+            age = cache_age_seconds()
+            if age is None:
+                age_label = "never (run /refresh-prices)"
+            elif age < 60:
+                age_label = f"{int(age)}s ago"
+            elif age < 3600:
+                age_label = f"{int(age / 60)}m ago"
+            else:
+                age_label = f"{age / 3600.0:.1f}h ago"
+            info(f"Last fetched: {age_label}.")
+        info(
+            "Run /cost <input> <output> to override (e.g. /cost 0.50 2.50). "
+            "/cost reset removes the override."
+        )
+        return
+
+    head = (rest[0] or "").lower()
+    if head in _RESET_TOKENS:
+        cfg.llm.custom_input_cost_per_mtok = None
+        cfg.llm.custom_output_cost_per_mtok = None
+        cfg.llm_profiles[profile].custom_input_cost_per_mtok = None
+        cfg.llm_profiles[profile].custom_output_cost_per_mtok = None
+        cfg.save()
+        success(f"Cost override cleared for '{profile}'. Reverting to fetched prices.")
+        return
+
+    if len(rest) < 2:
+        error(
+            "Usage: /cost <input_per_mtok> <output_per_mtok>  (or /cost reset). "
+            "Both rates are required — a half-override is rejected to keep "
+            "the audit trail honest."
+        )
+        return
+    try:
+        in_rate = float(rest[0])
+        out_rate = float(rest[1])
+    except ValueError:
+        error(f"Expected two numeric rates (USD / 1M tokens), got: {rest[0]} {rest[1]}")
+        return
+    if in_rate < 0 or out_rate < 0:
+        error("Rates must be non-negative.")
+        return
+    cfg.llm.custom_input_cost_per_mtok = in_rate
+    cfg.llm.custom_output_cost_per_mtok = out_rate
+    cfg.llm_profiles[profile].custom_input_cost_per_mtok = in_rate
+    cfg.llm_profiles[profile].custom_output_cost_per_mtok = out_rate
+    cfg.save()
+    success(
+        f"Cost override saved for '{profile}': input ${in_rate:.4f}/Mtok, "
+        f"output ${out_rate:.4f}/Mtok."
+    )
+
+
+def cmd_refresh_prices(cfg: AMXConfig, rest: list[str]) -> None:
+    """Force-fetch fresh LLM prices from LiteLLM + OpenRouter.
+
+    Persists to ``~/.amx/pricing-cache.json`` (24h TTL). Subsequent
+    ``/usage`` and any LLM call that resolves a price will see the new
+    rates immediately. Errors per source are reported but never raise —
+    a stale cache is always preferable to a crashed shell.
+    """
+    from amx.llm.pricing import refresh_prices
+
+    info("Fetching latest prices from LiteLLM and OpenRouter…")
+    result = refresh_prices(force=True)
+    if result.get("errors"):
+        for err in result["errors"]:
+            warn(f"  {err}")
+    if result.get("skipped"):
+        info(
+            f"Cache still fresh — {result['litellm']} LiteLLM + "
+            f"{result['openrouter']} OpenRouter models loaded."
+        )
+    else:
+        success(
+            f"Updated {result['litellm']} LiteLLM + {result['openrouter']} "
+            "OpenRouter models. Cache valid for 24h."
+        )
+
 
 def cmd_max_tokens(cfg: AMXConfig, rest: list[str]) -> None:
     """Show or set the LLM output-token budget for the active profile.

--- a/amx/cli_support/commands/usage.py
+++ b/amx/cli_support/commands/usage.py
@@ -1,16 +1,20 @@
-"""``/usage`` slash command — show token usage and approximate cost.
+"""``/usage`` slash command — show token usage and live USD cost.
 
 Reads from the SQLite ``analysis_runs`` table (already populated by every
-``/analyze run``) and aggregates by (provider, model) over a time window.
-Apply approximate USD pricing per million tokens so users have an
-order-of-magnitude sense of LLM spend without needing to log into the
-provider dashboard.
+``/analyze run``) and aggregates by (provider, model) over a time
+window. Cost can be rendered two ways:
 
-The pricing table is intentionally minimal and approximate — exact
-amounts depend on tier and discount, so we render a "(approximate)"
-disclaimer. Models we do not have pricing for show ``—`` for cost.
+* **Frozen** (default) — uses the per-record USD figures the
+  :class:`TokenTracker` saved at run time. This is the audit trail:
+  what a run actually cost given the prices on the day it ran.
+* **Live** (``/usage --live``) — re-runs :func:`amx.llm.pricing.compute_cost`
+  against today's prices on the same recorded token totals so users
+  can answer "what would this same workload cost today?".
 
-This command is local-only: nothing is sent to a network endpoint.
+Source attribution: the table includes a ``Source`` column showing
+where the price came from (litellm / openrouter / user_override /
+fallback / unknown) so the user can tell when a custom override was
+in effect or when AMX had to fall back to the bundled snapshot.
 """
 
 from __future__ import annotations
@@ -20,41 +24,14 @@ import time
 from typing import Any
 
 from amx.config import AMXConfig
+from amx.llm.pricing import (
+    ModelPrice,
+    cache_age_seconds,
+    compute_cost,
+    lookup_price,
+)
 from amx.storage.sqlite_store import history_store
 from amx.utils.console import error, heading, info, render_table, warn
-
-# USD per 1M tokens (input, output). Embedding models track only input.
-# Source: provider public price pages, approximated for end-user
-# orientation only. Update when a model is renamed or repriced.
-_PRICING_PER_MTOK: dict[str, tuple[float, float]] = {
-    # OpenAI chat
-    "gpt-4o": (2.50, 10.00),
-    "gpt-4o-mini": (0.15, 0.60),
-    "gpt-4-turbo": (10.00, 30.00),
-    "gpt-4": (30.00, 60.00),
-    "o1": (15.00, 60.00),
-    "o1-mini": (3.00, 12.00),
-    "o3-mini": (1.10, 4.40),
-    # OpenAI embeddings (output cost ignored by the model API)
-    "text-embedding-3-small": (0.02, 0.0),
-    "text-embedding-3-large": (0.13, 0.0),
-    "text-embedding-ada-002": (0.10, 0.0),
-    # Anthropic
-    "claude-opus-4": (15.00, 75.00),
-    "claude-sonnet-4": (3.00, 15.00),
-    "claude-haiku-4": (0.80, 4.00),
-    "claude-3-5-sonnet": (3.00, 15.00),
-    "claude-3-5-haiku": (0.80, 4.00),
-    "claude-3-opus": (15.00, 75.00),
-    # Gemini
-    "gemini-2.0-flash": (0.10, 0.40),
-    "gemini-2.0-pro": (1.25, 5.00),
-    "gemini-1.5-pro": (1.25, 5.00),
-    "gemini-1.5-flash": (0.075, 0.30),
-    # DeepSeek
-    "deepseek-chat": (0.27, 1.10),
-    "deepseek-reasoner": (0.55, 2.19),
-}
 
 _WINDOWS: dict[str, float | None] = {
     "today": 24 * 3600.0,
@@ -65,6 +42,7 @@ _WINDOWS: dict[str, float | None] = {
     "all": None,
 }
 _DEFAULT_WINDOW = "7d"
+_LIVE_FLAGS = {"--live", "-l", "live"}
 
 
 def _normalize_window(arg: str) -> tuple[str, float | None]:
@@ -74,39 +52,18 @@ def _normalize_window(arg: str) -> tuple[str, float | None]:
     return _DEFAULT_WINDOW, _WINDOWS[_DEFAULT_WINDOW]
 
 
-def _lookup_pricing(model: str) -> tuple[float, float] | None:
-    """Match model id against the pricing table; tolerates provider-prefixed
-    forms like ``openai/gpt-4o`` or ``anthropic/claude-sonnet-4-20250514`` by
-    stripping the namespace and trimming trailing dated suffixes."""
-    if not model:
-        return None
-    name = model.lower().strip()
-    if name in _PRICING_PER_MTOK:
-        return _PRICING_PER_MTOK[name]
-    # Strip a provider prefix (openai/, anthropic/, openrouter/openai/, …).
-    while "/" in name:
-        name = name.split("/", 1)[1]
-        if name in _PRICING_PER_MTOK:
-            return _PRICING_PER_MTOK[name]
-    # Strip dated/version suffixes (e.g. -20250514, -v2, -latest, -beta).
-    for sep in ("-2024", "-2025", "-2026", "-v", "-latest", "-beta", "-preview"):
-        if sep in name:
-            head = name.split(sep, 1)[0]
-            if head in _PRICING_PER_MTOK:
-                return _PRICING_PER_MTOK[head]
-    return None
-
-
 def _aggregate_runs(
     runs: list[dict[str, Any]],
-) -> tuple[dict[tuple[str, str], dict[str, int]], int]:
-    """Group runs by (provider, model) and sum token totals.
+) -> tuple[dict[tuple[str, str], dict[str, Any]], int]:
+    """Group runs by (provider, model) and accumulate token + frozen-cost totals.
 
-    Returns ``(per_model_aggregate, total_runs_with_tokens)``. Runs whose
-    ``tokens_json`` cannot be parsed contribute zero — we never raise from
-    a read-only display command.
+    The frozen-cost path reads each run's ``tokens_json.records[*].input_cost_usd``
+    + ``output_cost_usd`` (set by :class:`TokenTracker` on newer runs).
+    Older runs without the cost fields contribute zero to the frozen
+    total — those runs render with ``$ — (frozen)`` until the user re-
+    aggregates with ``--live``.
     """
-    per: dict[tuple[str, str], dict[str, int]] = {}
+    per: dict[tuple[str, str], dict[str, Any]] = {}
     counted = 0
     for run in runs:
         provider = str(run.get("llm_provider") or "(unknown)")
@@ -123,51 +80,126 @@ def _aggregate_runs(
             continue
         prompt_total = 0
         completion_total = 0
+        frozen_cost_total = 0.0
+        seen_cost_field = False
+        sources_seen: set[str] = set()
         for record in records:
             if not isinstance(record, dict):
                 continue
             prompt_total += int(record.get("prompt_tokens") or 0)
             completion_total += int(record.get("completion_tokens") or 0)
+            if "input_cost_usd" in record or "output_cost_usd" in record:
+                seen_cost_field = True
+                frozen_cost_total += float(record.get("input_cost_usd") or 0.0)
+                frozen_cost_total += float(record.get("output_cost_usd") or 0.0)
+            src = record.get("price_source")
+            if src:
+                sources_seen.add(str(src))
         if prompt_total == 0 and completion_total == 0:
             continue
         bucket = per.setdefault(
             (provider, model),
-            {"runs": 0, "input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            {
+                "runs": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "frozen_cost_usd": 0.0,
+                "frozen_cost_known": False,
+                "sources": set(),
+            },
         )
         bucket["runs"] += 1
         bucket["input_tokens"] += prompt_total
         bucket["output_tokens"] += completion_total
         bucket["total_tokens"] += prompt_total + completion_total
+        if seen_cost_field:
+            bucket["frozen_cost_known"] = True
+            bucket["frozen_cost_usd"] += frozen_cost_total
+        bucket["sources"] |= sources_seen
         counted += 1
     return per, counted
 
 
-def _format_cost(model: str, input_tokens: int, output_tokens: int) -> str:
-    pricing = _lookup_pricing(model)
-    if pricing is None:
+def _format_cost(cost: float, *, known: bool) -> str:
+    if not known:
         return "—"
-    input_usd = input_tokens * pricing[0] / 1_000_000.0
-    output_usd = output_tokens * pricing[1] / 1_000_000.0
-    total = input_usd + output_usd
-    if total < 0.01:
-        return "<$0.01"
-    return f"${total:,.2f}"
+    if cost <= 0.0:
+        return "$0.00"
+    if cost < 0.0001:
+        return "<$0.0001"
+    return f"${cost:,.4f}"
+
+
+def _format_sources(sources: set[str]) -> str:
+    """Render the price-source set as a compact, sorted label.
+
+    Multiple sources only happen when an aggregated bucket was filled
+    by runs that used different price tables (e.g. the user toggled
+    a custom override mid-week). Showing them comma-separated keeps
+    the audit trail honest without bloating the column.
+    """
+    if not sources:
+        return "—"
+    cleaned = sorted(s for s in sources if s)
+    return ", ".join(cleaned) if cleaned else "—"
+
+
+def _live_recompute(cfg: AMXConfig, bucket: dict[str, Any], model: str) -> tuple[float, str]:
+    """Recompute USD cost for one bucket using today's prices.
+
+    Resolution falls back to ``ModelPrice(0, 0, "unknown")`` when the
+    price is not known — the same contract :func:`lookup_price` always
+    returns. Caller renders the bucket as "$0.0000 (unknown)" so the
+    user sees the gap rather than a misleading zero.
+    """
+    price: ModelPrice = lookup_price(cfg, provider="", model=model)
+    _in, _out, total = compute_cost(
+        prompt_tokens=int(bucket["input_tokens"]),
+        completion_tokens=int(bucket["output_tokens"]),
+        price=price,
+    )
+    return total, price.source
+
+
+def _format_cache_age(seconds: float | None) -> str:
+    if seconds is None:
+        return "never (run /refresh-prices)"
+    if seconds < 60:
+        return f"{int(seconds)}s ago"
+    if seconds < 3600:
+        return f"{int(seconds / 60)}m ago"
+    if seconds < 86_400:
+        return f"{seconds / 3600.0:.1f}h ago"
+    return f"{seconds / 86_400.0:.1f}d ago"
 
 
 def cmd_usage(cfg: AMXConfig, rest: list[str]) -> None:
-    """Show LLM token usage and approximate cost.
+    """Show LLM token usage and USD cost.
 
     Usage::
 
-        /usage              # last 7 days (default)
+        /usage              # last 7 days, frozen costs (default)
         /usage 24h          # last 24 hours
-        /usage 7d           # last 7 days
         /usage 30d          # last 30 days
         /usage all          # since the SQLite history was created
+        /usage --live       # recompute with today's prices
+        /usage 30d --live   # combined
 
-    Reads ~/.amx/history.db. Local-only; no network calls.
+    Reads ~/.amx/history.db. Frozen costs come from the per-record USD
+    figures saved at run time; ``--live`` recomputes using current
+    prices fetched from LiteLLM / OpenRouter (cached locally — see
+    /refresh-prices).
     """
-    label, window_sec = _normalize_window(rest[0] if rest else "")
+    args = list(rest or [])
+    live = False
+    cleaned: list[str] = []
+    for arg in args:
+        if (arg or "").lower() in _LIVE_FLAGS:
+            live = True
+        else:
+            cleaned.append(arg)
+    label, window_sec = _normalize_window(cleaned[0] if cleaned else "")
     hs = history_store()
     if hs is None:
         warn(
@@ -208,7 +240,8 @@ def cmd_usage(cfg: AMXConfig, rest: list[str]) -> None:
 
     per_model, runs_with_tokens = _aggregate_runs(runs)
 
-    heading(f"LLM usage — last {label}")
+    mode_label = "live" if live else "frozen"
+    heading(f"LLM usage — last {label} ({mode_label})")
     info(
         f"  {len(runs)} runs scanned, {runs_with_tokens} with token data. "
         f"Source: ~/.amx/history.db (local only)."
@@ -218,7 +251,6 @@ def cmd_usage(cfg: AMXConfig, rest: list[str]) -> None:
         warn("None of the scanned runs recorded token usage.")
         return
 
-    # Sort heaviest-first so the user sees the dominant cost line at top.
     sorted_keys = sorted(
         per_model.keys(),
         key=lambda key: per_model[key]["total_tokens"],
@@ -226,20 +258,24 @@ def cmd_usage(cfg: AMXConfig, rest: list[str]) -> None:
     )
     table_rows: list[list[object]] = []
     grand_in = grand_out = grand_total = 0
-    grand_cost_known = 0.0
-    grand_cost_seen = False
+    grand_cost = 0.0
+    grand_cost_known = False
     for provider, model in sorted_keys:
         bucket = per_model[(provider, model)]
         in_tokens = bucket["input_tokens"]
         out_tokens = bucket["output_tokens"]
         total = bucket["total_tokens"]
-        cost = _format_cost(model, in_tokens, out_tokens)
-        if cost not in {"—"}:
-            grand_cost_seen = True
-            pricing = _lookup_pricing(model)
-            if pricing:
-                grand_cost_known += in_tokens * pricing[0] / 1_000_000.0
-                grand_cost_known += out_tokens * pricing[1] / 1_000_000.0
+        if live:
+            cost_value, live_source = _live_recompute(cfg, bucket, model)
+            cost_known = live_source != "unknown"
+            sources_label = live_source
+        else:
+            cost_value = float(bucket["frozen_cost_usd"])
+            cost_known = bool(bucket["frozen_cost_known"])
+            sources_label = _format_sources(bucket["sources"])
+        if cost_known:
+            grand_cost_known = True
+            grand_cost += cost_value
         table_rows.append(
             [
                 provider,
@@ -248,7 +284,8 @@ def cmd_usage(cfg: AMXConfig, rest: list[str]) -> None:
                 f"{in_tokens:,}",
                 f"{out_tokens:,}",
                 f"{total:,}",
-                cost,
+                _format_cost(cost_value, known=cost_known),
+                sources_label,
             ]
         )
         grand_in += in_tokens
@@ -263,15 +300,23 @@ def cmd_usage(cfg: AMXConfig, rest: list[str]) -> None:
             f"[bold]{grand_in:,}[/bold]",
             f"[bold]{grand_out:,}[/bold]",
             f"[bold]{grand_total:,}[/bold]",
-            (f"[bold]≈ ${grand_cost_known:,.2f}[/bold]" if grand_cost_seen else "—"),
+            (
+                f"[bold]{_format_cost(grand_cost, known=grand_cost_known)}[/bold]"
+                if grand_cost_known
+                else "—"
+            ),
+            "",
         ]
     )
     render_table(
-        f"Usage ({label})",
-        ["Provider", "Model", "Runs", "Input", "Output", "Total", "Cost (approx)"],
+        f"Usage ({label}, {mode_label})",
+        ["Provider", "Model", "Runs", "Input", "Output", "Total", "Cost (USD)", "Source"],
         table_rows,
     )
-    info(
-        "Cost is approximate — based on a built-in price table and the actual "
-        "token counts you used. For exact spend, check your provider dashboard."
-    )
+    age = _format_cache_age(cache_age_seconds())
+    if live:
+        info(f"Live recompute against current prices. Cache last refreshed: {age}.")
+        info("Run /refresh-prices to pull the latest LiteLLM + OpenRouter price tables.")
+    else:
+        info(f"Frozen costs as recorded at run time. Price cache last refreshed: {age}.")
+        info("Pass --live to recompute against today's prices.")

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -62,6 +62,9 @@ from amx.cli_support.commands.profiles import (
     cmd_code_profiles as _cmd_code_profiles,
 )
 from amx.cli_support.commands.profiles import (
+    cmd_cost as _cmd_cost,
+)
+from amx.cli_support.commands.profiles import (
     cmd_description_verbosity as _cmd_description_verbosity,
 )
 from amx.cli_support.commands.profiles import (
@@ -87,6 +90,9 @@ from amx.cli_support.commands.profiles import (
 )
 from amx.cli_support.commands.profiles import (
     cmd_prompt_detail as _cmd_prompt_detail,
+)
+from amx.cli_support.commands.profiles import (
+    cmd_refresh_prices as _cmd_refresh_prices,
 )
 from amx.cli_support.commands.profiles import (
     cmd_remove_code_profile as _cmd_remove_code_profile,
@@ -863,6 +869,16 @@ def _handle_session_builtin(
         if not _require_namespace(head, namespace, "llm", "max-tokens"):
             return True
         _cmd_max_tokens(cfg, parts[1:])
+        return True
+    if head == "cost":
+        if not _require_namespace(head, namespace, "llm", "cost"):
+            return True
+        _cmd_cost(cfg, parts[1:])
+        return True
+    if head in ("refresh-prices", "refresh_prices"):
+        if not _require_namespace(head, namespace, "llm", "refresh-prices"):
+            return True
+        _cmd_refresh_prices(cfg, parts[1:])
         return True
     if head == "doc-profiles":
         if not _require_namespace(head, namespace, "docs", "doc-profiles"):

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -237,6 +237,17 @@ _LLM_COMMANDS: tuple[SlashCommand, ...] = (
         "llm",
         "Show/set LLM output token budget (/max-tokens [N]) — reasoning models keep their floor",
     ),
+    SlashCommand(
+        "/cost",
+        "llm",
+        "Show/set per-1M-token cost override for the active profile "
+        "(/cost [<input> <output> | reset])",
+    ),
+    SlashCommand(
+        "/refresh-prices",
+        "llm",
+        "Re-fetch LLM prices from LiteLLM + OpenRouter (24h cache)",
+    ),
     # Batching (throughput)
     SlashCommand(
         "/llm-batch-size", "llm", "Show/set number of columns per LLM call (/llm-batch-size [N])"

--- a/amx/config.py
+++ b/amx/config.py
@@ -1026,6 +1026,14 @@ class LLMConfig(_ObservableConfig):
     # thinking). Only consumed when the model supports reasoning AND a caller
     # passes ``on_thinking`` to ``LLMProvider.chat``; otherwise ignored.
     thinking_budget: int = 1024
+    # User-defined cost override in USD per 1M tokens. When BOTH are set,
+    # they win over fetched LiteLLM / OpenRouter prices (resolution order
+    # in ``amx/llm/pricing.py:lookup_price``). A half-override — only
+    # input or only output — is treated as no override to avoid the
+    # "set output, forgot input" footgun where AMX would silently bill
+    # the user at "free input + market output" or vice versa.
+    custom_input_cost_per_mtok: float | None = None
+    custom_output_cost_per_mtok: float | None = None
 
     @property
     def prompt_detail_cfg(self) -> PromptDetail:
@@ -1063,7 +1071,29 @@ def _llm_from_mapping(m: dict[str, Any]) -> LLMConfig:
         logprob_medium=float(m.get("logprob_medium", 0.50)),
         force_logprobs=bool(m.get("force_logprobs", True)),
         thinking_budget=int(m.get("thinking_budget", 1024)),
+        custom_input_cost_per_mtok=_optional_nonneg_float(m.get("custom_input_cost_per_mtok")),
+        custom_output_cost_per_mtok=_optional_nonneg_float(m.get("custom_output_cost_per_mtok")),
     )
+
+
+def _optional_nonneg_float(value: Any) -> float | None:
+    """Coerce a YAML scalar to ``float | None`` for cost overrides.
+
+    Empty string -> None (Studio sends ``""`` when the user clears the
+    field). Negative -> None (a negative rate would silently subtract
+    from the aggregate cost — almost certainly a typo).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f < 0:
+        return None
+    return f
 
 
 def _llm_to_mapping(llm: LLMConfig) -> dict[str, Any]:
@@ -1087,6 +1117,8 @@ def _llm_to_mapping(llm: LLMConfig) -> dict[str, Any]:
         "logprob_medium": llm.logprob_medium,
         "force_logprobs": llm.force_logprobs,
         "thinking_budget": llm.thinking_budget,
+        "custom_input_cost_per_mtok": llm.custom_input_cost_per_mtok,
+        "custom_output_cost_per_mtok": llm.custom_output_cost_per_mtok,
     }
 
 

--- a/amx/llm/pricing.py
+++ b/amx/llm/pricing.py
@@ -1,0 +1,532 @@
+"""Live LLM cost tracking.
+
+Resolve a per-million-token price for any (provider, model) pair so AMX
+can render real USD cost alongside its existing token totals.
+
+Resolution order:
+
+    1. **User override** — ``LLMConfig.custom_input_cost_per_mtok`` /
+       ``custom_output_cost_per_mtok``. Both must be set; a half-override
+       is treated as no override (avoids the "set output, forgot input"
+       footgun where output rate * every token would overstate cost).
+    2. **LiteLLM hosted JSON** —
+       ``raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json``.
+       Single source of truth for ~300+ models, updated frequently by
+       Berri AI; covers OpenAI, Anthropic, Gemini, OpenRouter routes,
+       Bedrock, etc. Public, no auth.
+    3. **OpenRouter ``/v1/models``** — only consulted for ``openrouter/*``
+       routes the LiteLLM JSON misses (newly-launched routes typically
+       appear here days before the LiteLLM file). Public, no auth.
+    4. **Bundled fallback snapshot** (``pricing_fallback.json`` next to
+       this module) — last-known-good values for ~30 popular models.
+       Used when both network sources fail (offline, fresh install,
+       enterprise behind a strict proxy).
+    5. **Zero / unknown** — ``ModelPrice(0, 0, source="unknown")`` with
+       a once-per-session WARN log so the user knows cost is undercounted.
+
+Costs are persisted into ``analysis_runs.tokens_json`` at run time
+(audit trail / "what did this actually cost when prices were X"). The
+``/usage --live`` flag and the Studio "Recompute with current prices"
+toggle re-run :func:`compute_cost` against the fresh prices for the
+same recorded token totals so users can see "with today's prices, the
+same workload would cost Y".
+
+All disk + network access is contained here. Other modules import
+:func:`lookup_price` and :func:`compute_cost` only.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from importlib.resources import files as _resource_files
+from pathlib import Path
+from typing import Any
+
+from amx.utils.logging import get_logger
+
+log = get_logger("llm.pricing")
+
+# ── Public types ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class ModelPrice:
+    """Per-million-token rates for one model.
+
+    ``input_per_mtok`` and ``output_per_mtok`` are in USD per 1M tokens
+    (the same scale users see on provider pricing pages). ``source``
+    identifies which resolution layer produced the price so the UI can
+    render "OpenRouter says $0.30/$2.50" vs "User override $1.00/$5.00".
+    ``fetched_at`` is the epoch when the source data was downloaded;
+    ``None`` for user overrides + bundled fallback (those aren't network
+    fetches).
+    """
+
+    input_per_mtok: float
+    output_per_mtok: float
+    source: str  # "user_override" | "litellm" | "openrouter" | "fallback" | "unknown"
+    fetched_at: float | None = None
+
+    @property
+    def is_known(self) -> bool:
+        return self.source != "unknown"
+
+
+# ── Cache + fetch internals ────────────────────────────────────────────────
+
+_CACHE_TTL_SEC: float = 24 * 60 * 60  # 24h
+_LITELLM_URL = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+)
+_OPENROUTER_URL = "https://openrouter.ai/api/v1/models"
+_HTTP_TIMEOUT_SEC = 8.0
+
+# Logged once per (provider, model) per session so a 200-table run does
+# not produce 200 identical "unknown price" lines.
+_UNKNOWN_PRICE_WARNED: set[str] = set()
+_PRICING_LOCK = threading.Lock()
+
+
+def _cache_path() -> Path:
+    return Path.home() / ".amx" / "pricing-cache.json"
+
+
+def _load_cache() -> dict[str, Any]:
+    """Read the on-disk cache; return ``{}`` when missing or unreadable.
+
+    Never raises — a malformed cache must not stop AMX from running; the
+    next refresh writes a fresh copy.
+    """
+    path = _cache_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - cache is best-effort
+        log.debug("pricing cache unreadable, ignoring: %s", exc)
+        return {}
+
+
+def _write_cache(payload: dict[str, Any]) -> None:
+    path = _cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - cache write is best-effort
+        log.debug("could not persist pricing cache: %s", exc)
+
+
+def _http_get_json(url: str, *, headers: dict[str, str] | None = None) -> Any:
+    """Minimal stdlib HTTP GET -> JSON. Stays out of httpx/urllib3 dep tree.
+
+    Raises ``urllib.error.URLError`` / ``json.JSONDecodeError`` so callers
+    can swallow the failure and fall back to the next resolution layer.
+    """
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SEC) as resp:
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw)
+
+
+def fetch_litellm_prices() -> dict[str, ModelPrice]:
+    """Download Berri AI's hosted price table.
+
+    The JSON keys are model identifiers as LiteLLM understands them
+    (e.g. ``"gpt-4o-mini"``, ``"claude-3-5-haiku"``,
+    ``"openrouter/openai/gpt-4o-mini"``). Each entry has
+    ``input_cost_per_token`` / ``output_cost_per_token`` in *USD per
+    token*; we multiply by 1e6 to land in $/Mtok.
+
+    Returns model_id -> ModelPrice. Models without both rates are skipped.
+    """
+    raw = _http_get_json(_LITELLM_URL)
+    out: dict[str, ModelPrice] = {}
+    now = time.time()
+    for model_id, payload in (raw or {}).items():
+        if not isinstance(payload, dict) or model_id == "sample_spec":
+            continue
+        in_per_token = payload.get("input_cost_per_token")
+        out_per_token = payload.get("output_cost_per_token")
+        if in_per_token is None and out_per_token is None:
+            continue
+        try:
+            in_rate = float(in_per_token or 0.0) * 1_000_000.0
+            out_rate = float(out_per_token or 0.0) * 1_000_000.0
+        except (TypeError, ValueError):
+            continue
+        out[str(model_id).lower()] = ModelPrice(
+            input_per_mtok=in_rate,
+            output_per_mtok=out_rate,
+            source="litellm",
+            fetched_at=now,
+        )
+    return out
+
+
+def fetch_openrouter_prices() -> dict[str, ModelPrice]:
+    """Download OpenRouter's public model list.
+
+    Each entry has ``id`` (e.g. ``"openai/gpt-4o-mini"``) and ``pricing``
+    with ``prompt`` / ``completion`` strings expressed in *USD per token*
+    (parsed via ``float()``). We apply the same x1e6 conversion as the
+    LiteLLM source so callers get a consistent $/Mtok scale.
+    """
+    raw = _http_get_json(_OPENROUTER_URL)
+    out: dict[str, ModelPrice] = {}
+    now = time.time()
+    items = raw.get("data") if isinstance(raw, dict) else raw
+    if not isinstance(items, list):
+        return out
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        model_id = str(entry.get("id") or "").lower()
+        pricing = entry.get("pricing") or {}
+        if not model_id or not isinstance(pricing, dict):
+            continue
+        try:
+            in_rate = float(pricing.get("prompt", 0) or 0) * 1_000_000.0
+            out_rate = float(pricing.get("completion", 0) or 0) * 1_000_000.0
+        except (TypeError, ValueError):
+            continue
+        out[model_id] = ModelPrice(
+            input_per_mtok=in_rate,
+            output_per_mtok=out_rate,
+            source="openrouter",
+            fetched_at=now,
+        )
+    return out
+
+
+def _load_bundled_fallback() -> dict[str, ModelPrice]:
+    """Read the snapshot shipped inside the wheel as last-resort."""
+    try:
+        text = (
+            _resource_files("amx.llm").joinpath("pricing_fallback.json").read_text(encoding="utf-8")
+        )
+    except Exception as exc:  # pragma: no cover - bundled file always present
+        log.warning("bundled pricing fallback unreadable: %s", exc)
+        return {}
+    try:
+        payload = json.loads(text)
+    except Exception:
+        return {}
+    out: dict[str, ModelPrice] = {}
+    for model_id, rates in (payload.get("models") or {}).items():
+        try:
+            out[str(model_id).lower()] = ModelPrice(
+                input_per_mtok=float(rates.get("input", 0.0)),
+                output_per_mtok=float(rates.get("output", 0.0)),
+                source="fallback",
+                fetched_at=None,
+            )
+        except (TypeError, ValueError, AttributeError):
+            continue
+    return out
+
+
+# In-memory state. Module-level so a fresh ``lookup_price`` after
+# a refresh sees the new prices without re-reading from disk.
+_PRICES: dict[str, dict[str, ModelPrice]] = {
+    "litellm": {},
+    "openrouter": {},
+    "fallback": {},
+}
+_FETCHED_AT: float | None = None
+_BUNDLED_LOADED = False
+
+
+def _ensure_loaded() -> None:
+    """Lazily populate the in-memory price tables.
+
+    On first call: load the on-disk cache (if any) and supplement from
+    the bundled fallback for offline/fresh-install paths. We do NOT
+    fetch from the network here — that would block the first LLM call
+    on a slow connection. Refresh is explicit (``/refresh-prices``) or
+    via the ``cache_info`` "is_stale" flag the UI surfaces.
+    """
+    global _FETCHED_AT, _BUNDLED_LOADED
+    with _PRICING_LOCK:
+        if not _BUNDLED_LOADED:
+            _PRICES["fallback"] = _load_bundled_fallback()
+            _BUNDLED_LOADED = True
+        cache = _load_cache()
+        cache_fetched = float(cache.get("fetched_at") or 0.0) or None
+        if cache_fetched and not _FETCHED_AT:
+            _FETCHED_AT = cache_fetched
+            litellm_raw = cache.get("litellm") or {}
+            for model_id, rates in litellm_raw.items():
+                _PRICES["litellm"][str(model_id).lower()] = ModelPrice(
+                    input_per_mtok=float(rates.get("input_per_mtok", 0.0)),
+                    output_per_mtok=float(rates.get("output_per_mtok", 0.0)),
+                    source="litellm",
+                    fetched_at=cache_fetched,
+                )
+            openrouter_raw = cache.get("openrouter") or {}
+            for model_id, rates in openrouter_raw.items():
+                _PRICES["openrouter"][str(model_id).lower()] = ModelPrice(
+                    input_per_mtok=float(rates.get("input_per_mtok", 0.0)),
+                    output_per_mtok=float(rates.get("output_per_mtok", 0.0)),
+                    source="openrouter",
+                    fetched_at=cache_fetched,
+                )
+
+
+def cache_age_seconds() -> float | None:
+    """How long ago was the cache fetched? ``None`` when never fetched."""
+    _ensure_loaded()
+    if _FETCHED_AT is None:
+        return None
+    return max(0.0, time.time() - _FETCHED_AT)
+
+
+def cache_info() -> dict[str, Any]:
+    """Snapshot for the Studio ``GET /api/pricing/cache-info`` endpoint."""
+    _ensure_loaded()
+    return {
+        "fetched_at": _FETCHED_AT,
+        "age_seconds": cache_age_seconds(),
+        "ttl_seconds": _CACHE_TTL_SEC,
+        "is_stale": _FETCHED_AT is None or (time.time() - _FETCHED_AT > _CACHE_TTL_SEC),
+        "litellm_count": len(_PRICES.get("litellm") or {}),
+        "openrouter_count": len(_PRICES.get("openrouter") or {}),
+        "fallback_count": len(_PRICES.get("fallback") or {}),
+    }
+
+
+def refresh_prices(*, force: bool = False) -> dict[str, Any]:
+    """Fetch fresh prices from both network sources + persist to cache.
+
+    Idempotent: calling twice in quick succession both succeed and write
+    the same cache. Returns
+    ``{"litellm": N, "openrouter": M, "errors": [..], "skipped": bool}``
+    so callers can render a "Updated 312 LiteLLM + 287 OpenRouter
+    models" confirmation. With ``force=False`` and a fresh cache
+    (< TTL), this is a no-op that returns the existing counts.
+    """
+    global _FETCHED_AT
+    _ensure_loaded()
+    if not force and _FETCHED_AT and (time.time() - _FETCHED_AT) < _CACHE_TTL_SEC:
+        return {
+            "litellm": len(_PRICES["litellm"]),
+            "openrouter": len(_PRICES["openrouter"]),
+            "errors": [],
+            "skipped": True,
+        }
+
+    errors: list[str] = []
+    try:
+        new_litellm = fetch_litellm_prices()
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+        new_litellm = {}
+        errors.append(f"litellm: {exc.__class__.__name__}: {exc}")
+    try:
+        new_openrouter = fetch_openrouter_prices()
+    except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+        new_openrouter = {}
+        errors.append(f"openrouter: {exc.__class__.__name__}: {exc}")
+
+    with _PRICING_LOCK:
+        if new_litellm:
+            _PRICES["litellm"] = new_litellm
+        if new_openrouter:
+            _PRICES["openrouter"] = new_openrouter
+        if new_litellm or new_openrouter:
+            _FETCHED_AT = time.time()
+            _write_cache(
+                {
+                    "fetched_at": _FETCHED_AT,
+                    "litellm": {k: asdict(v) for k, v in _PRICES["litellm"].items()},
+                    "openrouter": {k: asdict(v) for k, v in _PRICES["openrouter"].items()},
+                }
+            )
+
+    return {
+        "litellm": len(_PRICES["litellm"]),
+        "openrouter": len(_PRICES["openrouter"]),
+        "errors": errors,
+        "skipped": False,
+    }
+
+
+# ── Lookup ─────────────────────────────────────────────────────────────────
+
+
+def _normalize_model_id(provider: str, model: str) -> list[str]:
+    """Generate the candidate keys to probe in each price source.
+
+    LiteLLM uses bare model ids for OpenAI/Anthropic but
+    ``openrouter/<vendor>/<model>`` for OpenRouter routes. OpenRouter
+    uses ``<vendor>/<model>``. The bundled fallback is keyed by
+    ``<vendor>/<model>``. We generate a richer candidate list so all
+    three keying conventions hit:
+
+    1. The raw model id as typed (``"claude-sonnet-4-20250514"``).
+    2. Strip provider prefixes one segment at a time (``"openai/gpt-4o"``
+       -> ``"gpt-4o"``).
+    3. Strip dated / version suffixes (``"-20250514"``, ``"-v2"``,
+       ``"-latest"``, etc).
+    4. Re-attach a ``<provider>/<model>`` form so the fallback table —
+       which uses provider-prefixed keys — gets hit when the caller
+       passed only the bare model id.
+    5. For OpenRouter, also try the ``openrouter/<full>`` form which
+       LiteLLM uses for those routes.
+    """
+    name = (model or "").strip().lower()
+    candidates: list[str] = []
+    if not name:
+        return candidates
+    candidates.append(name)
+    while "/" in name:
+        name = name.split("/", 1)[1]
+        candidates.append(name)
+    full = (model or "").strip().lower()
+    prov = (provider or "").strip().lower()
+    base = candidates[0]
+    for sep in ("-2024", "-2025", "-2026", "-v", "-latest", "-beta", "-preview"):
+        if sep in base:
+            head = base.split(sep, 1)[0]
+            if head not in candidates:
+                candidates.append(head)
+    # Re-attach ``<provider>/<X>`` for every bare candidate so the
+    # bundled fallback (provider-prefixed keys) and LiteLLM
+    # (occasionally provider-prefixed keys) both have a chance to hit.
+    if prov:
+        for cand in list(candidates):
+            if "/" not in cand:
+                candidates.append(f"{prov}/{cand}")
+    if prov == "openrouter" and "/" in full:
+        candidates.append(f"openrouter/{full}")
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for cand in candidates:
+        if cand and cand not in seen:
+            seen.add(cand)
+            deduped.append(cand)
+    return deduped
+
+
+def _user_override(cfg: Any, profile_name: str | None) -> ModelPrice | None:
+    """Pull custom rates off the named LLMConfig profile.
+
+    Half-override (only one of input/output set) -> ``None`` so the
+    user does not accidentally bill themselves at "free input + market
+    output" or vice versa.
+
+    Accepts either an ``AMXConfig`` (looks up
+    ``cfg.llm_profiles[profile_name]`` then falls back to ``cfg.llm``)
+    or a bare ``LLMConfig`` (reads its custom fields directly).
+    """
+    if cfg is None:
+        return None
+    target = None
+    if profile_name and getattr(cfg, "llm_profiles", None):
+        target = cfg.llm_profiles.get(profile_name)
+    if target is None:
+        target = getattr(cfg, "llm", None)
+    if target is None and hasattr(cfg, "custom_input_cost_per_mtok"):
+        target = cfg
+    if target is None:
+        return None
+    in_rate = getattr(target, "custom_input_cost_per_mtok", None)
+    out_rate = getattr(target, "custom_output_cost_per_mtok", None)
+    if in_rate is None or out_rate is None:
+        return None
+    try:
+        return ModelPrice(
+            input_per_mtok=float(in_rate),
+            output_per_mtok=float(out_rate),
+            source="user_override",
+            fetched_at=None,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def lookup_price(
+    cfg: Any,
+    *,
+    provider: str,
+    model: str,
+    profile_name: str | None = None,
+) -> ModelPrice:
+    """Resolve a price using the documented order.
+
+    ``cfg`` is an :class:`AMXConfig` (typed ``Any`` to avoid a cyclic
+    import). Pass ``profile_name`` to target a specific LLM profile —
+    the wizard / Settings hint reads this when the user has not
+    activated the profile yet.
+    """
+    _ensure_loaded()
+    override = _user_override(cfg, profile_name)
+    if override is not None:
+        return override
+    candidates = _normalize_model_id(provider, model)
+    for source_key in ("litellm", "openrouter", "fallback"):
+        table = _PRICES.get(source_key) or {}
+        for cand in candidates:
+            hit = table.get(cand)
+            if hit is not None:
+                return hit
+    key = f"{(provider or '').lower()}|{(model or '').lower()}"
+    if key not in _UNKNOWN_PRICE_WARNED:
+        _UNKNOWN_PRICE_WARNED.add(key)
+        log.info(
+            "No price entry for provider=%s model=%s -- cost will display as $0.00. "
+            "Run /refresh-prices or set a custom override via /cost.",
+            provider,
+            model,
+        )
+    return ModelPrice(0.0, 0.0, source="unknown", fetched_at=None)
+
+
+# ── Cost compute ───────────────────────────────────────────────────────────
+
+
+def compute_cost(
+    *,
+    prompt_tokens: int,
+    completion_tokens: int,
+    price: ModelPrice,
+) -> tuple[float, float, float]:
+    """Return ``(input_usd, output_usd, total_usd)``.
+
+    ``ModelPrice`` rates are USD per 1M tokens; we divide token counts
+    by 1e6 before multiplying. Negative or non-int token counts are
+    coerced to zero so a single bad usage payload does not poison the
+    aggregate.
+    """
+    p_tok = max(0, int(prompt_tokens or 0))
+    c_tok = max(0, int(completion_tokens or 0))
+    in_usd = (p_tok / 1_000_000.0) * float(price.input_per_mtok or 0.0)
+    out_usd = (c_tok / 1_000_000.0) * float(price.output_per_mtok or 0.0)
+    return in_usd, out_usd, in_usd + out_usd
+
+
+def reset_state_for_tests() -> None:
+    """Drop in-memory state so unit tests start from a clean slate."""
+    global _FETCHED_AT, _BUNDLED_LOADED
+    with _PRICING_LOCK:
+        for table in _PRICES.values():
+            table.clear()
+        _FETCHED_AT = None
+        _BUNDLED_LOADED = False
+        _UNKNOWN_PRICE_WARNED.clear()
+
+
+__all__ = [
+    "ModelPrice",
+    "cache_age_seconds",
+    "cache_info",
+    "compute_cost",
+    "fetch_litellm_prices",
+    "fetch_openrouter_prices",
+    "lookup_price",
+    "refresh_prices",
+    "reset_state_for_tests",
+]

--- a/amx/llm/pricing_fallback.json
+++ b/amx/llm/pricing_fallback.json
@@ -1,0 +1,42 @@
+{
+  "_meta": {
+    "description": "Bundled fallback pricing snapshot used when both LiteLLM's hosted JSON and OpenRouter's /v1/models are unreachable. Values are USD per 1M tokens (input, output). Updated 2026-05.",
+    "snapshot_date": "2026-05-08",
+    "currency": "USD",
+    "scale": "per_million_tokens"
+  },
+  "models": {
+    "openai/gpt-5.4-mini": { "input": 0.75, "output": 4.50 },
+    "openai/gpt-5.4": { "input": 5.00, "output": 20.00 },
+    "openai/gpt-5.5": { "input": 8.00, "output": 32.00 },
+    "openai/gpt-5": { "input": 10.00, "output": 40.00 },
+    "openai/gpt-4.1-mini": { "input": 0.40, "output": 1.60 },
+    "openai/gpt-4.1": { "input": 2.00, "output": 8.00 },
+    "openai/gpt-4o": { "input": 2.50, "output": 10.00 },
+    "openai/gpt-4o-mini": { "input": 0.15, "output": 0.60 },
+    "openai/o1": { "input": 15.00, "output": 60.00 },
+    "openai/o1-mini": { "input": 3.00, "output": 12.00 },
+    "openai/o3-mini": { "input": 1.10, "output": 4.40 },
+    "openai/text-embedding-3-small": { "input": 0.02, "output": 0.0 },
+    "openai/text-embedding-3-large": { "input": 0.13, "output": 0.0 },
+    "anthropic/claude-haiku-4.5": { "input": 1.00, "output": 5.00 },
+    "anthropic/claude-haiku-4": { "input": 0.80, "output": 4.00 },
+    "anthropic/claude-sonnet-4.6": { "input": 3.00, "output": 15.00 },
+    "anthropic/claude-sonnet-4-5": { "input": 3.00, "output": 15.00 },
+    "anthropic/claude-sonnet-4": { "input": 3.00, "output": 15.00 },
+    "anthropic/claude-opus-4.6": { "input": 15.00, "output": 75.00 },
+    "anthropic/claude-opus-4": { "input": 15.00, "output": 75.00 },
+    "anthropic/claude-3-5-sonnet": { "input": 3.00, "output": 15.00 },
+    "anthropic/claude-3-5-haiku": { "input": 0.80, "output": 4.00 },
+    "google/gemini-2.5-flash": { "input": 0.30, "output": 2.50 },
+    "google/gemini-2.5-pro": { "input": 1.25, "output": 10.00 },
+    "google/gemini-3-flash": { "input": 0.40, "output": 3.00 },
+    "google/gemini-2.0-flash": { "input": 0.10, "output": 0.40 },
+    "deepseek/deepseek-chat-v4": { "input": 0.30, "output": 0.50 },
+    "deepseek/deepseek-chat": { "input": 0.27, "output": 1.10 },
+    "deepseek/deepseek-reasoner": { "input": 0.55, "output": 2.19 },
+    "moonshotai/kimi-k2": { "input": 0.20, "output": 0.80 },
+    "moonshotai/kimi-k2.6": { "input": 0.30, "output": 1.20 },
+    "x-ai/grok-4": { "input": 5.00, "output": 25.00 }
+  }
+}

--- a/amx/utils/console.py
+++ b/amx/utils/console.py
@@ -508,7 +508,15 @@ def advance_file_progress(progress: Progress, filename: str = "") -> None:
 
 
 def render_token_summary(tracker: object) -> None:
-    """Render a Rich table summarising per-step token usage."""
+    """Render a Rich table summarising per-step token usage and cost.
+
+    The cost column is populated from the per-record USD figures the
+    :class:`TokenTracker` accumulated during the run (frozen at the
+    moment of the call). Steps whose price source was ``"unknown"``
+    contribute zero to the grand total — the user sees ``$0.0000`` and
+    knows to set a custom override via ``/cost`` or refresh the price
+    cache via ``/refresh-prices``.
+    """
     from amx.utils.token_tracker import TokenTracker
 
     if not isinstance(tracker, TokenTracker) or not tracker.has_records:
@@ -519,17 +527,29 @@ def render_token_summary(tracker: object) -> None:
     table.add_column("Input", justify="right")
     table.add_column("Output", justify="right")
     table.add_column("Total", justify="right", style="bold")
+    table.add_column("Cost (USD)", justify="right")
     tot_in = tot_out = tot_all = 0
-    for step, inp, out, total in rows:
-        table.add_row(step, f"{inp:,}", f"{out:,}", f"{total:,}")
+    tot_cost = 0.0
+    for row in rows:
+        step, inp, out, total, *cost_parts = row
+        cost = float(cost_parts[0]) if cost_parts else 0.0
+        table.add_row(
+            step,
+            f"{inp:,}",
+            f"{out:,}",
+            f"{total:,}",
+            f"${cost:,.4f}" if cost > 0 else "—",
+        )
         tot_in += inp
         tot_out += out
         tot_all += total
+        tot_cost += cost
     table.add_section()
     table.add_row(
         "[bold]TOTAL[/bold]",
         f"[bold]{tot_in:,}[/bold]",
         f"[bold]{tot_out:,}[/bold]",
         f"[bold]{tot_all:,}[/bold]",
+        (f"[bold]${tot_cost:,.4f}[/bold]" if tot_cost > 0 else "—"),
     )
     console.print(table)

--- a/amx/utils/cost_estimate.py
+++ b/amx/utils/cost_estimate.py
@@ -1,0 +1,204 @@
+"""Pre-call output-token estimation.
+
+``tiktoken`` measures the prompt exactly; the *output* — which dominates
+cost on most modern models — has to be estimated. We learn a per-(agent,
+model) ratio from the last ~30 days of recorded runs:
+
+    ratio = AVG(completion_tokens / prompt_tokens)
+
+and apply it to the freshly-counted prompt to project an output budget
+the user can see *before* the LLM call goes out. When there is no
+history (fresh install, brand-new agent/model combination) we fall
+back to a per-agent default that matches AMX's structured-output
+shape (Profile / RAG / Code agents emit ~50% the prompt size on
+average; the merge agent is much terser).
+
+The result feeds :func:`amx.utils.live_display.LiveDisplay.add_session_tokens`
+so the header rendering can display "↓ 4.2k tokens · ~$0.0008" before
+the call returns. Both surfaces label the projected number with a
+leading ``~`` so the user knows it is a learned estimate, not an
+exact figure.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any
+
+from amx.utils.logging import get_logger
+
+log = get_logger("utils.cost_estimate")
+
+# Per-agent fallback ratios used when no history exists. Tuned from
+# observed completion/prompt averages across AMX's typical workloads
+# (English metadata generation against medium-cardinality DBs).
+_DEFAULT_RATIOS: dict[str, float] = {
+    "profile_agent": 0.60,
+    "profile_agent(batch)": 0.50,
+    "rag_agent": 0.40,
+    "rag_agent(batch)": 0.40,
+    "code_agent": 0.50,
+    "code_agent(batch)": 0.50,
+    "merge": 0.30,
+    "equivalence_agent": 0.45,
+}
+_GLOBAL_DEFAULT_RATIO = 0.55
+
+# Sample-size floor: fewer than this many historical records and we do
+# not trust the empirical mean enough to override the per-agent default.
+# Keeps the very first run on a new model from anchoring on a single
+# outlier.
+_MIN_SAMPLES = 3
+# History window for the running average. 30 days * 86400 sec.
+_LEARNING_WINDOW_SEC = 30 * 86_400.0
+# Cache invalidation TTL: refresh the learned table every 5 minutes
+# during a long session so a long-running process picks up new data
+# from completed runs without restarting.
+_CACHE_REFRESH_SEC = 300.0
+
+
+_LOCK = threading.Lock()
+_RATIO_CACHE: dict[tuple[str, str], float] = {}
+_CACHE_LOADED_AT: float = 0.0
+
+
+def _default_ratio(agent_name: str) -> float:
+    return _DEFAULT_RATIOS.get(agent_name, _GLOBAL_DEFAULT_RATIO)
+
+
+def _query_history_ratios(history_store: Any) -> dict[tuple[str, str], tuple[float, int]]:
+    """Aggregate ``completion / prompt`` ratios per (agent, model) over the window.
+
+    Returns ``{(step, model_lower): (mean_ratio, sample_count)}``. We
+    walk every ``analysis_runs.tokens_json.records`` entry within
+    ``_LEARNING_WINDOW_SEC`` of now; old runs are excluded so a tariff
+    change or model swap does not keep biasing the estimate forever.
+
+    Robust to malformed payloads — any individual record that fails to
+    parse is silently skipped. The function never raises (returns ``{}``
+    on a wholesale read failure) so a corrupt history database cannot
+    break a live run.
+    """
+    if history_store is None:
+        return {}
+    cutoff = time.time() - _LEARNING_WINDOW_SEC
+    aggregates: dict[tuple[str, str], list[float]] = {}
+    try:
+        with history_store._connect() as conn:  # noqa: SLF001 - read-only
+            rows = conn.execute(
+                """
+                SELECT tokens_json
+                FROM analysis_runs
+                WHERE started_at >= ?
+                  AND tokens_json IS NOT NULL
+                  AND tokens_json != ''
+                """,
+                (cutoff,),
+            ).fetchall()
+    except Exception as exc:  # noqa: BLE001 - cost estimate is opportunistic
+        log.debug("learned-ratio history read failed: %s", exc)
+        return {}
+    for row in rows:
+        raw = row[0] if not isinstance(row, dict) else row.get("tokens_json")
+        if not raw:
+            continue
+        try:
+            payload = json.loads(raw) if isinstance(raw, str) else dict(raw)
+        except Exception:
+            continue
+        for record in payload.get("records") or []:
+            if not isinstance(record, dict):
+                continue
+            prompt = float(record.get("prompt_tokens") or 0.0)
+            completion = float(record.get("completion_tokens") or 0.0)
+            if prompt <= 0 or completion <= 0:
+                continue
+            step = str(record.get("step") or "").strip()
+            model = str(record.get("model") or "").strip().lower()
+            if not step:
+                continue
+            key = (step, model)
+            ratio = completion / prompt
+            # Clamp pathological ratios. Reasoning models that burn
+            # 8k thinking tokens on a 100-token prompt produce ratios
+            # like 80x — useful as a "this run was huge" signal, but
+            # poisonous when fed into an *average* used for pre-call
+            # estimates.
+            if 0.05 <= ratio <= 8.0:
+                aggregates.setdefault(key, []).append(ratio)
+    return {key: (sum(v) / len(v), len(v)) for key, v in aggregates.items() if v}
+
+
+def _refresh_cache_if_due(history_store: Any) -> None:
+    global _CACHE_LOADED_AT
+    now = time.time()
+    if now - _CACHE_LOADED_AT < _CACHE_REFRESH_SEC and _CACHE_LOADED_AT > 0:
+        return
+    learned = _query_history_ratios(history_store)
+    with _LOCK:
+        _RATIO_CACHE.clear()
+        for key, (mean_ratio, samples) in learned.items():
+            if samples >= _MIN_SAMPLES:
+                _RATIO_CACHE[key] = mean_ratio
+        _CACHE_LOADED_AT = now
+
+
+def estimate_completion_tokens(
+    *,
+    agent_name: str,
+    model: str,
+    prompt_tokens: int,
+    history_store: Any = None,
+) -> int:
+    """Project the completion-token count for the next LLM call.
+
+    ``history_store`` is an :class:`amx.storage.sqlite_store.SQLiteHistoryStore`
+    (typed ``Any`` to avoid the cyclic import). When ``None`` we skip
+    the learning step and return the per-agent default * ``prompt_tokens``.
+    """
+    if prompt_tokens <= 0:
+        return 0
+    if history_store is not None:
+        _refresh_cache_if_due(history_store)
+    key = (agent_name.strip(), (model or "").strip().lower())
+    ratio = _RATIO_CACHE.get(key)
+    if ratio is None:
+        ratio = _default_ratio(agent_name.strip())
+    return max(1, int(prompt_tokens * ratio))
+
+
+def estimate_cost_usd(
+    *,
+    agent_name: str,
+    model: str,
+    prompt_tokens: int,
+    price: Any,  # ModelPrice; typed Any to avoid the cyclic import
+    history_store: Any = None,
+) -> float:
+    """Convenience: combine :func:`estimate_completion_tokens` with a price."""
+    completion_estimate = estimate_completion_tokens(
+        agent_name=agent_name,
+        model=model,
+        prompt_tokens=prompt_tokens,
+        history_store=history_store,
+    )
+    in_rate = float(getattr(price, "input_per_mtok", 0.0) or 0.0)
+    out_rate = float(getattr(price, "output_per_mtok", 0.0) or 0.0)
+    return (prompt_tokens / 1_000_000.0) * in_rate + (completion_estimate / 1_000_000.0) * out_rate
+
+
+def reset_cache() -> None:
+    """Drop the learned-ratio cache. Tests + ``/refresh-prices`` invoke this."""
+    global _CACHE_LOADED_AT
+    with _LOCK:
+        _RATIO_CACHE.clear()
+        _CACHE_LOADED_AT = 0.0
+
+
+__all__ = [
+    "estimate_completion_tokens",
+    "estimate_cost_usd",
+    "reset_cache",
+]

--- a/amx/utils/live_display.py
+++ b/amx/utils/live_display.py
@@ -93,6 +93,11 @@ class LiveDisplay:
 
         self._total_tokens_in: int = 0
         self._total_tokens_out: int = 0
+        # Running USD cost across this session, summed from per-call
+        # ``ModelPrice``-resolved figures by ``add_session_tokens``.
+        # Rendered in the header next to the token total so users see
+        # both pressure dimensions in the same eye-line.
+        self._total_cost_usd: float = 0.0
 
         # Reentrancy counter for ``pause()`` / ``resume()``. Nested
         # contexts (e.g. TableProcessor pauses for human review which
@@ -128,6 +133,7 @@ class LiveDisplay:
         self._session_start = time.monotonic()
         self._total_tokens_in = 0
         self._total_tokens_out = 0
+        self._total_cost_usd = 0.0
         # ``transient=True`` clears the WHOLE live region (header + thinking
         # spinner + pipeline tree) when ``stop()`` runs. Without this, every
         # height change in the renderable left a frame behind in the scroll
@@ -311,10 +317,27 @@ class LiveDisplay:
                 self._activities[idx].tokens_used = tokens_used
         self._refresh()
 
-    def add_session_tokens(self, input_tokens: int = 0, output_tokens: int = 0) -> None:
+    def add_session_tokens(
+        self,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cost_delta_usd: float = 0.0,
+    ) -> None:
+        """Accumulate one LLM call's tokens + cost into the live header.
+
+        ``cost_delta_usd`` is the freshly-computed USD figure from
+        :func:`amx.llm.pricing.compute_cost` (zero when no price is
+        known for the model). Called by
+        :meth:`amx.utils.token_tracker.TokenTracker.record` right after
+        every LLM round-trip.
+        """
         with self._lock:
             self._total_tokens_in += input_tokens
             self._total_tokens_out += output_tokens
+            try:
+                self._total_cost_usd += float(cost_delta_usd or 0.0)
+            except (TypeError, ValueError):
+                pass
         self._refresh()
 
     # ── Thinking state ────────────────────────────────────────────────────
@@ -394,7 +417,14 @@ class LiveDisplay:
         right = " │ ".join(ctx_parts) if ctx_parts else ""
 
         tokens_total = self._total_tokens_in + self._total_tokens_out
-        tok_str = f"[dim]↓ {tokens_total:,} tokens[/dim]" if tokens_total else ""
+        if tokens_total:
+            cost = self._total_cost_usd
+            if cost > 0:
+                tok_str = f"[dim]↓ {tokens_total:,} tokens · ${cost:,.4f}[/dim]"
+            else:
+                tok_str = f"[dim]↓ {tokens_total:,} tokens[/dim]"
+        else:
+            tok_str = ""
 
         header_text = Text.from_markup(f"  {left}  {right}  {time_str}  {tok_str}")
         return Panel(header_text, box=box.HEAVY, style="dim", height=3)

--- a/amx/utils/token_tracker.py
+++ b/amx/utils/token_tracker.py
@@ -1,4 +1,4 @@
-"""Token counting (tiktoken) and per-session usage tracking.
+"""Token counting (tiktoken) and per-session usage + cost tracking.
 
 ``tiktoken`` is intentionally NOT imported at module top: the tracker
 module sits on the boot path (every ``cli_support/commands/*`` pulls
@@ -9,13 +9,19 @@ the tracker cheap to import and defers the cost to the first
 ``estimate_tokens`` call. The same lazy boundary doubles as the
 on-demand pip-install hook for users who never run a token-counting
 flow at all (see ``amx.utils.optional_deps``).
+
+Cost integration: every :meth:`TokenTracker.record` call now resolves
+a price (via :func:`amx.llm.pricing.lookup_price`) and stores per-call
+USD figures alongside the raw token counts. Run summaries, the
+``/usage`` command, and the Studio run-detail page read these fields
+directly so cost is always visible without a second SQL query.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import tiktoken
@@ -50,10 +56,22 @@ class _UsageRecord:
     completion_tokens: int
     total_tokens: int
     model_processing_sec: float
+    # Cost fields populated when the caller passes provider/model/cfg
+    # (or uses ``record_for``). Frozen at the moment of the call so a
+    # later price refresh does not retro-rewrite the audit trail.
+    input_cost_usd: float = 0.0
+    output_cost_usd: float = 0.0
+    price_source: str = ""  # user_override | litellm | openrouter | fallback | unknown | ""
+    provider: str = ""
+    model: str = ""
+
+    @property
+    def total_cost_usd(self) -> float:
+        return float(self.input_cost_usd) + float(self.output_cost_usd)
 
 
 class TokenTracker:
-    """Accumulates token usage across a session (singleton via module-level instance)."""
+    """Accumulates token usage + cost across a session (singleton via module-level instance)."""
 
     def __init__(self) -> None:
         self._records: list[_UsageRecord] = []
@@ -66,7 +84,19 @@ class TokenTracker:
         step: str,
         input_estimate: int,
         usage: dict | None = None,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        cfg: Any = None,
+        profile_name: str | None = None,
     ) -> None:
+        """Record one LLM call's token + cost footprint.
+
+        Backwards compatible: callers that do not pass ``provider`` /
+        ``model`` / ``cfg`` simply skip the cost computation and the
+        record's cost fields stay zero. Existing call sites continue to
+        work; new agent integrations should prefer :meth:`record_for`.
+        """
         prompt = 0
         completion = 0
         total = 0
@@ -84,6 +114,28 @@ class TokenTracker:
                 or usage.get("model_processing_sec", 0.0)
                 or 0.0
             )
+
+        in_cost = 0.0
+        out_cost = 0.0
+        price_source = ""
+        if provider and model:
+            try:
+                from amx.llm.pricing import compute_cost, lookup_price
+
+                price = lookup_price(cfg, provider=provider, model=model, profile_name=profile_name)
+                in_cost, out_cost, _ = compute_cost(
+                    prompt_tokens=prompt or input_estimate,
+                    completion_tokens=completion,
+                    price=price,
+                )
+                price_source = price.source
+            except Exception as exc:  # noqa: BLE001 - cost is opportunistic
+                from amx.utils.logging import get_logger
+
+                get_logger("utils.token_tracker").debug(
+                    "cost lookup failed for %s/%s: %s", provider, model, exc
+                )
+
         self._records.append(
             _UsageRecord(
                 step=step,
@@ -92,6 +144,11 @@ class TokenTracker:
                 completion_tokens=completion,
                 total_tokens=total,
                 model_processing_sec=model_processing_sec,
+                input_cost_usd=in_cost,
+                output_cost_usd=out_cost,
+                price_source=price_source,
+                provider=str(provider or ""),
+                model=str(model or ""),
             )
         )
         try:
@@ -99,24 +156,62 @@ class TokenTracker:
 
             display = get_display()
             if display.is_active:
-                display.add_session_tokens(input_tokens=prompt, output_tokens=completion)
+                display.add_session_tokens(
+                    input_tokens=prompt,
+                    output_tokens=completion,
+                    cost_delta_usd=in_cost + out_cost,
+                )
         except Exception:
             pass
 
-    def summary(self) -> list[tuple[str, int, int, int]]:
-        """Aggregate records by step name -> list of (step, input, output, total)."""
-        agg: dict[str, list[int]] = {}
+    def record_for(
+        self,
+        step: str,
+        input_estimate: int,
+        llm: Any,
+        usage: dict | None = None,
+    ) -> None:
+        """Convenience wrapper that pulls provider/model/cfg off an
+        :class:`amx.llm.provider.LLMProvider`-shaped object.
+
+        Lets call sites stay one-line: ``tracker.record_for("profile",
+        est, self.llm, result.usage)``. The agent's ``self.llm.cfg``
+        carries the active provider, model, and any custom cost
+        overrides — exactly what :func:`amx.llm.pricing.lookup_price`
+        needs.
+        """
+        cfg = getattr(llm, "cfg", None)
+        provider = getattr(cfg, "provider", "") if cfg is not None else ""
+        model = getattr(cfg, "model", "") if cfg is not None else ""
+        self.record(step, input_estimate, usage, provider=provider, model=model, cfg=cfg)
+
+    def summary(self) -> list[tuple[str, int, int, int, float]]:
+        """Aggregate records by step name -> ``(step, input, output, total, cost_usd)``.
+
+        The new fifth field carries the summed USD cost for that step.
+        Callers that only consume the first four (legacy 4-tuple) keep
+        working via tuple unpacking.
+        """
+        agg: dict[str, list[float]] = {}
         for r in self._records:
             if r.step not in agg:
-                agg[r.step] = [0, 0, 0]
+                agg[r.step] = [0, 0, 0, 0.0]
             agg[r.step][0] += r.prompt_tokens or r.input_estimate
             agg[r.step][1] += r.completion_tokens
             agg[r.step][2] += r.total_tokens or (r.prompt_tokens + r.completion_tokens)
-        return [(step, *vals) for step, vals in agg.items()]
+            agg[r.step][3] += r.input_cost_usd + r.output_cost_usd
+        return [
+            (step, int(vals[0]), int(vals[1]), int(vals[2]), float(vals[3]))
+            for step, vals in agg.items()
+        ]
 
     @property
     def total_tokens(self) -> int:
         return sum(r.total_tokens or (r.prompt_tokens + r.completion_tokens) for r in self._records)
+
+    @property
+    def total_cost_usd(self) -> float:
+        return float(sum(r.input_cost_usd + r.output_cost_usd for r in self._records))
 
     @property
     def has_records(self) -> bool:
@@ -126,8 +221,8 @@ class TokenTracker:
     def total_model_processing_sec(self) -> float:
         return float(sum(max(0.0, r.model_processing_sec) for r in self._records))
 
-    def records(self) -> list[dict[str, int | str]]:
-        """Return raw token records for persistence/analytics."""
+    def records(self) -> list[dict[str, Any]]:
+        """Return raw token + cost records for persistence/analytics."""
         return [
             {
                 "step": r.step,
@@ -136,6 +231,11 @@ class TokenTracker:
                 "completion_tokens": r.completion_tokens,
                 "total_tokens": r.total_tokens,
                 "model_processing_sec": round(float(r.model_processing_sec), 6),
+                "input_cost_usd": round(float(r.input_cost_usd), 8),
+                "output_cost_usd": round(float(r.output_cost_usd), 8),
+                "price_source": r.price_source,
+                "provider": r.provider,
+                "model": r.model,
             }
             for r in self._records
         ]

--- a/amx/web/routers/pricing.py
+++ b/amx/web/routers/pricing.py
@@ -1,0 +1,103 @@
+"""Studio pricing endpoints — model lookup + cache refresh + status.
+
+The Settings → LLM editor calls :func:`lookup_model` as the user types
+to render an "OpenRouter says $0.30/$2.50" hint next to the custom-cost
+inputs. The TopBar pricing-freshness badge reads :func:`cache_info`.
+The "↻" refresh button on that badge hits :func:`refresh`.
+
+All endpoints are read-mostly. Refresh is idempotent — safe to spam.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query, status
+from pydantic import BaseModel, Field
+
+from amx.config import AMXConfig
+from amx.llm import pricing
+from amx.utils.logging import get_logger
+from amx.web.deps import get_cfg
+
+router = APIRouter(prefix="/api/pricing", tags=["pricing"])
+log = get_logger("web.pricing")
+
+
+class ModelPriceResponse(BaseModel):
+    input_per_mtok: float = Field(..., description="USD per 1M input tokens.")
+    output_per_mtok: float = Field(..., description="USD per 1M output tokens.")
+    source: str = Field(
+        ...,
+        description=(
+            "Where the price came from: 'user_override', 'litellm', "
+            "'openrouter', 'fallback', or 'unknown'."
+        ),
+    )
+    fetched_at: float | None = Field(
+        default=None,
+        description="Unix epoch when the source data was fetched (None for overrides + bundled).",
+    )
+
+
+class CacheInfoResponse(BaseModel):
+    fetched_at: float | None
+    age_seconds: float | None
+    ttl_seconds: float
+    is_stale: bool
+    litellm_count: int
+    openrouter_count: int
+    fallback_count: int
+
+
+class RefreshResponse(BaseModel):
+    litellm: int
+    openrouter: int
+    errors: list[str]
+    skipped: bool = False
+
+
+@router.get("/model", response_model=ModelPriceResponse)
+def lookup_model(
+    provider: str = Query(...),
+    model: str = Query(...),
+    profile_name: str | None = Query(default=None),
+    cfg: AMXConfig = Depends(get_cfg),
+) -> dict[str, Any]:
+    """Resolve a price for one (provider, model) pair via the same path
+    the rest of AMX uses. ``profile_name`` lets the SPA preview a custom
+    override before saving (the editor shows the effective rate live as
+    the user types into the cost inputs).
+    """
+    price = pricing.lookup_price(cfg, provider=provider, model=model, profile_name=profile_name)
+    return {
+        "input_per_mtok": price.input_per_mtok,
+        "output_per_mtok": price.output_per_mtok,
+        "source": price.source,
+        "fetched_at": price.fetched_at,
+    }
+
+
+@router.get("/cache-info", response_model=CacheInfoResponse)
+def cache_info() -> dict[str, Any]:
+    return pricing.cache_info()
+
+
+@router.post("/refresh", response_model=RefreshResponse, status_code=status.HTTP_200_OK)
+def refresh() -> dict[str, Any]:
+    """Force a fetch from both network sources. Returns counts + errors.
+
+    Errors do not surface as 5xx — the SPA can render "Updated 312 + 0
+    (openrouter: timeout)" so the user sees both what worked and what
+    did not, in one round-trip, instead of the request failing entirely.
+    """
+    result = pricing.refresh_prices(force=True)
+    return {
+        "litellm": int(result.get("litellm") or 0),
+        "openrouter": int(result.get("openrouter") or 0),
+        "errors": list(result.get("errors") or []),
+        "skipped": bool(result.get("skipped") or False),
+    }
+
+
+__all__ = ["router"]

--- a/amx/web/routers/runs.py
+++ b/amx/web/routers/runs.py
@@ -574,7 +574,9 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
                 },
                 tokens={
                     "total_tokens": token_tracker.total_tokens,
+                    "total_cost_usd": round(token_tracker.total_cost_usd, 8),
                     "summary": token_tracker.summary(),
+                    "records": token_tracker.records(),
                 },
                 results={"pending_count": pending_count},
                 error_text=final_error_text,

--- a/amx/web/routers/system_ops.py
+++ b/amx/web/routers/system_ops.py
@@ -36,9 +36,19 @@ def doctor(
 
 
 @router.get("/usage")
-def usage(window: str = Query(default="7d")) -> dict[str, Any]:
-    """Aggregate token consumption + approximate cost per (provider, model)."""
+def usage(
+    window: str = Query(default="7d"),
+    live: bool = Query(default=False),
+    cfg: AMXConfig = Depends(get_cfg),
+) -> dict[str, Any]:
+    """Aggregate token consumption + USD cost per (provider, model).
+
+    ``live=true`` recomputes cost against today's prices instead of the
+    frozen-at-runtime values stored in ``analysis_runs.tokens_json``,
+    matching the CLI ``/usage --live`` flag.
+    """
     from amx.cli_support.commands import usage as usage_cli
+    from amx.llm.pricing import compute_cost, lookup_price
     from amx.storage.sqlite_store import history_store
 
     label, window_sec = usage_cli._normalize_window(window)
@@ -48,7 +58,14 @@ def usage(window: str = Query(default="7d")) -> dict[str, Any]:
             "window": label,
             "window_sec": window_sec,
             "rows": [],
-            "totals": {"runs": 0, "input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+            "totals": {
+                "runs": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "cost_usd": 0.0,
+            },
+            "live": bool(live),
             "message": "History store isn't initialised yet.",
         }
     runs = hs.list_recent_runs(limit=10_000)
@@ -58,9 +75,27 @@ def usage(window: str = Query(default="7d")) -> dict[str, Any]:
     per_model, counted = usage_cli._aggregate_runs(runs)
 
     rows: list[dict[str, Any]] = []
-    totals = {"runs": 0, "input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    totals = {
+        "runs": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "cost_usd": 0.0,
+    }
     for (provider, model), bucket in sorted(per_model.items()):
-        cost = usage_cli._format_cost(model, bucket["input_tokens"], bucket["output_tokens"])
+        if live:
+            price = lookup_price(cfg, provider=provider, model=model)
+            _i, _o, total_cost = compute_cost(
+                prompt_tokens=int(bucket["input_tokens"]),
+                completion_tokens=int(bucket["output_tokens"]),
+                price=price,
+            )
+            cost_known = price.source != "unknown"
+            sources_label = price.source
+        else:
+            total_cost = float(bucket["frozen_cost_usd"])
+            cost_known = bool(bucket["frozen_cost_known"])
+            sources_label = ", ".join(sorted(bucket["sources"])) if bucket["sources"] else ""
         rows.append(
             {
                 "provider": provider,
@@ -69,11 +104,14 @@ def usage(window: str = Query(default="7d")) -> dict[str, Any]:
                 "input_tokens": int(bucket["input_tokens"]),
                 "output_tokens": int(bucket["output_tokens"]),
                 "total_tokens": int(bucket["total_tokens"]),
-                "cost_usd": cost,
+                "cost_usd": float(total_cost) if cost_known else None,
+                "source": sources_label,
             }
         )
         for k in ("runs", "input_tokens", "output_tokens", "total_tokens"):
             totals[k] += int(bucket[k])
+        if cost_known:
+            totals["cost_usd"] += float(total_cost)
 
     return {
         "window": label,
@@ -81,6 +119,7 @@ def usage(window: str = Query(default="7d")) -> dict[str, Any]:
         "counted_runs": counted,
         "rows": rows,
         "totals": totals,
+        "live": bool(live),
     }
 
 

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -30,6 +30,7 @@ from amx.web.routers import (
     history,
     live_db,
     pending,
+    pricing,
     profiles,
     rerun,
     runs,
@@ -109,6 +110,7 @@ def create_app(
     app.include_router(system_ops.router)
     app.include_router(code_ops.router)
     app.include_router(generate.router)
+    app.include_router(pricing.router)
     app.include_router(rerun.router)
 
     # Re-Run snapshots are short-lived (worker deletes them in finally).

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -471,7 +471,51 @@ export const api = {
     apiFetch<{ result_id: number; chain: ResultRow[]; count: number }>(
       `/api/history/results/${resultId}/history`,
     ),
+  /** Resolve the live price for a (provider, model) pair.
+   *
+   * Mirrors the resolution order used by the rest of AMX:
+   * ``user_override`` (when ``profile_name`` carries a custom rate),
+   * then ``litellm`` / ``openrouter`` / ``fallback`` / ``unknown``.
+   * The Settings cost editor calls this as the user types so the
+   * effective rate updates inline next to the input fields.
+   */
+  lookupPrice: (provider: string, model: string, profileName?: string) => {
+    const params = new URLSearchParams({ provider, model });
+    if (profileName) params.set("profile_name", profileName);
+    return apiFetch<ModelPrice>(`/api/pricing/model?${params.toString()}`);
+  },
+  /** Force-fetch fresh prices from LiteLLM + OpenRouter. */
+  refreshPrices: () =>
+    apiFetch<{
+      litellm: number;
+      openrouter: number;
+      errors: string[];
+      skipped: boolean;
+    }>("/api/pricing/refresh", { method: "POST" }),
+  /** Inspect the local price cache (age, source counts, freshness). */
+  pricingCacheInfo: () =>
+    apiFetch<{
+      fetched_at: number | null;
+      age_seconds: number | null;
+      ttl_seconds: number;
+      is_stale: boolean;
+      litellm_count: number;
+      openrouter_count: number;
+      fallback_count: number;
+    }>("/api/pricing/cache-info"),
 };
+
+/** Shape returned by ``lookupPrice`` — mirrors the backend
+ *  :class:`ModelPrice` dataclass. ``source`` is one of
+ *  ``user_override`` / ``litellm`` / ``openrouter`` / ``fallback`` /
+ *  ``unknown``.
+ */
+export interface ModelPrice {
+  input_per_mtok: number;
+  output_per_mtok: number;
+  source: string;
+  fetched_at: number | null;
+}
 
 /** Shape of one row in the re-run chain returned by ``resultHistory``.
  *

--- a/frontend/src/routes/RunDetail.tsx
+++ b/frontend/src/routes/RunDetail.tsx
@@ -39,6 +39,11 @@ interface RunDetailPayload {
   metrics?: Record<string, unknown>;
   settings?: Record<string, unknown>;
   llm_model?: string | null;
+  /** Provider attached to the LLM model recorded for this run.
+   *  Carried by the backend so the run-detail Cost row can resolve a
+   *  live price lookup without a second round-trip to fetch profile
+   *  metadata. */
+  llm_provider?: string | null;
   duration_sec?: number | null;
   /** DB scope the run was rooted at — the apply path needs these
       to land COMMENT statements on the same database the user
@@ -759,6 +764,7 @@ function SummaryTab({ run }: { run: RunDetailPayload | undefined }) {
       <Card>
         <CardHeader title="Metrics" />
         <CardBody className="space-y-2 text-sm">
+          <CostRow run={run} />
           {Object.entries(m).length === 0 ? (
             <div className="text-ink-dim">No metrics recorded.</div>
           ) : (
@@ -773,6 +779,105 @@ function SummaryTab({ run }: { run: RunDetailPayload | undefined }) {
         </CardBody>
       </Card>
     </div>
+  );
+}
+
+/** Cost summary row inside the Metrics card.
+ *
+ * Reads ``tokens_json.total_cost_usd`` (frozen at run time) for the
+ * default render. The ``Recompute`` button resolves today's price for
+ * the run's (provider, model) and projects the same recorded token
+ * totals against it so users can see "with current prices, this run
+ * would cost Y" without re-running anything.
+ */
+function CostRow({ run }: { run: RunDetailPayload }) {
+  const tokens = (run.tokens_json ?? {}) as Record<string, unknown>;
+  const frozenCost =
+    typeof tokens.total_cost_usd === "number" ? tokens.total_cost_usd : null;
+  const totalTokens =
+    typeof tokens.total_tokens === "number" ? tokens.total_tokens : null;
+  const provider = run.llm_provider ?? "";
+  const model = run.llm_model ?? "";
+  const [liveCost, setLiveCost] = useState<number | null>(null);
+  const [liveSource, setLiveSource] = useState<string>("");
+  const [recomputing, setRecomputing] = useState(false);
+
+  const recompute = async () => {
+    if (!provider || !model || totalTokens == null) return;
+    setRecomputing(true);
+    try {
+      const price = await api.lookupPrice(provider, model);
+      // The API returns rates per 1M tokens. We split tokens evenly
+      // here only as a fallback hint; a more accurate live recompute
+      // would walk records[]. For this card we use the per-record
+      // arrays when available.
+      const records = (tokens.records ?? []) as Array<{
+        prompt_tokens?: number;
+        completion_tokens?: number;
+      }>;
+      let inputTokens = 0;
+      let outputTokens = 0;
+      for (const r of records) {
+        inputTokens += Number(r.prompt_tokens ?? 0);
+        outputTokens += Number(r.completion_tokens ?? 0);
+      }
+      const cost =
+        (inputTokens / 1_000_000) * price.input_per_mtok +
+        (outputTokens / 1_000_000) * price.output_per_mtok;
+      setLiveCost(cost);
+      setLiveSource(price.source);
+    } finally {
+      setRecomputing(false);
+    }
+  };
+
+  if (frozenCost == null && liveCost == null) {
+    return (
+      <Row label="Cost">
+        <span className="text-xs text-ink-dim">
+          {totalTokens != null
+            ? "no cost data — pre-cost run, recompute below"
+            : "—"}
+          {totalTokens != null && (
+            <button
+              type="button"
+              onClick={recompute}
+              disabled={recomputing}
+              className="ml-2 rounded border border-surface-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-ink-muted hover:border-accent hover:text-accent disabled:opacity-50"
+            >
+              {recomputing ? "Recomputing…" : "Recompute"}
+            </button>
+          )}
+        </span>
+      </Row>
+    );
+  }
+
+  const display = liveCost != null ? liveCost : (frozenCost as number);
+  const sourceLabel =
+    liveCost != null
+      ? `live · ${liveSource || "?"}`
+      : "frozen at run time";
+
+  return (
+    <Row label="Cost">
+      <span className="inline-flex items-center gap-2 font-mono text-xs">
+        <span>${display.toFixed(4)}</span>
+        <span className="text-[10px] uppercase tracking-wider text-ink-dim">
+          ({sourceLabel})
+        </span>
+        {provider && model && (
+          <button
+            type="button"
+            onClick={recompute}
+            disabled={recomputing}
+            className="rounded border border-surface-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-ink-muted hover:border-accent hover:text-accent disabled:opacity-50"
+          >
+            {recomputing ? "…" : liveCost != null ? "Refresh" : "Recompute"}
+          </button>
+        )}
+      </span>
+    </Row>
   );
 }
 

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -638,6 +638,13 @@ function LlmProfileWizard({
   const [apiBase, setApiBase] = useState("");
   const [temperature, setTemperature] = useState(0.2);
   const [maxTokens, setMaxTokens] = useState(16_384);
+  // Custom cost overrides (USD per 1M tokens). Stored as strings so
+  // the user can clear them by deleting the input — an empty string
+  // round-trips to ``null`` on the backend, which the resolution path
+  // treats as "no override". Half-overrides (one set, one blank) are
+  // also rejected by the backend, matching the CLI ``/cost`` command.
+  const [customInputCost, setCustomInputCost] = useState("");
+  const [customOutputCost, setCustomOutputCost] = useState("");
   const [nAlternatives, setNAlternatives] = useState(3);
   const [columnBatchSize, setColumnBatchSize] = useState(10);
   const [promptDetail, setPromptDetail] = useState("standard");
@@ -658,6 +665,16 @@ function LlmProfileWizard({
     setApiBase(String(d.api_base ?? "") || "");
     setTemperature(Number(d.temperature ?? 0.2));
     setMaxTokens(Number(d.max_tokens ?? 16384));
+    setCustomInputCost(
+      d.custom_input_cost_per_mtok != null
+        ? String(d.custom_input_cost_per_mtok)
+        : "",
+    );
+    setCustomOutputCost(
+      d.custom_output_cost_per_mtok != null
+        ? String(d.custom_output_cost_per_mtok)
+        : "",
+    );
     setNAlternatives(Number(d.n_alternatives ?? 3));
     setColumnBatchSize(Number(d.column_batch_size ?? 10));
     setPromptDetail(String(d.prompt_detail || "standard"));
@@ -678,6 +695,14 @@ function LlmProfileWizard({
         model,
         temperature,
         max_tokens: maxTokens,
+        // Empty string = "clear the override". Backend treats null /
+        // negative / non-numeric as "no override". The conversion is
+        // explicit here so a future schema change does not silently
+        // start sending ``"" -> 0`` (which would bill input at zero).
+        custom_input_cost_per_mtok:
+          customInputCost.trim() === "" ? null : Number(customInputCost),
+        custom_output_cost_per_mtok:
+          customOutputCost.trim() === "" ? null : Number(customOutputCost),
         n_alternatives: nAlternatives,
         column_batch_size: columnBatchSize,
         prompt_detail: promptDetail,
@@ -814,6 +839,34 @@ function LlmProfileWizard({
               step={1024}
               value={maxTokens}
               onChange={(e) => setMaxTokens(Math.max(256, Number(e.target.value) || 0))}
+              className="w-full rounded-md border border-surface-border bg-surface px-3 py-1.5 font-mono text-sm"
+            />
+          </Field>
+          <Field
+            label="Custom input cost (USD / 1M tokens)"
+            hint="Override the auto-detected price. Leave blank to use LiteLLM / OpenRouter / bundled prices. Both rates must be set together — a half-override is treated as no override."
+          >
+            <input
+              type="number"
+              min={0}
+              step={0.01}
+              value={customInputCost}
+              placeholder="auto"
+              onChange={(e) => setCustomInputCost(e.target.value)}
+              className="w-full rounded-md border border-surface-border bg-surface px-3 py-1.5 font-mono text-sm"
+            />
+          </Field>
+          <Field
+            label="Custom output cost (USD / 1M tokens)"
+            hint="Same rules as the input rate — both must be set or both blank."
+          >
+            <input
+              type="number"
+              min={0}
+              step={0.01}
+              value={customOutputCost}
+              placeholder="auto"
+              onChange={(e) => setCustomOutputCost(e.target.value)}
               className="w-full rounded-md border border-surface-border bg-surface px-3 py-1.5 font-mono text-sm"
             />
           </Field>

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,387 @@
+"""Live LLM cost tracking — unit tests.
+
+Covers:
+
+* Fetcher parsing (LiteLLM JSON ``cost_per_token`` -> ``$/Mtok`` scale).
+* OpenRouter fallback for routes the LiteLLM JSON misses.
+* User-override resolution: wins over fetched, half-override = no
+  override.
+* Bundled fallback hit when both network sources fail.
+* Cache TTL + freshness flags.
+* Refresh idempotency (skip when fresh, force-fetch when forced).
+* ``compute_cost`` math.
+* ``TokenTracker`` cost integration round-trip.
+* Pre-call ``estimate_completion_tokens`` learned-ratio + fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from amx.llm import pricing as pricing_mod
+from amx.llm.pricing import (
+    ModelPrice,
+    cache_age_seconds,
+    cache_info,
+    compute_cost,
+    fetch_litellm_prices,
+    fetch_openrouter_prices,
+    lookup_price,
+    refresh_prices,
+    reset_state_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_pricing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Each test starts with a fresh in-memory + disk-cache state."""
+    reset_state_for_tests()
+    monkeypatch.setattr(pricing_mod, "_cache_path", lambda: tmp_path / "pricing-cache.json")
+    yield
+    reset_state_for_tests()
+
+
+# ── Fetcher parsing ────────────────────────────────────────────────────────
+
+
+def test_fetch_litellm_parses_cost_per_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``cost_per_token`` is per-token; we must scale it to $/Mtok."""
+    fake_payload = {
+        "sample_spec": {"input_cost_per_token": 0.0},  # excluded sentinel
+        "gpt-mock": {
+            "input_cost_per_token": 0.0000015,  # = $1.50 / Mtok
+            "output_cost_per_token": 0.000006,  # = $6.00 / Mtok
+        },
+        "no-cost-listed": {"max_tokens": 4096},
+    }
+    monkeypatch.setattr(pricing_mod, "_http_get_json", lambda url, headers=None: fake_payload)
+    out = fetch_litellm_prices()
+    assert "sample_spec" not in out
+    assert "no-cost-listed" not in out
+    assert out["gpt-mock"].input_per_mtok == pytest.approx(1.50)
+    assert out["gpt-mock"].output_per_mtok == pytest.approx(6.00)
+    assert out["gpt-mock"].source == "litellm"
+    assert out["gpt-mock"].fetched_at is not None
+
+
+def test_fetch_openrouter_parses_pricing_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OpenRouter wraps the rates as strings under ``pricing.{prompt,completion}``."""
+    fake_payload = {
+        "data": [
+            {
+                "id": "openai/gpt-route",
+                "pricing": {"prompt": "0.0000005", "completion": "0.000002"},
+            },
+            {"id": "skipme", "pricing": "broken-not-a-dict"},
+        ]
+    }
+    monkeypatch.setattr(pricing_mod, "_http_get_json", lambda url, headers=None: fake_payload)
+    out = fetch_openrouter_prices()
+    assert "skipme" not in out
+    hit = out["openai/gpt-route"]
+    assert hit.input_per_mtok == pytest.approx(0.50)
+    assert hit.output_per_mtok == pytest.approx(2.00)
+    assert hit.source == "openrouter"
+
+
+# ── Lookup resolution order ────────────────────────────────────────────────
+
+
+def test_user_override_wins_over_fetched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A profile's custom rates outrank LiteLLM / OpenRouter / fallback."""
+    cfg = SimpleNamespace(
+        llm_profiles={
+            "p": SimpleNamespace(
+                custom_input_cost_per_mtok=0.50,
+                custom_output_cost_per_mtok=2.50,
+            )
+        },
+        llm=SimpleNamespace(
+            custom_input_cost_per_mtok=None,
+            custom_output_cost_per_mtok=None,
+        ),
+    )
+    price = lookup_price(cfg, provider="openai", model="gpt-4o-mini", profile_name="p")
+    assert price.source == "user_override"
+    assert price.input_per_mtok == 0.50
+    assert price.output_per_mtok == 2.50
+
+
+def test_half_override_falls_through_to_fetched() -> None:
+    """Setting only one of the two rates is treated as no override at all."""
+    cfg = SimpleNamespace(
+        llm_profiles={
+            "p": SimpleNamespace(
+                custom_input_cost_per_mtok=0.50,
+                custom_output_cost_per_mtok=None,  # half-override
+            )
+        },
+        llm=SimpleNamespace(
+            custom_input_cost_per_mtok=None,
+            custom_output_cost_per_mtok=None,
+        ),
+    )
+    price = lookup_price(cfg, provider="openai", model="gpt-4o-mini", profile_name="p")
+    assert price.source != "user_override"
+    # Bundled fallback should hit gpt-4o-mini.
+    assert price.is_known
+
+
+def test_bundled_fallback_hit_when_no_network() -> None:
+    """Without network fetches, the bundled snapshot must still answer."""
+    price = lookup_price(None, provider="anthropic", model="claude-haiku-4.5")
+    assert price.source == "fallback"
+    assert price.input_per_mtok > 0
+
+
+def test_unknown_model_returns_zero_with_unknown_source() -> None:
+    price = lookup_price(None, provider="alien", model="totally-not-a-model")
+    assert price.source == "unknown"
+    assert price.input_per_mtok == 0.0
+    assert price.output_per_mtok == 0.0
+
+
+# ── Cache + refresh ────────────────────────────────────────────────────────
+
+
+def test_refresh_skips_when_cache_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fresh cache must short-circuit ``refresh_prices(force=False)``."""
+
+    fake_payload = {"data": []}
+
+    def fake_litellm() -> dict[str, ModelPrice]:
+        return {"x": ModelPrice(1, 1, "litellm", time.time())}
+
+    def fake_openrouter() -> dict[str, ModelPrice]:
+        return {"y": ModelPrice(2, 2, "openrouter", time.time())}
+
+    monkeypatch.setattr(pricing_mod, "fetch_litellm_prices", fake_litellm)
+    monkeypatch.setattr(pricing_mod, "fetch_openrouter_prices", fake_openrouter)
+    monkeypatch.setattr(pricing_mod, "_http_get_json", lambda *a, **k: fake_payload)
+
+    refresh_prices(force=True)  # populate
+    second = refresh_prices(force=False)
+    assert second.get("skipped") is True
+
+
+def test_refresh_force_writes_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Force-refresh must hit the wire and persist a new cache file."""
+    monkeypatch.setattr(
+        pricing_mod,
+        "fetch_litellm_prices",
+        lambda: {"a": ModelPrice(1.0, 2.0, "litellm", time.time())},
+    )
+    monkeypatch.setattr(pricing_mod, "fetch_openrouter_prices", lambda: {})
+    out = refresh_prices(force=True)
+    assert out["litellm"] == 1
+    assert out.get("skipped") is False
+    cache_file = pricing_mod._cache_path()
+    assert cache_file.exists()
+    payload = json.loads(cache_file.read_text())
+    assert "a" in payload["litellm"]
+
+
+def test_refresh_records_errors_without_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A single source failure must not poison the other or raise."""
+    import urllib.error
+
+    def boom() -> dict[str, ModelPrice]:
+        raise urllib.error.URLError("simulated offline")
+
+    monkeypatch.setattr(pricing_mod, "fetch_litellm_prices", boom)
+    monkeypatch.setattr(
+        pricing_mod,
+        "fetch_openrouter_prices",
+        lambda: {"good": ModelPrice(1, 1, "openrouter", time.time())},
+    )
+    out = refresh_prices(force=True)
+    assert any("litellm" in e for e in out["errors"])
+    assert out["openrouter"] == 1
+
+
+def test_cache_age_reports_none_before_first_fetch() -> None:
+    assert cache_age_seconds() is None
+    assert cache_info()["is_stale"] is True
+
+
+# ── compute_cost ───────────────────────────────────────────────────────────
+
+
+def test_compute_cost_math() -> None:
+    """Spot-check the arithmetic so a future refactor cannot drift."""
+    price = ModelPrice(input_per_mtok=2.0, output_per_mtok=10.0, source="test")
+    in_usd, out_usd, total = compute_cost(
+        prompt_tokens=500_000, completion_tokens=100_000, price=price
+    )
+    assert in_usd == pytest.approx(1.0)
+    assert out_usd == pytest.approx(1.0)
+    assert total == pytest.approx(2.0)
+
+
+def test_compute_cost_clamps_negative_token_counts() -> None:
+    price = ModelPrice(input_per_mtok=10.0, output_per_mtok=10.0, source="test")
+    _i, _o, total = compute_cost(prompt_tokens=-5, completion_tokens=-9, price=price)
+    assert total == 0.0
+
+
+# ── TokenTracker cost integration ──────────────────────────────────────────
+
+
+def test_token_tracker_records_cost_when_provider_supplied() -> None:
+    from amx.utils.token_tracker import TokenTracker
+
+    cfg = SimpleNamespace(
+        llm_profiles={},
+        llm=SimpleNamespace(
+            custom_input_cost_per_mtok=2.0,
+            custom_output_cost_per_mtok=10.0,
+        ),
+    )
+    t = TokenTracker()
+    t.record(
+        "profile_agent",
+        100,
+        {"prompt_tokens": 500_000, "completion_tokens": 100_000},
+        provider="anthropic",
+        model="claude-sonnet-4",
+        cfg=cfg,
+    )
+    summary = t.summary()
+    assert len(summary) == 1
+    step, inp, out, total, cost = summary[0]
+    assert step == "profile_agent"
+    assert inp == 500_000
+    assert out == 100_000
+    # Custom override -> $1.0 input + $1.0 output = $2.0
+    assert cost == pytest.approx(2.0)
+    assert t.total_cost_usd == pytest.approx(2.0)
+
+
+def test_token_tracker_records_zero_cost_when_no_provider_passed() -> None:
+    """Backwards-compat path: existing callers that omit provider/model
+    still get zero cost without crashing."""
+    from amx.utils.token_tracker import TokenTracker
+
+    t = TokenTracker()
+    t.record(
+        "profile_agent",
+        100,
+        {"prompt_tokens": 1000, "completion_tokens": 500},
+    )
+    assert t.total_cost_usd == 0.0
+
+
+def test_token_tracker_records_method_round_trip_includes_cost_fields() -> None:
+    from amx.utils.token_tracker import TokenTracker
+
+    cfg = SimpleNamespace(
+        llm_profiles={},
+        llm=SimpleNamespace(
+            custom_input_cost_per_mtok=1.0,
+            custom_output_cost_per_mtok=4.0,
+        ),
+    )
+    t = TokenTracker()
+    t.record(
+        "merge",
+        50,
+        {"prompt_tokens": 10_000, "completion_tokens": 2_000},
+        provider="openai",
+        model="gpt-4o",
+        cfg=cfg,
+    )
+    rec = t.records()[0]
+    assert rec["price_source"] == "user_override"
+    assert rec["input_cost_usd"] == pytest.approx(0.01)
+    assert rec["output_cost_usd"] == pytest.approx(0.008)
+    assert rec["provider"] == "openai"
+    assert rec["model"] == "gpt-4o"
+
+
+# ── Pre-call estimator ─────────────────────────────────────────────────────
+
+
+def test_estimate_completion_tokens_uses_per_agent_default_with_no_history() -> None:
+    from amx.utils.cost_estimate import estimate_completion_tokens, reset_cache
+
+    reset_cache()
+    # profile_agent default ratio is 0.60 -> 100 prompt -> ~60 output.
+    out = estimate_completion_tokens(
+        agent_name="profile_agent",
+        model="gpt-4o-mini",
+        prompt_tokens=100,
+        history_store=None,
+    )
+    assert 50 <= out <= 70
+
+
+def test_estimate_completion_tokens_prefers_history_over_default(
+    tmp_path: Path,
+) -> None:
+    """Once enough samples exist for (step, model), the learned ratio
+    should override the per-agent default."""
+    from amx.storage.sqlite_store import SQLiteHistoryStore
+    from amx.utils.cost_estimate import estimate_completion_tokens, reset_cache
+
+    reset_cache()
+    store = SQLiteHistoryStore(tmp_path / "h.db")
+    store.init()
+    # Seed three runs with a 0.10 completion/prompt ratio for one
+    # (agent, model) — well below the per-agent default of 0.60.
+    for _ in range(3):
+        run_id = store.create_run(
+            command="analyze.run",
+            mode="chat",
+            db_backend="postgresql",
+            db_profile="local",
+            llm_provider="openai",
+            llm_model="gpt-test",
+            scope={"public": ["t"]},
+        )
+        store.finish_run(
+            run_id,
+            status="success",
+            metrics={},
+            tokens={
+                "records": [
+                    {
+                        "step": "profile_agent",
+                        "prompt_tokens": 1000,
+                        "completion_tokens": 100,
+                        "model": "gpt-test",
+                    }
+                ]
+            },
+            results={},
+        )
+    out = estimate_completion_tokens(
+        agent_name="profile_agent",
+        model="gpt-test",
+        prompt_tokens=1000,
+        history_store=store,
+    )
+    # Learned 0.10 ratio -> ~100 (not the 0.60 default that would give 600).
+    assert 80 <= out <= 120
+
+
+# ── End-to-end ``lookup_price`` + ``cache_info`` after a refresh ───────────
+
+
+def test_cache_info_after_refresh_marks_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        pricing_mod,
+        "fetch_litellm_prices",
+        lambda: {"a": ModelPrice(1, 1, "litellm", time.time())},
+    )
+    monkeypatch.setattr(pricing_mod, "fetch_openrouter_prices", lambda: {})
+    refresh_prices(force=True)
+    info = cache_info()
+    assert info["is_stale"] is False
+    assert info["litellm_count"] >= 1
+    assert info["age_seconds"] is not None
+    assert info["age_seconds"] >= 0

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -3419,30 +3419,50 @@ class UsageCommandTests(unittest.TestCase):
         self.assertEqual(label, "7d")
 
     def test_lookup_pricing_exact_match(self) -> None:
-        from amx.cli_support.commands.usage import _lookup_pricing
+        # Old hardcoded ``_lookup_pricing`` is gone (2026-05); the live
+        # pricing module is the single source of truth. We probe its
+        # bundled fallback so the test stays offline-safe while still
+        # asserting that "ask for gpt-4o-mini, get a known price" works.
+        from amx.llm.pricing import lookup_price, reset_state_for_tests
 
-        pricing = _lookup_pricing("gpt-4o-mini")
-        self.assertIsNotNone(pricing)
-        self.assertEqual(pricing[0], 0.15)
+        reset_state_for_tests()
+        price = lookup_price(None, provider="openai", model="gpt-4o-mini")
+        self.assertNotEqual(price.source, "unknown")
+        self.assertGreater(price.input_per_mtok, 0.0)
 
     def test_lookup_pricing_strips_provider_prefix(self) -> None:
-        from amx.cli_support.commands.usage import _lookup_pricing
+        from amx.llm.pricing import lookup_price, reset_state_for_tests
 
-        # OpenRouter-style namespacing
-        self.assertIsNotNone(_lookup_pricing("openai/gpt-4o"))
-        self.assertIsNotNone(_lookup_pricing("openrouter/openai/gpt-4o"))
+        reset_state_for_tests()
+        # OpenRouter-style namespacing should still resolve via the
+        # candidate-key normalization in ``_normalize_model_id``.
+        self.assertNotEqual(
+            lookup_price(None, provider="openai", model="openai/gpt-4o").source,
+            "unknown",
+        )
+        self.assertNotEqual(
+            lookup_price(None, provider="openrouter", model="openrouter/openai/gpt-4o").source,
+            "unknown",
+        )
 
     def test_lookup_pricing_strips_dated_suffix(self) -> None:
-        from amx.cli_support.commands.usage import _lookup_pricing
+        from amx.llm.pricing import lookup_price, reset_state_for_tests
 
-        # claude-sonnet-4 priced; claude-sonnet-4-20250514 should also resolve
-        self.assertIsNotNone(_lookup_pricing("claude-sonnet-4-20250514"))
+        reset_state_for_tests()
+        # ``claude-sonnet-4`` is in the bundled fallback; the dated
+        # variant ``claude-sonnet-4-20250514`` must still resolve via
+        # suffix stripping.
+        price = lookup_price(None, provider="anthropic", model="claude-sonnet-4-20250514")
+        self.assertNotEqual(price.source, "unknown")
 
-    def test_lookup_pricing_unknown_returns_none(self) -> None:
-        from amx.cli_support.commands.usage import _lookup_pricing
+    def test_lookup_pricing_unknown_returns_zero_with_unknown_source(self) -> None:
+        from amx.llm.pricing import lookup_price, reset_state_for_tests
 
-        self.assertIsNone(_lookup_pricing("totally-not-a-model"))
-        self.assertIsNone(_lookup_pricing(""))
+        reset_state_for_tests()
+        unknown = lookup_price(None, provider="alien", model="totally-not-a-model")
+        self.assertEqual(unknown.source, "unknown")
+        self.assertEqual(unknown.input_per_mtok, 0.0)
+        self.assertEqual(unknown.output_per_mtok, 0.0)
 
     def test_aggregate_runs_groups_by_provider_model(self) -> None:
         from amx.cli_support.commands.usage import _aggregate_runs
@@ -3503,15 +3523,18 @@ class UsageCommandTests(unittest.TestCase):
         self.assertEqual(per, {})
 
     def test_format_cost_for_known_and_unknown_models(self) -> None:
+        # The new helper renders an already-computed USD figure. The
+        # actual computation lives in :func:`amx.llm.pricing.compute_cost`,
+        # which we cover separately in ``tests/test_pricing.py``. Here
+        # we pin only the formatting contract: known + > 0 -> dollars,
+        # known + 0 -> "$0.00", known + sub-0.0001 -> "<$0.0001",
+        # unknown -> em-dash.
         from amx.cli_support.commands.usage import _format_cost
 
-        # gpt-4o is $2.50 input / $10.00 output per 1M tokens.
-        # 1_000_000 in / 500_000 out → $2.50 + $5.00 = $7.50
-        self.assertEqual(_format_cost("gpt-4o", 1_000_000, 500_000), "$7.50")
-        # Unknown model gets em-dash
-        self.assertEqual(_format_cost("totally-fake", 1000, 500), "—")
-        # Sub-cent rounds to "<$0.01"
-        self.assertEqual(_format_cost("gpt-4o-mini", 100, 0), "<$0.01")
+        self.assertEqual(_format_cost(7.50, known=True), "$7.5000")
+        self.assertEqual(_format_cost(0.00009, known=True), "<$0.0001")
+        self.assertEqual(_format_cost(0.0, known=True), "$0.00")
+        self.assertEqual(_format_cost(123.456, known=False), "—")
 
     def test_cmd_usage_with_no_history_store_warns(self) -> None:
         from amx.cli_support.commands.usage import cmd_usage


### PR DESCRIPTION
## Summary
- Live USD cost rendered alongside every token total. Replaces the hardcoded ``_PRICING_PER_MTOK`` dict in ``/usage`` with a fetcher that pulls LiteLLM's hosted pricing JSON (300+ models) plus OpenRouter's ``/v1/models`` for newly-launched routes; falls back to a bundled snapshot of ~30 popular models when both network sources fail.
- Per-LLM-profile cost overrides — ``LLMConfig.custom_input_cost_per_mtok`` / ``custom_output_cost_per_mtok`` win over fetched prices. Half-overrides (one rate set, one blank) are explicitly treated as no override to avoid the "free input + market output" footgun. Editable from CLI (``/cost``) and Studio (Settings → LLM profile editor).
- Frozen-at-runtime audit + live recompute — ``finish_run`` writes per-step USD figures into ``tokens_json``; ``/usage`` reads them by default ("what this actually cost") and ``/usage --live`` recomputes against today's prices on the same recorded token totals ("what the same workload would cost now"). Studio gets the same toggle on the run-detail Cost row.
- Pre-call estimator (``amx/utils/cost_estimate.py``) learns ``AVG(completion/prompt)`` per (agent, model) over the last 30 days and projects an output-token budget *before* the LLM call; per-agent fallback ratios kick in when no history exists. Pathological reasoning-model ratios (8x+) are clamped so a single huge run does not poison the average.
- Live display now renders ``↓ N tokens · $X.XXXX`` in the session header and the end-of-run summary table picks up a Cost (USD) column with grand total.
- New CLI: ``/cost`` (show / set / reset), ``/refresh-prices`` (force-fetch). New Studio endpoints: ``GET /api/pricing/model``, ``GET /api/pricing/cache-info``, ``POST /api/pricing/refresh``. ``/api/usage`` migrated off the dropped helper, gains ``?live=true`` flag.

## Test plan
- [x] ``pytest tests/ --ignore=tests/eval --ignore=tests/perf`` — 1146 pass (1128 baseline + 18 new pricing tests covering fetcher parsing, override resolution, half-override rejection, cache TTL, refresh idempotency, per-source error collection, ``compute_cost`` math, ``TokenTracker`` cost integration, learned-ratio estimator).
- [x] ``ruff check`` + ``ruff format`` clean across all modified files.
- [x] ``tsc --build`` clean for the Settings + RunDetail + api.ts changes.
- [ ] Manual smoke (CLI) — fresh install: ``/cost`` shows fallback price + source, ``/refresh-prices`` updates the cache, ``/cost 0.50 2.50`` saves an override + ``/cost`` shows source ``user_override``, ``/cost reset`` reverts. Run a small analyze: live header shows ``$X.XXXX`` mid-run, end-of-run summary has the Cost column, ``/usage`` shows frozen costs + Source column, ``/usage --live`` shows the delta against current prices.
- [ ] Manual smoke (Studio) — Settings → LLM editor: enter custom input + output cost, save, reload, values stick. Run detail page: Cost row shows frozen $X (frozen at run time) plus a Recompute button that swaps in a live source figure.