### PR TITLE
feat(rerun): cache first-run table profile, reuse on re-run

### DIFF
--- a/amx/agents/_orchestrator/table_processor.py
+++ b/amx/agents/_orchestrator/table_processor.py
@@ -118,6 +118,14 @@ class TableProcessor:
         self._check_cancel(phase="profile_fetch")
         profile = self._fetch_profile()
 
+        # Cache the freshly-profiled table so a re-run on any of its
+        # columns skips the 5-30s ``profile_table`` round-trip. Cached
+        # rows live until the apply path drops them (or the 24h TTL
+        # expires, defending against out-of-band schema changes the
+        # cache can't see). Best-effort — a cache write never breaks
+        # the analyze loop.
+        self._cache_profile_for_rerun(profile)
+
         self._check_cancel(phase="filters")
         if not self._apply_filters(profile):
             return []
@@ -139,6 +147,53 @@ class TableProcessor:
                 self.table,
                 asset_kind=self.asset_kind,
             )
+
+    def _cache_profile_for_rerun(self, profile: TableProfile) -> None:
+        """Persist the table profile for re-use on subsequent re-runs.
+
+        Reads ``db_profile`` (the named profile, not the connector's
+        config dataclass) off the history row when ``self.orch.run_id``
+        is set; otherwise no-ops because the cache key needs the name
+        to disambiguate two profiles pointing at databases with the
+        same string. ``database`` falls back to ``self.orch.db.cfg``
+        for analytics backends that pin it on the connector.
+        """
+        from amx.agents.rerun_context import cache_table_profile
+        from amx.storage.sqlite_store import history_store
+
+        try:
+            hs = history_store()
+            db_profile_name = ""
+            database = ""
+            if hs is not None and self.orch.run_id is not None:
+                run = hs.get_run(int(self.orch.run_id))
+                if isinstance(run, dict):
+                    db_profile_name = str(run.get("db_profile") or "")
+                    database = str(run.get("database") or "")
+            if not database:
+                database = (
+                    getattr(self.orch.db.cfg, "database", "")
+                    or getattr(self.orch.db.cfg, "project", "")
+                    or getattr(self.orch.db.cfg, "catalog", "")
+                    or ""
+                )
+            if not db_profile_name:
+                # Without a profile name we'd write a cache row keyed
+                # only on (database, schema, table) — fine for users
+                # with a single profile but ambiguous in multi-profile
+                # setups. Skip rather than risk a wrong-profile hit.
+                return
+            cache_table_profile(
+                profile=profile,
+                db=self.orch.db,
+                db_profile_name=db_profile_name,
+                database=database,
+                run_id=self.orch.run_id,
+            )
+        except Exception:
+            # Best-effort caching — analyze must continue even if the
+            # cache layer is misconfigured (e.g. SQLite locked).
+            pass
 
     # ── Phase 2: filter chain ──────────────────────────────────────────
 

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -577,6 +577,28 @@ def apply_review_results_to_db(
                                     audit_run_id=audit_run_id,
                                     old_comment=(pre_old[offset - 1] if pre_old else None),
                                 )
+                                # Mirror the per-row branch's cache GC
+                                # so a successful batch apply also drops
+                                # the cached first-run profile for the
+                                # touched table. Best-effort.
+                                if audit_log is not None:
+                                    try:
+                                        audit_log.delete_run_context_cache(
+                                            db_profile=audit_profile or "",
+                                            database=db.cfg.database
+                                            or db.cfg.project
+                                            or db.cfg.catalog
+                                            or "",
+                                            schema=item.schema,
+                                            table=item.table or "",
+                                        )
+                                    except Exception as cache_exc:
+                                        log.debug(
+                                            "delete_run_context_cache (batch) failed for %s.%s: %s",
+                                            item.schema,
+                                            item.table,
+                                            cache_exc,
+                                        )
                             index = next_index
                             continue
                     except Exception as batch_exc:
@@ -624,6 +646,26 @@ def apply_review_results_to_db(
                     audit_run_id=audit_run_id,
                     old_comment=pre_old_value,
                 )
+                # Drop the cached first-run profile for this table so
+                # we don't keep stale-but-valid context around for a
+                # row the user has already accepted. The cache write
+                # path is best-effort, so the GC must be too — a
+                # failed delete must never break the apply loop.
+                if audit_log is not None:
+                    try:
+                        audit_log.delete_run_context_cache(
+                            db_profile=audit_profile or "",
+                            database=db.cfg.database or db.cfg.project or db.cfg.catalog or "",
+                            schema=r.schema,
+                            table=r.table or "",
+                        )
+                    except Exception as cache_exc:
+                        log.debug(
+                            "delete_run_context_cache failed for %s.%s: %s",
+                            r.schema,
+                            r.table,
+                            cache_exc,
+                        )
             except Exception as exc:
                 if on_progress is not None:
                     on_progress(r, "failed", index + 1, total, str(exc))

--- a/amx/agents/rerun_context.py
+++ b/amx/agents/rerun_context.py
@@ -69,26 +69,20 @@ def _connector_for_db_profile(cfg: AMXConfig, profile_name: str) -> DatabaseConn
     return DatabaseConnector(base)
 
 
-def _build_db_profile_dict(
+def _table_profile_to_dicts(
+    profile: Any,
     db: DatabaseConnector,
-    schema: str,
-    table: str,
     *,
-    asset_kind: AssetKind | None = None,
     only_column: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Assemble the ``db_profile`` slice the agents read from.
+    """Convert a freshly-built ``TableProfile`` to the snapshot dict shape.
 
-    Returns ``(db_profile_dict, existing_metadata_dict)`` matching the
-    shape :meth:`Orchestrator._build_context` produces, so the agent
-    prompt builders work without any branching for the re-run path.
-    When ``only_column`` is provided, ``db_profile['columns']`` is
-    narrowed to that single column — sibling columns are kept as
-    ``context_column_names`` so the LLM still sees the table shape.
+    Factored out of :func:`_build_db_profile_dict` so callers that
+    already have a ``TableProfile`` in memory (e.g. the first-run
+    orchestrator) can re-use the conversion without re-introspecting
+    the live database.
     """
-    profile = db.profile_table(schema, table, asset_kind=asset_kind)
     db_name = db.cfg.database or db.cfg.project or db.cfg.catalog or "N/A"
-
     all_cols = [
         {
             "name": c.name,
@@ -105,7 +99,6 @@ def _build_db_profile_dict(
         }
         for c in profile.columns
     ]
-
     if only_column:
         target_cols = [c for c in all_cols if c["name"] == only_column]
         sibling_names = [c["name"] for c in all_cols if c["name"] != only_column]
@@ -133,7 +126,6 @@ def _build_db_profile_dict(
     }
     if sibling_names:
         db_profile["context_column_names"] = sibling_names
-
     existing_metadata = {
         "database": db_name,
         "backend": db.backend,
@@ -142,6 +134,51 @@ def _build_db_profile_dict(
         "database_comment": profile.database_comment,
     }
     return db_profile, existing_metadata
+
+
+def _slice_cached_profile(
+    db_profile: dict[str, Any],
+    *,
+    only_column: str | None,
+) -> dict[str, Any]:
+    """Return a copy of a cached ``db_profile`` narrowed to one column.
+
+    The cache stores the full table profile (every column) so a
+    subsequent re-run targeting a *different* column can still use the
+    same row. This helper rebuilds the column-specific slice the
+    agents expect at call time.
+    """
+    if not only_column:
+        return dict(db_profile)
+    cols = list(db_profile.get("columns") or [])
+    target_cols = [c for c in cols if c.get("name") == only_column]
+    sibling_names = [c.get("name") for c in cols if c.get("name") != only_column]
+    out = dict(db_profile)
+    out["columns"] = target_cols
+    if sibling_names:
+        out["context_column_names"] = sibling_names
+    return out
+
+
+def _build_db_profile_dict(
+    db: DatabaseConnector,
+    schema: str,
+    table: str,
+    *,
+    asset_kind: AssetKind | None = None,
+    only_column: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Assemble the ``db_profile`` slice the agents read from.
+
+    Returns ``(db_profile_dict, existing_metadata_dict)`` matching the
+    shape :meth:`Orchestrator._build_context` produces, so the agent
+    prompt builders work without any branching for the re-run path.
+    When ``only_column`` is provided, ``db_profile['columns']`` is
+    narrowed to that single column — sibling columns are kept as
+    ``context_column_names`` so the LLM still sees the table shape.
+    """
+    profile = db.profile_table(schema, table, asset_kind=asset_kind)
+    return _table_profile_to_dicts(profile, db, only_column=only_column)
 
 
 def _resolve_asset_kind(raw: str | None) -> AssetKind | None:
@@ -249,29 +286,58 @@ def build_context_snapshot(
         )
         return snapshot_id
 
-    # Table / column re-run: live-profile the table fresh.
+    # Table / column re-run: prefer the cached first-run profile when
+    # the user hasn't touched the table out-of-band. Saves a 5-30s
+    # ``profile_table`` round-trip per re-run target. Cache miss /
+    # expiry / cross-database edge case all fall through to the live
+    # profile rebuild below.
     if not db_profile_name:
         raise RerunContextError(
             "Original run has no db_profile recorded and no active profile is set — "
             "cannot rebuild the database context for this re-run."
         )
 
-    db = _connector_for_db_profile(cfg, db_profile_name)
-    try:
-        db_profile, existing_metadata = _build_db_profile_dict(
-            db,
-            schema,
-            table,
-            asset_kind=asset_kind,
-            only_column=column if column else None,
-        )
-    finally:
-        try:
-            db.close()
-        except Exception:
-            pass
+    parent_database = (parent_run.get("database") or "") if parent_run else ""
+    cached = hs.lookup_run_context_cache(
+        db_profile=db_profile_name,
+        database=parent_database,
+        schema=schema,
+        table=table,
+    )
+    db_profile_dict: dict[str, Any] | None = None
+    existing_metadata: dict[str, Any] | None = None
+    if cached and isinstance(cached.get("payload"), dict):
+        cached_payload = cached["payload"]
+        cached_db_profile = cached_payload.get("db_profile")
+        cached_existing = cached_payload.get("existing_metadata")
+        if isinstance(cached_db_profile, dict) and isinstance(cached_existing, dict):
+            db_profile_dict = _slice_cached_profile(
+                cached_db_profile, only_column=column if column else None
+            )
+            existing_metadata = dict(cached_existing)
+            log.info(
+                "rerun: cache hit for %s.%s -- skipping live profile_table",
+                schema,
+                table,
+            )
 
-    payload["db_profile"] = db_profile
+    if db_profile_dict is None or existing_metadata is None:
+        db = _connector_for_db_profile(cfg, db_profile_name)
+        try:
+            db_profile_dict, existing_metadata = _build_db_profile_dict(
+                db,
+                schema,
+                table,
+                asset_kind=asset_kind,
+                only_column=column if column else None,
+            )
+        finally:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+    payload["db_profile"] = db_profile_dict
     payload["existing_metadata"] = existing_metadata
 
     snapshot_id = uuid.uuid4().hex
@@ -312,9 +378,56 @@ def serialize_context(ctx: AgentContext) -> dict[str, Any]:
     return asdict(ctx)
 
 
+def cache_table_profile(
+    *,
+    profile: Any,
+    db: DatabaseConnector,
+    db_profile_name: str,
+    database: str,
+    run_id: int | None = None,
+) -> bool:
+    """Persist the freshly-built table profile for re-use on re-run.
+
+    Called from the analyze path right after ``db.profile_table``
+    succeeds. Cache hits in :func:`build_context_snapshot` skip the
+    live profile rebuild — saving 5-30s per re-run target.
+
+    Returns ``True`` when the row was written, ``False`` on any
+    exception (best-effort: a failed cache write must never break the
+    analyze loop).
+    """
+    hs = history_store()
+    if hs is None:
+        return False
+    try:
+        db_profile_dict, existing_metadata = _table_profile_to_dicts(profile, db)
+        payload = {
+            "db_profile": db_profile_dict,
+            "existing_metadata": existing_metadata,
+        }
+        hs.save_run_context_cache(
+            db_profile=str(db_profile_name or ""),
+            database=str(database or ""),
+            schema=str(profile.schema or ""),
+            table=str(profile.name or ""),
+            payload=payload,
+            source_run_id=run_id,
+        )
+        return True
+    except Exception as exc:  # pragma: no cover - best-effort
+        log.debug(
+            "cache_table_profile failed for %s.%s: %s",
+            getattr(profile, "schema", "?"),
+            getattr(profile, "name", "?"),
+            exc,
+        )
+        return False
+
+
 __all__ = [
     "RerunContextError",
     "build_context_snapshot",
+    "cache_table_profile",
     "hydrate_context",
     "serialize_context",
 ]

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -215,6 +215,41 @@ class SQLiteHistoryStore:
                     "CREATE INDEX IF NOT EXISTS idx_run_results_shared_uuid "
                     "ON run_results(shared_uuid)"
                 )
+            # ── run_context_cache: persistent table-level context produced
+            # at first run, reused on subsequent re-runs to skip live
+            # ``profile_table`` introspection. Keyed on
+            # (db_profile, database, schema, table) so a re-run of any
+            # column on the same table can hit the same row. The cache
+            # is dropped from ``_record_audit`` after the row's COMMENT
+            # lands on the live database (i.e. we trust the table the
+            # user just touched is no longer a re-run target). A 24h
+            # TTL guards against silently serving stale schema after
+            # the user altered the table out-of-band.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS run_context_cache (
+                    cache_key       TEXT PRIMARY KEY,
+                    db_profile      TEXT NOT NULL,
+                    database_name   TEXT NOT NULL DEFAULT '',
+                    schema_name     TEXT NOT NULL,
+                    table_name      TEXT NOT NULL,
+                    payload_json    TEXT NOT NULL,
+                    source_run_id   INTEGER,
+                    created_at      REAL NOT NULL,
+                    expires_at      REAL
+                )
+                """
+            )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_run_context_cache_table "
+                    "ON run_context_cache(db_profile, database_name, schema_name, table_name)"
+                )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_run_context_cache_expires "
+                    "ON run_context_cache(expires_at)"
+                )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_run_results_run_id ON run_results(run_id)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_run_results_asset "
@@ -1160,6 +1195,156 @@ class SQLiteHistoryStore:
             cur = conn.execute(
                 "DELETE FROM rerun_context_snapshots WHERE created_at < ?",
                 (cutoff,),
+            )
+            return int(cur.rowcount or 0)
+
+    # ── run_context_cache: first-run table profiles reused on rerun ──
+
+    @staticmethod
+    def _context_cache_key(
+        *,
+        db_profile: str,
+        database: str,
+        schema: str,
+        table: str,
+    ) -> str:
+        return f"{db_profile}|{database or ''}|{schema}|{table}"
+
+    def save_run_context_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        schema: str,
+        table: str,
+        payload: dict[str, Any],
+        source_run_id: int | None = None,
+        ttl_seconds: float = 86400.0,
+    ) -> None:
+        """Persist a table-level context snapshot for re-use on re-run.
+
+        ``payload`` is the JSON-serialisable dict the rerun executor
+        normally rebuilds via ``_build_db_profile_dict`` — keys at
+        minimum: ``db_profile`` (the column-aware profile dict) and
+        ``existing_metadata``.  ``ttl_seconds`` defaults to 24 hours so
+        a stale schema can't silently produce wrong descriptions when
+        the user re-runs a week later.
+
+        Uses ``INSERT OR REPLACE`` keyed on
+        (db_profile, database, schema, table) so a re-analyze of the
+        same table refreshes the cache rather than appending duplicates.
+        """
+        cache_key = self._context_cache_key(
+            db_profile=str(db_profile or ""),
+            database=str(database or ""),
+            schema=str(schema or ""),
+            table=str(table or ""),
+        )
+        now = time.time()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO run_context_cache
+                    (cache_key, db_profile, database_name, schema_name, table_name,
+                     payload_json, source_run_id, created_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(cache_key) DO UPDATE SET
+                    payload_json = excluded.payload_json,
+                    source_run_id = excluded.source_run_id,
+                    created_at = excluded.created_at,
+                    expires_at = excluded.expires_at
+                """,
+                (
+                    cache_key,
+                    str(db_profile or ""),
+                    str(database or ""),
+                    str(schema or ""),
+                    str(table or ""),
+                    json.dumps(payload, ensure_ascii=True),
+                    int(source_run_id) if source_run_id is not None else None,
+                    now,
+                    (now + float(ttl_seconds)) if ttl_seconds > 0 else None,
+                ),
+            )
+
+    def lookup_run_context_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        schema: str,
+        table: str,
+    ) -> dict[str, Any] | None:
+        """Return the cached payload for a table, or ``None`` if missing/expired.
+
+        Expired rows are kept on disk (cheaper than rewriting) but the
+        lookup pretends they're absent so callers always rebuild from
+        the live database. ``gc_run_context_cache`` reaps them.
+        """
+        cache_key = self._context_cache_key(
+            db_profile=str(db_profile or ""),
+            database=str(database or ""),
+            schema=str(schema or ""),
+            table=str(table or ""),
+        )
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT payload_json, expires_at, source_run_id, created_at
+                FROM run_context_cache
+                WHERE cache_key = ?
+                """,
+                (cache_key,),
+            ).fetchone()
+        if row is None:
+            return None
+        expires_at = row["expires_at"]
+        if expires_at is not None and float(expires_at) < time.time():
+            return None
+        try:
+            payload = json.loads(row["payload_json"])
+        except Exception:
+            return None
+        return {
+            "payload": payload,
+            "source_run_id": row["source_run_id"],
+            "created_at": float(row["created_at"]),
+        }
+
+    def delete_run_context_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        schema: str,
+        table: str,
+    ) -> int:
+        """Drop the cache row for a single table; returns rowcount.
+
+        Called from the apply path after a successful COMMENT write so
+        we don't keep stale-but-valid context around for a row the
+        user has already accepted.
+        """
+        cache_key = self._context_cache_key(
+            db_profile=str(db_profile or ""),
+            database=str(database or ""),
+            schema=str(schema or ""),
+            table=str(table or ""),
+        )
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM run_context_cache WHERE cache_key = ?",
+                (cache_key,),
+            )
+            return int(cur.rowcount or 0)
+
+    def gc_run_context_cache(self) -> int:
+        """Sweep cache rows past their TTL; called at process startup."""
+        now = time.time()
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM run_context_cache WHERE expires_at IS NOT NULL AND expires_at < ?",
+                (now,),
             )
             return int(cur.rowcount or 0)
 

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -123,6 +123,10 @@ def create_app(
         _store = _hs()
         if _store is not None:
             _store.gc_orphan_rerun_snapshots()
+            # Also reap context-cache rows past their TTL so a stale
+            # schema doesn't quietly bias re-run prompts after the
+            # user altered the table out-of-band.
+            _store.gc_run_context_cache()
     except Exception:
         # Startup must never crash on a GC hiccup; the executor's own
         # cleanup keeps the table tidy regardless.

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -1013,3 +1013,174 @@ def test_rerun_items_cleans_up_snapshots_on_failure(
     with s._connect() as conn:
         count = conn.execute("SELECT COUNT(*) FROM rerun_context_snapshots").fetchone()[0]
     assert count == 0
+
+
+# ── run_context_cache (P4: skip live profile_table on re-run) ──
+
+
+def test_save_and_lookup_run_context_cache_round_trips(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Round-trip the cache key + payload."""
+    payload = {
+        "db_profile": {
+            "row_count": 42,
+            "columns": [{"name": "id"}, {"name": "status"}],
+        },
+        "existing_metadata": {"database": "shop"},
+    }
+    store.save_run_context_cache(
+        db_profile="prod_pg",
+        database="shop",
+        schema="public",
+        table="orders",
+        payload=payload,
+        source_run_id=7,
+    )
+    hit = store.lookup_run_context_cache(
+        db_profile="prod_pg",
+        database="shop",
+        schema="public",
+        table="orders",
+    )
+    assert hit is not None
+    assert hit["payload"] == payload
+    assert hit["source_run_id"] == 7
+
+
+def test_lookup_run_context_cache_misses_on_different_table(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Wrong (schema, table) coordinates return ``None`` not the wrong row."""
+    store.save_run_context_cache(
+        db_profile="prod_pg",
+        database="shop",
+        schema="public",
+        table="orders",
+        payload={"db_profile": {}, "existing_metadata": {}},
+    )
+    miss = store.lookup_run_context_cache(
+        db_profile="prod_pg",
+        database="shop",
+        schema="public",
+        table="customers",
+    )
+    assert miss is None
+
+
+def test_lookup_run_context_cache_treats_expired_as_missing(
+    store: SQLiteHistoryStore,
+) -> None:
+    """A row past ``expires_at`` reads back as ``None`` so callers rebuild."""
+    store.save_run_context_cache(
+        db_profile="prod_pg",
+        database="",
+        schema="public",
+        table="orders",
+        payload={"db_profile": {}, "existing_metadata": {}},
+        ttl_seconds=0.001,
+    )
+    import time as _time
+
+    _time.sleep(0.01)
+    miss = store.lookup_run_context_cache(
+        db_profile="prod_pg",
+        database="",
+        schema="public",
+        table="orders",
+    )
+    assert miss is None
+
+
+def test_delete_run_context_cache_drops_row(
+    store: SQLiteHistoryStore,
+) -> None:
+    """The apply path calls this once a COMMENT writes successfully."""
+    store.save_run_context_cache(
+        db_profile="prod_pg",
+        database="shop",
+        schema="public",
+        table="orders",
+        payload={"db_profile": {}, "existing_metadata": {}},
+    )
+    deleted = store.delete_run_context_cache(
+        db_profile="prod_pg",
+        database="shop",
+        schema="public",
+        table="orders",
+    )
+    assert deleted == 1
+    assert (
+        store.lookup_run_context_cache(
+            db_profile="prod_pg",
+            database="shop",
+            schema="public",
+            table="orders",
+        )
+        is None
+    )
+
+
+def test_save_run_context_cache_replaces_on_conflict(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Re-analyzing the same table refreshes -- does not duplicate -- the row."""
+    first_payload = {"db_profile": {"row_count": 1}, "existing_metadata": {}}
+    second_payload = {"db_profile": {"row_count": 999}, "existing_metadata": {}}
+    for payload in (first_payload, second_payload):
+        store.save_run_context_cache(
+            db_profile="prod_pg",
+            database="",
+            schema="public",
+            table="orders",
+            payload=payload,
+        )
+    hit = store.lookup_run_context_cache(
+        db_profile="prod_pg",
+        database="",
+        schema="public",
+        table="orders",
+    )
+    assert hit is not None
+    assert hit["payload"] == second_payload
+    with store._connect() as conn:
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM run_context_cache "
+            "WHERE db_profile=? AND schema_name=? AND table_name=?",
+            ("prod_pg", "public", "orders"),
+        ).fetchone()
+    assert rows[0] == 1
+
+
+def test_gc_run_context_cache_reaps_only_expired_rows(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Long-TTL rows survive GC; expired rows are dropped."""
+    store.save_run_context_cache(
+        db_profile="prod_pg",
+        database="",
+        schema="public",
+        table="orders",
+        payload={"db_profile": {}, "existing_metadata": {}},
+        ttl_seconds=0.001,
+    )
+    store.save_run_context_cache(
+        db_profile="prod_pg",
+        database="",
+        schema="public",
+        table="customers",
+        payload={"db_profile": {}, "existing_metadata": {}},
+        ttl_seconds=86400,
+    )
+    import time as _time
+
+    _time.sleep(0.01)
+    deleted = store.gc_run_context_cache()
+    assert deleted == 1
+    survivors = store.lookup_run_context_cache(
+        db_profile="prod_pg",
+        database="",
+        schema="public",
+        table="customers",
+    )
+    assert survivors is not None


### PR DESCRIPTION
## Summary

A user reported a **single-column re-run taking 121s while the original full-table analyze took 46s** — the re-run was paying the \`profile_table\` introspection cost from scratch (column samples, FK, stats) for every target. The first run already produced that exact data; we just threw it away.

This PR persists the freshly-built \`TableProfile\` to a new \`run_context_cache\` table right after the analyze loop's profile fetch. Subsequent re-runs targeting any column on that table hit the cache, skip the live introspection, and feed the agents in <100ms instead of 5-30s.

## Lifecycle

- **Producer** — \`TableProcessor._cache_profile_for_rerun\` runs once per table at first-run time. Best-effort — a failed write must never break the analyze loop.
- **Consumer** — \`build_context_snapshot\` checks the cache before opening a connector. The full-table profile is sliced to one column on demand so two re-runs targeting different columns of the same table share the cache row.
- **GC** — \`apply_review_results_to_db\` drops the row for any table whose COMMENT lands successfully (the user has accepted; cache is no longer load-bearing). 24h TTL guards against silent schema drift after an out-of-band \`ALTER\`. Startup sweep in \`server.py\` reaps anything past TTL.

The cache key intentionally requires a non-empty \`db_profile\` name so a multi-profile setup can't accidentally read a sibling's row.

## Test plan

- [x] \`pytest tests/ --ignore=tests/eval --ignore=tests/perf\` — **1153 pass** (6 new in \`tests/test_rerun.py\` covering save/lookup/expiry/delete/upsert/gc)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Manual smoke — analyze a table, re-run a column on it; expect cache-hit log line and <2s round-trip vs >5s today; apply the column, re-run again — expect cache miss (cleared by apply)