### PR TITLE
fix(usage): aggregate every run kind, not just analyze.run

### DIFF
--- a/amx/web/routers/system_ops.py
+++ b/amx/web/routers/system_ops.py
@@ -68,7 +68,15 @@ def usage(
             "live": bool(live),
             "message": "History store isn't initialised yet.",
         }
-    runs = hs.list_recent_runs(limit=10_000)
+    # ``command_filter=None`` so re-run + apply rows contribute their
+    # tokens too. The default filter keeps only ``analyze.run`` rows,
+    # which surfaced as a phantom-empty Overview when the user's
+    # history was dominated by re-runs (the dominant pattern after
+    # PR #244 made re-runs free per asset). The same filter mistake
+    # had to be fixed earlier in ``_build_enrichment_map``; mirror
+    # the fix here so the Overview cards + System usage table
+    # actually count work the user has done.
+    runs = hs.list_recent_runs(limit=10_000, command_filter=None)
     if window_sec is not None:
         cutoff = time.time() - float(window_sec)
         runs = [r for r in runs if float(r.get("started_at") or 0) >= cutoff]

--- a/tests/web/test_system_ops.py
+++ b/tests/web/test_system_ops.py
@@ -97,6 +97,28 @@ def test_usage_aggregates_by_provider_model(client, auth_headers, monkeypatch) -
     assert by_model[("anthropic", "claude-haiku-4-5")]["runs"] == 1
 
 
+def test_usage_pulls_all_command_kinds(client, auth_headers, monkeypatch) -> None:
+    """The endpoint must request command_filter=None so re-run + apply
+    rows contribute their tokens too. The default
+    list_recent_runs(command_filter="analyze.run") used to drop those
+    rows on the floor, leaving the Overview cards rendering "—" for
+    users whose history was dominated by re-runs."""
+    captured: dict[str, object] = {}
+
+    def fake_list(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return []
+
+    fake_hs = MagicMock(list_recent_runs=fake_list)
+    monkeypatch.setattr("amx.storage.sqlite_store.history_store", lambda: fake_hs)
+
+    response = client.get("/api/usage?window=all", headers=auth_headers)
+    assert response.status_code == 200
+    # Endpoint passes command_filter=None explicitly so every run kind
+    # surfaces -- analyze, rerun, apply alike.
+    assert captured["kwargs"].get("command_filter") is None
+
+
 def test_usage_filters_by_window(client, auth_headers, monkeypatch) -> None:
     """Older runs must drop out when a finite window is set."""
     now = time.time()


### PR DESCRIPTION
## Summary

The Overview page's **Input tokens / Output tokens / Total cost (USD)** cards stayed on \`—\` even for users with months of run history.

Root cause is the same filter mistake we already had to fix once on the pending queue's enrichment path: \`/api/usage\` calls \`list_recent_runs(limit=10_000)\` without an explicit \`command_filter\`, which defaults to \`"analyze.run"\` and drops every re-run + apply row on the floor. After PR #244 made re-runs near-free per asset, those re-runs became the dominant kind in a healthy history — so excluding them rendered the Overview phantom-empty.

Pass \`command_filter=None\` so the aggregator sees the whole dataset. Mirrors the same fix shipped earlier in \`pending.py:_build_enrichment_map\`.

## Test plan

- [x] \`pytest tests/ --ignore=tests/eval --ignore=tests/perf\` — **1154 pass**, including the new regression test asserting the endpoint passes \`command_filter=None\`
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Manual smoke — Overview should now show non-zero Input/Output tokens + cost (provided any historical run carried tokens_json with at least \`total_tokens\` or \`summary\`/\`records\`)