### PR TITLE
fix(usage): pull tokens_json in list_recent_runs so aggregation works

### DIFF
--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -1442,13 +1442,23 @@ class SQLiteHistoryStore:
             params.append(str(command_filter))
         where_sql = ("WHERE " + " AND ".join(clauses)) if clauses else ""
         params.append(max(1, int(limit)))
+        # ``tokens_json`` joins the SELECT so /api/usage's aggregator
+        # (and any future caller that reasons about per-run cost) can
+        # read the per-call records without a second round-trip. The
+        # column is small (~400-500B per run) and the SPA's runs list
+        # already pulls it via /api/history/runs/{id}, so the marginal
+        # bandwidth cost on a 50-row list query is in the same ballpark.
+        # Without this column on the SELECT, _aggregate_runs found
+        # ``run.get("tokens_json")`` to be ``None`` on every row and
+        # silently skipped them all -- the Overview cards rendered
+        # "--" even with months of usage in the history database.
         with self._connect() as conn:
             rows = conn.execute(
                 f"""
                 SELECT id, started_at, ended_at, duration_sec, status, command, mode,
                        db_backend, db_profile, llm_provider, llm_model,
                        llm_profile, doc_profile, code_profile,
-                       scope_json, metrics_json,
+                       scope_json, metrics_json, tokens_json,
                        created_by, hostname, client_version, shared_uuid
                 FROM analysis_runs
                 {where_sql}
@@ -1460,6 +1470,12 @@ class SQLiteHistoryStore:
         out: list[dict[str, Any]] = []
         for r in rows:
             d = dict(r)
+            # ``scope_json`` + ``metrics_json`` are eagerly JSON-decoded
+            # so the SPA's run list can render scope / metrics chips
+            # without re-parsing. ``tokens_json`` deliberately stays a
+            # raw string -- the aggregator handles either shape, and
+            # most readers (recent-runs feed, runs list table) only
+            # care that the field is non-empty, never its contents.
             for key in ("scope_json", "metrics_json"):
                 raw = d.get(key)
                 if isinstance(raw, str) and raw:

--- a/tests/test_apply_events_audit.py
+++ b/tests/test_apply_events_audit.py
@@ -163,3 +163,54 @@ def test_list_apply_events_respects_limit(store: SQLiteHistoryStore) -> None:
         store.record_apply_event(schema_name="s", new_comment=f"c-{i}")
     assert len(store.list_apply_events(limit=3)) == 3
     assert len(store.list_apply_events(limit=100)) == 10
+
+
+def test_list_recent_runs_returns_tokens_json_for_aggregation(
+    store: SQLiteHistoryStore,
+) -> None:
+    """``/api/usage`` aggregates per-run tokens by reading
+    ``tokens_json`` off each row. The previous SELECT skipped that
+    column so the aggregator silently received None and produced an
+    empty Overview. Pin the SELECT so this regression can't slip back.
+    """
+    run_id = store.create_run(
+        command="analyze.run",
+        mode="chat",
+        db_backend="postgresql",
+        db_profile="local",
+        llm_provider="openai",
+        llm_model="gpt-4o",
+        scope={},
+    )
+    store.finish_run(
+        run_id,
+        status="success",
+        metrics={"duration_sec": 1.0},
+        tokens={
+            "total_tokens": 300,
+            "total_cost_usd": 0.0042,
+            "records": [
+                {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 200,
+                    "input_cost_usd": 0.001,
+                    "output_cost_usd": 0.0032,
+                }
+            ],
+        },
+        results={},
+    )
+
+    runs = store.list_recent_runs(limit=10, command_filter=None)
+    assert len(runs) == 1
+    raw = runs[0].get("tokens_json")
+    assert raw, "tokens_json must be present on the returned dict"
+    # Either a JSON string the aggregator parses or a pre-parsed dict.
+    if isinstance(raw, str):
+        import json as _json
+
+        payload = _json.loads(raw)
+    else:
+        payload = raw
+    assert payload.get("total_tokens") == 300
+    assert payload.get("records")


### PR DESCRIPTION
## Summary

PR #252 removed the wrong-command-filter false negative, but the Overview cards stayed empty. Deeper bug: \`list_recent_runs\`'s SELECT never included \`tokens_json\`, so \`_aggregate_runs\` saw \`run.get("tokens_json") == None\` on every row and silently skipped them. With 48 runs in a healthy history, \`counted_runs\` came back zero and the Overview rendered \`—\`.

## Replay against the user's actual history.db

**Before (\`main\` post-#252):**
\`\`\`
runs returned: 48
counted_runs: 0
TOTALS: {'runs': 0, 'input_tokens': 0, 'output_tokens': 0,
         'total_tokens': 0, 'cost_usd': 0.0}
\`\`\`

**After:**
\`\`\`
runs returned: 48
counted_runs: 36
TOTALS: {'runs': 36, 'input_tokens': 409928,
         'output_tokens': 75915, 'total_tokens': 485843,
         'cost_usd': 0.18}
\`\`\`

Pin a regression test on the storage layer so the column can't be dropped from the SELECT again without breaking the suite.

## Test plan

- [x] \`pytest tests/ --ignore=tests/eval --ignore=tests/perf\` — **1155 pass** (1 new in \`test_apply_events_audit.py\` asserting \`tokens_json\` round-trips through \`list_recent_runs\`)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Manual smoke — Overview now reads non-zero Input/Output tokens + total cost on any history database that contains at least one run with non-empty \`tokens_json\`