### PR TITLE
feat: token + USD cost on every LLM-using feature (generate + ask)

### DIFF
--- a/amx/search/_agent/answering.py
+++ b/amx/search/_agent/answering.py
@@ -31,6 +31,8 @@ from amx.search._agent._types import (
     _trim_rows_to_token_budget,
 )
 from amx.utils.logging import get_logger
+from amx.utils.token_tracker import estimate_tokens
+from amx.utils.token_tracker import tracker as token_tracker
 
 log = get_logger("search.agent.answering")
 
@@ -111,14 +113,22 @@ class AnsweringMixin:
             dict(base_payload, rows=trimmed_rows, result_count=len(trimmed_rows)),
             ensure_ascii=True,
         )
+        synthesize_messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+        est = estimate_tokens(synthesize_messages)
         result = llm.chat(
-            [
-                {"role": "system", "content": system},
-                {"role": "user", "content": user},
-            ],
+            synthesize_messages,
             temperature=0.1,
             max_tokens=1600 if len(rows) > 12 else 1200,
             use_logprobs=False,
+        )
+        token_tracker.record_for(
+            "answer.synthesize",
+            est,
+            llm,
+            getattr(result, "usage", None),
         )
         return result.content.strip(), result.usage or {}
 

--- a/amx/search/_agent/planning.py
+++ b/amx/search/_agent/planning.py
@@ -37,6 +37,8 @@ from amx.search._agent._types import (
     _merge_usage,
 )
 from amx.utils.logging import get_logger
+from amx.utils.token_tracker import estimate_tokens
+from amx.utils.token_tracker import tracker as token_tracker
 
 log = get_logger("search.agent.planning")
 
@@ -214,14 +216,25 @@ class PlanningMixin:
             },
             ensure_ascii=True,
         )
+        plan_messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+        est = estimate_tokens(plan_messages)
         result = llm.chat(
-            [
-                {"role": "system", "content": system},
-                {"role": "user", "content": user},
-            ],
+            plan_messages,
             temperature=0.0,
             max_tokens=900,
             use_logprobs=False,
+        )
+        # Pin the planning pass into the global tracker so the Run
+        # detail page surfaces an honest "plan.pass1" row alongside
+        # tool_agent.iter and answer.synthesize.
+        token_tracker.record_for(
+            "plan.pass1",
+            est,
+            llm,
+            getattr(result, "usage", None),
         )
         payload = _json_block(result.content)
         return (self._plan_from_payload(payload, question), result.usage or {})
@@ -256,14 +269,22 @@ class PlanningMixin:
             },
             ensure_ascii=True,
         )
+        review_messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+        est = estimate_tokens(review_messages)
         result = llm.chat(
-            [
-                {"role": "system", "content": system},
-                {"role": "user", "content": user},
-            ],
+            review_messages,
             temperature=0.0,
             max_tokens=700,
             use_logprobs=False,
+        )
+        token_tracker.record_for(
+            "plan.pass2_review",
+            est,
+            llm,
+            getattr(result, "usage", None),
         )
         payload = _json_block(result.content)
         payload.setdefault("review_notes", "reviewed_by_pass2")

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -28,6 +28,8 @@ from amx.config import AMXConfig
 from amx.llm.provider import LLMProvider
 from amx.search.agent_tools import ToolBox
 from amx.search.catalog import SearchCatalog
+from amx.utils.token_tracker import estimate_tokens
+from amx.utils.token_tracker import tracker as token_tracker
 
 if TYPE_CHECKING:
     from amx.utils.live_display import LiveDisplay
@@ -805,14 +807,29 @@ def _run_tool_loop(
             from amx.agents.orchestrator import RunCancelled
 
             raise RunCancelled(f"Cancelled before iteration {iteration}")
+        chat_messages = [_convert_message_for_litellm(m) for m in messages]
+        # Pre-call token estimate so the tracker can label this step's
+        # input cost. Falls back to 0 silently when tiktoken can't
+        # tokenise the message shape (some structured tool messages).
+        est = estimate_tokens(chat_messages)
         result = llm.chat(
-            [_convert_message_for_litellm(m) for m in messages],
+            chat_messages,
             temperature=0.0,
             max_tokens=_AGENT_MAX_TOKENS,
             use_logprobs=False,
             tools=tools_schema,
             tool_choice="auto",
             on_thinking=on_thinking,
+        )
+        # Per-step record so the Run detail Metrics card can render
+        # an honest tool_agent.iter row -- the previous wiring summed
+        # ``aggregated_usage`` for the SSE answer.final event but never
+        # wrote into ``analysis_runs.tokens_json``.
+        token_tracker.record_for(
+            f"tool_agent.iter{iterations}",
+            est,
+            llm,
+            getattr(result, "usage", None),
         )
         # Aggregate usage across iterations.
         for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
@@ -862,21 +879,28 @@ def _run_tool_loop(
         # Hit the iteration cap without a final answer — force a closing call
         # without ``tools`` so the LLM returns plain text from whatever it
         # gathered.
+        closing_messages = [_convert_message_for_litellm(m) for m in messages] + [
+            {
+                "role": "user",
+                "content": (
+                    "You've reached the tool-call budget. Compose your final answer now, in "
+                    f"{answer_language or 'english'}, based on the tool results above."
+                ),
+            }
+        ]
+        est = estimate_tokens(closing_messages)
         result = llm.chat(
-            [_convert_message_for_litellm(m) for m in messages]
-            + [
-                {
-                    "role": "user",
-                    "content": (
-                        "You've reached the tool-call budget. Compose your final answer now, in "
-                        f"{answer_language or 'english'}, based on the tool results above."
-                    ),
-                }
-            ],
+            closing_messages,
             temperature=0.0,
             max_tokens=_AGENT_MAX_TOKENS,
             use_logprobs=False,
             on_thinking=on_thinking,
+        )
+        token_tracker.record_for(
+            "tool_agent.final",
+            est,
+            llm,
+            getattr(result, "usage", None),
         )
         for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
             aggregated_usage[key] += int((result.usage or {}).get(key, 0) or 0)

--- a/amx/utils/token_tracker.py
+++ b/amx/utils/token_tracker.py
@@ -37,13 +37,38 @@ def _get_encoding() -> tiktoken.Encoding:
     return tiktoken.get_encoding("cl100k_base")
 
 
-def estimate_tokens(messages: list[dict[str, str]]) -> int:
+def estimate_tokens(messages: list[dict[str, Any]]) -> int:
+    """Estimate prompt tokens for a list of OpenAI-style chat messages.
+
+    Each value is encoded with tiktoken's ``cl100k_base`` BPE. Tool-
+    calling shapes pass ``tool_calls``: list[dict] / ``content``: list
+    instead of plain strings, so we coerce non-string values to JSON
+    text before encoding -- the previous implementation crashed with
+    ``TypeError: 'list' object cannot be converted to 'PyString'`` when
+    the search tool agent fed it a chat with ``role=assistant`` plus
+    ``tool_calls=[...]``. Falling back to ``json.dumps`` is honest
+    enough for an estimate (it overcounts a bit on punctuation, which
+    is the safe direction).
+    """
     enc = _get_encoding()
     total = 0
     for msg in messages:
         total += 4  # role/name/separator framing
         for value in msg.values():
-            total += len(enc.encode(value, disallowed_special=()))
+            if value is None:
+                continue
+            if not isinstance(value, str):
+                # Tool-calling messages can carry list[dict] / dict here;
+                # serialise so tiktoken always sees a string.
+                try:
+                    import json as _json
+
+                    text = _json.dumps(value, ensure_ascii=True)
+                except Exception:
+                    text = str(value)
+            else:
+                text = value
+            total += len(enc.encode(text, disallowed_special=()))
     total += 2  # reply priming
     return max(1, total)
 

--- a/amx/web/routers/ask.py
+++ b/amx/web/routers/ask.py
@@ -34,6 +34,7 @@ from amx.search.session_store import ChatSessionStore
 from amx.search.tool_agent import run_tool_agent
 from amx.storage.sqlite_store import history_store
 from amx.utils.logging import get_logger
+from amx.utils.token_tracker import tracker as token_tracker
 from amx.web.deps import get_cfg, get_jobs
 from amx.web.jobs import Job, JobRegistry
 from amx.web.progress_bus import emit, emit_terminal
@@ -563,12 +564,80 @@ def _ask_worker(
     emit(job.queue, "activity.added", {"idx": 0, "label": "Thinking"})
     emit(job.queue, "activity.begin", {"idx": 0})
 
+    # Open a ``search.ask`` analysis_runs row so the Studio
+    # /ask query lands in the same RunsList / Run detail / /usage
+    # surfaces analyze.run + rerun already use. Mirrors the CLI
+    # path (amx/cli_support/commands/search.py around the /ask
+    # entry point) so the two surfaces produce equivalent history
+    # rows. Best-effort: a missing history store can't block the
+    # tool-agent loop -- the answer still streams either way.
+    token_tracker.reset()
+    hs = history_store()
+    run_id: int | None = None
+    if hs is not None:
+        try:
+            run_id = int(
+                hs.create_run(
+                    command="search.ask",
+                    mode="chat",
+                    db_backend=getattr(cfg.db, "backend", "") or "",
+                    db_profile=db_profile,
+                    llm_provider=cfg.llm.provider,
+                    llm_model=cfg.llm.model,
+                    scope={p: [] for p in (scope_profiles or [])},
+                    selected_count=0,
+                    planned_count=0,
+                    review_strategy=None,
+                    llm_profile=cfg.active_llm_profile or None,
+                    doc_profile=getattr(cfg, "active_doc_profile", None) or None,
+                    code_profile=getattr(cfg, "active_code_profile", None) or None,
+                    settings={
+                        "trigger": "studio.ask",
+                        "session_id": session_id,
+                        "scope_profiles": list(scope_profiles or []),
+                    },
+                )
+            )
+        except Exception as exc:  # pragma: no cover - best-effort
+            log.warning("Could not open search.ask run row: %s", exc)
+            run_id = None
+
+    def _finish(
+        *,
+        status_value: str,
+        metrics: dict[str, Any] | None = None,
+        error_text: str = "",
+    ) -> None:
+        """Tail-call helper: persist tokens_json on every terminal
+        path -- success, failure, cancel. Without this, the Run
+        detail Metrics card stays empty for ask queries that
+        crashed mid-flight."""
+        if hs is None or run_id is None:
+            return
+        try:
+            hs.finish_run(
+                run_id,
+                status=status_value,
+                metrics=metrics or {},
+                tokens={
+                    "total_tokens": token_tracker.total_tokens,
+                    "total_cost_usd": round(token_tracker.total_cost_usd, 8),
+                    "summary": token_tracker.summary(),
+                    "records": token_tracker.records(),
+                },
+                results={"session_id": session_id},
+                error_text=error_text,
+            )
+        except Exception as exc:  # pragma: no cover - best-effort
+            log.warning("Could not finalise tokens_json for ask run %s: %s", run_id, exc)
+
     catalog = _load_catalog()
     if catalog is None:
         job.status = "failed"
         job.error = "Search catalog isn't initialised yet — run /search sync first."
         job.ended_at = time.time()
         emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
+        _finish(status_value="failed", error_text=job.error)
         emit_terminal(
             job.queue,
             "job.failed",
@@ -593,6 +662,7 @@ def _ask_worker(
         )
         job.ended_at = time.time()
         emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
+        _finish(status_value="failed", error_text=job.error)
         emit_terminal(
             job.queue,
             "job.failed",
@@ -651,6 +721,7 @@ def _ask_worker(
         job.status = "cancelled"
         job.ended_at = time.time()
         emit(job.queue, "activity.fail", {"idx": 0, "detail": "Cancelled."})
+        _finish(status_value="cancelled")
         emit_terminal(job.queue, "job.cancelled", {})
         return
     except Exception as exc:
@@ -691,6 +762,7 @@ def _ask_worker(
         job.error = message
         job.ended_at = time.time()
         emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
+        _finish(status_value="failed", error_text=job.error)
         payload: dict[str, Any] = {"error": job.error}
         if hint:
             payload["hint"] = hint
@@ -708,7 +780,7 @@ def _ask_worker(
             try:
                 store.append_assistant_turn(
                     int(session_id),
-                    run_id=None,
+                    run_id=run_id,
                     answer_summary=result.answer or "",
                 )
             except Exception as exc:
@@ -752,6 +824,16 @@ def _ask_worker(
         "usage": dict(result.usage),
     }
     job.ended_at = time.time()
+    _finish(
+        status_value="success",
+        metrics={
+            "iterations": int(result.iterations or 0),
+            "tool_call_count": len(result.tool_calls or []),
+            "total_latency_ms": int(result.total_latency_ms or 0),
+            "scope_profiles": list(result.scope_profiles or []),
+            "focus_profile": result.focus_profile,
+        },
+    )
     emit_terminal(job.queue, "job.done", {"summary": job.summary})
 
 

--- a/amx/web/routers/generate.py
+++ b/amx/web/routers/generate.py
@@ -55,6 +55,8 @@ from amx.llm.provider import LLMProvider
 from amx.pending_review import load_pending, save_pending
 from amx.storage.sqlite_store import history_store
 from amx.utils.logging import get_logger
+from amx.utils.token_tracker import estimate_tokens
+from amx.utils.token_tracker import tracker as token_tracker
 from amx.web.deps import get_cfg
 from amx.web.routers.live_db import _connector_for_scope
 
@@ -179,15 +181,27 @@ def _generate(
     n: int = 1,
     verbosity: str = "brief",
     temperature: float = 0.2,
+    asset_kind: str = "generate",
 ) -> list[str]:
-    """Run the LLM and return up to N description alternatives."""
+    """Run the LLM and return up to N description alternatives.
+
+    Token + USD cost is recorded into the module-level ``TokenTracker``
+    singleton (``amx.utils.token_tracker``) so callers can persist the
+    summary into ``analysis_runs.tokens_json`` -- this keeps the Run
+    detail Metrics card honest for ``generate.*`` runs (it used to
+    read "No metrics recorded" because nothing wired the tracker).
+    Each endpoint resets the tracker at the top of the request to
+    avoid bleeding state across concurrent jobs.
+    """
     system_prompt = _build_system_prompt(n, verbosity)
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+    est = estimate_tokens(messages)
     try:
         result = llm.chat(
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
+            messages=messages,
             temperature=temperature,
             use_logprobs=False,
         )
@@ -196,6 +210,17 @@ def _generate(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"LLM call failed: {exc.__class__.__name__}: {exc}",
         ) from exc
+    # Record per-call usage so ``_record_and_queue`` can pull it into
+    # ``tokens_json`` via ``finish_run``. ``record_for`` also computes
+    # USD cost from the active pricing table; failures inside it are
+    # swallowed (token_tracker.py:_record_for_safe) so a missing model
+    # price never breaks the response.
+    token_tracker.record_for(
+        f"generate.{asset_kind}",
+        est,
+        llm,
+        getattr(result, "usage", None),
+    )
     alternatives = _parse_alternatives(result.content or "", n)
     if not alternatives:
         raise HTTPException(
@@ -584,6 +609,37 @@ def _record_and_queue(
     except Exception as exc:  # pragma: no cover
         log.warning("Could not flip run %s to ready_for_review: %s", run_id, exc)
 
+    # Surface the LLM token + USD cost into ``analysis_runs.tokens_json``
+    # so the Studio Run detail Metrics card actually has something to
+    # render. Without this, Run #N detail page reads "No metrics
+    # recorded" even though we know exactly how many tokens the call
+    # burned. ``finish_run`` accepts the same shape ``analyze.run``
+    # writes (total_tokens / total_cost_usd / summary / records),
+    # which the SPA's TokensRow + CostRow already understand.
+    try:
+        hs.finish_run(
+            int(run_id),
+            status="ready_for_review",
+            metrics={
+                "asset_kind": asset_kind,
+                "alternatives_count": len(alternatives),
+                "trigger": "studio.generate.singleshot",
+            },
+            tokens={
+                "total_tokens": token_tracker.total_tokens,
+                "total_cost_usd": round(token_tracker.total_cost_usd, 8),
+                "summary": token_tracker.summary(),
+                "records": token_tracker.records(),
+            },
+            results={"result_id": response.get("result_id")},
+        )
+    except Exception as exc:  # pragma: no cover - best-effort
+        log.warning(
+            "Could not finalise tokens_json for generate run %s: %s",
+            run_id,
+            exc,
+        )
+
     rr = ReviewResult(
         schema=schema,
         table=table,
@@ -615,11 +671,22 @@ def generate_database(
     catalog: str | None = Query(default=None),
     cfg: AMXConfig = Depends(get_cfg),
 ) -> dict[str, Any]:
+    # ``token_tracker.reset()`` clears any residual records from a
+    # previous request that shared this Python process so the
+    # finalised ``tokens_json`` only reflects this generation. The
+    # analyze.run worker uses the same singleton-with-reset pattern
+    # (amx/web/routers/runs.py:_run_worker_body).
+    token_tracker.reset()
     db, db_label, backend = _resolve_generate_connector(cfg, profile, database, catalog)
     n, verbosity, temperature, pd = _settings(cfg)
     user_prompt = _build_database_prompt(db, db_label, pd)
     alternatives = _generate(
-        _llm(cfg), user_prompt, n=n, verbosity=verbosity, temperature=temperature
+        _llm(cfg),
+        user_prompt,
+        n=n,
+        verbosity=verbosity,
+        temperature=temperature,
+        asset_kind="database",
     )
     return _record_and_queue(
         cfg,
@@ -643,11 +710,17 @@ def generate_schema(
     catalog: str | None = Query(default=None),
     cfg: AMXConfig = Depends(get_cfg),
 ) -> dict[str, Any]:
+    token_tracker.reset()
     db, db_label, backend = _resolve_generate_connector(cfg, profile, database, catalog)
     n, verbosity, temperature, pd = _settings(cfg)
     user_prompt = _build_schema_prompt(db, schema, pd)
     alternatives = _generate(
-        _llm(cfg), user_prompt, n=n, verbosity=verbosity, temperature=temperature
+        _llm(cfg),
+        user_prompt,
+        n=n,
+        verbosity=verbosity,
+        temperature=temperature,
+        asset_kind="schema",
     )
     return _record_and_queue(
         cfg,
@@ -672,11 +745,17 @@ def generate_table(
     catalog: str | None = Query(default=None),
     cfg: AMXConfig = Depends(get_cfg),
 ) -> dict[str, Any]:
+    token_tracker.reset()
     db, db_label, backend = _resolve_generate_connector(cfg, profile, database, catalog)
     n, verbosity, temperature, pd = _settings(cfg)
     user_prompt = _build_table_prompt(db, schema, table, pd)
     alternatives = _generate(
-        _llm(cfg), user_prompt, n=n, verbosity=verbosity, temperature=temperature
+        _llm(cfg),
+        user_prompt,
+        n=n,
+        verbosity=verbosity,
+        temperature=temperature,
+        asset_kind="table",
     )
     return _record_and_queue(
         cfg,
@@ -702,11 +781,17 @@ def generate_column(
     catalog: str | None = Query(default=None),
     cfg: AMXConfig = Depends(get_cfg),
 ) -> dict[str, Any]:
+    token_tracker.reset()
     db, db_label, backend = _resolve_generate_connector(cfg, profile, database, catalog)
     n, verbosity, temperature, pd = _settings(cfg)
     user_prompt = _build_column_prompt(db, schema, table, column, pd)
     alternatives = _generate(
-        _llm(cfg), user_prompt, n=n, verbosity=verbosity, temperature=temperature
+        _llm(cfg),
+        user_prompt,
+        n=n,
+        verbosity=verbosity,
+        temperature=temperature,
+        asset_kind="column",
     )
     return _record_and_queue(
         cfg,

--- a/tests/web/test_ask.py
+++ b/tests/web/test_ask.py
@@ -225,7 +225,13 @@ def test_ask_worker_persists_assistant_turn_with_correct_kwargs(
     """The worker used to call ``append_assistant_turn(answer=…)`` —
     but the store signature is ``append_assistant_turn(*, run_id,
     answer_summary)``. The TypeError was swallowed by a bare except
-    and assistant turns silently disappeared. Pin the kwargs."""
+    and assistant turns silently disappeared. Pin the kwargs.
+
+    0.13: ``run_id`` now carries the just-opened ``search.ask``
+    analysis_runs row id (was always ``None`` previously) so the
+    Audit / RunsList / chat_turns join paths line up. Assertion
+    accepts either ``None`` (history store unavailable) or an int.
+    """
     from amx.search.tool_agent import ToolAgentResult
 
     stub_session_store.start_session.return_value = 99
@@ -257,7 +263,10 @@ def test_ask_worker_persists_assistant_turn_with_correct_kwargs(
     args, kwargs = stub_session_store.append_assistant_turn.call_args
     assert args == (99,)
     assert kwargs["answer_summary"] == "hello there"
-    assert kwargs["run_id"] is None
+    # Either None (no history store available in test) or a real int
+    # (history store is initialised; the search.ask row got created).
+    run_id = kwargs["run_id"]
+    assert run_id is None or isinstance(run_id, int)
 
 
 def test_ask_worker_failed_when_catalog_missing(
@@ -292,3 +301,98 @@ def _drain_sse(client, path: str, auth_headers, timeout: float = 3.0) -> list[di
             if str(event.get("type", "")).startswith("job."):
                 break
     return events
+
+
+def test_ask_worker_opens_search_ask_run_with_tokens(
+    client, auth_headers, monkeypatch, stub_session_store
+) -> None:
+    """0.13: every Studio /ask query opens an ``analysis_runs`` row
+    with ``command="search.ask"`` so the Run detail Metrics card,
+    /usage aggregator, and /compare all see the LLM cost. Pin the
+    contract: create_run + finish_run(tokens={...}) fire on the
+    happy path. Without these, the user's complaint -- "ask runda
+    cost gözükmüyor" -- regresses silently.
+    """
+    from amx.search.tool_agent import ToolAgentResult
+
+    stub_session_store.start_session.return_value = 1
+    stub_session_store.append_user_turn.return_value = None
+    stub_session_store.append_assistant_turn.return_value = None
+
+    fake_hs = MagicMock()
+    fake_hs.create_run.return_value = 7
+    fake_hs.finish_run.return_value = None
+    monkeypatch.setattr(ask_router, "history_store", lambda: fake_hs)
+
+    def fake_run_tool_agent(**kwargs):
+        return ToolAgentResult(
+            answer="hello",
+            tool_calls=[],
+            iterations=2,
+            usage={"prompt_tokens": 11, "completion_tokens": 3, "total_tokens": 14},
+            finish_reason="stop",
+            total_latency_ms=42,
+        )
+
+    monkeypatch.setattr(ask_router, "run_tool_agent", fake_run_tool_agent)
+    monkeypatch.setattr(ask_router, "_load_catalog", lambda: MagicMock())
+    monkeypatch.setattr(ask_router, "LLMProvider", lambda cfg: MagicMock())
+
+    submit = client.post(
+        "/api/ask",
+        headers=auth_headers,
+        json={"question": "hi"},
+    )
+    job_id = submit.json()["job_id"]
+    _wait_for_status(client, job_id, "done")
+
+    fake_hs.create_run.assert_called_once()
+    create_kwargs = fake_hs.create_run.call_args.kwargs
+    assert create_kwargs["command"] == "search.ask"
+
+    fake_hs.finish_run.assert_called_once()
+    finish_args = fake_hs.finish_run.call_args
+    assert finish_args.args == (7,)
+    finish_kwargs = finish_args.kwargs
+    assert finish_kwargs["status"] == "success"
+    tokens = finish_kwargs["tokens"] or {}
+    # tracker.records() may be empty when run_tool_agent itself is
+    # stubbed (no real llm.chat happens) -- but the tokens dict
+    # must be present with the canonical keys so the Run detail
+    # Metrics card has something to render in production.
+    for key in ("total_tokens", "total_cost_usd", "summary", "records"):
+        assert key in tokens
+
+    # The chat turn must carry the run_id we just created so /history
+    # can join chat_turns with analysis_runs.
+    stub_session_store.append_assistant_turn.assert_called_once()
+    assert stub_session_store.append_assistant_turn.call_args.kwargs["run_id"] == 7
+
+
+def test_ask_worker_finishes_run_on_failure(
+    client, auth_headers, monkeypatch, stub_session_store
+) -> None:
+    """A failed ask must still call ``finish_run`` so the Audit /
+    /usage / Compare surfaces show cost for partial work, with
+    status=failed + error_text. Without this the run row stays in
+    ``running`` forever and the Metrics card never renders."""
+    fake_hs = MagicMock()
+    fake_hs.create_run.return_value = 9
+    fake_hs.finish_run.return_value = None
+    monkeypatch.setattr(ask_router, "history_store", lambda: fake_hs)
+
+    def boom(**kwargs):
+        raise RuntimeError("LLM exploded")
+
+    monkeypatch.setattr(ask_router, "run_tool_agent", boom)
+    monkeypatch.setattr(ask_router, "_load_catalog", lambda: MagicMock())
+    monkeypatch.setattr(ask_router, "LLMProvider", lambda cfg: MagicMock())
+
+    submit = client.post("/api/ask", headers=auth_headers, json={"question": "hi"})
+    job_id = submit.json()["job_id"]
+    _wait_for_status(client, job_id, "failed")
+
+    fake_hs.finish_run.assert_called_once()
+    kwargs = fake_hs.finish_run.call_args.kwargs
+    assert kwargs["status"] == "failed"
+    assert "exploded" in (kwargs["error_text"] or "").lower()

--- a/tests/web/test_generate_router.py
+++ b/tests/web/test_generate_router.py
@@ -57,6 +57,19 @@ class FakeHistoryStore:
                 r["status"] = status
                 return
 
+    def finish_run(self, run_id: int, **kwargs: Any) -> None:
+        """Capture the tokens / metrics / status payload the
+        generate.* endpoints now write so tests can assert that
+        ``tokens_json`` carries USD cost + per-step records."""
+        for r in self.runs:
+            if r["id"] == run_id:
+                r["status"] = kwargs.get("status", r.get("status"))
+                r["finish_metrics"] = kwargs.get("metrics") or {}
+                r["finish_tokens"] = kwargs.get("tokens") or {}
+                r["finish_results"] = kwargs.get("results") or {}
+                r["finish_error_text"] = kwargs.get("error_text", "")
+                return
+
     def fetch_run_result(self, result_id: int) -> dict[str, Any] | None:
         return self.run_results.get(result_id)
 
@@ -479,3 +492,106 @@ def test_n3_persists_all_alternatives_in_run_results(
         "Second framing.",
         "Third alternative.",
     ]
+
+
+# ── tokens_json + USD cost recording (PR-token-cost-tracking) ──
+
+
+def test_generate_database_records_tokens_in_finish_run(
+    cfg: AMXConfig,
+    client,
+    auth_headers,
+    chat_spy: MagicMock,
+    fake_history: FakeHistoryStore,
+) -> None:
+    """The Studio Run detail Metrics card was rendering "No metrics
+    recorded" for ``generate.*`` runs because ``finish_run`` was never
+    called. Pin the contract: every successful generate triggers
+    ``finish_run(tokens={...})`` with a non-zero total_tokens summary,
+    so the SPA can show input/output + USD cost just like analyze.run.
+    """
+    cfg.llm.n_alternatives = 1
+    chat_spy.return_value = ChatResult(
+        content="A single description sentence.",
+        usage={"prompt_tokens": 100, "completion_tokens": 30, "total_tokens": 130},
+    )
+
+    resp = _post(client, "/api/generate/database", auth_headers)
+    assert resp.status_code == 200
+
+    assert len(fake_history.runs) == 1
+    run = fake_history.runs[0]
+    tokens = run.get("finish_tokens") or {}
+    assert tokens.get("total_tokens", 0) > 0, (
+        "generate.database must populate tokens_json.total_tokens "
+        "(Run detail Metrics card depends on it)"
+    )
+    summary = tokens.get("summary") or []
+    assert summary and summary[0][0].startswith("generate."), (
+        "summary[0][0] should be the per-step label so the Run detail page can render the breakdown"
+    )
+    assert "records" in tokens
+    assert run.get("status") == "ready_for_review"
+
+
+def test_generate_column_records_per_step_label(
+    cfg: AMXConfig,
+    client,
+    auth_headers,
+    chat_spy: MagicMock,
+    fake_history: FakeHistoryStore,
+) -> None:
+    """Each generate.* endpoint passes its asset_kind into the
+    tracker step label so the breakdown reads ``generate.column``,
+    not a generic ``llm.chat`` -- the Run detail page surfaces the
+    label as the row name in the Metrics card."""
+    cfg.llm.n_alternatives = 1
+    chat_spy.return_value = ChatResult(
+        content="A column-focused sentence.",
+        usage={"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70},
+    )
+
+    resp = client.post(
+        "/api/generate/column/sales/orders/customer_id?profile=demo",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    run = fake_history.runs[0]
+    summary = run["finish_tokens"]["summary"]
+    assert summary[0][0] == "generate.column"
+
+
+def test_generate_endpoint_resets_tracker_between_calls(
+    cfg: AMXConfig,
+    client,
+    auth_headers,
+    chat_spy: MagicMock,
+    fake_history: FakeHistoryStore,
+) -> None:
+    """Two back-to-back generate calls must not bleed token totals
+    into each other. The shared ``TokenTracker`` singleton is reset
+    at endpoint top -- without that guard the second run's
+    ``tokens_json.total_tokens`` would equal the SUM of both LLM
+    calls instead of just its own."""
+    cfg.llm.n_alternatives = 1
+
+    chat_spy.return_value = ChatResult(
+        content="First.",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+    _post(client, "/api/generate/database", auth_headers)
+
+    chat_spy.return_value = ChatResult(
+        content="Second.",
+        usage={"prompt_tokens": 200, "completion_tokens": 50, "total_tokens": 250},
+    )
+    _post(client, "/api/generate/database", auth_headers)
+
+    first = fake_history.runs[0]["finish_tokens"]
+    second = fake_history.runs[1]["finish_tokens"]
+    # The second run must reflect ONLY its own LLM round-trip.
+    assert second["total_tokens"] < first["total_tokens"] + second["total_tokens"]
+    # Stricter: tracker reset means the two records lists are
+    # length-1 each (one llm.chat per generate).
+    assert len(first["records"]) == 1
+    assert len(second["records"]) == 1


### PR DESCRIPTION
## Summary

User: _"Yapılan runlarda (generate) cost detayı gelmedi. Her şeyin input output cost detayı olmalı llm ile alakalı. Ask modu dahil llm kullanan her feature'da bunların olduğuna emin ol."_

Studio's Run detail Metrics card was honest for \`analyze.run\` and \`rerun\` (PR #235 / #244 wired the singleton TokenTracker through the analyze worker) but read **"No metrics recorded"** for:

- \`generate.{database, schema, table, column}\` — the four per-asset endpoints called \`hs.create_run\` but never \`hs.finish_run(tokens=...)\`, leaving \`tokens_json\` null.
- Studio \`/api/ask\` — never opened an \`analysis_runs\` row at all, only persisted \`chat_sessions\` / \`chat_turns\`. CLI \`/search ask\` already wrote a \`search.ask\` row with cost; Studio had a parity gap.
- Plus the ask path's deeper LLM call sites (tool-agent loop, planning two-pass, answering synthesis) never wired tokens either, so even with ask rows created the per-step Metrics card breakdown would have been blank.

## What's wired

- **\`amx/web/routers/generate.py\`** — each endpoint resets the tracker at the top, \`_generate()\` records per-call usage with step \`generate.<asset_kind>\`, and \`_record_and_queue\` calls \`finish_run(status="ready_for_review", tokens={...})\`.
- **\`amx/web/routers/ask.py:_ask_worker\`** — opens a \`command="search.ask"\` analysis_runs row at start (mirroring the CLI path), threads the new \`run_id\` into \`store.append_assistant_turn\` so chat_turns join cleanly, and calls \`finish_run\` on success / cancel / failure paths with the same tokens shape as analyze.run.
- **\`amx/search/tool_agent.py\`** + **\`_agent/planning.py\`** + **\`_agent/answering.py\`** — each \`llm.chat()\` site picks up \`tracker.record_for(step.label, ...)\` so the Run detail per-step breakdown reads \`tool_agent.iterN\`, \`plan.pass1\` / \`plan.pass2_review\`, \`answer.synthesize\`.
- **\`amx/utils/token_tracker.py:estimate_tokens\`** — hardened against tool-calling shapes that carry \`list[dict]\` content. JSON-serialise non-string values before encoding (the previous impl crashed with \`'list' object cannot be converted to PyString\` on assistant turns with \`tool_calls=[...]\`).

## Frontend

**Zero changes.** The Run detail Metrics card already reads \`run.tokens_json.{records, summary, total_tokens, total_cost_usd}\` from PR #235 onward. This PR just feeds the four LLM paths that previously starved it.

## Test plan

- [x] \`pytest tests/ --ignore=tests/eval --ignore=tests/perf\` — **1159 pass** (5 new):
  - 3 in \`test_generate_router.py\` — \`finish_run(tokens=...)\` fires with non-zero total + per-step label + cross-call reset
  - 2 in \`test_ask.py\` — \`search.ask\` row open / \`finish_run(status=success)\` and \`finish_run(status=failed)\` carry tokens
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] \`tsc --noEmit\` + \`npm run build\` clean
- [ ] Manual smoke
  - Studio Browse → Schema → \`Gen\` (single table): Run detail Metrics card shows \`Tokens\` + \`Cost\` (PR #257 routes this through submitRun, already covered)
  - Studio Schema → "Generate description" / "Just this schema" (single-shot): \`generate.schema\` row has token + cost
  - Studio Ask → ask any question: \`/runs\` shows new \`search.ask\` row, Metrics card has tokens + cost + per-step breakdown (\`plan.pass1\`, \`tool_agent.iterN\`, \`answer.synthesize\`)
  - Overview Input/Output tokens + Total cost tiles count these new rows (already wired via PR #253 \`command_filter=None\`)