### PR TITLE
fix(generate): capture target database/catalog into the run row

### DIFF
--- a/amx/web/routers/generate.py
+++ b/amx/web/routers/generate.py
@@ -504,6 +504,8 @@ def _record_and_queue(
     asset_kind: str,
     db_profile: str | None = None,
     db_backend: str | None = None,
+    database: str | None = None,
+    catalog: str | None = None,
 ) -> dict[str, Any]:
     """Persist generated alternatives through history + pending queue.
 
@@ -555,6 +557,16 @@ def _record_and_queue(
 
     effective_profile = (db_profile or cfg.active_db_profile) or None
     effective_backend = db_backend or (cfg.db.backend if cfg.db else None)
+    # The endpoint already knows which database / catalog the
+    # connector was opened against (URL query string), but the
+    # previous wiring dropped that on the floor: only ``db_profile``
+    # made it onto the run row. Apply later then warned "this run
+    # didn't capture the target database" and forced the user to
+    # type the name back in. Stash both into ``settings_json`` so
+    # ``GET /api/history/runs/{id}`` (history.py:92-97) can flatten
+    # them onto the run payload exactly like the rerun path does.
+    effective_database = (database or "").strip() or None
+    effective_catalog = (catalog or "").strip() or None
     try:
         run_id = hs.create_run(
             command=command,
@@ -570,7 +582,11 @@ def _record_and_queue(
             llm_profile=cfg.active_llm_profile,
             doc_profile=cfg.active_doc_profile or None,
             code_profile=cfg.active_code_profile or None,
-            settings={"trigger": "studio.generate.singleshot"},
+            settings={
+                "trigger": "studio.generate.singleshot",
+                "database": effective_database,
+                "catalog": effective_catalog,
+            },
         )
     except Exception as exc:  # pragma: no cover — DB-layer failure
         log.warning("Could not record generate run: %s", exc)
@@ -699,6 +715,8 @@ def generate_database(
         asset_kind="database",
         db_profile=db_label,
         db_backend=backend or None,
+        database=database,
+        catalog=catalog,
     )
 
 
@@ -733,6 +751,8 @@ def generate_schema(
         asset_kind="schema",
         db_profile=db_label,
         db_backend=backend or None,
+        database=database,
+        catalog=catalog,
     )
 
 
@@ -768,6 +788,8 @@ def generate_table(
         asset_kind="table",
         db_profile=db_label,
         db_backend=backend or None,
+        database=database,
+        catalog=catalog,
     )
 
 
@@ -804,6 +826,8 @@ def generate_column(
         asset_kind="column",
         db_profile=db_label,
         db_backend=backend or None,
+        database=database,
+        catalog=catalog,
     )
 
 

--- a/tests/web/test_generate_router.py
+++ b/tests/web/test_generate_router.py
@@ -595,3 +595,35 @@ def test_generate_endpoint_resets_tracker_between_calls(
     # length-1 each (one llm.chat per generate).
     assert len(first["records"]) == 1
     assert len(second["records"]) == 1
+
+
+def test_generate_schema_captures_target_database_in_settings(
+    cfg: AMXConfig,
+    client,
+    auth_headers,
+    chat_spy: MagicMock,
+    fake_history: FakeHistoryStore,
+) -> None:
+    """User report: opening Run detail for a generate.schema run
+    showed "this run didn't capture the target database" even
+    though the request URL clearly carried ``?database=bird_train``.
+    Pin the contract: the URL's ``database`` and ``catalog`` query
+    args must round-trip into ``settings_json`` so
+    ``GET /api/history/runs/{id}`` (history.py:92-97) can flatten
+    them onto the run row and the Apply CTA stays unblocked.
+    """
+    cfg.llm.n_alternatives = 1
+    chat_spy.return_value = ChatResult(
+        content="schema-level description",
+        usage={"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+    )
+
+    resp = client.post(
+        "/api/generate/schema/sales?profile=demo&database=bird_train",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    run = fake_history.runs[0]
+    settings = run["settings"]
+    assert settings["database"] == "bird_train"
+    assert settings["catalog"] is None


### PR DESCRIPTION
## Summary

User: _"Burası ne salaklık ya. Kardeşim bu tabloyu run ederken yeri yurdu belli değil mi? Ben niye nereye yazacağını seçmek zorunda kalıyorum?"_

Translation: opened the Run detail page for a \`generate.*\` run. Saw the warning **"This run didn't capture the target database. Pick the database the schemas live in so apply targets it directly..."** and was forced to type the database name back in.

Root cause: the SPA's request was already
\`\`\`
POST /api/generate/schema/{schema}?profile=postgre&database=bird_train
\`\`\`
The endpoint had the database — it just dropped it between \`Query(...)\` and \`hs.create_run\`. Only \`db_profile\` made it onto the run row; the run's \`settings_json\` had no \`database\` / \`catalog\`, so \`GET /api/history/runs/{id}\` (history.py:92-97) had nothing to flatten and the Run detail page (RunDetail.tsx) rendered the empty-target warning + the database picker.

## Fix

Mirrors the fix already shipped for the rerun path (#244): forward the URL's \`database\` and \`catalog\` query args into \`settings_json\` on \`hs.create_run\`, so the run row carries them exactly like \`analyze.run\` and \`rerun\` do. \`_record_and_queue\` gained \`database=\` and \`catalog=\` kwargs; all four endpoints (database / schema / table / column) pass them through.

## Test plan

- [x] \`pytest tests/ --ignore=tests/eval --ignore=tests/perf\` — **1160 pass** (1 new in \`test_generate_router.py\` pinning that \`?database=bird_train\` round-trips into \`settings_json\`)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] Manual smoke — Browse → Schema → "Generate description" / "Just this schema" on a profile + database; open the resulting run; confirm the warning is gone and the Apply CTA is enabled