### PR TITLE
fix(compare): auto-detect brew Pango/Cairo so PDF export works on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,13 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
   Pango / Cairo system libraries — `brew install pango cairo
   gdk-pixbuf libffi` on macOS, or
   `apt-get install libpango-1.0-0 libpangoft2-1.0-0` on Debian /
-  Ubuntu Docker images.
+  Ubuntu Docker images. AMX auto-detects the Homebrew prefix
+  (`/opt/homebrew/lib` on Apple Silicon, `/usr/local/lib` on Intel)
+  and the standard Linux distro library directories at render time
+  and appends them to `DYLD_FALLBACK_LIBRARY_PATH` /
+  `LD_LIBRARY_PATH` before WeasyPrint imports, so a plain
+  `brew install pango cairo` "just works" without the user having
+  to set any env var.
 
 ## [0.14.0] - 2026-05-08
 

--- a/amx/cli_support/commands/compare.py
+++ b/amx/cli_support/commands/compare.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import csv
 import difflib
 import json
+import os
+import sys
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
@@ -1352,6 +1354,54 @@ def _build_pdf_context(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _bootstrap_weasyprint_native_libs() -> None:
+    """Make sure WeasyPrint's cffi-driven dlopen of libpango / libcairo
+    can find Homebrew copies on macOS.
+
+    The ``pip install weasyprint`` wheel only carries the Python
+    bindings; the native Pango / Cairo / GObject / harfbuzz dylibs
+    have to come from the OS package manager (Homebrew on macOS,
+    apt on Debian / Ubuntu). On a default macOS install ``cffi``
+    calls ``ctypes.util.find_library('pango-1.0')`` which only
+    searches a handful of system paths — ``/opt/homebrew/lib``
+    (Apple Silicon brew prefix) and ``/usr/local/lib`` (Intel brew
+    prefix) are *not* on that list, so a user who ran
+    ``brew install pango cairo`` still gets a confusing
+    "cannot load library 'libpango-1.0-0'" 500.
+
+    We work around this by appending the brew library directory to
+    ``DYLD_FALLBACK_LIBRARY_PATH`` *before* the WeasyPrint import
+    runs. macOS ``dyld`` re-reads this variable on every dlopen
+    call (unlike ``DYLD_LIBRARY_PATH``, which is read once at
+    process start), so setting it from inside Python actually
+    takes effect on the very next ``ffi.dlopen`` WeasyPrint runs.
+    Linux gets the same treatment via ``LD_LIBRARY_PATH`` for
+    Nix / non-FHS layouts.
+
+    Idempotent — safe to call before every render.
+    """
+    if sys.platform == "darwin":
+        env_var = "DYLD_FALLBACK_LIBRARY_PATH"
+        candidates = ("/opt/homebrew/lib", "/usr/local/lib")
+    elif sys.platform.startswith("linux"):
+        env_var = "LD_LIBRARY_PATH"
+        candidates = (
+            "/usr/lib/x86_64-linux-gnu",
+            "/usr/lib/aarch64-linux-gnu",
+            "/usr/lib64",
+            "/usr/lib",
+        )
+    else:
+        return
+
+    existing = os.environ.get(env_var, "")
+    existing_parts = [p for p in existing.split(os.pathsep) if p]
+    additions = [p for p in candidates if Path(p).is_dir() and p not in existing_parts]
+    if not additions:
+        return
+    os.environ[env_var] = os.pathsep.join([*existing_parts, *additions])
+
+
 def render_compare_pdf(payload: dict[str, Any]) -> bytes:
     """Render a ``compare_runs`` payload as a landscape A4 PDF report.
 
@@ -1370,6 +1420,12 @@ def render_compare_pdf(payload: dict[str, Any]) -> bytes:
         ],
         feature="Compare PDF export",
     )
+
+    # Augment dyld / ld search paths *before* the WeasyPrint import
+    # so the very first ffi.dlopen() in this process finds Homebrew
+    # / distro Pango. Cheap to call repeatedly (returns early when
+    # the env var already lists the directory).
+    _bootstrap_weasyprint_native_libs()
 
     from jinja2 import Environment, FileSystemLoader, select_autoescape
     from weasyprint import HTML

--- a/amx/web/routers/history.py
+++ b/amx/web/routers/history.py
@@ -300,6 +300,22 @@ def compare_pdf(body: CompareRequest) -> StreamingResponse:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=str(exc),
         ) from exc
+    except OSError as exc:
+        # cffi raises OSError when WeasyPrint imports cleanly but
+        # ctypes can't dlopen the native Pango / Cairo libs — happens
+        # on a vanilla macOS box without ``brew install pango cairo``
+        # or a slim Linux container without ``libpango-1.0-0``. Map to
+        # a 503 with a one-line install hint so the SPA can render an
+        # actionable error instead of an opaque ASGI 500.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "PDF export needs the Pango / Cairo system libraries. "
+                "Install them with `brew install pango cairo` (macOS) or "
+                "`apt install libpango-1.0-0 libpangoft2-1.0-0` (Debian / "
+                f"Ubuntu) and reload Studio. Original error: {exc}"
+            ),
+        ) from exc
     run_ids_label = "-".join(str(r["id"]) for r in payload["runs"])
     filename = f"compare-{run_ids_label}.pdf"
     return StreamingResponse(

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -13,6 +13,7 @@ Covers three slices:
 
 from __future__ import annotations
 
+import os
 import sqlite3
 import tempfile
 import unittest
@@ -873,6 +874,39 @@ class ComparePdfRenderingTests(unittest.TestCase):
             "no winner highlight.",
         )
 
+    def test_bootstrap_appends_brew_prefix_on_macos(self) -> None:
+        """The dyld bootstrap is what made the first user-facing
+        report work — without it the ``brew install pango`` prefix
+        ``/opt/homebrew/lib`` never enters dyld's search path and
+        WeasyPrint's first dlopen fails with a 500 in production.
+        Pin the env-var augmentation so a future refactor can't
+        silently drop it.
+        """
+        import sys as _sys
+
+        if _sys.platform != "darwin":
+            self.skipTest("macOS-only behaviour")
+
+        from amx.cli_support.commands import compare as compare_mod
+
+        # Pretend the brew prefix exists even on hosts where it
+        # doesn't, so the test doesn't depend on whether the dev
+        # has actually run ``brew install pango``.
+        before = os.environ.get("DYLD_FALLBACK_LIBRARY_PATH", "")
+        os.environ.pop("DYLD_FALLBACK_LIBRARY_PATH", None)
+        with patch("amx.cli_support.commands.compare.Path") as MockPath:
+            instance = MockPath.return_value
+            instance.is_dir.return_value = True
+            try:
+                compare_mod._bootstrap_weasyprint_native_libs()
+                got = os.environ.get("DYLD_FALLBACK_LIBRARY_PATH", "")
+            finally:
+                if before:
+                    os.environ["DYLD_FALLBACK_LIBRARY_PATH"] = before
+                else:
+                    os.environ.pop("DYLD_FALLBACK_LIBRARY_PATH", None)
+        self.assertIn("/opt/homebrew/lib", got)
+
     def test_render_compare_pdf_returns_pdf_bytes(self) -> None:
         """Smoke test: WeasyPrint produces a valid PDF blob for an
         8-run payload (the dense layout case the user explicitly
@@ -880,18 +914,15 @@ class ComparePdfRenderingTests(unittest.TestCase):
         the test host — CI image installs them; local devs can
         ``brew install pango cairo`` to opt in.
         """
-        try:
-            import jinja2  # noqa: F401
-            import weasyprint  # noqa: F401
-        except ImportError as exc:
-            self.skipTest(f"PDF deps not installed: {exc}")
-        except OSError as exc:
-            # ``import weasyprint`` itself triggers the native Pango /
-            # Cairo dlopen on first import. On a vanilla macOS box
-            # without ``brew install pango cairo`` (or a slim Linux
-            # image without ``libpango-1.0-0``) that fails before we
-            # even reach the render call.
-            self.skipTest(f"WeasyPrint native libs missing: {exc}")
+        # Check the pip packages are present *without* importing
+        # WeasyPrint — that would trigger the native dlopen too
+        # early, before render_compare_pdf's bootstrap helper has
+        # had a chance to point dyld at the brew prefix.
+        import importlib.util
+
+        for module_name in ("jinja2", "weasyprint"):
+            if importlib.util.find_spec(module_name) is None:
+                self.skipTest(f"PDF deps not installed: {module_name}")
 
         from amx.cli_support.commands.compare import render_compare_pdf
 
@@ -899,6 +930,11 @@ class ComparePdfRenderingTests(unittest.TestCase):
         try:
             pdf_bytes = render_compare_pdf(payload)
         except OSError as exc:
+            # render_compare_pdf augments DYLD_FALLBACK_LIBRARY_PATH /
+            # LD_LIBRARY_PATH with the standard brew / distro prefixes
+            # before importing WeasyPrint. If the dlopen still fails
+            # the host genuinely has no Pango installed — skip the
+            # smoke test instead of failing the suite.
             self.skipTest(f"WeasyPrint native libs missing: {exc}")
         self.assertTrue(pdf_bytes.startswith(b"%PDF-"), "Output must be a PDF blob")
         self.assertGreater(len(pdf_bytes), 1000, "PDF should not be a stub")


### PR DESCRIPTION
## Summary

- The first user-facing click on "Download PDF" hit `OSError: cannot load library 'libpango-1.0-0'` even with `brew install pango cairo` already in place. `cffi` only searches Apple-blessed paths — `/opt/homebrew/lib` and `/usr/local/lib` are not on that list — and the route had no OSError handler, so the dlopen failure escaped as an ASGI 500.
- New `_bootstrap_weasyprint_native_libs` helper runs before the WeasyPrint import inside `render_compare_pdf` and appends the brew prefix to `DYLD_FALLBACK_LIBRARY_PATH` on macOS (and the standard distro library dirs to `LD_LIBRARY_PATH` on Linux). dyld re-reads the fallback path on every dlopen, so this takes effect immediately on the same process.
- `/api/history/compare/pdf` now catches `OSError` and returns a 503 with the recommended `brew install` / `apt install` command, so the modal footer renders an actionable error instead of a 500 stack trace.
- Tests pin the macOS bootstrap behaviour and switch the smoke test to `find_spec`-based gating so the bootstrap helper actually has a chance to run.

## Test plan

- [x] `pytest tests/test_compare.py` with no `DYLD_FALLBACK_LIBRARY_PATH` set: 64 passed, smoke test now actually generates an 8-run PDF on a vanilla `brew install pango` host (previously skipped).
- [x] `python -c "from amx.cli_support.commands.compare import render_compare_pdf; ..."` produces a 54k `%PDF-1.7` blob with no env var tweaks.
- [ ] Manual: launch `amx /studio` from a fresh shell (no `DYLD_*` exports), pick 2–8 runs, click Download PDF, file lands cleanly.
- [ ] Manual on a Linux container: `apt install libpango-1.0-0 libpangoft2-1.0-0` is enough; no extra `LD_LIBRARY_PATH` export needed.