### PR TITLE
feat(compare): brand the PDF with the AMX logo on every page

### DIFF
--- a/amx/cli_support/commands/compare.py
+++ b/amx/cli_support/commands/compare.py
@@ -9,6 +9,7 @@ where users naturally end up after running questions.
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import csv
 import difflib
@@ -1404,7 +1405,33 @@ def _build_pdf_context(payload: dict[str, Any]) -> dict[str, Any]:
         "asset_col_pct": f"{asset_col_pct:.1f}",
         "run_col_pct": f"{run_col_pct:.2f}",
         "aggregate_run_col_pct": f"{aggregate_run_col_pct:.2f}",
+        "logo_data_url": _amx_logo_data_url(),
     }
+
+
+def _amx_logo_data_url() -> str:
+    """Encode the AMX favicon as a base64 ``data:`` URL so the PDF
+    template can drop it into a CSS ``content: url(...)`` running
+    header without WeasyPrint having to resolve a filesystem path
+    at render time.
+
+    Reads ``amx/web/static/favicon.png`` (the same mark the SPA
+    serves at ``/favicon.png`` and the browser tab uses) so the
+    PDF brand exactly matches the Studio tab. Returns an empty
+    string if the file isn't shipped — running header degrades
+    gracefully to no logo instead of breaking the render.
+    """
+    # Walk up from amx/cli_support/commands/compare.py to the
+    # ``amx/`` package root, then hop into ``web/static/``.
+    pkg_root = Path(__file__).resolve().parent.parent.parent
+    logo_path = pkg_root / "web" / "static" / "favicon.png"
+    if not logo_path.is_file():
+        return ""
+    try:
+        encoded = base64.b64encode(logo_path.read_bytes()).decode("ascii")
+    except OSError:
+        return ""
+    return f"data:image/png;base64,{encoded}"
 
 
 def _bootstrap_weasyprint_native_libs() -> None:

--- a/amx/cli_support/templates/compare_report.html
+++ b/amx/cli_support/templates/compare_report.html
@@ -7,8 +7,24 @@
   /* ── Page geometry ─────────────────────────────────────────────── */
   @page {
     size: A4 landscape;
-    margin: 14mm 14mm 16mm 14mm;
+    /* Top margin holds the AMX logo running header. 18mm is enough
+       for the 12mm-tall mark plus 3mm breathing room above and
+       below — the page content starts cleanly below it so a table
+       never collides with the logo. */
+    margin: 18mm 14mm 16mm 14mm;
     background: rgb(15, 15, 14);
+    {% if logo_data_url %}
+    @top-right {
+      /* ``content: element()`` pulls the .running-logo block in
+         from the document body. Going through a running element
+         (instead of ``content: url()`` directly) lets us pin the
+         image to a real CSS box size — without it WeasyPrint
+         renders the favicon at its 256×256px native size and
+         clips the right edge against the page trim. */
+      content: element(amxlogo);
+      vertical-align: top;
+    }
+    {% endif %}
     @bottom-right {
       content: counter(page) " / " counter(pages);
       font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
@@ -21,6 +37,24 @@
       font-size: 8pt;
       color: rgb(120, 113, 108);
     }
+  }
+
+  /* Hidden source for the running-header logo. ``position: running()``
+     yanks this out of the normal flow on every page and parks it in
+     the @top-right margin box. The wrapping div fixes the box size
+     so the favicon scales cleanly instead of being drawn at 256px
+     native (which would clip past the page edge). */
+  .running-logo {
+    position: running(amxlogo);
+    width: 12mm;
+    height: 12mm;
+    line-height: 0;
+    margin-top: 3mm;
+  }
+  .running-logo img {
+    width: 12mm;
+    height: 12mm;
+    display: block;
   }
 
   /* ── Density (scales with run count) ───────────────────────────── */
@@ -240,6 +274,12 @@
 </style>
 </head>
 <body>
+
+{% if logo_data_url %}
+<div class="running-logo" aria-hidden="true">
+  <img src="{{ logo_data_url|safe }}" alt="">
+</div>
+{% endif %}
 
 <header class="report-header">
   <h1>Comparison · {{ runs|length }} run{% if runs|length != 1 %}s{% endif %}</h1>

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -907,6 +907,37 @@ class ComparePdfRenderingTests(unittest.TestCase):
                     os.environ.pop("DYLD_FALLBACK_LIBRARY_PATH", None)
         self.assertIn("/opt/homebrew/lib", got)
 
+    def test_amx_logo_embeds_as_data_url(self) -> None:
+        """The PDF running header pulls the AMX favicon from
+        ``amx/web/static/favicon.png`` and inlines it as a base64
+        data URL. The static dir is shipped inside the wheel
+        (``[tool.setuptools.package-data]``), so the lookup must
+        succeed both for an editable install and for a built wheel.
+        """
+        from amx.cli_support.commands.compare import _amx_logo_data_url
+
+        data_url = _amx_logo_data_url()
+        self.assertTrue(
+            data_url.startswith("data:image/png;base64,"),
+            "Favicon must encode as a PNG data URL; got "
+            + (data_url[:40] if data_url else "(empty)"),
+        )
+        # Sanity: real favicon is ~13 KB; the encoded payload ought
+        # to be at least an order of magnitude larger than the
+        # ``data:image/png;base64,`` prefix.
+        self.assertGreater(len(data_url), 1000)
+
+    def test_logo_url_threaded_into_template_context(self) -> None:
+        from amx.cli_support.commands.compare import _build_pdf_context
+
+        ctx = _build_pdf_context(self._payload([1, 2]))
+        self.assertIn("logo_data_url", ctx)
+        self.assertTrue(
+            ctx["logo_data_url"].startswith("data:image/png;base64,"),
+            "Context must carry the logo as a data URL so the @page "
+            "@top-right rule can render it on every page.",
+        )
+
     def test_render_compare_pdf_returns_pdf_bytes(self) -> None:
         """Smoke test: WeasyPrint produces a valid PDF blob for an
         8-run payload (the dense layout case the user explicitly


### PR DESCRIPTION
## Summary

- Stamp the AMX favicon (same mark the SPA serves at `/favicon.png`) into the `@top-right` margin box of every page in the saved comparison PDF.
- Logo is read from `amx/web/static/favicon.png`, base64-encoded, and threaded into the Jinja context as a `data:image/png;base64,...` URL — no filesystem lookup at render time, ships clean inside the wheel.
- Uses CSS `position: running()` instead of `@top-right { content: url(...) }`. The simpler form draws the 256×256 favicon at native size and clips past the page trim (only the left half renders); running elements give us a real CSS box to pin at 12mm × 12mm.
- Page top margin grew 14mm → 18mm so the 12mm logo + 3mm of breathing room above and below sits above the content area without colliding with any table.

## Test plan

- [x] `pytest tests/test_compare.py` — 67 passed (2 new tests pin the data-URL helper and the context wiring so a future move of `favicon.png` trips a red test).
- [x] Visual: rendered a 3-page PDF with 8 runs and 20 per-column rows; logo appears top-right on every page, sized correctly, no clip, no overlap with any section card.
- [ ] Manual: in `amx /studio`, hit Download PDF on a multi-page comparison; confirm logo on every page.