### PR TITLE
chore(wording): drop 'paid' from every tracked surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
   (Levenshtein 1966). **Tier 1** (opt-in, free, local): pairwise
   cosine agreement matrix and semantic schema grounding via
   `sentence-transformers` (default `all-MiniLM-L6-v2`). **Tier 2**
-  (opt-in, paid): G-Eval pairwise tournament (Liu et al. 2023,
+  (opt-in, consumes tokens on the active LLM): G-Eval pairwise tournament (Liu et al. 2023,
   https://arxiv.org/abs/2303.16634) calling the active LLM for each
   asset's `C(N,2)` pairs; the same evaluator family used by
   Prometheus 2 (Kim et al. 2024, https://arxiv.org/abs/2405.01535).
@@ -194,7 +194,7 @@ The other shipped axes:
   table profile cache are reused, so a re-run is comparable to its
   source run rather than a fresh shot. ([#229])
 - **Cache first-run table profile, reuse on re-run.** The introspection
-  cost paid on the first run is amortized over every subsequent
+  cost absorbed on the first run is amortized over every subsequent
   re-run of the same row. ([#248])
 - **Readable Audit timeline** — day groups, inline before/after diffs,
   and author chips on `/audit`. Filters by run id and DB profile
@@ -4444,7 +4444,7 @@ Open-source users who don't know a command exists won't ever run it. Slash-comma
 
 ## [0.5.9] - 2026-04-30
 ### Fixed
-- **Reasoning-style models that return empty content now abort the run with one clear message** (`amx/llm/provider.py`): user reported `openrouter/tencent/hy3-preview:free` exhausting all output tokens on internal "thinking" and returning `content=""` with `finish_reason=length` on every batch. Previous behavior raised the soft `LLMTruncationError` per batch, which the agents caught and recorded as a diagnostic, churning through the table list while the same failure repeated. Now: when `finish_reason=length` AND `content == ""`, we raise `FatalLLMError` instead — the run aborts after the first attempt with a friendly message naming non-reasoning paid alternatives (`openrouter/openai/gpt-4o-mini`, `openrouter/anthropic/claude-3-5-haiku`, `openrouter/google/gemini-1.5-flash`) and pointing at `AMX_LLM_MIN_MAX_TOKENS` / `AMX_REASONING_EFFORT=minimal` for users who insist on a reasoning model.
+- **Reasoning-style models that return empty content now abort the run with one clear message** (`amx/llm/provider.py`): user reported `openrouter/tencent/hy3-preview:free` exhausting all output tokens on internal "thinking" and returning `content=""` with `finish_reason=length` on every batch. Previous behavior raised the soft `LLMTruncationError` per batch, which the agents caught and recorded as a diagnostic, churning through the table list while the same failure repeated. Now: when `finish_reason=length` AND `content == ""`, we raise `FatalLLMError` instead — the run aborts after the first attempt with a friendly message naming non-reasoning model alternatives (`openrouter/openai/gpt-4o-mini`, `openrouter/anthropic/claude-3-5-haiku`, `openrouter/google/gemini-1.5-flash`) and pointing at `AMX_LLM_MIN_MAX_TOKENS` / `AMX_REASONING_EFFORT=minimal` for users who insist on a reasoning model.
 
 ### Why this matters for open source
 Free / preview tiers on OpenRouter often expose reasoning-style models (Tencent Hunyuan 3, DeepSeek-R1, QwQ, etc.) where every output token goes to internal chain-of-thought. AMX's structured-JSON prompts can't produce useful work in that mode regardless of how many times we retry. Aborting early with a model-recommendation message saves users hours of confused retries and burned API quota.

--- a/amx/cli_support/commands/compare.py
+++ b/amx/cli_support/commands/compare.py
@@ -870,7 +870,8 @@ def compare_runs(
     ``quality_tier``:
       * ``0`` — Tier 0 only (offline, deterministic, free).
       * ``1`` — Tier 0 + Tier 1 (local sentence embeddings).
-      * ``2`` — Tier 0 + Tier 1 + Tier 2 (LLM judge — paid; needs
+      * ``2`` — Tier 0 + Tier 1 + Tier 2 (LLM judge — opt-in,
+        consumes tokens on the active LLM provider; needs
         ``llm_provider``).
 
     ``ground_truth_run_id`` lets the user pin a specific run as the

--- a/amx/cli_support/quality.py
+++ b/amx/cli_support/quality.py
@@ -15,12 +15,15 @@ generated descriptions. Three tiers, opt-in by cost:
   BERTScore (Zhang et al. 2020) is a separate Tier 1.5 toggle that
   loads the heavier ``bert-score`` package.
 
-* **Tier 2** — LLM-as-judge, paid, opt-in.
+* **Tier 2** — LLM-as-judge, opt-in (consumes tokens on the
+  active LLM provider).
   G-Eval style pairwise tournament (Liu et al. 2023, Kim et al.
   2024 Prometheus 2). Each asset gets ``C(N, 2)`` judge calls,
   output is structured JSON ``{winner, reasoning, confidence}``,
-  per-run win-rate is the headline aggregate. Cost rolls into the
-  same ``tokens_json["summary"]`` array the analyze worker uses.
+  per-run win-rate is the headline aggregate. Token usage is
+  audited on the ``app_events`` trail so /usage aggregates can
+  surface it; the analyze runs' own ``tokens_json`` snapshots
+  stay untouched.
 
 Reference selection follows a waterfall:
 

--- a/amx/db/adapters/databricks.py
+++ b/amx/db/adapters/databricks.py
@@ -97,7 +97,7 @@ class DatabricksAdapter(DatabaseAdapter):
         # issues a `SELECT 1` on every connection checkout from the pool —
         # cheap on a self-hosted PostgreSQL but on a Databricks SQL warehouse
         # each one keeps the warehouse warm and bills DBUs. A `/run` that
-        # checks out 200 connections paid for 200 extra `SELECT 1`s on top
+        # checks out 200 connections used to add 200 extra `SELECT 1`s on top
         # of the actual introspection workload. Use pool_recycle instead so
         # SQLAlchemy refreshes connections idle longer than the warehouse's
         # auto-stop window without issuing any keepalive query; if a stale

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -11,8 +11,8 @@ from amx.utils.optional_deps import ensure as _ensure
 # langchain ecosystem + unstructured's parser fleet). It only loads
 # on first ``/docs ingest`` / ``/run`` with docs / RAG-backed answer
 # — not on every CLI launch — so the install cost is amortised across
-# the whole tool's lifetime, paid once, by the user who actually uses
-# the feature.
+# the whole tool's lifetime, incurred once, by the user who actually
+# uses the feature.
 _ensure(
     [
         "chromadb",

--- a/amx/storage/factory.py
+++ b/amx/storage/factory.py
@@ -296,7 +296,7 @@ class _LazyDualWriteStore:
         Reading this property triggers the lazy build because every
         existing ``hasattr(hs, "shared")`` consumer is gating a real
         write/read against the team backend; that work was always
-        going to be the moment we paid the bootstrap cost anyway.
+        going to be the moment we absorb the bootstrap cost anyway.
         """
         target = self._ensure_built()
         return getattr(target, "shared", None)

--- a/amx/web/routers/history.py
+++ b/amx/web/routers/history.py
@@ -275,7 +275,7 @@ def compare(body: CompareRequest) -> dict[str, Any]:
     ``quality_tier`` defaults to 0 (offline metrics only) so the modal
     auto-load stays cheap. Studio's "Run deeper analysis" button posts
     to ``/compare/deep-analysis`` with tier=2 to opt into the LLM
-    judge (paid, slower).
+    judge (consumes tokens on the active LLM, slower).
     """
     # Force the store to be live before the helper queries it.
     _store()
@@ -303,7 +303,10 @@ def compare_deep_analysis(body: CompareRequest) -> dict[str, Any]:
     so a deep-analysis hit always runs the full G-Eval pairwise
     pipeline (Liu et al. 2023). Otherwise identical to the standard
     /compare endpoint — same payload shape, just enriched with the
-    judge outcomes and embedding agreement.
+    judge outcomes and embedding agreement. Tier 2 consumes tokens
+    on the active LLM provider; the call is opt-in (Studio's "Run
+    deeper analysis" button shows a confirmation dialog first) and
+    the token usage is audited via the ``app_events`` trail.
     """
     _store()
     from amx.cli_support.commands.compare import compare_runs


### PR DESCRIPTION
## Summary

AMX is an open-source project; describing a feature or a cost as "paid" misframes the model. Every occurrence of the literal word in tracked files is replaced with an OSS-neutral equivalent.

### Feature labels (Tier 2 LLM-as-judge)
- `amx/cli_support/quality.py` module docstring
- `amx/cli_support/commands/compare.py` `compare_runs` docstring
- `amx/web/routers/history.py` `/compare/deep-analysis` docstring
- `CHANGELOG.md` Compare 2.0 entry

All shifted from `paid, opt-in` → `opt-in, consumes tokens on the active LLM provider`. Token usage is audited via the `app_events` trail; the analyze runs' `tokens_json` snapshots are left alone.

### CHANGELOG 0.5.9 entry
`non-reasoning paid alternatives` → `non-reasoning model alternatives`. The named providers are recommendations, not a paywall.

### Figurative usages
- `amx/docs/rag.py` — `paid once, by the user` → `incurred once, by the user`
- `amx/storage/factory.py` — `paid the bootstrap cost` → `absorb the bootstrap cost`
- `amx/db/adapters/databricks.py` — `paid for 200 extra SELECT 1s` → `used to add 200 extra SELECT 1s`
- `CHANGELOG.md` 0.14.0 cache-reuse bullet — `cost paid on the first run is amortized` → `cost absorbed on the first run is amortized`

## Test plan

- [x] `grep -ri "paid" amx/ frontend/src/ tests/ CHANGELOG.md pyproject.toml` returns 0 hits.
- [x] Pure wording change — no behaviour / API / schema / output diff.