### PR TITLE
fix(ask): drop into sticky ask> REPL after a seeded one-shot

### DIFF
--- a/amx/cli_support/commands/search.py
+++ b/amx/cli_support/commands/search.py
@@ -490,16 +490,26 @@ def launch_ask_session(
     question_text: str,
     *,
     log_event: LogEvent,
+    follow_up: bool = True,
 ) -> None:
-    """Launch a one-shot ``/ask`` session for a pre-formed question.
+    """Launch a seeded ``/ask`` session for a pre-formed question and
+    leave the user in the sticky ``ask>`` REPL so they can act on
+    whatever follow-up the LLM offered.
 
     Used by sibling commands (``/history compare``) when the user
     accepts a "next: Ask AMX about this" prompt. Performs the same
     LLM-config pre-flight as the normal ``/search ask`` Click command,
-    builds a service for the persisted DB scope, and routes through
-    ``_run_search_ask`` so the seeded chat behaves identically to the
-    user-typed path. No-ops with a clean error message when the LLM
-    isn't configured (so callers don't have to repeat the guard).
+    builds a service for the persisted DB scope, routes the seed
+    question through ``_run_search_ask`` so the answer renders
+    identically to the user-typed path, and then drops into the
+    sticky ``ask>`` REPL — without that drop the LLM's
+    "If you want, I can next drill into the per-column comparison"
+    nudge was unactionable: control returned to the parent slash
+    prompt and the user couldn't reply without losing the chat
+    session's context.
+
+    ``follow_up=False`` skips the REPL drop (used by callers / tests
+    that want strict one-shot semantics).
     """
     if not cfg.llm_profiles:
         error(
@@ -522,6 +532,35 @@ def launch_ask_session(
         return
     with svc:
         _run_search_ask(cfg, svc, text, log_event=log_event)
+
+    if not follow_up:
+        return
+    # Drop into the sticky ``ask>`` REPL. ``_run_search_ask`` updates
+    # ``cfg.active_chat_session_id`` as a side effect of the agent
+    # call, so the REPL resumes the same chat thread instead of
+    # opening a fresh one — follow-up turns inherit the seed prompt
+    # as context. We pull ``main_command`` from the active Click
+    # context (compare runs inside the REPL's ``main_command.main()``
+    # dispatch, so the root group is always reachable). Outside any
+    # Click context (unit tests, scripted invocations) we silently
+    # skip the REPL — the seed answer already rendered.
+    try:
+        from click import get_current_context
+
+        from amx.cli_support.session import _run_ask_repl
+
+        ctx = get_current_context(silent=True)
+    except Exception:
+        return
+    if ctx is None:
+        return
+    main_command = ctx.find_root().command
+    try:
+        _run_ask_repl(cfg, main_command=main_command, log_event=log_event)
+    except (EOFError, KeyboardInterrupt):
+        # Non-TTY stdin (CI, piped invocation) — the seed answer
+        # already printed; just return cleanly.
+        pass
 
 
 def _run_search_ask(


### PR DESCRIPTION
## Summary

User feedback: when `/history compare`'s "Ask AMX about this comparison" prompt fires, the LLM answers the seed question and often closes with *"If you want, I can next drill into the per-column comparison."* The previous `launch_ask_session` was strictly one-shot — control returned to the parent slash prompt and the user couldn't reply without losing the chat session's context. The LLM's follow-up nudge was unactionable.

`launch_ask_session` now does the seed one-shot, then drops into the existing sticky `ask>` REPL (`cli_support/session._run_ask_repl`) so subsequent turns inherit the same chat session id and stay in context. The Click context is reachable via `get_current_context` because compare always runs inside the REPL's `main_command.main()` dispatch; non-TTY environments (CI, piped stdin) hit an `EOFError` / `KeyboardInterrupt` branch and silently return instead of crashing.

A new `follow_up=False` kwarg preserves strict one-shot semantics for any future test that needs it.

## Studio

No change needed. AskChat's input box is gated only on `activeJob`, which the SSE `answer.final` / `job.failed` / stream-close handlers all clear. After a `/ask` response the input re-opens and the user can submit a follow-up that inherits the same `session_id` from the running chat session.

## Test plan

- [x] `pytest tests/test_compare.py` — 83 passed (default `Done` choice means existing tests don't enter the new REPL path).
- [ ] Manual: in `amx /studio`-less REPL, type `/history compare 58 59`, choose `1) Ask AMX about this comparison`, verify the LLM answer renders, then `ask>` prompt appears, then a follow-up like "drill into the per-column comparison" lands in the same chat session.