### PR TITLE
fix(deps): pin transformers>=4.56 in extras + runtime guard

### DIFF
--- a/amx/cli_support/quality.py
+++ b/amx/cli_support/quality.py
@@ -347,6 +347,33 @@ def bert_score_for_pair(prediction: str, reference: str) -> float | None:
     except ImportError:
         return None
 
+    # Defensive transformers version check. bert-score pulls tokenizers
+    # 0.22+ on a fresh install, but if the user already has an older
+    # transformers (4.51.x and below pin tokenizers<0.22) sitting in
+    # the environment, the BERTScorer constructor either crashes with
+    # a cryptic ``ImportError`` or silently scores with an incompatible
+    # tokenizer. Surface a clean upgrade hint and skip cleanly so the
+    # rest of the quality response still ships.
+    try:
+        import transformers as _transformers
+
+        _ver = tuple(int(p) for p in _transformers.__version__.split(".")[:2])
+        if _ver < (4, 56):
+            from amx.utils.console import warn as _warn
+
+            _warn(
+                f"BERTScore (Tier 1.5) skipped — transformers "
+                f"{_transformers.__version__} pre-dates the tokenizers "
+                f"0.22 cutover. Run: pip install --upgrade "
+                f"\"transformers>=4.56\""
+            )
+            return None
+    except (ImportError, ValueError, AttributeError):
+        # Couldn't parse the version string — let the BERTScorer
+        # constructor decide. Real errors fall into the broader
+        # ``except Exception`` below.
+        pass
+
     # Silence transformers' "Some weights of RobertaModel were not
     # initialized..." warning AND any direct stderr writes the
     # tokenizer / accelerate libraries make during the first model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,15 @@ quality = [
 ]
 bertscore = [
     "bert-score>=0.3",
+    # Pin transformers above 4.55 so it accepts tokenizers >= 0.22 —
+    # without this floor, an older transformers (e.g. 4.51.x) sticks
+    # around in the user's env after another package upgrades
+    # tokenizers, and pip's resolver flags the mismatch with a noisy
+    # post-install ERROR ("transformers 4.51.3 requires
+    # tokenizers<0.22, but you have tokenizers 0.22.2 which is
+    # incompatible"). The mismatch is harmless at runtime but the
+    # message scares users who think the install actually failed.
+    "transformers>=4.56",
 ]
 cloud-sources = [
     "boto3>=1.34",
@@ -143,6 +152,12 @@ code-intel = [
 ]
 local-embeddings = [
     "sentence-transformers>=3.0",
+    # Match the floor in the ``bertscore`` extra: sentence-transformers
+    # also pulls transformers + tokenizers, and the same dependency-
+    # resolver mismatch surfaces here when a previously-pinned
+    # transformers stays at 4.51.x while tokenizers gets bumped to
+    # 0.22.x.
+    "transformers>=4.56",
 ]
 # ── Database backend extras ───────────────────────────────────────────────
 # Each backend's drivers live in their own extra so the default install
@@ -213,6 +228,13 @@ all = [
     "sacrebleu>=2.4",
     "rouge-score>=0.1",
     "bert-score>=0.3",
+    # Same transformers floor as the ``bertscore`` and
+    # ``local-embeddings`` extras above — keeps pip from leaving an
+    # older transformers (4.51.x, tokenizers<0.22 spec) installed
+    # while bert-score / sentence-transformers pull tokenizers 0.22+
+    # and the resolver flags the mismatch on every install.
+    "transformers>=4.56",
+    "sentence-transformers>=3.0",
     "boto3>=1.34",
     "google-api-python-client>=2.0",
     "google-auth>=2.0",


### PR DESCRIPTION
## Summary

User report: pip flagged a dependency-resolver mismatch on a fresh install:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. ...
transformers 4.51.3 requires tokenizers<0.22,>=0.21, but you have tokenizers 0.22.2 which is incompatible.
Successfully installed amx-cli-0.14.0 tokenizers-0.22.2
```

Root cause: `bert-score` and `sentence-transformers` (BERTScore Tier 1.5 + Tier 1 embedding paths) pull `tokenizers 0.22+` on a fresh resolve, but a previously-pinned `transformers 4.51.x` in the environment still spec'd `tokenizers<0.22`. Pip installed the new tokenizers anyway and warned with the noisy ERROR line — install actually succeeded but the message reads like a hard failure to end users.

## Fix: pyproject

- `bertscore` extra: adds `transformers>=4.56`
- `local-embeddings` extra: adds `transformers>=4.56`
- `all` extra: adds `transformers>=4.56` + `sentence-transformers>=3.0`

With these floors in the metadata, `pip install amx-cli[bertscore]` (or any extra that lands transformers / tokenizers) upgrades transformers to a version that accepts tokenizers 0.22 — the resolver mismatch never fires.

## Fix: runtime guard

Environments where `pip install amx-cli` already ran with the old constraints can still have `transformers 4.51.x` sitting around. `bert_score_for_pair` now version-checks transformers before constructing the `BERTScorer` and surfaces a one-line upgrade hint instead of crashing or silently scoring with the wrong tokenizer:

```
BERTScore (Tier 1.5) skipped — transformers 4.51.3 pre-dates the
tokenizers 0.22 cutover. Run: pip install --upgrade "transformers>=4.56"
```

The rest of the quality response (Tier 0 + Tier 1 + Tier 2) still ships normally — only the one metric that actually needs the new transformers is skipped.

## Test plan

- [x] `pytest tests/test_compare.py` — 83 passed (no API surface change).
- [ ] Manual: `pip install amx-cli[bertscore]` in a fresh venv — confirm transformers gets upgraded to 4.56+, no resolver ERROR.
- [ ] Manual: pin transformers 4.51.3 in a venv, run `compare --quality full --ground-truth-run X` — confirm the BERTScore row reports the upgrade hint while chrF / ROUGE-L / embedding agreement / judge still produce numbers.