### PR TITLE
fix(runs): demote successful runs with no applied to ready_for_review

### DIFF
--- a/amx/web/routers/runs.py
+++ b/amx/web/routers/runs.py
@@ -579,6 +579,20 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
             log.warning("Auto-apply after run failed: %s", exc)
             final_error_text = f"Auto-apply failed: {exc}"
 
+    # Demote successful runs to ``ready_for_review`` when nothing was
+    # actually written to the catalog. The worker finished cleanly but
+    # 119/119 suggestions still sitting in the pending queue is not a
+    # "success" — it's a queue waiting on the human review step. CLI's
+    # ``analyze.run`` interrupt path uses the same rule (see
+    # ``amx/cli_support/commands/_analyze/interrupt.py:65``); web
+    # parity here keeps both surfaces telling the user the same story.
+    if (
+        final_status == "success"
+        and pending_count > 0
+        and int(applied) == 0
+    ):
+        final_status = "ready_for_review"
+
     if hs is not None and run_id is not None:
         try:
             hs.finish_run(
@@ -608,7 +622,11 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
         except Exception as exc:
             log.warning("finish_run failed: %s", exc)
 
-    if final_status == "success":
+    if final_status in ("success", "ready_for_review"):
+        # Both terminal states close the job from the worker side; the
+        # SSE consumer treats ``job.done`` as "worker exited" and reads
+        # the persisted run status to decide whether the run actually
+        # succeeded or merely landed suggestions in the pending queue.
         job.status = "done"
         job.summary = {
             "run_id": run_id,
@@ -616,6 +634,7 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
             "failed": len(failed_assets),
             "pending": pending_count,
             "applied": int(applied),
+            "run_status": final_status,
         }
         job.ended_at = time.time()
         emit_terminal(job.queue, "job.done", {"summary": job.summary})


### PR DESCRIPTION
## Summary

User report: a Studio `analyze.run` that produced 119 suggestions, 0 applied, 119 queued ended up flagged **success**. That's misleading — the worker finished without errors, but every suggestion is sitting in the pending queue waiting on the human review step. Calling that 'success' nudges the user to think nothing's left to do; the right label is **ready_for_review**.

CLI's `/analyze run` interrupt path already uses this rule (`amx/cli_support/commands/_analyze/interrupt.py:65`). Web parity brings both surfaces in line.

## Logic

After the worker's main loop and the optional auto-apply pass, if `final_status == 'success' AND pending_count > 0 AND applied == 0`, demote to `ready_for_review` before `hs.finish_run`.

| Scenario | Old | New |
|---|---|---|
| `apply=false`, 119 produced, 0 applied | success | **ready_for_review** |
| `apply=true`, auto-applied 119 | success | success (unchanged) |
| `apply=true` but auto-apply failed (0 applied), 119 pending | success | **ready_for_review** |
| 0 produced, 0 applied (empty workload) | success | success (unchanged) |
| Failed mid-run | failed | failed (unchanged) |
| Cancelled | cancelled | cancelled (unchanged) |

The SSE job summary now carries `run_status` alongside the existing counts so the run-detail SSE consumer can render the right pill without an extra GET. `job.status` stays `done` for both 'success' and 'ready_for_review' — the JOB exited; the persisted RUN status is what the user sees on Runs / Run detail.

Frontend already renders `ready_for_review` as a neutral 'ready' pill via `statusLabel` / `statusTone` so no UI change is needed.

## Test plan

- [x] `pytest tests/` — 1209 passed.
- [ ] Manual: run analyze.run from Studio without `apply`, confirm the run-detail status pill reads 'ready' instead of 'success'.
- [ ] Manual: run analyze.run with `apply=true`, confirm it stays 'success' when all rows actually wrote to the DB.