### PR TITLE
fix(agents): merge step honours description_verbosity instead of collapsing to one sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`description_verbosity = exhaustive` (and `comprehensive` /
+  `detailed`) silently collapsed to a single sentence on multi-agent
+  runs.** When the orchestrator's `_merge_suggestions` step ran —
+  which happens whenever ProfileAgent + RAG / Code agents propose
+  the same column — the merge LLM was told to "Aim for one tight
+  sentence (≤ 25 words) unless the user's verbosity preset asks for
+  more" but the prompt never actually disclosed which preset was
+  active. The merge step also parsed only the first line of
+  `BEST_DESCRIPTION`, so any multi-paragraph answer that did slip
+  through got truncated on the way back into the suggestion list.
+  Both layers fixed: the verbosity's length rule is now injected
+  into `MERGE_PROMPT` (same `length_rule()` ProfileAgent uses), the
+  hardcoded "≤ 25 words" line is gone, the merge call's max_tokens
+  scales with `per_col_token_budget(verbosity)` so dense exhaustive
+  batches don't truncate, and `_parse_merge_response` accumulates
+  continuation lines into `BEST_DESCRIPTION` and `REASONING` so
+  multi-paragraph answers round-trip cleanly. Single-line responses
+  (the brief-mode common case) keep parsing unchanged.
+
 ### Added
 
 - **Per-run LLM fine-tuning overrides.** Studio's `/runs/new` page

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -18,6 +18,7 @@ from amx.agents.rag_agent import RAGAgent
 from amx.codebase.analyzer import CodebaseReport
 from amx.db.connector import AssetKind, DatabaseConnector, TableProfile
 from amx.docs.rag import RAGStore
+from amx.llm.prompts import length_rule
 from amx.llm.provider import LLMProvider
 from amx.storage.sqlite_store import history_store
 from amx.utils.console import (
@@ -41,10 +42,12 @@ MERGE_PROMPT = """\
 You are merging metadata suggestions from multiple sources for database columns.
 Produce one best description per column using evidence discipline, not averaging.
 
+Length rule (CRITICAL — honour the user's verbosity preset):
+{description_length_rule}
+
 Output rules:
 - Write every description and reasoning string in **clear, business-friendly American English**.
 - Use complete sentences. End every description with a period.
-- Aim for one tight sentence (≤ 25 words) unless the user's verbosity preset asks for more.
 - No hedging language ("might", "possibly", "could be") unless the evidence really is ambiguous —
   in which case lower CONFIDENCE rather than soften the description.
 - Never start a description with the column name or "This column" — describe the *meaning*, not the row.
@@ -114,7 +117,9 @@ REASONING: <why>
 MERGE_SYSTEM_PROMPT = """\
 You merge metadata suggestions conservatively.
 Do not invent meaning not present in the source proposals or their reasoning.
-Prefer directly supported and reusable catalog language over verbose prose.
+Honour the user-supplied verbosity preset in the user message — do not
+silently shorten an "exhaustive" or "comprehensive" answer to a single
+sentence.
 """
 
 META_SYSTEM_PROMPT = """\
@@ -1219,16 +1224,36 @@ class Orchestrator:
             columns_blocks.append(f"### {label}\n{source_text}")
 
         columns_text = "\n\n".join(columns_blocks)
+        # Inject the active LLM profile's verbosity directive so the
+        # merge step preserves an "exhaustive" / "comprehensive"
+        # answer instead of collapsing every column to one tight
+        # sentence. Without this the per-agent agents already write
+        # the long form, but this LLM call summarises it back down.
+        verbosity = getattr(self.llm.cfg, "description_verbosity", "brief")
         messages = [
             {"role": "system", "content": MERGE_SYSTEM_PROMPT},
             {
                 "role": "user",
-                "content": MERGE_PROMPT.format(columns_text=columns_text),
+                "content": MERGE_PROMPT.format(
+                    columns_text=columns_text,
+                    description_length_rule=length_rule(verbosity),
+                ),
             },
         ]
         est = estimate_tokens(messages)
+        # Scale the merge call's output budget the same way ProfileAgent
+        # does: ~1600 tokens per column at the exhaustive preset, less
+        # for shorter presets. Without this the merge call inherits
+        # cfg.max_tokens (16k by default) and truncates mid-column on a
+        # multi-column comprehensive/exhaustive batch.
+        from amx.llm.prompts import per_col_token_budget
+
+        merge_max_tokens = max(
+            self.llm.cfg.max_tokens,
+            len(needs_merge) * per_col_token_budget(verbosity),
+        )
         with step_spinner(f"Merging suggestions: {len(needs_merge)} columns", token_estimate=est):
-            result = self.llm.chat(messages)
+            result = self.llm.chat(messages, max_tokens=merge_max_tokens)
         tracker.record_for("merge", est, self.llm, result.usage)
 
         parsed = self._parse_merge_response(result.content)
@@ -1376,34 +1401,62 @@ class Orchestrator:
     def _parse_merge_response(
         text: str,
     ) -> dict[str, tuple[str, Confidence, str]]:
-        """Parse batched merge response into {column: (description, confidence, reasoning)}."""
+        """Parse batched merge response into {column: (description, confidence, reasoning)}.
+
+        ``BEST_DESCRIPTION`` and ``REASONING`` may span multiple lines
+        when the user picks a verbose preset (``comprehensive`` /
+        ``exhaustive``) so we accumulate continuation lines into the
+        most recent multi-line field until another known label
+        appears. The pre-2026-05 single-line parser silently truncated
+        multi-paragraph answers to the first sentence.
+        """
         text = _strip_code_fences(text)
         results: dict[str, tuple[str, Confidence, str]] = {}
         current_col = ""
-        best = ""
+        best_lines: list[str] = []
+        reasoning_lines: list[str] = []
         conf = Confidence.MEDIUM
-        reasoning = ""
+        active: str | None = None  # "best" | "reasoning" | None
 
-        for line in text.splitlines():
-            line = line.strip()
-            if line.startswith("COLUMN:"):
-                if current_col and best:
-                    results[current_col] = (best, conf, reasoning)
-                current_col = line.split(":", 1)[1].strip()
-                best = ""
+        def _flush() -> None:
+            if current_col and best_lines:
+                description = "\n".join(line.rstrip() for line in best_lines).strip()
+                reasoning_text = "\n".join(
+                    line.rstrip() for line in reasoning_lines
+                ).strip()
+                results[current_col] = (description, conf, reasoning_text)
+
+        for raw_line in text.splitlines():
+            stripped = raw_line.strip()
+            if stripped.startswith("COLUMN:"):
+                _flush()
+                current_col = stripped.split(":", 1)[1].strip()
+                best_lines = []
+                reasoning_lines = []
                 conf = Confidence.MEDIUM
-                reasoning = ""
-            elif line.startswith("BEST_DESCRIPTION:"):
-                best = line.split(":", 1)[1].strip()
-            elif line.startswith("CONFIDENCE:"):
-                raw = line.split(":", 1)[1].strip().upper()
+                active = None
+            elif stripped.startswith("BEST_DESCRIPTION:"):
+                first = stripped.split(":", 1)[1].strip()
+                best_lines = [first] if first else []
+                active = "best"
+            elif stripped.startswith("CONFIDENCE:"):
+                raw = stripped.split(":", 1)[1].strip().upper()
                 conf = Confidence[raw] if raw in Confidence.__members__ else Confidence.MEDIUM
-            elif line.startswith("REASONING:"):
-                reasoning = line.split(":", 1)[1].strip()
+                active = None
+            elif stripped.startswith("REASONING:"):
+                first = stripped.split(":", 1)[1].strip()
+                reasoning_lines = [first] if first else []
+                active = "reasoning"
+            else:
+                # Continuation line for the most recently opened
+                # multi-line field. Preserves blank lines so multi-
+                # paragraph answers keep their paragraph breaks.
+                if active == "best":
+                    best_lines.append(raw_line)
+                elif active == "reasoning":
+                    reasoning_lines.append(raw_line)
 
-        if current_col and best:
-            results[current_col] = (best, conf, reasoning)
-
+        _flush()
         return results
 
     def _human_review(

--- a/tests/test_merge_verbosity.py
+++ b/tests/test_merge_verbosity.py
@@ -1,0 +1,129 @@
+"""Merge step honours the user's ``description_verbosity`` preset.
+
+Regression test for a user-reported bug: picking
+``description_verbosity = "exhaustive"`` (or comprehensive / detailed)
+in the LLM profile or the per-run override panel shipped a verbose
+prompt to ProfileAgent / RAGAgent / CodeAgent, but the orchestrator's
+``_merge_suggestions`` step then summarised every multi-source
+column back down to one short sentence — burying the long form the
+user explicitly asked for.
+
+Two contributing problems:
+
+1. ``MERGE_PROMPT`` carried a hardcoded "Aim for one tight sentence
+   (≤ 25 words)" rule and made an unsupported reference to "the
+   user's verbosity preset" without ever telling the LLM what that
+   preset actually was.
+2. ``_parse_merge_response`` only kept the first line of the
+   ``BEST_DESCRIPTION`` field, so multi-paragraph "exhaustive"
+   answers returned by the LLM were truncated to the first sentence
+   on the way back into the suggestion list.
+
+These tests pin both fixes so a future refactor of the merge prompt
+or parser can't silently revive the bug.
+"""
+
+from __future__ import annotations
+
+from amx.agents.orchestrator import MERGE_PROMPT, MERGE_SYSTEM_PROMPT, Orchestrator
+from amx.llm.prompts import length_rule
+
+
+def test_merge_prompt_drops_hardcoded_word_cap() -> None:
+    """The merge prompt no longer carries a "≤ 25 words" instruction
+    that would over-rule the verbosity preset's length rule."""
+    formatted = MERGE_PROMPT.format(
+        columns_text="### col\n  [profile_agent] (confidence=HIGH): description\n    reasoning: r",
+        description_length_rule=length_rule("exhaustive"),
+    )
+    assert "≤ 25 words" not in formatted
+    assert "one tight sentence" not in formatted
+
+
+def test_merge_prompt_injects_length_rule_for_each_preset() -> None:
+    """Every verbosity preset's length rule reaches the merge prompt
+    verbatim — the LLM sees the same expectation as the per-agent
+    layer, not a generic "be brief" instruction."""
+    payload = "### col\n  [profile_agent] (confidence=HIGH): d\n    reasoning: r"
+    for preset in ("brief", "detailed", "comprehensive", "exhaustive"):
+        formatted = MERGE_PROMPT.format(
+            columns_text=payload,
+            description_length_rule=length_rule(preset),
+        )
+        # The first chunk of the length rule (e.g. "A COMPREHENSIVE
+        # description") shows up inside the merge prompt body.
+        rule = length_rule(preset)
+        head = rule.split(".")[0]
+        assert head in formatted, f"merge prompt missing '{head}' for preset={preset}"
+
+
+def test_merge_system_prompt_warns_against_collapsing_long_form() -> None:
+    """The system prompt now explicitly tells the merge LLM not to
+    silently shorten an exhaustive/comprehensive answer."""
+    assert "exhaustive" in MERGE_SYSTEM_PROMPT.lower()
+    # The pre-fix system prompt nudged toward "verbose prose" being
+    # bad — that contradicted the verbosity preset.
+    assert "verbose prose" not in MERGE_SYSTEM_PROMPT.lower()
+
+
+def test_parse_merge_response_keeps_multi_paragraph_best_description() -> None:
+    """A multi-paragraph BEST_DESCRIPTION (exhaustive preset) round-trips
+    through the parser instead of being truncated to the first line."""
+    merged_text = (
+        "COLUMN: orders.id\n"
+        "BEST_DESCRIPTION: Primary key for the orders table.\n"
+        "It is a monotonically increasing integer assigned at insert time.\n"
+        "\n"
+        "Downstream pipelines join on this column to attribute revenue\n"
+        "back to a single ordering event.\n"
+        "CONFIDENCE: HIGH\n"
+        "REASONING: profile + code agree.\n"
+    )
+    parsed = Orchestrator._parse_merge_response(merged_text)
+    assert "orders.id" in parsed
+    description, conf, reasoning = parsed["orders.id"]
+    # All three paragraphs survive — first sentence + the
+    # continuation lines + the empty-line paragraph break.
+    assert description.startswith("Primary key for the orders table.")
+    assert "Downstream pipelines join on this column" in description
+    assert "monotonically increasing integer" in description
+    assert "\n" in description, "paragraph break dropped"
+    # Reasoning stays single-line as before.
+    assert reasoning == "profile + code agree."
+    assert conf.value == "high"
+
+
+def test_parse_merge_response_handles_multiple_columns() -> None:
+    """Multi-column response: each column's BEST_DESCRIPTION still
+    parses independently after the multi-line fix."""
+    merged_text = (
+        "COLUMN: a\n"
+        "BEST_DESCRIPTION: First description, line one.\n"
+        "First description, line two.\n"
+        "CONFIDENCE: HIGH\n"
+        "REASONING: x\n"
+        "COLUMN: b\n"
+        "BEST_DESCRIPTION: Second description.\n"
+        "CONFIDENCE: MEDIUM\n"
+        "REASONING: y\n"
+    )
+    parsed = Orchestrator._parse_merge_response(merged_text)
+    assert set(parsed.keys()) == {"a", "b"}
+    desc_a, _, _ = parsed["a"]
+    desc_b, _, _ = parsed["b"]
+    assert "First description, line one." in desc_a
+    assert "First description, line two." in desc_a
+    assert desc_b == "Second description."
+
+
+def test_parse_merge_response_handles_single_line_legacy() -> None:
+    """Existing brief-mode single-line responses must still parse —
+    the fix added multi-line support without breaking the simple
+    case ProfileAgent/RAGAgent already produce."""
+    parsed = Orchestrator._parse_merge_response(
+        "COLUMN: id\nBEST_DESCRIPTION: Order primary key.\nCONFIDENCE: HIGH\nREASONING: r\n"
+    )
+    desc, conf, reasoning = parsed["id"]
+    assert desc == "Order primary key."
+    assert reasoning == "r"
+    assert conf.value == "high"


### PR DESCRIPTION
## Summary

User-reported bug: even with \`description_verbosity = exhaustive\`, multi-agent runs returned a one-sentence description. The orchestrator's \`_merge_suggestions\` LLM call was the culprit — it ran with a hardcoded "Aim for one tight sentence (≤ 25 words)" rule and never told the LLM which verbosity preset was active. Plus the parser only kept the first line of \`BEST_DESCRIPTION\`, so any multi-paragraph answer that did come back got truncated.

Four fixes in lockstep:

1. \`MERGE_PROMPT\` interpolates the active profile's length rule (\`length_rule(verbosity)\` — same helper ProfileAgent uses).
2. \`MERGE_SYSTEM_PROMPT\` explicitly tells the LLM not to silently shorten exhaustive/comprehensive answers; old "verbose prose is bad" line removed.
3. Merge call's \`max_tokens\` scales with \`per_col_token_budget(verbosity)\` so dense exhaustive batches don't truncate.
4. \`_parse_merge_response\` accumulates continuation lines into \`BEST_DESCRIPTION\` / \`REASONING\` so multi-paragraph answers round-trip cleanly. Single-line brief-mode parsing unchanged.

## Test plan

- [x] \`pytest tests/test_merge_verbosity.py\` — 6 new regression tests (hardcoded cap dropped, length rule injected per preset, multi-line parser, multi-column round-trip, legacy single-line still works).
- [x] \`pytest tests/\` — 1242/1242 (was 1236; +6 new).
- [ ] Studio smoke (after restart): start a run with verbosity = exhaustive, confirm merged columns return multi-paragraph descriptions.