### PR TITLE
fix(agents): alternative descriptions honour description_verbosity preset

### DIFF
--- a/amx/agents/code_agent.py
+++ b/amx/agents/code_agent.py
@@ -12,7 +12,11 @@ from amx.agents.base import (
     apply_logprob_confidence,
 )
 from amx.codebase.analyzer import CodebaseReport, CodeReference
-from amx.llm.prompts import length_rule, per_col_token_budget
+from amx.llm.prompts import (
+    ALTERNATIVES_LENGTH_RULE_REMINDER,
+    length_rule,
+    per_col_token_budget,
+)
 from amx.llm.provider import LLMProvider
 from amx.utils.console import step_spinner
 from amx.utils.logging import get_logger
@@ -48,6 +52,7 @@ Confidence rules:
 - LOW: only superficial or sparse references exist.
 Reasoning must mention the concrete code patterns that justify the description.
 
+{alternatives_length_reminder}
 Respond in this format for each column (one block per column):
 
 COLUMN: <column_name>
@@ -66,13 +71,20 @@ REASONING: The code joins, filters, and groups records by this field across rela
 
 def _build_system_prompt(n_alternatives: int, description_verbosity: str = "brief") -> str:
     n = max(1, min(5, n_alternatives))
-    desc_lines = (
-        "\n".join(f"DESCRIPTION_{i}: <alternative>" for i in range(2, n + 1)) if n > 1 else ""
-    )
+    if n > 1:
+        desc_lines = "\n".join(
+            f"DESCRIPTION_{i}: <alternative description — apply the SAME length rule as DESCRIPTION_1>"
+            for i in range(2, n + 1)
+        )
+        alternatives_length_reminder = ALTERNATIVES_LENGTH_RULE_REMINDER
+    else:
+        desc_lines = ""
+        alternatives_length_reminder = ""
     return (
         _BASE_SYSTEM_PROMPT.format(
             desc_lines=desc_lines,
             description_length_rule=length_rule(description_verbosity),
+            alternatives_length_reminder=alternatives_length_reminder,
         ).strip()
         + "\n"
     )

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -52,6 +52,11 @@ Alternative descriptions:
 - An "alternative" must offer a meaningfully different interpretation
   (different business role, different unit, different scope) — not just
   a rephrasing of DESCRIPTION_1.
+- The Length rule above applies EQUALLY to DESCRIPTION_1, DESCRIPTION_2,
+  ..., DESCRIPTION_{n_alternatives}. An alternative is a different
+  interpretation, not a shorter version. Do not collapse alternatives
+  into one-sentence summaries when the verbosity preset is comprehensive
+  or exhaustive.
 - If the evidence does not support a distinct alternative for a slot,
   write a single em-dash "—" on that line. Do NOT pad with paraphrases.
 
@@ -102,6 +107,10 @@ For EACH column below:
   that are missing from the existing list.
 - Each new alternative MUST offer a meaningfully different interpretation
   from the existing ones — different business role, scope, or unit.
+- The Length rule above applies EQUALLY to every DESCRIPTION_N slot you
+  fill. An alternative is a different interpretation, not a shorter
+  version — do not collapse alternatives into one-sentence summaries
+  when the verbosity preset is comprehensive or exhaustive.
 - If the evidence truly does not support another distinct alternative for
   a slot, write a single em-dash "—" on that line. Do NOT pad with
   rephrasings of an existing description.
@@ -1280,7 +1289,10 @@ class Orchestrator:
         verbosity = getattr(self.llm.cfg, "description_verbosity", "brief")
         cap = max(1, min(5, getattr(self.llm.cfg, "n_alternatives", 3)))
         description_lines = (
-            "\n".join(f"DESCRIPTION_{i}: <alternative>" for i in range(2, cap + 1))
+            "\n".join(
+                f"DESCRIPTION_{i}: <alternative description — apply the SAME length rule as DESCRIPTION_1>"
+                for i in range(2, cap + 1)
+            )
             if cap > 1
             else ""
         )
@@ -1413,7 +1425,8 @@ class Orchestrator:
 
         columns_text = "\n\n".join(blocks)
         fillup_response_lines = "\n".join(
-            f"DESCRIPTION_{i}: <alternative or — if none is supported>" for i in range(2, cap + 1)
+            f"DESCRIPTION_{i}: <alternative — apply the SAME length rule as DESCRIPTION_1, or — if none is supported>"
+            for i in range(2, cap + 1)
         )
 
         messages = [

--- a/amx/agents/profile_agent.py
+++ b/amx/agents/profile_agent.py
@@ -13,7 +13,11 @@ from amx.agents.base import (
     apply_logprob_confidence,
 )
 from amx.config import PromptDetail
-from amx.llm.prompts import length_rule, per_col_token_budget
+from amx.llm.prompts import (
+    ALTERNATIVES_LENGTH_RULE_REMINDER,
+    length_rule,
+    per_col_token_budget,
+)
 from amx.llm.provider import FatalLLMError, LLMProvider
 from amx.utils.console import step_spinner
 from amx.utils.logging import LAST_PROFILE_RESPONSE_FILE, get_logger
@@ -47,6 +51,7 @@ Coverage rule (CRITICAL): emit one COLUMN block for EVERY column listed in the i
 For EACH column provide:
 1. {description_length_rule}
 {alt_instruction}
+{alternatives_length_reminder}
 {extra_items}
 A confidence level: HIGH / MEDIUM / LOW.
 Brief reasoning for your choice.
@@ -91,18 +96,25 @@ def _build_system_prompt(
         extra_items = ""
         desc_lines = ""
         table_desc_lines = ""
+        alternatives_length_reminder = ""
     else:
         alt_instruction = f"Up to {n} alternative descriptions ranked by likelihood."
         extra_items = ""
-        desc_lines = "\n".join(f"DESCRIPTION_{i}: <alternative>" for i in range(2, n + 1))
-        table_desc_lines = "\n".join(
-            f"TABLE_DESCRIPTION_{i}: <alternative table description>" for i in range(2, n + 1)
+        desc_lines = "\n".join(
+            f"DESCRIPTION_{i}: <alternative description — apply the SAME length rule as DESCRIPTION_1>"
+            for i in range(2, n + 1)
         )
+        table_desc_lines = "\n".join(
+            f"TABLE_DESCRIPTION_{i}: <alternative table description — apply the SAME length rule as TABLE_DESCRIPTION_1>"
+            for i in range(2, n + 1)
+        )
+        alternatives_length_reminder = ALTERNATIVES_LENGTH_RULE_REMINDER
     description_length_rule = length_rule(description_verbosity)
     return (
         _BASE_SYSTEM_PROMPT.format(
             description_length_rule=description_length_rule,
             alt_instruction=alt_instruction,
+            alternatives_length_reminder=alternatives_length_reminder,
             extra_items=extra_items,
             desc_lines=desc_lines,
             table_desc_lines=table_desc_lines,

--- a/amx/agents/rag_agent.py
+++ b/amx/agents/rag_agent.py
@@ -14,7 +14,11 @@ from amx.agents.base import (
 from amx.config import PromptDetail
 from amx.core.token_budget import MaxTokenValidator
 from amx.docs.rag import RAGStore
-from amx.llm.prompts import length_rule, per_col_token_budget
+from amx.llm.prompts import (
+    ALTERNATIVES_LENGTH_RULE_REMINDER,
+    length_rule,
+    per_col_token_budget,
+)
 from amx.llm.provider import LLMProvider
 from amx.utils.console import step_spinner
 from amx.utils.logging import get_logger
@@ -50,6 +54,7 @@ Confidence rules:
 - LOW: excerpts provide only weak surrounding context.
 Reasoning must cite the document evidence pattern, not just repeat the description.
 
+{alternatives_length_reminder}
 Respond in this format for each column (one block per column):
 
 COLUMN: <column_name>
@@ -68,13 +73,20 @@ REASONING: The retrieved excerpts describe monetary amounts and refer to a compa
 
 def _build_system_prompt(n_alternatives: int, description_verbosity: str = "brief") -> str:
     n = max(1, min(5, n_alternatives))
-    desc_lines = (
-        "\n".join(f"DESCRIPTION_{i}: <alternative>" for i in range(2, n + 1)) if n > 1 else ""
-    )
+    if n > 1:
+        desc_lines = "\n".join(
+            f"DESCRIPTION_{i}: <alternative description — apply the SAME length rule as DESCRIPTION_1>"
+            for i in range(2, n + 1)
+        )
+        alternatives_length_reminder = ALTERNATIVES_LENGTH_RULE_REMINDER
+    else:
+        desc_lines = ""
+        alternatives_length_reminder = ""
     return (
         _BASE_SYSTEM_PROMPT.format(
             desc_lines=desc_lines,
             description_length_rule=length_rule(description_verbosity),
+            alternatives_length_reminder=alternatives_length_reminder,
         ).strip()
         + "\n"
     )

--- a/amx/llm/prompts/__init__.py
+++ b/amx/llm/prompts/__init__.py
@@ -9,6 +9,7 @@ description is produced by ``ProfileAgent`` (bulk run) or
 """
 
 from amx.llm.prompts.length import (
+    ALTERNATIVES_LENGTH_RULE_REMINDER,
     DESCRIPTION_LENGTH_RULES,
     VERBOSITY_PER_COL_TOKEN_BUDGET,
     length_rule,
@@ -16,6 +17,7 @@ from amx.llm.prompts.length import (
 )
 
 __all__ = [
+    "ALTERNATIVES_LENGTH_RULE_REMINDER",
     "DESCRIPTION_LENGTH_RULES",
     "VERBOSITY_PER_COL_TOKEN_BUDGET",
     "length_rule",

--- a/amx/llm/prompts/length.py
+++ b/amx/llm/prompts/length.py
@@ -43,6 +43,20 @@ DESCRIPTION_LENGTH_RULES: dict[str, str] = {
 }
 
 
+# Reminder line injected into every prompt that asks for N ranked
+# description alternatives. Without it the LLM treats DESCRIPTION_2..N
+# as "shorter rephrasings" of DESCRIPTION_1 — collapsing comprehensive /
+# exhaustive presets back to one-sentence briefs for every alternative
+# slot. Pinning the rule next to the slot template restores the
+# user-visible length expectation across all alternatives.
+ALTERNATIVES_LENGTH_RULE_REMINDER = (
+    "The Length rule above applies EQUALLY to every DESCRIPTION_N slot. "
+    "An alternative is a different interpretation, not a shorter version — "
+    "do not collapse alternatives into one-sentence summaries when the "
+    "verbosity preset is comprehensive or exhaustive."
+)
+
+
 # Per-column output budget used to size ``max_tokens`` for a batch.
 # Scaled by ``description_verbosity`` so a 100-column batch in
 # ``comprehensive`` / ``exhaustive`` mode doesn't truncate halfway

--- a/tests/test_code_agent_verbosity.py
+++ b/tests/test_code_agent_verbosity.py
@@ -1,0 +1,60 @@
+"""CodeAgent honours ``description_verbosity`` for every alternative slot.
+
+Regression test for the user-reported bug where DESCRIPTION_1 came
+back exhaustive (multi-paragraph) but DESCRIPTION_2 / DESCRIPTION_3
+collapsed to one-sentence briefs even at
+``description_verbosity="exhaustive"``. The bare ``<alternative>``
+placeholder in the response-format template told the LLM the
+alternative slots were short rephrasings rather than full-length
+distinct interpretations.
+
+Mirror of :mod:`tests.test_profile_agent_verbosity` for the CodeAgent
+branch so a future refactor of any one of the three sub-agents cannot
+silently revive the bug.
+"""
+
+from __future__ import annotations
+
+from amx.agents.code_agent import _build_system_prompt
+from amx.llm.prompts import ALTERNATIVES_LENGTH_RULE_REMINDER, length_rule
+
+
+def test_code_agent_prompt_injects_length_rule_for_each_preset() -> None:
+    """Every preset's length rule reaches the system prompt verbatim."""
+    for preset in ("brief", "detailed", "comprehensive", "exhaustive"):
+        prompt = _build_system_prompt(3, description_verbosity=preset)
+        rule = length_rule(preset)
+        head = rule.split(".")[0]
+        assert head in prompt, f"prompt missing '{head}' for preset={preset}"
+
+
+def test_code_agent_prompt_emits_n_alternative_slots() -> None:
+    """``n_alternatives=3`` templates DESCRIPTION_2 / DESCRIPTION_3 slots."""
+    prompt = _build_system_prompt(3, description_verbosity="exhaustive")
+    assert "DESCRIPTION_1:" in prompt
+    assert "DESCRIPTION_2:" in prompt
+    assert "DESCRIPTION_3:" in prompt
+
+
+def test_code_agent_prompt_alternatives_carry_length_rule() -> None:
+    """Alternative slots carry the "same length rule" rider and the
+    prompt body includes the shared length-rule reminder."""
+    for preset in ("brief", "detailed", "comprehensive", "exhaustive"):
+        prompt = _build_system_prompt(3, description_verbosity=preset)
+        assert ALTERNATIVES_LENGTH_RULE_REMINDER in prompt, (
+            f"alternatives reminder missing at preset={preset}"
+        )
+        assert "DESCRIPTION_2: <alternative>" not in prompt, (
+            f"bare <alternative> placeholder leaked at preset={preset}"
+        )
+        assert "DESCRIPTION_2: <alternative description — apply the SAME length rule" in prompt
+        assert "DESCRIPTION_3: <alternative description — apply the SAME length rule" in prompt
+
+
+def test_code_agent_prompt_n_alternatives_one_omits_alt_slots() -> None:
+    """No DESCRIPTION_2 slot or reminder when only one alternative is
+    requested — keeps the brief-mode prompt as small as before."""
+    prompt = _build_system_prompt(1, description_verbosity="brief")
+    assert "DESCRIPTION_1:" in prompt
+    assert "DESCRIPTION_2:" not in prompt
+    assert ALTERNATIVES_LENGTH_RULE_REMINDER not in prompt

--- a/tests/test_merge_verbosity.py
+++ b/tests/test_merge_verbosity.py
@@ -146,12 +146,8 @@ def test_merge_prompt_reminds_length_rule_applies_to_alternatives() -> None:
         assert "DESCRIPTION_2: <alternative>" not in formatted, (
             f"bare <alternative> placeholder leaked at preset={preset}"
         )
-        assert (
-            "DESCRIPTION_2: <alternative description — apply the SAME length rule" in formatted
-        )
-        assert (
-            "DESCRIPTION_3: <alternative description — apply the SAME length rule" in formatted
-        )
+        assert "DESCRIPTION_2: <alternative description — apply the SAME length rule" in formatted
+        assert "DESCRIPTION_3: <alternative description — apply the SAME length rule" in formatted
 
     # Same contract on the fill-up retry path so a column that came
     # back short does not get refilled with one-sentence briefs.

--- a/tests/test_merge_verbosity.py
+++ b/tests/test_merge_verbosity.py
@@ -25,7 +25,12 @@ or parser can't silently revive the bug.
 
 from __future__ import annotations
 
-from amx.agents.orchestrator import MERGE_PROMPT, MERGE_SYSTEM_PROMPT, Orchestrator
+from amx.agents.orchestrator import (
+    MERGE_FILLUP_PROMPT,
+    MERGE_PROMPT,
+    MERGE_SYSTEM_PROMPT,
+    Orchestrator,
+)
 from amx.llm.prompts import length_rule
 
 
@@ -38,13 +43,32 @@ def _format_merge_prompt(*, columns_text: str, preset: str, n: int = 1) -> str:
     contract.
     """
     description_lines = (
-        "\n".join(f"DESCRIPTION_{i}: <alternative>" for i in range(2, n + 1)) if n > 1 else ""
+        "\n".join(
+            f"DESCRIPTION_{i}: <alternative description — apply the SAME length rule as DESCRIPTION_1>"
+            for i in range(2, n + 1)
+        )
+        if n > 1
+        else ""
     )
     return MERGE_PROMPT.format(
         columns_text=columns_text,
         description_length_rule=length_rule(preset),
         n_alternatives=n,
         description_lines=description_lines,
+    )
+
+
+def _format_fillup_prompt(*, columns_text: str, preset: str, n: int = 3) -> str:
+    """Mirror of :func:`_format_merge_prompt` for the fill-up retry."""
+    fillup_response_lines = "\n".join(
+        f"DESCRIPTION_{i}: <alternative — apply the SAME length rule as DESCRIPTION_1, or — if none is supported>"
+        for i in range(2, n + 1)
+    )
+    return MERGE_FILLUP_PROMPT.format(
+        n_alternatives=n,
+        description_length_rule=length_rule(preset),
+        columns_text=columns_text,
+        fillup_response_lines=fillup_response_lines,
     )
 
 
@@ -90,6 +114,55 @@ def test_merge_prompt_lists_n_alternatives_slots() -> None:
     assert "DESCRIPTION_3" in formatted
     # The schema label that used to live here is gone.
     assert "BEST_DESCRIPTION" not in formatted
+
+
+def test_merge_prompt_reminds_length_rule_applies_to_alternatives() -> None:
+    """Regression test for the user-reported bug where DESCRIPTION_1
+    came back exhaustive but DESCRIPTION_2 / DESCRIPTION_3 collapsed
+    to one-sentence briefs even at
+    ``description_verbosity="exhaustive"``.
+
+    Two pinned guarantees:
+    1. ``MERGE_PROMPT`` body explicitly states that the length rule
+       applies EQUALLY to every DESCRIPTION_N slot, not just to
+       DESCRIPTION_1. The phrasing is checked by stable substrings so
+       a future copy-edit can move text around without breaking the
+       test, but a removal of the contract surfaces immediately.
+    2. The slot template no longer reads bare ``<alternative>`` —
+       every DESCRIPTION_<i> slot must carry the "apply the SAME
+       length rule" rider that fixes the bug.
+
+    The fill-up prompt carries the same contract.
+    """
+    for preset in ("brief", "detailed", "comprehensive", "exhaustive"):
+        formatted = _format_merge_prompt(
+            columns_text="### col\n  [profile_agent] (confidence=HIGH): d\n    reasoning: r",
+            preset=preset,
+            n=3,
+        )
+        assert "applies EQUALLY to DESCRIPTION_1" in formatted, (
+            f"merge prompt missing equal-length contract at preset={preset}"
+        )
+        assert "DESCRIPTION_2: <alternative>" not in formatted, (
+            f"bare <alternative> placeholder leaked at preset={preset}"
+        )
+        assert (
+            "DESCRIPTION_2: <alternative description — apply the SAME length rule" in formatted
+        )
+        assert (
+            "DESCRIPTION_3: <alternative description — apply the SAME length rule" in formatted
+        )
+
+    # Same contract on the fill-up retry path so a column that came
+    # back short does not get refilled with one-sentence briefs.
+    fillup = _format_fillup_prompt(
+        columns_text="### col\nExisting:\n  - first description.\nStill to fill: DESCRIPTION_2, DESCRIPTION_3",
+        preset="exhaustive",
+        n=3,
+    )
+    assert "applies EQUALLY to every DESCRIPTION_N slot" in fillup
+    assert "DESCRIPTION_2: <alternative or — if none is supported>" not in fillup
+    assert "DESCRIPTION_2: <alternative — apply the SAME length rule" in fillup
 
 
 def test_merge_system_prompt_warns_against_collapsing_long_form() -> None:

--- a/tests/test_profile_agent_verbosity.py
+++ b/tests/test_profile_agent_verbosity.py
@@ -106,7 +106,10 @@ def test_profile_agent_prompt_alternatives_carry_length_rule() -> None:
         assert "DESCRIPTION_2: <alternative description — apply the SAME length rule" in prompt
         assert "DESCRIPTION_3: <alternative description — apply the SAME length rule" in prompt
         # Same shape for the table-level alternatives block.
-        assert "TABLE_DESCRIPTION_2: <alternative table description — apply the SAME length rule" in prompt
+        assert (
+            "TABLE_DESCRIPTION_2: <alternative table description — apply the SAME length rule"
+            in prompt
+        )
 
 
 def test_profile_agent_prompt_n_alternatives_one_omits_reminder() -> None:

--- a/tests/test_profile_agent_verbosity.py
+++ b/tests/test_profile_agent_verbosity.py
@@ -28,7 +28,7 @@ prompt cannot silently revive the bug.
 from __future__ import annotations
 
 from amx.agents.profile_agent import _build_system_prompt
-from amx.llm.prompts import length_rule
+from amx.llm.prompts import ALTERNATIVES_LENGTH_RULE_REMINDER, length_rule
 
 
 def test_profile_agent_prompt_drops_hardcoded_word_cap() -> None:
@@ -79,3 +79,39 @@ def test_profile_agent_prompt_n_alternatives_one_omits_alt_slots() -> None:
     prompt = _build_system_prompt(1, description_verbosity="brief")
     assert "DESCRIPTION_1:" in prompt
     assert "DESCRIPTION_2:" not in prompt
+
+
+def test_profile_agent_prompt_alternatives_carry_length_rule() -> None:
+    """Regression test for the bug where DESCRIPTION_1 came back
+    exhaustive but DESCRIPTION_2 / DESCRIPTION_3 collapsed to one-
+    sentence briefs even at ``description_verbosity="exhaustive"``.
+
+    Two pinned guarantees:
+    1. The shared :data:`ALTERNATIVES_LENGTH_RULE_REMINDER` blurb is
+       present in the prompt so the LLM sees the length rule applied
+       to every alternative slot, not just to DESCRIPTION_1.
+    2. Each ``DESCRIPTION_<i>`` slot template reads "apply the SAME
+       length rule as DESCRIPTION_1" — the bare ``<alternative>``
+       placeholder that caused the bug never returns.
+    """
+    for preset in ("brief", "detailed", "comprehensive", "exhaustive"):
+        prompt = _build_system_prompt(3, description_verbosity=preset)
+        assert ALTERNATIVES_LENGTH_RULE_REMINDER in prompt, (
+            f"alternatives reminder missing at preset={preset}"
+        )
+        assert "DESCRIPTION_2: <alternative>" not in prompt, (
+            f"bare <alternative> placeholder leaked at preset={preset}"
+        )
+        assert "DESCRIPTION_3: <alternative>" not in prompt
+        assert "DESCRIPTION_2: <alternative description — apply the SAME length rule" in prompt
+        assert "DESCRIPTION_3: <alternative description — apply the SAME length rule" in prompt
+        # Same shape for the table-level alternatives block.
+        assert "TABLE_DESCRIPTION_2: <alternative table description — apply the SAME length rule" in prompt
+
+
+def test_profile_agent_prompt_n_alternatives_one_omits_reminder() -> None:
+    """At ``n_alternatives=1`` there are no alternative slots to
+    govern, so the reminder should not appear — keeps the brief-mode
+    prompt as small as before the fix."""
+    prompt = _build_system_prompt(1, description_verbosity="brief")
+    assert ALTERNATIVES_LENGTH_RULE_REMINDER not in prompt

--- a/tests/test_rag_agent_verbosity.py
+++ b/tests/test_rag_agent_verbosity.py
@@ -1,0 +1,48 @@
+"""RAGAgent honours ``description_verbosity`` for every alternative slot.
+
+Regression test for the user-reported bug where DESCRIPTION_1 came
+back exhaustive but DESCRIPTION_2 / DESCRIPTION_3 collapsed to one-
+sentence briefs even at ``description_verbosity="exhaustive"``.
+Mirror of :mod:`tests.test_code_agent_verbosity` for the RAG branch.
+"""
+
+from __future__ import annotations
+
+from amx.agents.rag_agent import _build_system_prompt
+from amx.llm.prompts import ALTERNATIVES_LENGTH_RULE_REMINDER, length_rule
+
+
+def test_rag_agent_prompt_injects_length_rule_for_each_preset() -> None:
+    """Every preset's length rule reaches the system prompt verbatim."""
+    for preset in ("brief", "detailed", "comprehensive", "exhaustive"):
+        prompt = _build_system_prompt(3, description_verbosity=preset)
+        rule = length_rule(preset)
+        head = rule.split(".")[0]
+        assert head in prompt, f"prompt missing '{head}' for preset={preset}"
+
+
+def test_rag_agent_prompt_emits_n_alternative_slots() -> None:
+    prompt = _build_system_prompt(3, description_verbosity="exhaustive")
+    assert "DESCRIPTION_1:" in prompt
+    assert "DESCRIPTION_2:" in prompt
+    assert "DESCRIPTION_3:" in prompt
+
+
+def test_rag_agent_prompt_alternatives_carry_length_rule() -> None:
+    """Alternative slots carry the "same length rule" rider and the
+    prompt body includes the shared length-rule reminder."""
+    for preset in ("brief", "detailed", "comprehensive", "exhaustive"):
+        prompt = _build_system_prompt(3, description_verbosity=preset)
+        assert ALTERNATIVES_LENGTH_RULE_REMINDER in prompt, (
+            f"alternatives reminder missing at preset={preset}"
+        )
+        assert "DESCRIPTION_2: <alternative>" not in prompt
+        assert "DESCRIPTION_2: <alternative description — apply the SAME length rule" in prompt
+        assert "DESCRIPTION_3: <alternative description — apply the SAME length rule" in prompt
+
+
+def test_rag_agent_prompt_n_alternatives_one_omits_alt_slots() -> None:
+    prompt = _build_system_prompt(1, description_verbosity="brief")
+    assert "DESCRIPTION_1:" in prompt
+    assert "DESCRIPTION_2:" not in prompt
+    assert ALTERNATIVES_LENGTH_RULE_REMINDER not in prompt


### PR DESCRIPTION
## Summary

- Picking `description_verbosity=exhaustive` with `n_alternatives>=2` returned an exhaustive `DESCRIPTION_1` but collapsed `DESCRIPTION_2..N` to one-sentence briefs.
- The alternative slot template read `DESCRIPTION_<i>: <alternative>`, which the LLM read as "alternatives are short rephrasings of DESCRIPTION_1" rather than distinct interpretations honouring the same length rule.
- Fix reinforces the length contract at every site that templates alternative slots: ProfileAgent, CodeAgent, RAGAgent, and the orchestrator's merge + fill-up prompts. A shared `ALTERNATIVES_LENGTH_RULE_REMINDER` constant lives next to `length_rule()` so future edits cannot drift between sites.

## Test plan

- [x] `pytest tests/test_merge_verbosity.py tests/test_profile_agent_verbosity.py tests/test_code_agent_verbosity.py tests/test_rag_agent_verbosity.py` — 24 / 24 pass.
- [x] `AMX_NO_NETWORK=1 pytest tests/ --ignore=tests/eval` — 1248 passed, 0 failures.
- [x] `ruff check` clean on all touched files.
- [ ] Studio smoke: open Settings, set `description_verbosity=exhaustive` and `n_alternatives=5`, run a fresh analysis on `chicago_crime`, and verify B / C / D / E descriptions render multi-paragraph alongside DESCRIPTION_1.