### PR TITLE
feat(cli): adapt brand palette to light terminal backgrounds

### DIFF
--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -27,6 +27,7 @@ from amx.utils.console import (
 )
 from amx.utils.live_commands import command_display
 from amx.utils.logging import get_logger
+from amx.utils.terminal_theme import accent_color
 from amx.utils.token_tracker import tracker as token_tracker
 
 log = get_logger("cli.analyze_flow")
@@ -591,8 +592,8 @@ def _resolve_completion_mode(cfg: AMXConfig, llm: object, mode: str | None) -> b
                 "All LLM requests will be submitted as a single batch job.\n"
                 "Typical turnaround: [bold]2–30 minutes[/bold]  |  Cost: [bold green]~50 % lower[/bold green]\n"
                 "[dim]Live polling status will appear below.[/dim]",
-                title="[#fb923c]Mode: Batch[/#fb923c]",
-                border_style="#fb923c",
+                title="[accent]Mode: Batch[/accent]",
+                border_style=accent_color(),
             )
         )
     else:

--- a/amx/cli_support/commands/compare.py
+++ b/amx/cli_support/commands/compare.py
@@ -36,6 +36,7 @@ from amx.utils.console import (
     success,
     warn,
 )
+from amx.utils.terminal_theme import info_color
 
 LogEvent = Callable[..., None]
 
@@ -401,7 +402,7 @@ def _render_run_settings(runs: list[dict[str, Any]]) -> None:
         show_lines=True,
         box=box.SIMPLE_HEAVY,
     )
-    table.add_column("Run", style="#22d3ee", no_wrap=True)
+    table.add_column("Run", style=info_color(), no_wrap=True)
     table.add_column("Prompt detail", no_wrap=True)
     table.add_column("Language", no_wrap=True)
     table.add_column("Verbosity", no_wrap=True)
@@ -432,7 +433,7 @@ def _render_run_settings(runs: list[dict[str, Any]]) -> None:
     for r in runs:
         s = _settings_for_run(r)
         cells = [
-            Text(f"#{r.get('id')}", style="#22d3ee"),
+            Text(f"#{r.get('id')}", style=info_color()),
             Text(_opt(s, "prompt_detail")),
             Text(_opt(s, "language")),
             Text(_opt(s, "description_verbosity")),
@@ -456,10 +457,10 @@ def _render_run_summary(runs: list[dict[str, Any]], by: str) -> None:
         show_lines=True,
         box=box.SIMPLE_HEAVY,
     )
-    table.add_column("Run", style="#22d3ee", no_wrap=True)
-    table.add_column("Started", style="#22d3ee", no_wrap=True)
+    table.add_column("Run", style=info_color(), no_wrap=True)
+    table.add_column("Started", style=info_color(), no_wrap=True)
     table.add_column("Status", no_wrap=True)
-    table.add_column("Command", style="#22d3ee", no_wrap=True)
+    table.add_column("Command", style=info_color(), no_wrap=True)
     table.add_column("DB profile", no_wrap=True)
     table.add_column("LLM profile", no_wrap=True)
     table.add_column("Model", no_wrap=True)
@@ -484,7 +485,7 @@ def _render_run_summary(runs: list[dict[str, Any]], by: str) -> None:
             else "—"
         )
         cells = [
-            Text(f"#{r.get('id')}", style="#22d3ee"),
+            Text(f"#{r.get('id')}", style=info_color()),
             Text(_fmt_dt(r.get("started_at"))),
             Text(
                 str(r.get("status") or "—"),
@@ -554,7 +555,7 @@ def _render_per_column_pivot(
         show_lines=True,
         box=box.SIMPLE_HEAVY,
     )
-    table.add_column("Schema.Table.Column", style="#22d3ee", no_wrap=False, overflow="fold")
+    table.add_column("Schema.Table.Column", style=info_color(), no_wrap=False, overflow="fold")
     for r in runs:
         table.add_column(
             f"Run #{r.get('id')}",
@@ -585,7 +586,7 @@ def _render_per_column_pivot(
             base_row = runs_for_asset.get(int(runs[0]["id"]))
             baseline_text = _top_alternative(base_row) if base_row else ""
 
-        cells: list[Text] = [Text(label, style="#22d3ee")]
+        cells: list[Text] = [Text(label, style=info_color())]
         for col_idx, run in enumerate(runs):
             row = runs_for_asset.get(int(run["id"]))
             if not row:
@@ -633,12 +634,12 @@ def _render_aggregate_metrics(
         show_lines=True,
         box=box.SIMPLE_HEAVY,
     )
-    table.add_column("Metric", style="#22d3ee", no_wrap=True)
+    table.add_column("Metric", style=info_color(), no_wrap=True)
     for r in runs:
         table.add_column(f"Run #{r.get('id')}", justify="right")
 
     def _row(label: str, values: list[Any], best_idx: int | None) -> None:
-        cells: list[Text] = [Text(label, style="#22d3ee")]
+        cells: list[Text] = [Text(label, style=info_color())]
         for i, v in enumerate(values):
             text = Text(str(v))
             if i == best_idx:

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -1325,7 +1325,7 @@ def cmd_inspect(cfg: AMXConfig, rest: list[str]) -> None:
 
     profile = cfg.db_profiles[profile_name]
     heading(f"DB profile: {profile_name}")
-    info_styled("  Backend", profile.backend, value_style="#22d3ee")
+    info_styled("  Backend", profile.backend, value_style="info")
     info(f"  Connection: {profile.display_summary}")
 
     # Print non-secret connection fields per backend so users can sanity-
@@ -1454,9 +1454,9 @@ def cmd_profiling(cfg: AMXConfig, rest: list[str]) -> None:
         max_label = "off" if max_rows <= 0 else f"{max_rows:,}"
         info(
             "Current profiling guardrails: "
-            f"mode=[#22d3ee]{cfg.db.profiling_mode}[/#22d3ee], "
-            f"max_full_scan_rows=[#22d3ee]{max_label}[/#22d3ee], "
-            f"sample_size=[#22d3ee]{cfg.db.profiling_sample_size}[/#22d3ee]. "
+            f"mode=[info]{cfg.db.profiling_mode}[/info], "
+            f"max_full_scan_rows=[info]{max_label}[/info], "
+            f"sample_size=[info]{cfg.db.profiling_sample_size}[/info]. "
             "Use /profiling <full|sampled|metadata> [max_rows|off] [sample_size]."
         )
         return
@@ -1518,8 +1518,8 @@ def cmd_tls(cfg: AMXConfig, rest: list[str]) -> None:
         ca_path = str(getattr(cfg.db, "tls_trusted_ca_file", "") or "").strip() or "(none)"
         info(
             "Current Databricks TLS settings: "
-            f"tls_no_verify=[#22d3ee]{bool(getattr(cfg.db, 'tls_no_verify', False))}[/#22d3ee], "
-            f"trusted_ca=[#22d3ee]{ca_path}[/#22d3ee]. "
+            f"tls_no_verify=[info]{bool(getattr(cfg.db, 'tls_no_verify', False))}[/info], "
+            f"trusted_ca=[info]{ca_path}[/info]. "
             "Use /tls <on|off> [ca_path|clear]."
         )
         return

--- a/amx/cli_support/commands/doctor.py
+++ b/amx/cli_support/commands/doctor.py
@@ -330,7 +330,7 @@ def _render_results(results: list[CheckResult]) -> int:
     """Render the report and return an exit code (0 = clean)."""
     fail_count = sum(1 for r in results if not r.ok)
     console.print()
-    console.print("[bold #fb923c]AMX doctor report[/bold #fb923c]")
+    console.print("[heading]AMX doctor report[/heading]")
     console.print()
     for r in results:
         marker = "[bold green]✓[/]" if r.ok else "[bold red]✗[/]"

--- a/amx/cli_support/commands/history.py
+++ b/amx/cli_support/commands/history.py
@@ -12,6 +12,7 @@ import click
 from amx.config import AMXConfig
 from amx.storage.sqlite_store import history_store
 from amx.utils.console import confirm, console, error, heading, info, render_table, success, warn
+from amx.utils.terminal_theme import accent_color
 
 LogEvent = Callable[..., None]
 
@@ -181,7 +182,7 @@ def register_history_commands(
                         "failed": "[bold red]failed[/bold red]",
                         "cancelled": "[bold yellow]cancelled[/bold yellow]",
                         "ready_for_review": "[bold #fed7aa]ready_for_review[/bold #fed7aa]",
-                        "running": "[bold #fb923c]running[/bold #fb923c]",
+                        "running": "[heading]running[/heading]",
                     }.get(str(row.get("status", "")), str(row.get("status", ""))),
                     str(row.get("mode", "")),
                     str(row.get("db_backend", "")),
@@ -377,8 +378,8 @@ def register_history_commands(
                 console.print(
                     Panel(
                         "\n".join(lines),
-                        title=f"[bold #fb923c]{kind} DESCRIPTION[/bold #fb923c] - {asset_label}  [dim][{status_label}][/dim]",
-                        border_style="#fb923c",
+                        title=f"[heading]{kind} DESCRIPTION[/heading] - {asset_label}  [dim][{status_label}][/dim]",
+                        border_style=accent_color(),
                         expand=False,
                     )
                 )

--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -595,9 +595,9 @@ def cmd_prompt_detail(cfg: AMXConfig, rest: list[str]) -> None:
             rows.append(row)
         render_table("Preset comparison", ["Field", *PROMPT_DETAIL_LEVELS], rows)
         info(
-            f"Current level: [#22d3ee]{current}[/#22d3ee]  "
+            f"Current level: [info]{current}[/info]  "
             f"(n_alternatives={cfg.llm.n_alternatives})  "
-            "- run [#22d3ee]/prompt-detail <level>[/#22d3ee] to change."
+            "- run [info]/prompt-detail <level>[/info] to change."
         )
         return
 
@@ -611,7 +611,7 @@ def cmd_prompt_detail(cfg: AMXConfig, rest: list[str]) -> None:
         cfg.llm_profiles[cfg.active_llm_profile].prompt_detail = level
     cfg.save()
     success(
-        f"Prompt detail set to [#22d3ee]{level}[/#22d3ee] and saved "
+        f"Prompt detail set to [info]{level}[/info] and saved "
         f"for LLM profile '{cfg.active_llm_profile}'."
     )
     prompt_detail = prompt_detail_for(level)
@@ -660,9 +660,9 @@ def cmd_description_verbosity(cfg: AMXConfig, rest: list[str]) -> None:
             "usage patterns and caveats.\n"
             "  exhaustive    — multi-paragraph reference-style entry; best for "
             "documentation generation, not interactive runs.\n"
-            f"\nCurrent: [#22d3ee]{current}[/#22d3ee] for LLM profile "
+            f"\nCurrent: [info]{current}[/info] for LLM profile "
             f"'{cfg.active_llm_profile or 'default'}'.\n"
-            f"Run [#22d3ee]/description-verbosity {levels_pipe}[/#22d3ee] to change."
+            f"Run [info]/description-verbosity {levels_pipe}[/info] to change."
         )
         return
 
@@ -676,7 +676,7 @@ def cmd_description_verbosity(cfg: AMXConfig, rest: list[str]) -> None:
         cfg.llm_profiles[cfg.active_llm_profile].description_verbosity = level
     cfg.save()
     success(
-        f"Description verbosity set to [#22d3ee]{level}[/#22d3ee] and saved "
+        f"Description verbosity set to [info]{level}[/info] and saved "
         f"for LLM profile '{cfg.active_llm_profile or 'default'}'."
     )
     cost_hint = _DESCRIPTION_VERBOSITY_COST_HINTS.get(level)
@@ -692,9 +692,9 @@ def cmd_n_alternatives(cfg: AMXConfig, rest: list[str]) -> None:
     if not rest:
         current = getattr(cfg.llm, "n_alternatives", 3)
         info(
-            f"Current n_alternatives: [#22d3ee]{current}[/#22d3ee]  "
+            f"Current n_alternatives: [info]{current}[/info]  "
             "(1 = cheapest, 5 = maximum alternatives)  "
-            "- run [#22d3ee]/n-alternatives <N>[/#22d3ee] to change."
+            "- run [info]/n-alternatives <N>[/info] to change."
         )
         return
 
@@ -720,7 +720,7 @@ def cmd_n_alternatives(cfg: AMXConfig, rest: list[str]) -> None:
         5: "maximum context, highest cost",
     }.get(value, "")
     success(
-        f"n_alternatives set to [#22d3ee]{value}[/#22d3ee] ({cost_note}) and saved "
+        f"n_alternatives set to [info]{value}[/info] ({cost_note}) and saved "
         f"for LLM profile '{cfg.active_llm_profile}'."
     )
 
@@ -730,9 +730,9 @@ def cmd_llm_batch_size(cfg: AMXConfig, rest: list[str]) -> None:
     if not rest:
         current = getattr(cfg.llm, "column_batch_size", 10)
         info(
-            f"Current LLM batch size: [#22d3ee]{current}[/#22d3ee] columns  "
+            f"Current LLM batch size: [info]{current}[/info] columns  "
             "(Small = safer/more precise, Large = faster/cheaper)  "
-            "- run [#22d3ee]/llm-batch-size <N>[/#22d3ee] to change."
+            "- run [info]/llm-batch-size <N>[/info] to change."
         )
         return
 
@@ -766,9 +766,9 @@ def cmd_batch_context_columns(cfg: AMXConfig, rest: list[str]) -> None:
         else:
             current_label = f"{current} names"
         info(
-            f"Current batch context columns: [#22d3ee]{current_label}[/#22d3ee]. "
-            "Use [#22d3ee]/batch-context-columns off[/#22d3ee], [#22d3ee]all[/#22d3ee], "
-            "or [#22d3ee]/batch-context-columns <N>[/#22d3ee]."
+            f"Current batch context columns: [info]{current_label}[/info]. "
+            "Use [info]/batch-context-columns off[/info], [info]all[/info], "
+            "or [info]/batch-context-columns <N>[/info]."
         )
         return
 

--- a/amx/cli_support/commands/search.py
+++ b/amx/cli_support/commands/search.py
@@ -40,6 +40,7 @@ from amx.utils.console import (
 )
 from amx.utils.live_commands import command_display
 from amx.utils.live_display import get_display
+from amx.utils.terminal_theme import accent_color, info_color
 
 LogEvent = Callable[..., None]
 
@@ -131,10 +132,10 @@ def _render_search_rows(
         # Inventory rows have no useful score; render as a focused inventory table
         # rather than the generic Search matches grid.
         inventory = Table(title="Inventory", show_lines=True, box=box.SIMPLE_HEAVY)
-        inventory.add_column("Schema", style="#22d3ee", no_wrap=True)
-        inventory.add_column("Table", style="#22d3ee", no_wrap=True)
-        inventory.add_column("Columns", style="#22d3ee", no_wrap=True, justify="right")
-        inventory.add_column("Rows", style="#22d3ee", no_wrap=True, justify="right")
+        inventory.add_column("Schema", style=info_color(), no_wrap=True)
+        inventory.add_column("Table", style=info_color(), no_wrap=True)
+        inventory.add_column("Columns", style=info_color(), no_wrap=True, justify="right")
+        inventory.add_column("Rows", style=info_color(), no_wrap=True, justify="right")
         inventory.add_column("Cluster", style="white", overflow="fold", max_width=40)
         for row in rows:
             inventory.add_row(
@@ -163,7 +164,7 @@ def _render_search_rows(
                 title = f"Key columns — {schema_name}.{table_name}"
                 break
         summary_table = Table(title=title, show_lines=False, box=box.SIMPLE_HEAVY)
-        summary_table.add_column("Column", style="#22d3ee", no_wrap=True)
+        summary_table.add_column("Column", style=info_color(), no_wrap=True)
         summary_table.add_column("Type", style="white", no_wrap=True)
         summary_table.add_column("Description", style="white", overflow="fold", max_width=72)
         rendered = 0
@@ -198,17 +199,17 @@ def _render_search_rows(
     show_profile_col = len(profiles_in_view) > 1
     table = Table(title="Search matches", show_lines=True, box=box.SIMPLE_HEAVY)
     if show_profile_col:
-        table.add_column("Profile", style="#fb923c", no_wrap=True)
-    table.add_column("Schema.Table", style="#22d3ee", no_wrap=True)
+        table.add_column("Profile", style=accent_color(), no_wrap=True)
+    table.add_column("Schema.Table", style=info_color(), no_wrap=True)
     table.add_column("Match", no_wrap=True)
     table.add_column("Why", style="white", overflow="fold", max_width=32)
-    table.add_column("Rows", style="#22d3ee", no_wrap=True, justify="right")
-    table.add_column("Cols", style="#22d3ee", no_wrap=True, justify="right")
+    table.add_column("Rows", style=info_color(), no_wrap=True, justify="right")
+    table.add_column("Cols", style=info_color(), no_wrap=True, justify="right")
     table.add_column("Description", style="white", overflow="fold", max_width=60)
     if debug:
-        table.add_column("Score", style="#22d3ee", no_wrap=True, justify="right")
-        table.add_column("Source", style="#22d3ee", no_wrap=True)
-        table.add_column("Conf", style="#22d3ee", no_wrap=True)
+        table.add_column("Score", style=info_color(), no_wrap=True, justify="right")
+        table.add_column("Source", style=info_color(), no_wrap=True)
+        table.add_column("Conf", style=info_color(), no_wrap=True)
     for row in visible:
         score = float(row.get("rank_score") or row.get("score") or 0)
         match_label = _confidence_band(score)

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -266,12 +266,12 @@ def _print_session_help(*, namespace: str, cfg: AMXConfig) -> None:
         out.print(
             f"""
 [heading]Help — /db namespace[/heading]
-Engines: [#22d3ee]{engines}[/#22d3ee] — each profile stores one backend. /add-db-profile asks which engine first.
+Engines: [info]{engines}[/info] — each profile stores one backend. /add-db-profile asks which engine first.
 
 Context:
-  Active DB profile: [#22d3ee]{active}[/#22d3ee]
-  Current schema: [#22d3ee]{ctx_schema}[/#22d3ee]
-  Current table:  [#22d3ee]{ctx_table}[/#22d3ee]
+  Active DB profile: [info]{active}[/info]
+  Current schema: [info]{ctx_schema}[/info]
+  Current table:  [info]{ctx_table}[/info]
 
 Commands (in order):
   1) /back                         Return to root namespace
@@ -573,9 +573,9 @@ SQLite file:
         f"""
 [heading]Help — root[/heading]
 Context:
-  Active DB profile: [#22d3ee]{active}[/#22d3ee]
-  Current schema: [#22d3ee]{ctx_schema}[/#22d3ee]
-  Current table:  [#22d3ee]{ctx_table}[/#22d3ee]
+  Active DB profile: [info]{active}[/info]
+  Current schema: [info]{ctx_schema}[/info]
+  Current table:  [info]{ctx_table}[/info]
 
 Getting started (in order):
   1) /setup                        First-time wizard (DB + LLM + sources)

--- a/amx/llm/batch.py
+++ b/amx/llm/batch.py
@@ -54,7 +54,7 @@ class OpenAIBatchProvider(BatchProvider):
         model = self._resolve_model() or "gpt-4o-mini"
 
         console.print(
-            f"[bold #fb923c]Batch[/bold #fb923c] Preparing {len(requests)} request(s) "
+            f"[heading]Batch[/heading] Preparing {len(requests)} request(s) "
             f"→ model [yellow]{model}[/yellow]"
         )
 
@@ -278,7 +278,7 @@ class AnthropicBatchProvider(BatchProvider):
         model = self._resolve_model() or "claude-sonnet-4-20250514"
 
         console.print(
-            f"[bold #fb923c]Batch[/bold #fb923c] Preparing {len(requests)} request(s) "
+            f"[heading]Batch[/heading] Preparing {len(requests)} request(s) "
             f"→ model [yellow]{model}[/yellow]"
         )
 

--- a/amx/utils/console.py
+++ b/amx/utils/console.py
@@ -23,15 +23,9 @@ from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
 
-_theme = Theme(
-    {
-        "info": "#22d3ee",
-        "success": "bold green",
-        "warning": "bold yellow",
-        "error": "bold red",
-        "heading": "bold #fb923c",
-    }
-)
+from amx.utils.terminal_theme import accent_color, info_color, themed_palette
+
+_theme = Theme(themed_palette())
 
 _real_console = Console(theme=_theme)
 # Long-lived /dev/null sink the proxy routes to while a thread is in
@@ -116,6 +110,12 @@ def show_banner(force: bool = False) -> None:
     asterisks so the framing matches the Unicode block of the ASCII
     art instead of mixing vector glyphs with grid art.
 
+    The accent color is resolved at render time via
+    :func:`amx.utils.terminal_theme.accent_color`, which probes the
+    terminal background once per process and shifts the brand orange
+    one step darker on light terminals so the WCAG contrast clears
+    AA. The ASCII art and panel layout do not change.
+
     The version is intentionally NOT shown here. The "AMX Interactive
     Session" info block (rendered by the session module) already lists
     ``Version`` alongside the runtime Config / Database / LLM context;
@@ -128,7 +128,8 @@ def show_banner(force: bool = False) -> None:
     if os.getenv("AMX_NO_BANNER", "").lower() in {"1", "true", "yes"}:
         return
 
-    tagline = Text("┃  Agentic Metadata Extractor  ┃", style="bold #fb923c")
+    accent = accent_color()
+    tagline = Text("┃  Agentic Metadata Extractor  ┃", style=f"bold {accent}")
     art = Text(
         "\n".join(
             [
@@ -140,9 +141,9 @@ def show_banner(force: bool = False) -> None:
                 "╚═╝  ╚═╝╚═╝     ╚═╝╚═╝  ╚═╝",
             ]
         ),
-        style="bold #fb923c",
+        style=f"bold {accent}",
     )
-    footer = Text("AI-inferred database descriptions", style="#fb923c")
+    footer = Text("AI-inferred database descriptions", style=accent)
 
     content = Text.assemble(
         tagline,
@@ -155,7 +156,7 @@ def show_banner(force: bool = False) -> None:
     console.print(
         Panel(
             Align.center(content),
-            border_style="#fb923c",
+            border_style=accent,
             box=box.DOUBLE_EDGE,
             padding=(1, 2),
         )
@@ -180,7 +181,7 @@ def info(text: str) -> None:
     console.print(f"[info]ℹ  {_markup_escape(text)}[/info]")
 
 
-def info_styled(label: str, value: str, *, value_style: str = "bold #fb923c") -> None:
+def info_styled(label: str, value: str, *, value_style: str | None = None) -> None:
     """``info()`` with the *value* visually emphasized.
 
     Renders ``ℹ  <label>: <styled value>``. Both ``label`` and ``value``
@@ -190,9 +191,16 @@ def info_styled(label: str, value: str, *, value_style: str = "bold #fb923c") ->
     Use this instead of ``info(f"... [bold]{x}[/]")`` — the plain
     :func:`info` helper escapes the whole string and turns those tags
     into literal text that leaks to the terminal.
+
+    ``value_style`` defaults to the bold brand accent resolved against
+    the current terminal background (orange-400 on dark, orange-800 on
+    light). Pass an explicit style to override (e.g. ``"bold green"``
+    for OK badges or ``info_color()`` for cyan emphasis).
     """
     if is_quiet():
         return
+    if value_style is None:
+        value_style = f"bold {accent_color()}"
     console.print(
         f"[info]ℹ  {_markup_escape(label)}: "
         f"[{value_style}]{_markup_escape(value)}[/{value_style}][/info]"
@@ -421,8 +429,9 @@ def confirm(question: str, default: bool = True) -> bool:
 
 def render_table(title: str, columns: list[str], rows: list[list[Any]]) -> None:
     table = Table(title=title, show_lines=True)
+    column_style = info_color()
     for col in columns:
-        table.add_column(col, style="#22d3ee")
+        table.add_column(col, style=column_style)
     for row in rows:
         table.add_row(*[str(v) for v in row])
     console.print(table)
@@ -523,7 +532,7 @@ def render_token_summary(tracker: object) -> None:
         return
     rows = tracker.summary()
     table = Table(title="Token usage", show_lines=True, box=box.SIMPLE_HEAVY)
-    table.add_column("Step", style="#22d3ee")
+    table.add_column("Step", style=info_color())
     table.add_column("Input", justify="right")
     table.add_column("Output", justify="right")
     table.add_column("Total", justify="right", style="bold")

--- a/amx/utils/live_display.py
+++ b/amx/utils/live_display.py
@@ -122,7 +122,7 @@ class ActivityState(Enum):
 
 _STATE_GLYPH = {
     ActivityState.PENDING: "[dim]○[/dim]",
-    ActivityState.ACTIVE: "[bold #fb923c]✦[/bold #fb923c]",
+    ActivityState.ACTIVE: "[heading]✦[/heading]",
     ActivityState.DONE: "[green]●[/green]",
     ActivityState.FAILED: "[red]✗[/red]",
 }
@@ -292,7 +292,7 @@ class LiveDisplay:
             mark = {
                 ActivityState.DONE: "[green]✓[/green]",
                 ActivityState.FAILED: "[red]✗[/red]",
-                ActivityState.ACTIVE: "[#fb923c]…[/#fb923c]",
+                ActivityState.ACTIVE: "[accent]…[/accent]",
             }.get(act.state, "[dim]·[/dim]")
             tree.add(f"{mark} [dim]{act.label}[/dim] [dim]({elapsed:.1f}s)[/dim]")
         return tree
@@ -590,19 +590,19 @@ class LiveDisplay:
 
     def _render_header(self) -> Panel:
         ver = getattr(amx, "__version__", "?")
-        left = f"[bold #fb923c]AMX[/bold #fb923c] [dim]v{ver}[/dim]"
+        left = f"[heading]AMX[/heading] [dim]v{ver}[/dim]"
 
         ctx_parts: list[str] = []
         if self._context_provider and self._context_model:
-            ctx_parts.append(f"[#fb923c]{self._context_provider}/{self._context_model}[/#fb923c]")
+            ctx_parts.append(f"[accent]{self._context_provider}/{self._context_model}[/accent]")
         if self._context_schema:
             schema_str = self._context_schema
             if self._context_table:
                 schema_str += f".{self._context_table}"
-            ctx_parts.append(f"[#22d3ee]{schema_str}[/#22d3ee]")
+            ctx_parts.append(f"[info]{schema_str}[/info]")
         if self._context_mode:
-            mode_color = "green" if self._context_mode == "batch" else "#fb923c"
-            ctx_parts.append(f"[{mode_color}]{self._context_mode.upper()}[/{mode_color}]")
+            mode_tag = "green" if self._context_mode == "batch" else "accent"
+            ctx_parts.append(f"[{mode_tag}]{self._context_mode.upper()}[/{mode_tag}]")
 
         elapsed_total = time.monotonic() - self._session_start if self._session_start else 0
         time_str = f"[dim]{elapsed_total:.0f}s[/dim]"
@@ -627,7 +627,7 @@ class LiveDisplay:
         dots = "." * (int(elapsed * 2) % 4)
         collapsed_hint = "[dim](Tab to expand)[/dim]" if self._collapsed else ""
         header = Text.from_markup(
-            f"  [bold #fb923c]⟳[/bold #fb923c] {self._thinking_label}{dots} "
+            f"  [heading]⟳[/heading] {self._thinking_label}{dots} "
             f"[dim]({elapsed:.0f}s)[/dim] {collapsed_hint}"
         )
         if not self._thinking_text:
@@ -670,7 +670,7 @@ class LiveDisplay:
             if act.state == ActivityState.ACTIVE:
                 idx = int(time.monotonic() * 10) % 8
                 spinner = ["⢹", "⢺", "⢼", "⣸", "⣇", "⡧", "⡏", "⡟"][idx]
-                glyph = f"[bold #fb923c]{spinner}[/bold #fb923c]"
+                glyph = f"[heading]{spinner}[/heading]"
             else:
                 glyph = _STATE_GLYPH[act.state]
 

--- a/amx/utils/terminal_theme.py
+++ b/amx/utils/terminal_theme.py
@@ -20,9 +20,12 @@ Detection runs in tiers, ordered by reliability + cost:
        when ``WT_SESSION`` is unset; Windows Terminal supports OSC 11
        directly.
     5. OSC 11 escape query (xterm/iTerm2/Kitty/Alacritty/WezTerm/foot/
-       VS Code/Windows Terminal). Skipped on Apple_Terminal — the OS
-       Terminal.app does not respond and the timeout is wasted.
-    6. Fallback: "dark" (preserves the pre-detection behavior).
+       VS Code/Windows Terminal). 150 ms timeout.
+    6. Apple_Terminal AppleScript fallback (``osascript`` reads the
+       active tab's background color). Only fires when ``TERM_PROGRAM``
+       is ``Apple_Terminal`` and OSC 11 didn't reply — Terminal.app
+       does not implement OSC 11 across most macOS versions.
+    7. Fallback: "dark" (preserves the pre-detection behavior).
 
 The result is memoized for the process lifetime; banner rendering hits
 this once. Theme switches mid-session require restarting the CLI.
@@ -274,8 +277,7 @@ def _normalize_rgb_hex(r_hex: str, g_hex: str, b_hex: str) -> tuple[float, float
 
 
 _APPLESCRIPT_BG_QUERY = (
-    'tell application "Terminal" to get background color '
-    "of selected tab of window 1"
+    'tell application "Terminal" to get background color of selected tab of window 1'
 )
 _APPLESCRIPT_TIMEOUT_S = 0.5
 

--- a/amx/utils/terminal_theme.py
+++ b/amx/utils/terminal_theme.py
@@ -1,0 +1,376 @@
+"""Cross-platform terminal background detection.
+
+The startup banner uses a single brand-orange accent (``#fb923c``). On a
+black terminal that hits ~5.7:1 contrast — fine. On a white terminal it
+falls to ~2.3:1, well below WCAG AA (4.5:1), and the banner is unreadable
+on Terminal.app default profile, GNOME Terminal "Light", solarized-light,
+Windows Terminal "Light", VS Code Light theme, etc.
+
+This module asks the terminal what its background is and lets callers
+pick a darker accent (``#9a3412``) when the foreground is on white. The
+ASCII art and panel layout do not change — only the hex color does.
+
+Detection runs in tiers, ordered by reliability + cost:
+
+    1. ``AMX_THEME=light|dark|auto`` — manual override, highest priority.
+    2. ``NO_COLOR`` set or stdout/stdin not a TTY → "unknown" (caller
+       should not apply any styling).
+    3. ``COLORFGBG`` env var (rxvt/urxvt/Konsole/Terminator family).
+    4. Windows Console API (legacy cmd / conhost PowerShell). Only used
+       when ``WT_SESSION`` is unset; Windows Terminal supports OSC 11
+       directly.
+    5. OSC 11 escape query (xterm/iTerm2/Kitty/Alacritty/WezTerm/foot/
+       VS Code/Windows Terminal). Skipped on Apple_Terminal — the OS
+       Terminal.app does not respond and the timeout is wasted.
+    6. Fallback: "dark" (preserves the pre-detection behavior).
+
+The result is memoized for the process lifetime; banner rendering hits
+this once. Theme switches mid-session require restarting the CLI.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from typing import Literal
+
+# Brand-orange accent for dark/unknown backgrounds (Tailwind orange-400).
+ACCENT_DARK_BG = "#fb923c"
+# Burnt-orange accent for light backgrounds (Tailwind orange-800).
+# Same hue family — preserves brand identity, but lifts contrast on
+# white from ~2.3:1 to ~6.4:1 (WCAG AA pass).
+ACCENT_LIGHT_BG = "#9a3412"
+
+# Info / secondary cyan for dark backgrounds (Tailwind cyan-400). The
+# pre-existing brand teal — unchanged on dark terminals.
+INFO_DARK_BG = "#22d3ee"
+# Deep teal for light backgrounds (Tailwind cyan-700). Cyan-400 on
+# white is ~2.0:1 contrast (unreadable); cyan-700 lands at ~6.0:1
+# while staying inside the same hue family.
+INFO_LIGHT_BG = "#0e7490"
+
+Background = Literal["light", "dark", "unknown"]
+
+_OSC11_TIMEOUT_S = 0.15
+
+_cached_background: Background | None = None
+
+
+def detect_background() -> Background:
+    """Return the detected terminal background, memoized for the process.
+
+    ``"unknown"`` means we should not apply theme-conditional styling
+    (NO_COLOR, non-TTY, piped output).
+    """
+    global _cached_background
+    if _cached_background is None:
+        _cached_background = _detect_uncached()
+    return _cached_background
+
+
+def accent_color() -> str:
+    """Resolve the WCAG-passing brand accent for the current terminal."""
+    bg = detect_background()
+    return ACCENT_LIGHT_BG if bg == "light" else ACCENT_DARK_BG
+
+
+def info_color() -> str:
+    """Resolve the WCAG-passing info / secondary cyan for the current terminal."""
+    bg = detect_background()
+    return INFO_LIGHT_BG if bg == "light" else INFO_DARK_BG
+
+
+def themed_palette() -> dict[str, str]:
+    """Build the Rich theme map with background-aware brand colors.
+
+    Three keys cover everything that touches the brand palette:
+
+    - ``info`` — secondary cyan; used by ``info()`` / ``info_styled()`` /
+      ``info_markdown()`` and any inline ``[info]…[/info]`` markup.
+    - ``accent`` — non-bold brand orange.
+    - ``heading`` — bold brand orange; used by ``heading()`` and panel
+      titles.
+
+    The ``success`` / ``warning`` / ``error`` styles intentionally still
+    use ANSI palette names so the user's terminal palette controls them
+    — the brand-orange / brand-cyan are the only colors AMX hardcodes.
+    """
+    accent = accent_color()
+    return {
+        "info": info_color(),
+        "accent": accent,
+        "heading": f"bold {accent}",
+        "success": "bold green",
+        "warning": "bold yellow",
+        "error": "bold red",
+    }
+
+
+def reset_cache() -> None:
+    """Clear the memoized background. Test-only entry point."""
+    global _cached_background
+    _cached_background = None
+
+
+def _detect_uncached() -> Background:
+    explicit = os.getenv("AMX_THEME", "").strip().lower()
+    if explicit in {"light", "dark"}:
+        return explicit  # type: ignore[return-value]
+
+    if os.getenv("NO_COLOR") is not None:
+        return "unknown"
+    try:
+        if not (sys.stdout.isatty() and sys.stdin.isatty()):
+            return "unknown"
+    except (ValueError, OSError):
+        return "unknown"
+
+    cfg = _parse_colorfgbg(os.getenv("COLORFGBG"))
+    if cfg is not None:
+        return cfg
+
+    if os.name == "nt" and not os.getenv("WT_SESSION"):
+        win = _query_windows_console()
+        if win is not None:
+            return win
+        return "dark"
+
+    rgb = _query_osc11()
+    if rgb is not None:
+        return "light" if _relative_luminance(*rgb) > 0.5 else "dark"
+
+    if os.environ.get("TERM_PROGRAM") == "Apple_Terminal":
+        rgb = _query_apple_terminal()
+        if rgb is not None:
+            return "light" if _relative_luminance(*rgb) > 0.5 else "dark"
+
+    return "dark"
+
+
+def _parse_colorfgbg(raw: str | None) -> Background | None:
+    """Map the ``COLORFGBG=fg;bg`` (or ``fg;default;bg``) env var to a theme.
+
+    The trailing field is the background palette index. Indices 7
+    (light gray) and 15 (white) indicate a light terminal; 0–6 and 8–14
+    indicate dark. Unparseable values return ``None`` so the next tier
+    can take over.
+    """
+    if not raw:
+        return None
+    parts = [p.strip() for p in raw.split(";") if p.strip()]
+    if len(parts) < 2:
+        return None
+    try:
+        bg = int(parts[-1])
+    except ValueError:
+        return None
+    return "light" if bg in {7, 15} else "dark"
+
+
+def _relative_luminance(r: float, g: float, b: float) -> float:
+    """WCAG 2.x relative luminance for sRGB inputs in [0, 1]."""
+
+    def channel(c: float) -> float:
+        c = max(0.0, min(1.0, c))
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+
+
+_OSC11_RGB_RE = re.compile(r"rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)")
+
+
+def _query_osc11() -> tuple[float, float, float] | None:
+    """Send OSC 11 to the terminal and parse the background-color reply.
+
+    Returns RGB in [0, 1] or ``None`` if the terminal didn't reply
+    inside the timeout window. Restores the tty state in a ``finally``
+    so a partial reply can't leave the user's shell in raw mode.
+
+    POSIX-only — Windows Terminal also supports OSC 11 but the input
+    side requires ``ENABLE_VIRTUAL_TERMINAL_INPUT`` plumbing; the
+    Console API tier covers the conhost case and ``AMX_THEME`` covers
+    the rest.
+    """
+    if os.name != "posix":
+        return None
+    try:
+        import select
+        import termios
+        import tty
+    except ImportError:
+        return None
+
+    try:
+        fd = sys.stdin.fileno()
+    except (ValueError, OSError, AttributeError):
+        return None
+
+    try:
+        old_attrs = termios.tcgetattr(fd)
+    except (termios.error, OSError):
+        return None
+
+    buf = b""
+    try:
+        tty.setraw(fd)
+        try:
+            sys.stdout.write("\x1b]11;?\x07")
+            sys.stdout.flush()
+        except (OSError, ValueError):
+            return None
+        deadline = time.monotonic() + _OSC11_TIMEOUT_S
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                ready, _, _ = select.select([fd], [], [], remaining)
+            except (OSError, ValueError):
+                break
+            if not ready:
+                break
+            try:
+                chunk = os.read(fd, 64)
+            except OSError:
+                break
+            if not chunk:
+                break
+            buf += chunk
+            if b"\x07" in buf or b"\x1b\\" in buf:
+                break
+    finally:
+        try:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_attrs)
+        except (termios.error, OSError):
+            pass
+
+    text = buf.decode("ascii", errors="ignore")
+    match = _OSC11_RGB_RE.search(text)
+    if not match:
+        return None
+    return _normalize_rgb_hex(*match.groups())
+
+
+def _normalize_rgb_hex(r_hex: str, g_hex: str, b_hex: str) -> tuple[float, float, float] | None:
+    """Convert xterm-style ``rgb:RRRR/GGGG/BBBB`` triplets to [0, 1].
+
+    Each channel may be 1, 2, 4, 8, 12, or 16 hex digits. Truncate or
+    left-pad to 4 digits before scaling so the math is predictable.
+    """
+    out: list[float] = []
+    for hex_str in (r_hex, g_hex, b_hex):
+        if not hex_str:
+            return None
+        s = hex_str.ljust(4, "0")[:4]
+        try:
+            value = int(s, 16) / 0xFFFF
+        except ValueError:
+            return None
+        out.append(value)
+    return out[0], out[1], out[2]
+
+
+_APPLESCRIPT_BG_QUERY = (
+    'tell application "Terminal" to get background color '
+    "of selected tab of window 1"
+)
+_APPLESCRIPT_TIMEOUT_S = 0.5
+
+
+def _query_apple_terminal() -> tuple[float, float, float] | None:
+    """Read Terminal.app's active-tab background via AppleScript.
+
+    Terminal.app is the one mainstream macOS terminal that does not
+    answer OSC 11. AppleScript is its supported public API for the
+    current background color and works reliably on every macOS that
+    ships Terminal.app — at the cost of one ``osascript`` subprocess
+    (~50–200 ms) and a one-time Automation permission prompt the
+    first time AMX runs in a given Terminal.app session.
+
+    Returns RGB in [0, 1] or ``None`` when the user denied automation,
+    no Terminal.app window is open, or osascript isn't available.
+    """
+    try:
+        import subprocess
+    except ImportError:
+        return None
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", _APPLESCRIPT_BG_QUERY],
+            capture_output=True,
+            text=True,
+            timeout=_APPLESCRIPT_TIMEOUT_S,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    parts = [p.strip() for p in result.stdout.strip().split(",")]
+    if len(parts) != 3:
+        return None
+    try:
+        # AppleScript returns 16-bit unsigned color components (0–65535).
+        return tuple(int(p) / 65535 for p in parts)  # type: ignore[return-value]
+    except ValueError:
+        return None
+
+
+_WIN_LIGHT_BG_INDICES = {7, 11, 14, 15}
+
+
+def _query_windows_console() -> Background | None:
+    """Read the legacy console buffer's background attribute via ctypes.
+
+    Only meaningful on Windows when the user is on classic conhost
+    (cmd, legacy PowerShell). Windows Terminal renders its own theme
+    on top of these attributes, so we skip this path when
+    ``WT_SESSION`` is set.
+    """
+    if os.name != "nt":
+        return None
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except Exception:
+        return None
+
+    STD_OUTPUT_HANDLE = -11
+
+    class COORD(ctypes.Structure):
+        _fields_ = [("X", wintypes.SHORT), ("Y", wintypes.SHORT)]
+
+    class SMALL_RECT(ctypes.Structure):
+        _fields_ = [
+            ("Left", wintypes.SHORT),
+            ("Top", wintypes.SHORT),
+            ("Right", wintypes.SHORT),
+            ("Bottom", wintypes.SHORT),
+        ]
+
+    class CONSOLE_SCREEN_BUFFER_INFO(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", COORD),
+            ("dwCursorPosition", COORD),
+            ("wAttributes", wintypes.WORD),
+            ("srWindow", SMALL_RECT),
+            ("dwMaximumWindowSize", COORD),
+        ]
+
+    try:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+        if handle in (None, 0, ctypes.c_void_p(-1).value):
+            return None
+        info = CONSOLE_SCREEN_BUFFER_INFO()
+        ok = kernel32.GetConsoleScreenBufferInfo(handle, ctypes.byref(info))
+        if not ok:
+            return None
+        bg_index = (info.wAttributes >> 4) & 0x0F
+    except Exception:
+        return None
+
+    return "light" if bg_index in _WIN_LIGHT_BG_INDICES else "dark"

--- a/tests/test_terminal_theme.py
+++ b/tests/test_terminal_theme.py
@@ -10,8 +10,6 @@ would either flake on CI or open a permission dialog on macOS.
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from amx.utils import terminal_theme as tt
@@ -353,9 +351,7 @@ def test_windows_terminal_skips_console_api(
 ) -> None:
     monkeypatch.setattr("os.name", "nt", raising=False)
     monkeypatch.setenv("WT_SESSION", "fake-session-guid")
-    monkeypatch.setattr(
-        tt, "_query_windows_console", lambda: pytest.fail("Console API reached")
-    )
+    monkeypatch.setattr(tt, "_query_windows_console", lambda: pytest.fail("Console API reached"))
     monkeypatch.setattr(tt, "_query_osc11", lambda: (1.0, 1.0, 1.0))
     assert tt.detect_background() == "light"
 

--- a/tests/test_terminal_theme.py
+++ b/tests/test_terminal_theme.py
@@ -1,0 +1,415 @@
+"""Tests for terminal background detection.
+
+The detection runs once per process and caches; every test resets the
+cache via the ``_reset`` autouse fixture so ordering can't make a stale
+result leak from one test into the next. Real terminal I/O (OSC 11
+escape, Windows Console API ctypes call) is monkeypatched to keep the
+suite hermetic — touching ``/dev/tty`` or kernel32 from inside pytest
+would either flake on CI or open a permission dialog on macOS.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from amx.utils import terminal_theme as tt
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    tt.reset_cache()
+
+
+@pytest.fixture
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every env var that the pipeline consults, so individual
+    tests opt back in to exactly the signal they want to assert on."""
+    for name in (
+        "AMX_THEME",
+        "NO_COLOR",
+        "COLORFGBG",
+        "WT_SESSION",
+        "TERM_PROGRAM",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def _force_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make stdout / stdin look like a tty so the non-TTY short-circuit
+    doesn't fire when the test is itself running under pytest's capture."""
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+
+# ── _parse_colorfgbg ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("15;0", "dark"),
+        ("0;15", "light"),
+        ("7;0", "dark"),
+        ("0;7", "light"),
+        ("15;default;0", "dark"),
+        ("0;default;15", "light"),
+        ("0;1", "dark"),
+        ("0;8", "dark"),
+    ],
+)
+def test_parse_colorfgbg_known_values(raw: str, expected: str) -> None:
+    assert tt._parse_colorfgbg(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [None, "", "garbage", "15", "15;default", "15;abc"])
+def test_parse_colorfgbg_unparseable_returns_none(raw: str | None) -> None:
+    assert tt._parse_colorfgbg(raw) is None
+
+
+# ── _relative_luminance ──────────────────────────────────────────────────────
+
+
+def test_relative_luminance_endpoints() -> None:
+    assert tt._relative_luminance(0.0, 0.0, 0.0) == pytest.approx(0.0)
+    assert tt._relative_luminance(1.0, 1.0, 1.0) == pytest.approx(1.0)
+
+
+def test_relative_luminance_white_is_light_black_is_dark() -> None:
+    assert tt._relative_luminance(1.0, 1.0, 1.0) > 0.5
+    assert tt._relative_luminance(0.0, 0.0, 0.0) < 0.5
+
+
+def test_relative_luminance_clamps_out_of_range() -> None:
+    # Should not throw and should treat negatives as 0, > 1 as 1.
+    assert tt._relative_luminance(-0.5, -0.5, -0.5) == pytest.approx(0.0)
+    assert tt._relative_luminance(2.0, 2.0, 2.0) == pytest.approx(1.0)
+
+
+# ── _normalize_rgb_hex ───────────────────────────────────────────────────────
+
+
+def test_normalize_rgb_hex_4digit() -> None:
+    r, g, b = tt._normalize_rgb_hex("ffff", "ffff", "ffff")
+    assert (r, g, b) == (1.0, 1.0, 1.0)
+
+
+def test_normalize_rgb_hex_2digit_padded() -> None:
+    # Terminal.app-style "rgb:ff/ff/ff" should still resolve to white.
+    r, g, b = tt._normalize_rgb_hex("ff", "ff", "ff")
+    # "ff" left-pads to "ff00" → 0xff00/0xffff ≈ 0.996 (close to white,
+    # well above the 0.5 light/dark threshold). The whole point of the
+    # test is that the function tolerates the short form without crashing.
+    assert b > 0.99
+    assert g > 0.99
+    assert r > 0.99
+
+
+def test_normalize_rgb_hex_empty_returns_none() -> None:
+    assert tt._normalize_rgb_hex("", "ffff", "ffff") is None
+
+
+# ── _query_apple_terminal ────────────────────────────────────────────────────
+
+
+class _FakeProcess:
+    def __init__(self, *, stdout: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def test_apple_terminal_parses_white_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``Novel`` / ``Basic`` profiles return ``65535, 65535, 65535``-ish."""
+
+    def fake_run(*args: object, **kwargs: object) -> _FakeProcess:
+        return _FakeProcess(stdout="65535, 64751, 56541\n", returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    rgb = tt._query_apple_terminal()
+    assert rgb is not None
+    assert all(v > 0.85 for v in rgb)
+    assert tt._relative_luminance(*rgb) > 0.5
+
+
+def test_apple_terminal_parses_dark_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``Pro`` profile returns small RGB values."""
+
+    def fake_run(*args: object, **kwargs: object) -> _FakeProcess:
+        return _FakeProcess(stdout="5866, 5866, 5866\n", returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    rgb = tt._query_apple_terminal()
+    assert rgb is not None
+    assert tt._relative_luminance(*rgb) < 0.5
+
+
+def test_apple_terminal_returns_none_on_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Permission denied / Terminal.app closed surface as a non-zero exit."""
+
+    def fake_run(*args: object, **kwargs: object) -> _FakeProcess:
+        return _FakeProcess(stdout="", returncode=1)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert tt._query_apple_terminal() is None
+
+
+def test_apple_terminal_returns_none_on_malformed_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(*args: object, **kwargs: object) -> _FakeProcess:
+        return _FakeProcess(stdout="not a triple\n", returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert tt._query_apple_terminal() is None
+
+
+def test_apple_terminal_returns_none_when_osascript_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(*args: object, **kwargs: object) -> _FakeProcess:
+        raise FileNotFoundError("osascript not on PATH")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert tt._query_apple_terminal() is None
+
+
+# ── detect_background priority order ─────────────────────────────────────────
+
+
+def test_amx_theme_explicit_light_wins_over_everything(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+) -> None:
+    monkeypatch.setenv("AMX_THEME", "light")
+    monkeypatch.setenv("COLORFGBG", "15;0")  # would say dark
+    monkeypatch.setenv("NO_COLOR", "1")  # would say unknown
+    assert tt.detect_background() == "light"
+
+
+def test_amx_theme_explicit_dark_wins(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+) -> None:
+    monkeypatch.setenv("AMX_THEME", "dark")
+    monkeypatch.setenv("COLORFGBG", "0;15")  # would say light
+    assert tt.detect_background() == "dark"
+
+
+def test_amx_theme_auto_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setenv("AMX_THEME", "auto")
+    monkeypatch.setenv("COLORFGBG", "0;15")
+    assert tt.detect_background() == "light"
+
+
+def test_no_color_returns_unknown_even_on_tty(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("COLORFGBG", "0;15")
+    assert tt.detect_background() == "unknown"
+
+
+def test_non_tty_returns_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+) -> None:
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setenv("COLORFGBG", "0;15")  # would say light if we got that far
+    assert tt.detect_background() == "unknown"
+
+
+def test_colorfgbg_used_when_set_and_tty(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setenv("COLORFGBG", "0;15")
+    # Ensure OSC 11 path isn't reached — if it were, this assertion
+    # would still pass by coincidence, but the test would be brittle.
+    monkeypatch.setattr(tt, "_query_osc11", lambda: pytest.fail("OSC 11 reached"))
+    assert tt.detect_background() == "light"
+
+
+def test_apple_terminal_falls_back_to_applescript_when_osc11_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+    monkeypatch.setattr(tt, "_query_osc11", lambda: None)
+    monkeypatch.setattr(tt, "_query_apple_terminal", lambda: (1.0, 1.0, 1.0))
+    monkeypatch.setattr("os.name", "posix", raising=False)
+    assert tt.detect_background() == "light"
+
+
+def test_apple_terminal_uses_osc11_when_it_responds(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    """If a future Terminal.app build starts answering OSC 11, the
+    AppleScript subprocess should be skipped — the cheap path wins."""
+    monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+    monkeypatch.setattr(tt, "_query_osc11", lambda: (1.0, 1.0, 1.0))
+    monkeypatch.setattr(
+        tt,
+        "_query_apple_terminal",
+        lambda: pytest.fail("AppleScript reached even though OSC 11 succeeded"),
+    )
+    monkeypatch.setattr("os.name", "posix", raising=False)
+    assert tt.detect_background() == "light"
+
+
+def test_non_apple_terminal_does_not_call_applescript(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+    monkeypatch.setattr(tt, "_query_osc11", lambda: None)
+    monkeypatch.setattr(
+        tt,
+        "_query_apple_terminal",
+        lambda: pytest.fail("AppleScript reached for non-Apple_Terminal"),
+    )
+    monkeypatch.setattr("os.name", "posix", raising=False)
+    assert tt.detect_background() == "dark"
+
+
+def test_apple_terminal_applescript_returns_none_falls_back_to_dark(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    """Permission denied / Terminal.app closed → dark fallback so
+    AMX_THEME=light remains the documented escape hatch."""
+    monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+    monkeypatch.setattr(tt, "_query_osc11", lambda: None)
+    monkeypatch.setattr(tt, "_query_apple_terminal", lambda: None)
+    monkeypatch.setattr("os.name", "posix", raising=False)
+    assert tt.detect_background() == "dark"
+
+
+def test_osc11_white_response_resolves_to_light(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setattr(tt, "_query_osc11", lambda: (1.0, 1.0, 1.0))
+    monkeypatch.setattr("os.name", "posix", raising=False)
+    assert tt.detect_background() == "light"
+
+
+def test_osc11_black_response_resolves_to_dark(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setattr(tt, "_query_osc11", lambda: (0.0, 0.0, 0.0))
+    monkeypatch.setattr("os.name", "posix", raising=False)
+    assert tt.detect_background() == "dark"
+
+
+def test_osc11_no_reply_falls_back_to_dark(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setattr(tt, "_query_osc11", lambda: None)
+    monkeypatch.setattr("os.name", "posix", raising=False)
+    assert tt.detect_background() == "dark"
+
+
+# ── Cross-platform Windows path ──────────────────────────────────────────────
+
+
+def test_windows_legacy_calls_console_api(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setattr("os.name", "nt", raising=False)
+    monkeypatch.setattr(tt, "_query_windows_console", lambda: "light")
+    # OSC 11 path must not be reached on legacy Windows conhost.
+    monkeypatch.setattr(tt, "_query_osc11", lambda: pytest.fail("OSC 11 reached"))
+    assert tt.detect_background() == "light"
+
+
+def test_windows_terminal_skips_console_api(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setattr("os.name", "nt", raising=False)
+    monkeypatch.setenv("WT_SESSION", "fake-session-guid")
+    monkeypatch.setattr(
+        tt, "_query_windows_console", lambda: pytest.fail("Console API reached")
+    )
+    monkeypatch.setattr(tt, "_query_osc11", lambda: (1.0, 1.0, 1.0))
+    assert tt.detect_background() == "light"
+
+
+# ── accent_color resolver ────────────────────────────────────────────────────
+
+
+def test_accent_color_dark_returns_orange_400(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+) -> None:
+    monkeypatch.setenv("AMX_THEME", "dark")
+    assert tt.accent_color() == tt.ACCENT_DARK_BG == "#fb923c"
+
+
+def test_accent_color_light_returns_orange_800(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+) -> None:
+    monkeypatch.setenv("AMX_THEME", "light")
+    assert tt.accent_color() == tt.ACCENT_LIGHT_BG == "#9a3412"
+
+
+def test_accent_color_unknown_falls_back_to_dark_accent(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+    _force_tty: None,
+) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    # NO_COLOR yields "unknown"; the resolver picks the dark accent so
+    # the brand color stays consistent rather than disappearing.
+    assert tt.accent_color() == tt.ACCENT_DARK_BG
+
+
+# ── Cache behavior ───────────────────────────────────────────────────────────
+
+
+def test_detect_is_memoized_across_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+) -> None:
+    monkeypatch.setenv("AMX_THEME", "light")
+    first = tt.detect_background()
+    monkeypatch.setenv("AMX_THEME", "dark")
+    second = tt.detect_background()
+    assert first == second == "light"
+
+
+def test_reset_cache_re_detects(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_env: None,
+) -> None:
+    monkeypatch.setenv("AMX_THEME", "light")
+    assert tt.detect_background() == "light"
+    tt.reset_cache()
+    monkeypatch.setenv("AMX_THEME", "dark")
+    assert tt.detect_background() == "dark"


### PR DESCRIPTION
## Summary

- Brand-orange (#fb923c) and brand-cyan (#22d3ee) hit ~2:1 contrast on white — unreadable on Terminal.app Novel/Basic, GNOME Terminal Light, solarized-light, Windows Terminal Light, VS Code Light.
- Adds a tiered terminal-background detector (`AMX_THEME` override → `COLORFGBG` → Windows Console API → OSC 11 → Apple_Terminal AppleScript → dark fallback) cached once per process, no new dependency.
- Light terminals shift to orange-800 (#9a3412) / cyan-700 (#0e7490), both WCAG AA on white. Dark terminals render byte-identically to before.
- Sweeps hardcoded inline `[#22d3ee]…[/#22d3ee]`, `[bold #fb923c]…`, and `style="#fb923c"` callsites across `/db`, `/search`, `/history`, `/profiles`, `/compare`, `/doctor`, `/analyze`, and the live-display footer to use the new `info` / `accent` / `heading` theme keys, so the adaptation flows through the whole CLI.

## Test plan

- [x] `pytest tests/test_terminal_theme.py` — 45 tests cover parser, luminance, priority order, AMX_THEME override, NO_COLOR, COLORFGBG, OSC 11, Windows Console API, Apple_Terminal AppleScript fallback, accent/info resolvers, cache.
- [x] `pytest tests/` — 1287 passed, 22 deselected (no regressions on console / live_display / compare / doctor suites).
- [x] Manual macOS Terminal.app — Pro profile (dark) renders the original orange-400 / cyan-400 palette; Novel profile triggers AppleScript fallback and shifts to orange-800 / cyan-700.
- [x] `AMX_THEME=light` and `AMX_THEME=dark` overrides verified end-to-end via `show_banner()`.
- [ ] Cross-platform: Linux (GNOME / Alacritty / Kitty), Windows (cmd / Windows Terminal Light), WSL, VS Code integrated terminal — pending. Detection paths for each are exercised in unit tests with mocked I/O; physical devices welcome.

## Notes

- First Apple_Terminal run triggers the macOS Automation permission dialog ("Terminal wants to control Terminal"). One-time grant; subsequent runs use the cached result. Denying still works — falls back to `dark` and `AMX_THEME=light` remains the documented escape hatch.
- No new third-party dependency — `terminal_theme.py` is stdlib-only (`os`, `sys`, `subprocess`, `termios`, `tty`, `select`, `ctypes`).