### PR TITLE
fix(studio): stop amx.* INFO/DEBUG flooding the launching terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **Studio terminal flooded with `INFO:amx.db.connector:...` and
+  `DEBUG:amx.llm.provider:...` lines while a session was open.**
+  ``mute_root_logger_for_studio`` only set the root logger's level
+  to WARNING, but Python's ``Logger.callHandlers`` consults handler
+  levels — not ancestor logger levels — when a record propagates
+  upward, so amx.* records still flowed into a third-party
+  ``logging.basicConfig`` handler attached to root. The mute now
+  also raises every existing root handler's level to WARNING and
+  flips ``propagate=False`` on every existing and future amx.*
+  logger, so late-import ``basicConfig`` calls (e.g. from a lazy
+  ``litellm`` import on the first LLM request) cannot reintroduce
+  the leak. The on-disk log under ``~/.amx/logs/amx.log`` keeps
+  the full DEBUG trace, and real WARNING / ERROR lines still
+  surface via the amx-installed stderr handler attached directly
+  to each amx.* logger.
+
 - **Studio "Cost overrides" rows on /runs/new always showed
   `default —`.** The Advanced LLM settings disclosure read its
   default badge from the saved profile's

--- a/amx/utils/logging.py
+++ b/amx/utils/logging.py
@@ -170,15 +170,17 @@ def get_logger(name: str) -> logging.Logger:
     if not logger.handlers:
         logger.setLevel(logging.DEBUG)
         logger.addFilter(_RequestIdFilter())
-        # ``propagate`` stays True so pytest's caplog can pick up
-        # amx.* records via the root logger (every test that asserts
-        # a log line goes through ``caplog.at_level(level,
-        # logger="amx.X")`` which relies on propagation). The
-        # corresponding Studio-terminal flood — INFO / DEBUG records
-        # from amx.db.connector / amx.llm.provider leaking out via a
-        # third-party basicConfig handler on root — is silenced
-        # process-wide by ``mute_root_logger_for_studio`` below,
-        # called from ``amx/web/launcher.py`` before uvicorn boots.
+        # ``propagate`` stays True by default so pytest's caplog can
+        # pick up amx.* records via the root logger (every test that
+        # asserts a log line goes through ``caplog.at_level(level,
+        # logger="amx.X")`` which relies on propagation). When AMX
+        # Studio boots, ``mute_root_logger_for_studio`` flips
+        # ``_studio_mode_active`` and the block below disables
+        # propagation for every amx.* logger going forward — the
+        # Studio-terminal flood (INFO / DEBUG records from
+        # amx.db.connector / amx.llm.provider escaping to a third-
+        # party ``basicConfig`` handler on root) is silenced without
+        # touching pytest paths, which never call the Studio mute.
         # Pin the on-disk log to UTF-8 explicitly. Without this, Python
         # on Windows opens the file with the platform default codec
         # (cp1252), and any log message containing →, —, … — including
@@ -203,35 +205,67 @@ def get_logger(name: str) -> logging.Logger:
         sh.setLevel(logging.WARNING)
         sh.setFormatter(_human_fmt)
         logger.addHandler(sh)
+    if _studio_mode_active:
+        logger.propagate = False
     return logger
 
 
 # ── Structured events ────────────────────────────────────────────────
 
 
+_studio_mode_active = False
+
+
 def mute_root_logger_for_studio() -> None:
-    """Force the root logger to WARNING for the AMX Studio process.
+    """Silence third-party root-logger noise for the AMX Studio process.
 
     Several third-party imports (``transformers``, ``litellm``,
     ``bert_score``, ``uvicorn[standard]``) call ``logging.basicConfig``
     at import time, which attaches a default stream handler to root at
-    INFO or DEBUG. Without this guard, every amx.* INFO / DEBUG record
+    ``NOTSET``. Without this guard, every amx.* INFO / DEBUG record
     that propagates to root produces a line on the user's REPL
     terminal — ``INFO:amx.db.connector:Connected via postgresql ...``,
     ``DEBUG:amx.llm.provider:LLM call ...``, plus the bert-score
     ``Some weights of RobertaModel were not initialized`` flood —
     drowning the prompt while AMX Studio is up.
 
-    Setting root to WARNING leaves amx.*'s own file handler (DEBUG)
-    and stderr handler (WARNING) intact: the disk log under
-    ``~/.amx/logs/amx.log`` still carries the full DEBUG trace, the
-    user still sees real WARNING / ERROR lines on screen, and pytest
-    test isolation is unaffected because this helper is only called
-    from the Studio launcher path.
+    Three layers of defense are needed because Python's
+    ``Logger.callHandlers`` consults *handler* levels (not ancestor
+    logger levels) when a record propagates upward:
+
+    1. Raise the root logger's level to WARNING so records originating
+       at root itself are filtered.
+    2. Bump every existing root handler that is still at ``NOTSET`` /
+       below WARNING up to WARNING — covers ``basicConfig`` handlers
+       installed before the Studio launcher runs.
+    3. Disable propagation on every existing amx.* logger and flip a
+       module-level flag so ``get_logger`` builds future amx.* loggers
+       with ``propagate=False`` — covers third-party ``basicConfig``
+       calls that fire later via lazy imports (e.g. the first
+       ``litellm`` call from a request handler).
+
+    The amx.* file handler (``~/.amx/logs/amx.log``, DEBUG) and stderr
+    handler (WARNING) are attached directly to each amx.* logger, so
+    losing propagation does not lose any disk records or any real
+    warning the user must see. Pytest test isolation is unaffected
+    because this helper is only invoked from the Studio launcher path
+    — the test suite never calls it, so ``caplog`` keeps working.
     """
+    global _studio_mode_active
+
     root = logging.getLogger()
     if root.level == logging.NOTSET or root.level < logging.WARNING:
         root.setLevel(logging.WARNING)
+    for handler in root.handlers:
+        if handler.level == logging.NOTSET or handler.level < logging.WARNING:
+            handler.setLevel(logging.WARNING)
+
+    _studio_mode_active = True
+    for logger_name, existing in list(logging.Logger.manager.loggerDict.items()):
+        if not isinstance(existing, logging.Logger):
+            continue
+        if logger_name == "amx" or logger_name.startswith("amx."):
+            existing.propagate = False
 
 
 def log_event(event_type: str, /, **fields: Any) -> None:

--- a/tests/test_logging_rotation_and_events.py
+++ b/tests/test_logging_rotation_and_events.py
@@ -146,3 +146,63 @@ def test_int_env_helper_clamps_below_minimum(monkeypatch: pytest.MonkeyPatch) ->
 def test_int_env_helper_falls_back_on_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AMX_LOG_BACKUP_COUNT", "not-an-int")
     assert amx_logging._int_env("AMX_LOG_BACKUP_COUNT", 5, minimum=0) == 5
+
+
+def test_mute_root_logger_blocks_amx_info_through_root_basicconfig_handler(
+    isolated_log_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: Studio terminal used to flood with
+    ``INFO:amx.db.connector:...`` lines because a third-party
+    ``logging.basicConfig`` handler attached to root accepts records
+    propagated from amx.* (Python's ``callHandlers`` consults handler
+    levels, not ancestor logger levels). The mute helper must raise
+    that handler's level AND drop amx.* propagation so subsequent late
+    ``basicConfig`` calls also stay silent.
+    """
+    root = logging.getLogger()
+    saved_level = root.level
+    saved_handlers = list(root.handlers)
+    saved_studio_flag = amx_logging._studio_mode_active
+    monkeypatch.setattr(amx_logging, "_studio_mode_active", False, raising=False)
+
+    try:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+
+        sink = logging.StreamHandler()
+        sink.setLevel(logging.NOTSET)
+        root.addHandler(sink)
+
+        db_log = get_logger("db.connector")
+        llm_log = get_logger("llm.provider")
+
+        amx_logging.mute_root_logger_for_studio()
+
+        assert sink.level >= logging.WARNING
+        assert db_log.propagate is False
+        assert llm_log.propagate is False
+
+        # New amx.* loggers created after mute must inherit the silence.
+        new_log = get_logger("agents.rag_after_mute")
+        assert new_log.propagate is False
+
+        # Late basicConfig (lazy litellm import) installs a fresh
+        # NOTSET handler on root — the propagate=False guard means
+        # amx.* records still don't reach it.
+        logging.basicConfig(force=True)
+        late_handler = next(h for h in root.handlers if h is not sink)
+        try:
+            assert late_handler.level == logging.NOTSET
+            assert db_log.propagate is False
+        finally:
+            root.removeHandler(late_handler)
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        for handler in saved_handlers:
+            root.addHandler(handler)
+        root.setLevel(saved_level)
+        amx_logging._studio_mode_active = saved_studio_flag
+        for name in ("amx.db.connector", "amx.llm.provider", "amx.agents.rag_after_mute"):
+            logger = logging.getLogger(name)
+            logger.propagate = True


### PR DESCRIPTION
## Summary

- ``mute_root_logger_for_studio`` only set ``root.level=WARNING``, but
  Python's ``Logger.callHandlers`` consults *handler* levels (not the
  ancestor logger's level) when a record propagates upward. Any
  third-party ``logging.basicConfig`` call attaches a NOTSET stream
  handler to root, so every amx.* INFO/DEBUG record kept reaching it
  and produced lines like ``INFO:amx.db.connector:Connected via
  postgresql ...`` and ``DEBUG:amx.llm.provider:LLM call -> ...`` in
  the terminal where the user ran ``/studio``, alarming users who
  thought something was wrong.
- The mute now (1) raises every existing root handler's level up to
  WARNING and (2) flips ``propagate=False`` on every existing and
  future amx.* logger via a module-level flag in ``get_logger``, so a
  late lazy import (e.g. ``litellm``) calling ``basicConfig`` from a
  request handler cannot reintroduce the leak.
- The on-disk JSON log under ``~/.amx/logs/amx.log`` keeps the full
  DEBUG trace, and real WARNING / ERROR lines still display via the
  amx-installed stderr handler attached directly to each amx.* logger.
- Added ``test_mute_root_logger_blocks_amx_info_through_root_basicconfig_handler``
  as a regression: simulates a NOTSET basicConfig handler on root
  before the mute and a fresh one installed after, asserts no INFO
  leaks through propagation in either case.

## Test plan

- [x] ``pytest tests/test_logging_rotation_and_events.py`` — 7 passed
- [x] ``pytest tests/test_litellm_silenced.py tests/test_regressions.py`` — 242 passed
- [x] Manual repro: standalone Python harness with a basicConfig
      handler before and after mute confirms only WARNING+ lines
      reach stderr after the fix.