### PR TITLE
fix: bug fixing batch (python-multipart, pricing SSL on Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **``Refresh prices`` in Studio raised ``URLError: <urlopen error
+  [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable
+  to get local issuer certificate>`` against both LiteLLM and
+  OpenRouter on Windows.** ``amx/llm/pricing.py``'s ``_http_get_json``
+  called ``urllib.request.urlopen`` with no SSL context, so plain
+  Windows Python (no shipped CA bundle, system trust store not
+  consulted) failed every HTTPS request out of the box, and
+  corporate-network users were ignored even when they had set
+  ``AMX_CA_BUNDLE`` for the LLM client. Pricing now builds an
+  ``ssl.SSLContext`` that mirrors the LLM provider's contract:
+  ``AMX_INSECURE_SSL=1`` returns an unverified context;
+  ``AMX_CA_BUNDLE`` / ``SSL_CERT_FILE`` (when pointing at an existing
+  file) seed a custom CA list; otherwise ``certifi.where()`` provides
+  the bundled Mozilla CAs. The exception surface
+  (``urllib.error.URLError`` / ``json.JSONDecodeError``) is unchanged
+  so the toast wiring at ``amx/web/routers/pricing.py`` and the
+  fallback flow in ``refresh_prices`` keep working as before.
+
 - **First ``/studio`` boot crashed with ``RuntimeError: Form data
   requires "python-multipart" to be installed`` on environments
   installed without the ``studio`` extra.** ``launch_studio`` only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **First ``/studio`` boot crashed with ``RuntimeError: Form data
+  requires "python-multipart" to be installed`` on environments
+  installed without the ``studio`` extra.** ``launch_studio`` only
+  pre-installed ``fastapi`` / ``uvicorn[standard]`` /
+  ``sse-starlette`` via ``ensure(...)``, so the drag-drop document
+  upload (``amx/web/routers/docs_ops.py``) blew up the moment
+  FastAPI parsed the first multipart request body — the install
+  step looked successful, but the Studio session was dead on
+  arrival. The ensure list now also declares
+  ``("python_multipart", "python-multipart")`` so the wheel
+  ``pyproject.toml``'s ``studio`` extra already pins is also
+  guaranteed under the lazy on-demand path.
+
 - **Studio terminal flooded with `INFO:amx.db.connector:...` and
   `DEBUG:amx.llm.provider:...` lines while a session was open.**
   ``mute_root_logger_for_studio`` only set the root logger's level

--- a/amx/llm/pricing.py
+++ b/amx/llm/pricing.py
@@ -38,6 +38,8 @@ All disk + network access is contained here. Other modules import
 from __future__ import annotations
 
 import json
+import os
+import ssl
 import threading
 import time
 import urllib.error
@@ -121,6 +123,54 @@ def _write_cache(payload: dict[str, Any]) -> None:
         log.debug("could not persist pricing cache: %s", exc)
 
 
+def _build_ssl_context() -> ssl.SSLContext:
+    """SSL context for the price-fetch ``urlopen`` calls.
+
+    Resolves a CA bundle in priority order so the same env vars users
+    already set for the LLM client (``AMX_CA_BUNDLE`` /
+    ``AMX_INSECURE_SSL``) also fix the pricing path:
+
+    1. ``AMX_INSECURE_SSL`` truthy — return an unverified context.
+       Mirrors :func:`amx.llm.provider._configure_ssl_environment`'s
+       contract; diagnostic-only escape hatch for hostile networks.
+    2. ``AMX_CA_BUNDLE`` set to an existing file — corporate CA bundle,
+       typical Zscaler / Netskope / on-prem MITM proxy fix.
+    3. ``SSL_CERT_FILE`` set to an existing file — already-set stdlib
+       env var, also written by ``_configure_ssl_environment`` so a
+       run that imported the LLM provider first is picked up here.
+    4. ``certifi.where()`` — bundled Mozilla CA list. This branch is
+       what fixes plain Windows Python: the CPython ``python.org``
+       distribution ships no default CA bundle and does not consult
+       the Windows trust store, so a bare ``urlopen`` raises
+       ``CERTIFICATE_VERIFY_FAILED`` against any HTTPS host.
+    5. System default — last resort when nothing above resolves.
+    """
+    insecure = os.getenv("AMX_INSECURE_SSL", "").strip().lower()
+    if insecure in ("1", "true", "yes", "on"):
+        return ssl._create_unverified_context()
+
+    cafile: str | None = None
+    for env_var in ("AMX_CA_BUNDLE", "SSL_CERT_FILE"):
+        candidate = os.getenv(env_var, "").strip()
+        if candidate and os.path.isfile(candidate):
+            cafile = candidate
+            break
+
+    if cafile is None:
+        try:
+            import certifi
+        except ImportError:
+            certifi = None  # type: ignore[assignment]
+        if certifi is not None:
+            bundled = certifi.where()
+            if bundled and os.path.isfile(bundled):
+                cafile = bundled
+
+    if cafile is not None:
+        return ssl.create_default_context(cafile=cafile)
+    return ssl.create_default_context()
+
+
 def _http_get_json(url: str, *, headers: dict[str, str] | None = None) -> Any:
     """Minimal stdlib HTTP GET -> JSON. Stays out of httpx/urllib3 dep tree.
 
@@ -128,7 +178,9 @@ def _http_get_json(url: str, *, headers: dict[str, str] | None = None) -> Any:
     can swallow the failure and fall back to the next resolution layer.
     """
     req = urllib.request.Request(url, headers=headers or {})
-    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SEC) as resp:
+    with urllib.request.urlopen(
+        req, timeout=_HTTP_TIMEOUT_SEC, context=_build_ssl_context()
+    ) as resp:
         raw = resp.read().decode("utf-8")
     return json.loads(raw)
 

--- a/amx/web/launcher.py
+++ b/amx/web/launcher.py
@@ -99,6 +99,14 @@ def launch_studio(
                 "fastapi",
                 ("uvicorn", "uvicorn[standard]"),
                 ("sse_starlette", "sse-starlette"),
+                # FastAPI's ``Form(...)`` / ``File(...)`` parsers raise
+                # ``RuntimeError: Form data requires "python-multipart"
+                # to be installed`` the first time a multipart route is
+                # hit (e.g. the doc-upload drag-drop endpoint in
+                # ``amx/web/routers/docs_ops.py``). Wheel name is
+                # ``python-multipart``; modern versions (>=0.0.12)
+                # expose the importable module as ``python_multipart``.
+                ("python_multipart", "python-multipart"),
             ],
             feature="AMX Studio (/studio)",
         )

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -17,6 +17,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import ssl
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -26,6 +27,8 @@ import pytest
 from amx.llm import pricing as pricing_mod
 from amx.llm.pricing import (
     ModelPrice,
+    _build_ssl_context,
+    _http_get_json,
     cache_age_seconds,
     cache_info,
     compute_cost,
@@ -67,6 +70,109 @@ def test_fetch_litellm_parses_cost_per_token(monkeypatch: pytest.MonkeyPatch) ->
     assert out["gpt-mock"].output_per_mtok == pytest.approx(6.00)
     assert out["gpt-mock"].source == "litellm"
     assert out["gpt-mock"].fetched_at is not None
+
+
+# ── SSL context for stdlib urlopen ─────────────────────────────────────────
+
+
+def _clear_pricing_ssl_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip the SSL env vars the helper consults so each test starts
+    from a known floor regardless of the developer's shell."""
+    for var in ("AMX_INSECURE_SSL", "AMX_CA_BUNDLE", "SSL_CERT_FILE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_build_ssl_context_uses_certifi_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: plain Windows Python ships no default CA bundle, so a
+    bare ``urlopen`` raises CERTIFICATE_VERIFY_FAILED. The helper must
+    fall back to ``certifi.where()`` so the price fetch succeeds out of
+    the box without any user env-var configuration."""
+    pytest.importorskip("certifi")
+    import certifi
+
+    _clear_pricing_ssl_env(monkeypatch)
+    ctx = _build_ssl_context()
+
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True
+    # Loaded a non-empty CA list — the certifi branch only "works" if
+    # the bundled bundle actually populates the context.
+    assert ctx.get_ca_certs(), "expected certifi CA bundle to populate context"
+
+
+def test_build_ssl_context_honours_amx_ca_bundle(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Corporate networks set ``AMX_CA_BUNDLE`` to a re-signed root.
+    The helper must read that file, not silently fall through to
+    certifi (which would not contain the corporate root and would
+    fail TLS verification against the proxy)."""
+    # Use certifi's bundle as a real, parseable PEM under a controlled
+    # path so we can assert the helper picked OUR file by name.
+    pytest.importorskip("certifi")
+    import certifi
+
+    bundle_pem = Path(certifi.where()).read_bytes()
+    custom_bundle = tmp_path / "corp-root.pem"
+    custom_bundle.write_bytes(bundle_pem)
+
+    _clear_pricing_ssl_env(monkeypatch)
+    monkeypatch.setenv("AMX_CA_BUNDLE", str(custom_bundle))
+
+    ctx = _build_ssl_context()
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.get_ca_certs(), "expected AMX_CA_BUNDLE PEM to populate context"
+
+
+def test_build_ssl_context_unverified_when_insecure_ssl_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``AMX_INSECURE_SSL=1`` is the documented escape hatch for hostile
+    networks. The helper must mirror the LLM provider's contract — an
+    unverified context with hostname check disabled — so the price
+    fetch behaves the same way the LLM call does in that mode."""
+    _clear_pricing_ssl_env(monkeypatch)
+    monkeypatch.setenv("AMX_INSECURE_SSL", "1")
+
+    ctx = _build_ssl_context()
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_NONE
+
+
+def test_http_get_json_passes_context_to_urlopen(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wiring guard: a future refactor must not silently drop the
+    ``context=`` kwarg. ``urlopen`` without a context is exactly the
+    bug the Windows user hit — locking this in keeps the fix from
+    regressing through an innocent-looking edit."""
+    captured: dict[str, object] = {}
+
+    class _FakeResponse:
+        def read(self) -> bytes:
+            return b'{"ok": true}'
+
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    def _fake_urlopen(req: object, *args: object, **kwargs: object) -> _FakeResponse:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeResponse()
+
+    monkeypatch.setattr(pricing_mod.urllib.request, "urlopen", _fake_urlopen)
+    out = _http_get_json("https://example.invalid/pricing.json")
+
+    assert out == {"ok": True}
+    ctx = captured["kwargs"].get("context")
+    assert isinstance(ctx, ssl.SSLContext), (
+        "_http_get_json must pass context=SSLContext to urlopen — without it, "
+        "Windows Python raises CERTIFICATE_VERIFY_FAILED on every HTTPS host"
+    )
 
 
 def test_fetch_openrouter_parses_pricing_block(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -88,7 +88,6 @@ def test_build_ssl_context_uses_certifi_by_default(monkeypatch: pytest.MonkeyPat
     fall back to ``certifi.where()`` so the price fetch succeeds out of
     the box without any user env-var configuration."""
     pytest.importorskip("certifi")
-    import certifi
 
     _clear_pricing_ssl_env(monkeypatch)
     ctx = _build_ssl_context()

--- a/tests/web/test_launcher.py
+++ b/tests/web/test_launcher.py
@@ -6,8 +6,10 @@ unit suite can verify without spawning a real listener."""
 
 from __future__ import annotations
 
+import inspect
 import socket
 
+from amx.web import launcher as launcher_module
 from amx.web.launcher import _pick_port
 
 
@@ -33,3 +35,17 @@ def test_pick_port_falls_back_when_preferred_busy() -> None:
     finally:
         holder.close()
     assert chosen != busy_port or chosen == 0  # OS may reuse busy_port the instant we close
+
+
+def test_launcher_ensures_python_multipart_for_form_routes() -> None:
+    """Regression: ``launch_studio`` used to ``ensure([fastapi,
+    uvicorn[standard], sse-starlette])`` only. On a fresh install
+    without the ``studio`` extra, the first multipart request
+    (``amx/web/routers/docs_ops.py`` doc-upload) raised
+    ``RuntimeError: Form data requires "python-multipart" to be
+    installed`` mid-session. The ensure list must declare
+    ``python-multipart`` (importable as ``python_multipart``) so the
+    drag-drop endpoint works on the very first ``/studio`` boot."""
+    source = inspect.getsource(launcher_module.launch_studio)
+    assert '"python-multipart"' in source
+    assert '"python_multipart"' in source


### PR DESCRIPTION
## Summary

Two bug fixes batched into a single PR per the user's instruction.

### 1. `/studio` boot crash on environments without the `studio` extra

``launch_studio`` only pre-installed ``fastapi`` / ``uvicorn[standard]`` /
``sse-starlette`` via ``optional_deps.ensure``. The drag-drop document
upload (``amx/web/routers/docs_ops.py``) raised
``RuntimeError: Form data requires \"python-multipart\" to be installed``
on the first multipart request. Added
``(\"python_multipart\", \"python-multipart\")`` to the ensure list so
the wheel the ``studio`` extra already pins is also guaranteed under
the lazy on-demand path. Locked in by an inspect-source regression
test in ``tests/web/test_launcher.py``.

### 2. ``Refresh prices`` SSL failure on Windows

``amx/llm/pricing.py:_http_get_json`` called
``urllib.request.urlopen`` with no SSL context. Plain Windows Python
ships no default CA bundle and does not consult the system trust
store, so every HTTPS host failed with
``CERTIFICATE_VERIFY_FAILED``. Corporate users who had set
``AMX_CA_BUNDLE`` for the LLM client were also ignored — that env
var is honoured only by ``amx/llm/provider.py``'s
``_configure_ssl_environment``, which the pricing path never invokes.

Added ``_build_ssl_context()`` mirroring the LLM provider's contract:
``AMX_INSECURE_SSL=1`` returns an unverified context;
``AMX_CA_BUNDLE`` / ``SSL_CERT_FILE`` (when pointing at an existing
file) seed a custom CA list; otherwise ``certifi.where()`` provides
the bundled Mozilla CAs. Exception surface
(``urllib.error.URLError`` / ``json.JSONDecodeError``) is unchanged
so the toast wiring at ``amx/web/routers/pricing.py`` and the
fallback flow in ``refresh_prices`` keep working as before.

Four regression tests in ``tests/test_pricing.py`` cover the certifi
default, the ``AMX_CA_BUNDLE`` override, the ``AMX_INSECURE_SSL``
escape hatch, and the wiring guard that asserts ``urlopen`` receives
a non-None ``context=`` kwarg.

## Test plan

- [x] ``python3 -m pytest tests/test_pricing.py -x -q`` — 22 passed
- [x] ``python3 -m pytest tests/web/test_launcher.py -x -q`` — 3 passed
- [x] ``python3 -m pytest tests/test_litellm_silenced.py tests/test_logging_rotation_and_events.py tests/web/test_launcher.py -x -q`` — 13 passed (no regressions across the related suites)
- [x] Sanity smoke: ``_build_ssl_context()`` loads 143 CA certs on macOS dev box; the full LiteLLM JSON fetch succeeds against ``raw.githubusercontent.com``.
- [x] House-rule grep: no ``paid`` hits and no Turkish in newly-added lines.