### PR TITLE
feat(install): single-step install with Studio + DuckDB in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Single-step install for the common AMX path.** A first-time
+  ``pip install amx-cli`` was followed by a second wave of pip
+  subprocesses the first time the user opened ``/studio`` or queried
+  a DuckDB profile, which split the bring-up across two phases and
+  felt like the CLI was "still installing itself". FastAPI, uvicorn,
+  ``sse-starlette``, ``python-multipart`` and the DuckDB driver pair
+  graduated from optional extras into core ``[project.dependencies]``
+  in ``pyproject.toml``, so opening Studio or querying a local DuckDB
+  profile no longer triggers any post-install download. The matching
+  ``studio`` and ``duckdb`` extras were removed (a dropped ``studio``
+  extra is a no-op for users who only ever ran ``pip install amx-cli``;
+  anyone who explicitly invoked ``pip install 'amx-cli[studio]'``
+  already gets the same packages from core). The unused
+  ``python-dotenv`` core dependency was deleted in the same pass.
+
+- **Niche backends and RAG bundle stay lazy, but as one bundle.**
+  ``amx/utils/optional_deps.py`` gained a ``BUNDLES`` registry so the
+  three RAG entry points (``/docs``, ``/search``, ``/code``) reference
+  a single shared package list instead of each rebuilding their own,
+  preventing the three-way duplicate fetches that used to happen when
+  a user opened those features in succession. The ``ensure()`` helper
+  now serialises concurrent calls under a process-wide
+  ``threading.Lock`` so the Studio HTTP worker and the REPL cannot
+  race the same install, and prompts once before triggering the
+  large ML bundles (``sentence-transformers``, ``bert-score``) at
+  interactive sites.
+
+- **Studio no longer pre-installs every saved profile's driver at
+  open.** ``amx/web/launcher.py`` used to loop over every configured
+  ``cfg.db_profiles`` entry and call ``ensure_backend_driver()`` for
+  each backend before uvicorn started, so a user with profiles for
+  six warehouses paid for six driver installs even when they opened
+  Studio just to inspect one of them. The loop is gone — drivers
+  install lazily on the first request that actually touches a
+  profile, through the same unified ``ensure()`` path.
+
 ### Added
 
 - **Live input/output price under the active LLM profile in the

--- a/amx/codebase/analyzer.py
+++ b/amx/codebase/analyzer.py
@@ -174,7 +174,12 @@ def _scan_sqlglot_sql_file(
     references: dict[str, list[CodeReference]],
     external_mentions: dict[str, list[CodeReference]],
 ) -> None:
-    """Optional richer SQL table mentions when ``sqlglot`` is installed (``pip install 'amx-cli[code-intel]'``)."""
+    """Optional richer SQL table mentions when ``sqlglot`` is installed.
+
+    Falls back silently to the regex scanner upstream when the
+    package is absent so a missing optional dependency cannot break
+    ``/code analyze``.
+    """
     try:
         import sqlglot
         from sqlglot import exp

--- a/amx/codebase/code_rag.py
+++ b/amx/codebase/code_rag.py
@@ -8,16 +8,10 @@ from pathlib import Path
 
 from amx.utils.optional_deps import ensure as _ensure
 
-# Codebase RAG shares chromadb + the splitter with /docs RAG; if the
-# user has already used /docs the ensure() call here is a cached
-# no-op. Otherwise this is the first /code ingest and we pull both.
-_ensure(
-    [
-        "chromadb",
-        ("langchain_text_splitters", "langchain-text-splitters"),
-    ],
-    feature="codebase RAG (/code)",
-)
+# Codebase RAG shares the ``rag`` bundle (chromadb + splitter +
+# tiktoken) with /docs and /search; whichever feature the user
+# touches first pays the install once.
+_ensure("rag")
 
 import chromadb  # noqa: E402
 from langchain_text_splitters import RecursiveCharacterTextSplitter  # noqa: E402

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -12,19 +12,9 @@ from amx.utils.optional_deps import ensure as _ensure
 # on first ``/docs ingest`` / ``/run`` with docs / RAG-backed answer
 # — not on every CLI launch — so the install cost is amortised across
 # the whole tool's lifetime, incurred once, by the user who actually
-# uses the feature.
-_ensure(
-    [
-        "chromadb",
-        ("langchain_community", "langchain-community"),
-        ("langchain_text_splitters", "langchain-text-splitters"),
-        "unstructured",
-        "pypdf",
-        ("docx", "python-docx"),
-        "openpyxl",
-    ],
-    feature="document RAG (/docs)",
-)
+# uses the feature. The bundle name is shared with /search and /code
+# so a user who has already touched any RAG path skips the install.
+_ensure("docs-extended")
 
 import chromadb  # noqa: E402
 from langchain_community.document_loaders import (  # noqa: E402

--- a/amx/search/embeddings.py
+++ b/amx/search/embeddings.py
@@ -36,8 +36,8 @@ from amx.utils.optional_deps import ensure as _ensure
 # Pulled in here (rather than at the entry-point of every /search and
 # /docs flow) because ``chromadb.api.types`` is referenced as a base
 # class below — the import has to succeed before class definitions
-# execute. ``_ensure`` is a cached no-op once the package is installed.
-_ensure(["chromadb"], feature="search index")
+# execute. ``_ensure`` is a cached no-op once any RAG path has run.
+_ensure("rag")
 
 from chromadb.api.types import Documents, EmbeddingFunction, Embeddings  # noqa: E402
 

--- a/amx/search/index.py
+++ b/amx/search/index.py
@@ -19,13 +19,12 @@ from typing import Any
 
 from amx.utils.optional_deps import ensure as _ensure
 
-# Idempotent after the first /search or /docs ingest — the cached set
-# inside ``optional_deps`` short-circuits subsequent imports. The
-# duplicate ``ensure`` calls across embeddings.py / index.py /
-# rag.py / code_rag.py exist because each of these modules can be
-# the very first chromadb-touching site depending on which feature
-# the user reaches first.
-_ensure(["chromadb"], feature="search index")
+# Shares the ``rag`` bundle (chromadb + splitter + tiktoken) with
+# /docs and /code. Idempotent after the first feature touches it —
+# the bundle registry in ``optional_deps`` is the single source of
+# truth, so /search no longer has to know which packages chromadb
+# brings along.
+_ensure("rag")
 
 import chromadb  # noqa: E402
 from chromadb.api.types import EmbeddingFunction  # noqa: E402

--- a/amx/utils/optional_deps.py
+++ b/amx/utils/optional_deps.py
@@ -1,57 +1,68 @@
 """On-demand pip-installer for feature-gated dependencies.
 
-A first-time ``pip install amx-cli`` ships a thin core only — the CLI
-shell, LLM client (litellm), config, and history store. Heavy
-clusters that not every user will touch — chromadb + langchain for
-RAG, fastapi/uvicorn for AMX Studio, boto3/google/msal for cloud
-document sources, openai/anthropic SDKs for Batch APIs — are pulled
+A first-time ``pip install amx-cli`` ships:
+
+- The CLI shell, LLM client (litellm), config, history store.
+- AMX Studio (FastAPI + uvicorn + sse-starlette + python-multipart).
+- A working DuckDB driver pair so a local profile is queryable
+  without a second download.
+
+Heavier clusters that not every user touches — chromadb + langchain
+for RAG, ``boto3`` / ``google`` / ``msal`` for cloud document sources,
+``openai`` / ``anthropic`` SDKs for Batch APIs, the niche DB drivers
+(Snowflake / Databricks / BigQuery / Postgres / MySQL / …), and the
+heavy ML bundles (sentence-transformers, bert-score) — are pulled
 in transparently the first time the relevant feature runs.
 
 Why this design:
 
-- A fresh install completes in seconds instead of pulling 300+ MB of
+- A fresh install completes quickly instead of pulling 500+ MB of
   wheels for features the user may never touch.
 - Users never have to learn extras syntax (``amx-cli[rag,docs]``) to
   make their tool work — AMX is the one that knows what each feature
   needs.
 - Already-installed packages are a single ``importlib.find_spec``
   no-op, so steady-state launches stay fast.
-- Failure modes are surfaced explicitly: when pip install fails
-  (offline, read-only env, permission denied), the user sees one
-  error line with the exact ``pip install`` command to run by hand.
-  We never half-install and crash deeper in the import chain.
+- Failure modes are surfaced explicitly: when a fetch fails (offline,
+  read-only env, permission denied), the user sees one error line
+  with the exact ``pip install`` command to run by hand. We never
+  half-install and crash deeper in the import chain.
 
-Usage from a feature module — ``ensure()`` runs BEFORE the heavy
-imports execute, so the imports below it are guaranteed to resolve::
+Two ways to call ``ensure()``:
 
-    # amx/docs/rag.py
-    from amx.utils.optional_deps import ensure
-    ensure(
-        [
-            "chromadb",
-            ("langchain_community", "langchain-community"),
-            ("langchain_text_splitters", "langchain-text-splitters"),
-            ("docx", "python-docx"),
-        ],
-        feature="document RAG (/docs)",
-    )
+1. **Bundle name (preferred for shared clusters).** The bundle
+   registry below is the single place where "what does the RAG
+   feature need" is recorded, so adding a package once propagates
+   to every entry point::
 
-    import chromadb  # now safe
-    from langchain_community.document_loaders import PyPDFLoader
+       from amx.utils.optional_deps import ensure
+       ensure("rag")  # docs / search / code RAG share this set
+       import chromadb  # now safe
 
-The bare-string form is used when the importable module name matches
-the pip distribution name (``chromadb`` → ``pip install chromadb``).
-The two-tuple form is used when they differ (``import docx`` is
-shipped by ``python-docx``) or when extras / version pins are needed
-(``("uvicorn", "uvicorn[standard]")``).
+2. **Inline list (for one-off / per-backend triples).** Used by
+   ``amx.db.drivers`` where each backend already has its own pair
+   table, and by per-feature one-package needs like ``bert-score``::
+
+       ensure(
+           [("docx", "python-docx"), "chromadb"],
+           feature="document RAG",
+       )
+
+The bare-string form inside the list is used when the importable
+module name matches the pip distribution name (``chromadb`` →
+``pip install chromadb``). The two-tuple form is used when they
+differ (``import docx`` is shipped by ``python-docx``) or when
+extras / version pins are needed (``("uvicorn", "uvicorn[standard]")``).
 """
 
 from __future__ import annotations
 
 import importlib
 import importlib.util
+import os
 import subprocess
 import sys
+import threading
 from collections.abc import Iterable
 
 #: Cache keys for module/pip pairs we have already verified or
@@ -59,7 +70,66 @@ from collections.abc import Iterable
 #: re-running ``find_spec`` once a feature has been used.
 _VERIFIED: set[str] = set()
 
+#: Single process-wide lock so two concurrent CLI flows (e.g. Studio's
+#: HTTP worker + the REPL's foreground command) cannot race a pip
+#: install for the same bundle. Without this, two parallel ``ensure``
+#: calls for ``"rag"`` would both observe missing packages, both spawn
+#: pip, and the second invocation could see an inconsistent on-disk
+#: state mid-install.
+_INSTALL_LOCK = threading.Lock()
+
 PackageSpec = str | tuple[str, str]
+
+#: Curated multi-package bundles. Adding a new feature cluster?
+#: Update the dict in one place — every callsite that names the
+#: bundle picks up the change automatically.
+#:
+#: Keys here intentionally line up with extras names in
+#: ``pyproject.toml`` so a user who wants to skip the auto-install
+#: prompt can still ``pip install amx-cli[<bundle>]``.
+BUNDLES: dict[str, list[PackageSpec]] = {
+    # Shared RAG core: chromadb + splitter + tiktoken. The /docs,
+    # /search, and /code ingest entry points all touch this set, so
+    # the first feature the user reaches pays the install once and
+    # the others reuse the cache.
+    "rag": [
+        "chromadb",
+        ("langchain_text_splitters", "langchain-text-splitters"),
+        "tiktoken",
+    ],
+    # Document loaders on top of ``rag``. Only the /docs ingest path
+    # needs these — search and code RAG do not.
+    "docs-extended": [
+        "chromadb",
+        ("langchain_community", "langchain-community"),
+        ("langchain_text_splitters", "langchain-text-splitters"),
+        "tiktoken",
+        "unstructured",
+        "pypdf",
+        ("docx", "python-docx"),
+        "openpyxl",
+    ],
+}
+
+#: Human-readable labels surfaced in the install banner when a bundle
+#: is invoked by name. Falls back to the bundle key if absent.
+BUNDLE_LABELS: dict[str, str] = {
+    "rag": "shared RAG core (/docs, /search, /code)",
+    "docs-extended": "document RAG (/docs ingest)",
+}
+
+#: Bundles whose total install footprint is large enough (sentence-
+#: transformers / bert-score pull torch + transformers + roberta-large
+#: weights — well over 1 GB) that we want a one-time interactive
+#: confirmation before kicking off the download. Skipped automatically
+#: when stdin is not a TTY (Studio worker, CI) or when the
+#: ``AMX_AUTO_INSTALL=1`` opt-out is set.
+_LARGE_PIP_TARGETS: frozenset[str] = frozenset(
+    {
+        "sentence-transformers",
+        "bert-score",
+    }
+)
 
 
 def _resolve(spec: PackageSpec) -> tuple[str, str]:
@@ -69,24 +139,82 @@ def _resolve(spec: PackageSpec) -> tuple[str, str]:
     return spec
 
 
-def ensure(packages: Iterable[PackageSpec], *, feature: str) -> None:
-    """Make sure each package in *packages* is importable.
+def _confirm_large_install(missing_pip: list[str], feature: str) -> bool:
+    """Prompt before fetching a known-large bundle.
 
-    Missing ones are pip-installed in a child process targeting
+    Returns ``True`` to proceed. Returns ``False`` only when the user
+    explicitly declines at an interactive prompt; non-interactive
+    callers (Studio HTTP worker, CI, AMX_AUTO_INSTALL=1) always
+    proceed, since interrupting them mid-flow would leave the request
+    half-handled with no recoverable surface.
+    """
+    if not any(pkg in _LARGE_PIP_TARGETS for pkg in missing_pip):
+        return True
+    if os.environ.get("AMX_AUTO_INSTALL", "").lower() in {"1", "true", "yes"}:
+        return True
+    if not sys.stdin.isatty():
+        return True
+    try:
+        from amx.utils.console import confirm
+    except Exception:
+        return True
+    return confirm(
+        f"{feature} needs to download a large bundle (>500 MB of model + ML wheels). Continue?",
+        default=True,
+    )
+
+
+def ensure(
+    packages: str | Iterable[PackageSpec],
+    *,
+    feature: str | None = None,
+) -> None:
+    """Make sure each package the feature needs is importable.
+
+    *packages* is either:
+
+    - The name of a bundle in :data:`BUNDLES` (e.g. ``"rag"``), in
+      which case the curated package list and a default *feature*
+      label are looked up in the registry, OR
+    - An iterable of :data:`PackageSpec` entries (the legacy
+      per-callsite form, used by ``amx.db.drivers`` and the few
+      one-package callsites).
+
+    Missing packages are pip-installed in a child process targeting
     ``sys.executable`` so the install lands in the same interpreter
     that's running AMX (avoids the system-pip-vs-venv-pip footgun).
+    The whole bundle goes through ONE pip subprocess — never one
+    invocation per package — so the user sees a single download phase
+    instead of N consecutive starts.
 
-    *feature* is a human-readable label for the message the user
-    sees ("First-time setup for document RAG (/docs) — installing
-    7 packages…").
+    Concurrent ``ensure`` calls (e.g. Studio's HTTP worker fielding a
+    request while the REPL handles another command) are serialised
+    by a process-wide lock so two threads cannot race the same pip
+    install.
 
     Raises ``RuntimeError`` if pip install fails. The exception
     message includes the exact command for the user to run by hand,
     so the error is recoverable without grepping the source.
     """
+    if isinstance(packages, str):
+        bundle_name = packages
+        try:
+            specs: Iterable[PackageSpec] = BUNDLES[bundle_name]
+        except KeyError as exc:
+            raise KeyError(
+                f"Unknown ensure() bundle: {bundle_name!r}. Known bundles: {sorted(BUNDLES)}"
+            ) from exc
+        if feature is None:
+            feature = BUNDLE_LABELS.get(bundle_name, bundle_name)
+    else:
+        specs = packages
+
+    if feature is None:
+        raise TypeError("ensure() requires a feature label when called with a package list")
+
     missing_pip: list[str] = []
     seen_keys: list[str] = []
-    for spec in packages:
+    for spec in specs:
         module_name, pip_name = _resolve(spec)
         cache_key = f"{module_name}|{pip_name}"
         seen_keys.append(cache_key)
@@ -114,48 +242,85 @@ def ensure(packages: Iterable[PackageSpec], *, feature: str) -> None:
     if not missing_pip:
         return
 
-    # Lazy console import — ``optional_deps`` itself sits at the top
-    # of feature modules, and we want it to stay cheap to load.
-    from amx.utils.console import info, success
+    with _INSTALL_LOCK:
+        # Re-check inside the lock: another thread may have installed
+        # the bundle while we were waiting. Without this every queued
+        # caller would still spawn its own pip subprocess for an
+        # already-satisfied set.
+        still_missing: list[str] = []
+        for pip_name in missing_pip:
+            module_name = next(
+                (_resolve(s)[0] for s in specs if _resolve(s)[1] == pip_name),
+                pip_name,
+            )
+            cache_key = f"{module_name}|{pip_name}"
+            if cache_key in _VERIFIED:
+                continue
+            if module_name in sys.modules:
+                _VERIFIED.add(cache_key)
+                continue
+            try:
+                spec_obj = importlib.util.find_spec(module_name)
+            except (ValueError, ModuleNotFoundError):
+                spec_obj = None
+            if spec_obj is not None:
+                _VERIFIED.add(cache_key)
+                continue
+            still_missing.append(pip_name)
 
-    info(
-        f"First-time setup for {feature} — installing "
-        f"{len(missing_pip)} package{'s' if len(missing_pip) > 1 else ''}: "
-        f"{', '.join(missing_pip)}"
-    )
-    info("This downloads from PyPI; pip output streams below so you see progress.")
-    cmd = [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        "--disable-pip-version-check",
-        *missing_pip,
-    ]
-    # Deliberately NO ``capture_output=True`` and NO ``--quiet``: a
-    # multi-package install (langchain-community + unstructured +
-    # pypdf is ~80 MB / 30+ s on a fresh machine) with captured
-    # output looks like the CLI froze. Streaming pip's native
-    # progress bars to the user's terminal is the same UX they
-    # already know from any other ``pip install`` and removes the
-    # "did it crash?" doubt that captured output produces.
-    try:
-        proc = subprocess.run(cmd, check=False)
-    except OSError as exc:
-        manual = "pip install " + " ".join(missing_pip)
-        raise RuntimeError(f"Could not invoke pip ({exc}). Install manually: {manual}") from exc
+        if not still_missing:
+            return
 
-    if proc.returncode != 0:
-        for key in seen_keys:
-            _VERIFIED.discard(key)
-        manual = "pip install " + " ".join(missing_pip)
-        raise RuntimeError(
-            f"pip install failed (exit code {proc.returncode}). Run manually: {manual}"
+        if not _confirm_large_install(still_missing, feature):
+            for key in seen_keys:
+                _VERIFIED.discard(key)
+            raise RuntimeError(
+                f"User declined to install the {feature} bundle. "
+                f"Run manually when ready: pip install {' '.join(still_missing)}"
+            )
+
+        # Lazy console import — ``optional_deps`` itself sits at the
+        # top of feature modules, and we want it to stay cheap to load.
+        from amx.utils.console import info, success
+
+        info(
+            f"First-time setup for {feature} — installing "
+            f"{len(still_missing)} package{'s' if len(still_missing) > 1 else ''}: "
+            f"{', '.join(still_missing)}"
         )
+        info("This downloads from PyPI; pip output streams below so you see progress.")
+        cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            *still_missing,
+        ]
+        # Deliberately NO ``capture_output=True`` and NO ``--quiet``: a
+        # multi-package install (langchain-community + unstructured +
+        # pypdf is ~80 MB / 30+ s on a fresh machine) with captured
+        # output looks like the CLI froze. Streaming pip's native
+        # progress bars to the user's terminal is the same UX they
+        # already know from any other ``pip install`` and removes the
+        # "did it crash?" doubt that captured output produces.
+        try:
+            proc = subprocess.run(cmd, check=False)
+        except OSError as exc:
+            manual = "pip install " + " ".join(still_missing)
+            raise RuntimeError(f"Could not invoke pip ({exc}). Install manually: {manual}") from exc
 
-    # Newly-installed packages weren't on sys.path at process start;
-    # invalidate finder caches so the upcoming ``import`` picks them up.
-    importlib.invalidate_caches()
-    for key in seen_keys:
-        _VERIFIED.add(key)
-    success(f"Installed: {', '.join(missing_pip)}.")
+        if proc.returncode != 0:
+            for key in seen_keys:
+                _VERIFIED.discard(key)
+            manual = "pip install " + " ".join(still_missing)
+            raise RuntimeError(
+                f"pip install failed (exit code {proc.returncode}). Run manually: {manual}"
+            )
+
+        # Newly-installed packages weren't on sys.path at process start;
+        # invalidate finder caches so the upcoming ``import`` picks them up.
+        importlib.invalidate_caches()
+        for key in seen_keys:
+            _VERIFIED.add(key)
+        success(f"Installed: {', '.join(still_missing)}.")

--- a/amx/web/launcher.py
+++ b/amx/web/launcher.py
@@ -91,28 +91,9 @@ def launch_studio(
         tests so the function returns once the server is reachable
         and the caller controls shutdown.
     """
-    from amx.utils.optional_deps import ensure
-
-    try:
-        ensure(
-            [
-                "fastapi",
-                ("uvicorn", "uvicorn[standard]"),
-                ("sse_starlette", "sse-starlette"),
-                # FastAPI's ``Form(...)`` / ``File(...)`` parsers raise
-                # ``RuntimeError: Form data requires "python-multipart"
-                # to be installed`` the first time a multipart route is
-                # hit (e.g. the doc-upload drag-drop endpoint in
-                # ``amx/web/routers/docs_ops.py``). Wheel name is
-                # ``python-multipart``; modern versions (>=0.0.12)
-                # expose the importable module as ``python_multipart``.
-                ("python_multipart", "python-multipart"),
-            ],
-            feature="AMX Studio (/studio)",
-        )
-    except RuntimeError as exc:
-        log.error("AMX Studio dependencies could not be installed: %s", exc)
-        return False
+    # FastAPI / uvicorn / sse-starlette / python-multipart are now
+    # core dependencies, so a fresh ``pip install amx-cli`` already
+    # has every Studio import. No ensure() needed here.
     import uvicorn
 
     # Silence the parent CLI terminal for the duration of the Studio
@@ -125,29 +106,14 @@ def launch_studio(
 
     mute_root_logger_for_studio()
 
-    # Pre-install drivers for every saved DB profile BEFORE uvicorn
-    # starts. A web request triggering pip-install mid-flight would
-    # hang the request for 10–30 s while the browser shows a
-    # never-resolving spinner; doing it up front means the user sees
-    # the progress in the launching terminal and Studio is fully
-    # responsive once the page loads.
-    from amx.db.drivers import ensure_backend_driver
-
-    seen_backends: set[str] = set()
-    for profile in cfg.db_profiles.values():
-        backend = (getattr(profile, "backend", "") or "").strip()
-        if backend and backend not in seen_backends:
-            seen_backends.add(backend)
-            try:
-                ensure_backend_driver(backend)
-            except RuntimeError as exc:
-                log.error(
-                    "Could not install driver for backend %r: %s. "
-                    "Studio will start, but operations against this "
-                    "profile will surface a clearer error in the UI.",
-                    backend,
-                    exc,
-                )
+    # DB drivers are intentionally NOT pre-installed for every saved
+    # profile here. A user with profiles for half a dozen warehouses
+    # would otherwise pay a long install at /studio open even when
+    # they only mean to inspect one of them. Drivers are fetched on
+    # the first request that actually touches a profile, routed
+    # through the same ``ensure()`` helper as the rest of AMX so the
+    # install banner shows in the launching terminal rather than
+    # appearing as a stalled HTTP request in the browser.
 
     from amx.web.server import create_app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,21 +42,33 @@ classifiers = [
 
 dependencies = [
     # ── Core: needed by EVERY ``amx`` invocation ────────────────────────
-    # Heavy clusters (RAG, /docs ingestion, AMX Studio, cloud sources,
-    # Batch APIs, gitpython, tiktoken) are auto-installed by AMX itself
-    # the first time the user reaches the relevant feature — see
-    # ``amx/utils/optional_deps.py``. This keeps ``pip install amx-cli``
-    # under ~50 MB and a few seconds for first-time users while still
-    # making every feature work end-to-end on demand.
+    # Heavier feature clusters (RAG document ingest, cloud sources,
+    # Batch APIs, gitpython, semantic embedding metrics) are auto-
+    # installed by AMX itself the first time the user reaches the
+    # relevant feature — see ``amx/utils/optional_deps.py``.
+    #
+    # AMX Studio (FastAPI / uvicorn / sse-starlette / multipart) and
+    # the DuckDB driver pair are part of the everyone-uses-them path,
+    # so they live in core: a single ``pip install amx-cli`` is
+    # sufficient to open ``/studio`` or query a local DuckDB profile
+    # without any second-stage download. Niche backends (Snowflake,
+    # Databricks, BigQuery, …) still install lazily per-profile.
     "click>=8.1",
     "rich>=13.0",
     "prompt_toolkit>=3.0.40",
     "sqlalchemy>=2.0",
     "pyyaml>=6.0",
-    "python-dotenv>=1.0",
     "litellm>=1.83.7",
     "requests>=2.31",
     "keyring>=24.0",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.27",
+    "sse-starlette>=2.0",
+    # Required by FastAPI's Form/File so the doc-upload drag-drop
+    # endpoint accepts multipart bodies.
+    "python-multipart>=0.0.7",
+    "duckdb>=1.0",
+    "duckdb-engine>=0.13",
 ]
 
 [project.urls]
@@ -92,14 +104,6 @@ docs = [
     # secure floor, so we pin one here. Drop this constraint once
     # ``unstructured``'s own pin catches up.
     "lxml>=6.1.0",
-]
-studio = [
-    "fastapi>=0.110",
-    "uvicorn[standard]>=0.27",
-    "sse-starlette>=2.0",
-    # Required by FastAPI's Form/File so the doc-upload drag-drop
-    # endpoint accepts multipart bodies.
-    "python-multipart>=0.0.7",
 ]
 # PDF report rendering for the Compare modal (auto-installed on
 # demand via amx.utils.optional_deps when the user clicks
@@ -146,7 +150,9 @@ batch = [
 git-sources = [
     "gitpython>=3.1",
 ]
-
+# Optional richer SQL parsing inside ``/code analyze``. When the
+# package is absent, the codebase analyzer falls back to a regex
+# scanner, so the feature degrades gracefully instead of failing.
 code-intel = [
     "sqlglot>=24.0",
 ]
@@ -186,9 +192,8 @@ clickhouse = [
     "clickhouse-connect>=0.7",
     "clickhouse-sqlalchemy>=0.3",
 ]
-duckdb = ["duckdb-engine>=0.13", "duckdb>=1.0"]
 all = [
-    # Every DB backend driver
+    # Niche DB backend drivers (DuckDB lives in core deps; not repeated here).
     "psycopg2-binary>=2.9",
     "snowflake-sqlalchemy>=1.6",
     "snowflake-connector-python>=3.6",
@@ -204,9 +209,9 @@ all = [
     "sqlalchemy-redshift>=0.8",
     "clickhouse-connect>=0.7",
     "clickhouse-sqlalchemy>=0.3",
-    "duckdb-engine>=0.13",
-    "duckdb>=1.0",
-    # Every feature cluster (auto-installed on demand otherwise)
+    # Every optional feature cluster (auto-installed on demand
+    # otherwise). Studio + DuckDB are core deps now and intentionally
+    # NOT repeated here.
     "chromadb>=0.5",
     "langchain-community>=0.3",
     "langchain-text-splitters>=0.3",
@@ -219,10 +224,6 @@ all = [
     # CVE-2026-41066 floor — see comment on the same pin in the
     # ``docs`` extra above.
     "lxml>=6.1.0",
-    "fastapi>=0.110",
-    "uvicorn[standard]>=0.27",
-    "sse-starlette>=2.0",
-    "python-multipart>=0.0.7",
     "weasyprint>=60",
     "jinja2>=3.1",
     "sacrebleu>=2.4",
@@ -257,10 +258,11 @@ dev = [
 #   pip install -e ".[perf]"
 #   pytest tests/perf -m perf --benchmark-only
 # Never auto-installed; never imported by the runtime amx package.
+# DuckDB is already a core dependency, so it is intentionally not
+# repeated here.
 perf = [
     "pytest-benchmark>=4.0",
     "psutil>=5.9",
-    "duckdb>=1.0",
 ]
 
 [project.scripts]

--- a/tests/web/test_launcher.py
+++ b/tests/web/test_launcher.py
@@ -1,4 +1,4 @@
-"""Launcher unit tests — port picking + import-failure handling.
+"""Launcher unit tests — port picking + Studio bootstrap invariants.
 
 The full ``launch_studio`` end-to-end (uvicorn boot + browser open
 + Ctrl-C) is exercised manually; here we only assert the pieces the
@@ -6,10 +6,10 @@ unit suite can verify without spawning a real listener."""
 
 from __future__ import annotations
 
-import inspect
+import re
 import socket
+from pathlib import Path
 
-from amx.web import launcher as launcher_module
 from amx.web.launcher import _pick_port
 
 
@@ -37,15 +37,44 @@ def test_pick_port_falls_back_when_preferred_busy() -> None:
     assert chosen != busy_port or chosen == 0  # OS may reuse busy_port the instant we close
 
 
-def test_launcher_ensures_python_multipart_for_form_routes() -> None:
-    """Regression: ``launch_studio`` used to ``ensure([fastapi,
-    uvicorn[standard], sse-starlette])`` only. On a fresh install
-    without the ``studio`` extra, the first multipart request
-    (``amx/web/routers/docs_ops.py`` doc-upload) raised
-    ``RuntimeError: Form data requires "python-multipart" to be
-    installed`` mid-session. The ensure list must declare
-    ``python-multipart`` (importable as ``python_multipart``) so the
-    drag-drop endpoint works on the very first ``/studio`` boot."""
-    source = inspect.getsource(launcher_module.launch_studio)
-    assert '"python-multipart"' in source
-    assert '"python_multipart"' in source
+def test_studio_runtime_packages_are_core_dependencies() -> None:
+    """Regression: an earlier design pulled FastAPI / uvicorn /
+    sse-starlette / python-multipart lazily on first ``/studio`` open,
+    which split the install across two phases and (in one historical
+    miss) forgot ``python-multipart`` so the first multipart request
+    raised ``RuntimeError: Form data requires "python-multipart" to
+    be installed`` mid-session.
+
+    The fix promoted those packages to core dependencies so a single
+    ``pip install amx-cli`` is sufficient. This test pins that
+    invariant against ``pyproject.toml`` directly so a future edit
+    that demotes any of them back to an extra fails CI immediately
+    instead of resurfacing as a runtime crash for the first user who
+    drag-drops a document.
+    """
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+
+    # Pull just the ``dependencies = [ ... ]`` block under ``[project]``
+    # so a string that only appears under an extras list cannot satisfy
+    # the assertion. Plain string operations keep the test usable on
+    # Python 3.10 where ``tomllib`` is not in the standard library.
+    match = re.search(
+        r"^\[project\][\s\S]*?^dependencies = \[(?P<deps>[\s\S]*?)^\]",
+        text,
+        re.MULTILINE,
+    )
+    assert match is not None, "could not locate [project].dependencies in pyproject.toml"
+    deps_block = match.group("deps")
+
+    requirements = [
+        re.sub(r'^\s*"', "", line).split('"', 1)[0]
+        for line in deps_block.splitlines()
+        if '"' in line
+    ]
+
+    def _declares(name: str) -> bool:
+        return any(req.split(" ")[0].split("[")[0].split(">")[0] == name for req in requirements)
+
+    for required in ("fastapi", "uvicorn", "sse-starlette", "python-multipart"):
+        assert _declares(required), f"{required!r} must stay in core dependencies"


### PR DESCRIPTION
## Summary

- Promote FastAPI / uvicorn / sse-starlette / python-multipart and the DuckDB driver pair from optional extras into core ``[project.dependencies]``, so opening ``/studio`` or querying a local DuckDB profile no longer triggers a second wave of pip subprocesses after ``pip install amx-cli``.
- Drop the unused ``python-dotenv`` core dep, remove the now-redundant ``studio`` and ``duckdb`` extras, and recompute ``[all]`` so it matches.
- Add a ``BUNDLES`` registry to ``amx/utils/optional_deps.py`` so the three RAG entry points (``/docs``, ``/search``, ``/code``) share one package list, serialise concurrent installs under a process-wide ``threading.Lock``, and confirm once before pulling the very large ML bundles (``sentence-transformers``, ``bert-score``).
- Remove the ``launch_studio`` loop that pre-installed every saved profile's driver before uvicorn boot — drivers now install lazily on the first request that actually touches a profile.

## Test plan

- [x] ``pytest tests/test_optional_deps.py tests/web/test_launcher.py tests/test_db_profile_optional_database.py`` — 26 pass.
- [x] Full ``pytest`` — 1331 pass (the one ``test_rerun`` flake is pre-existing on ``main``, unrelated to this change).
- [x] ``ruff check amx tests`` and ``ruff format --check amx tests`` clean.
- [x] Smoke imports: ``import amx.cli``, ``amx.web.launcher``, ``amx.utils.optional_deps`` — bundle resolution verified for the ``rag`` bundle.
- [ ] Manual: cold venv ``pip install -e .`` timing before / after on a fresh pip cache.
- [ ] Manual: ``amx /studio`` from a fresh ``$HOME`` confirms zero post-install pip subprocesses.
- [ ] Manual: open Studio with three configured profiles, hit only one — verify the other two drivers are NOT installed.