### PR TITLE
fix(ssl): consult the OS trust store so corporate-proxy networks work out of the box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pricing refresh failed with ``CERTIFICATE_VERIFY_FAILED`` on a
+  fresh install behind a corporate TLS-inspecting proxy** (Zscaler /
+  Netskope / Cloudflare WARP / similar). Studio rendered the toast
+  ``Prices partially refreshed — litellm: URLError: <urlopen error
+  [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
+  self-signed certificate in certificate chain ...>; openrouter:
+  URLError: <urlopen error ...>``, and the Prices listing
+  collapsed to the 32 bundled-fallback models with every row labelled
+  source = "Fallback". The same network proxy is one that the user's
+  Windows Cert Store / macOS Keychain / Linux ``ca-certificates``
+  already trusts (browsers and ``curl`` work fine), so the
+  user-visible failure was puzzling — and was caused entirely by AMX
+  itself, not the network. The pricing fetcher in
+  ``amx/llm/pricing.py`` forced ``ssl.create_default_context(cafile=certifi.where())``
+  whenever the user had not set ``AMX_CA_BUNDLE``. Passing
+  ``cafile=`` explicitly *replaces* the default certificate chain and
+  prevents ``load_default_certs()`` from reading the OS trust store,
+  so the corporate CA that browsers trust never reaches the verifier.
+  The certifi-forcing branch carried a docstring claiming it fixed
+  "plain Windows Python: ships no default CA bundle and does not
+  consult the Windows trust store", which was true of Python ≤ 3.3
+  but is no longer true on AMX's minimum Python 3.10.
+
+  The fix is three coordinated changes: (1) ``_build_ssl_context``
+  now returns plain ``ssl.create_default_context()`` when neither
+  ``AMX_INSECURE_SSL`` nor ``AMX_CA_BUNDLE`` / ``SSL_CERT_FILE`` is
+  set, so Python's default ``load_default_certs()`` consults the OS
+  trust store. (2) New ``amx.utils.network_trust.configure_trust_store``
+  helper called once at every CLI entrypoint (``run_cli``) and once
+  at Studio bootstrap (``create_app``) injects the PyPA-endorsed
+  ``truststore`` package (added as a core dependency) so the OS
+  store is consulted through first-class OS APIs even on edge-case
+  Linux / WSL openssl layouts; the same helper fans
+  ``AMX_CA_BUNDLE`` out to ``REQUESTS_CA_BUNDLE`` /
+  ``SSL_CERT_FILE`` / ``CURL_CA_BUNDLE`` so the override path keeps
+  working for users who deliberately point at an on-disk corporate
+  PEM. (3) ``refresh_prices`` now detects
+  ``ssl.SSLCertVerificationError`` specifically and emits one short
+  actionable hint per source ("TLS verification failed against
+  <host> — usually a corporate proxy. AMX consults the OS trust
+  store automatically; set AMX_CA_BUNDLE=/path/to/ca.pem if your
+  company CA is still missing") instead of the multi-line ``URLError:
+  <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] ...>`` blob.
+  Non-TLS failures keep the existing ``ClassName: message`` format so
+  real outages and parse errors still surface plainly.
+
+  Same fix transparently covers ``litellm`` / ``openai`` /
+  ``anthropic`` HTTPS calls and ``/docs scan`` downloads in
+  ``amx/docs/scanner.py``, since they all route through the same
+  default ``ssl.SSLContext`` that ``truststore.inject_into_ssl()``
+  rewrote.
+
 ### Changed
 
 - **Single-step install for the common AMX path.** A first-time

--- a/amx/cli.py
+++ b/amx/cli.py
@@ -171,6 +171,13 @@ def run_cli() -> None:
     rendered as a themed error line instead of a raw traceback. Set
     ``AMX_DEBUG=1`` (or pass ``--debug`` to ``amx``) to see the full traceback.
     """
+    # Route every later ``ssl.create_default_context()`` through the
+    # OS trust store BEFORE any HTTPS-touching import fires (pricing
+    # fetcher, scanner, litellm bootstrap). One-shot, idempotent.
+    from amx.utils.network_trust import configure_trust_store
+
+    configure_trust_store()
+
     if len(sys.argv) >= 4:
         _rewrite_sys_argv_for_codebase(sys.argv)
     try:

--- a/amx/llm/pricing.py
+++ b/amx/llm/pricing.py
@@ -43,6 +43,7 @@ import ssl
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass
 from importlib.resources import files as _resource_files
@@ -146,49 +147,97 @@ def _write_cache(payload: dict[str, Any]) -> None:
 def _build_ssl_context() -> ssl.SSLContext:
     """SSL context for the price-fetch ``urlopen`` calls.
 
-    Resolves a CA bundle in priority order so the same env vars users
-    already set for the LLM client (``AMX_CA_BUNDLE`` /
-    ``AMX_INSECURE_SSL``) also fix the pricing path:
+    Resolution order:
 
     1. ``AMX_INSECURE_SSL`` truthy — return an unverified context.
-       Mirrors :func:`amx.llm.provider._configure_ssl_environment`'s
-       contract; diagnostic-only escape hatch for hostile networks.
-    2. ``AMX_CA_BUNDLE`` set to an existing file — corporate CA bundle,
-       typical Zscaler / Netskope / on-prem MITM proxy fix.
-    3. ``SSL_CERT_FILE`` set to an existing file — already-set stdlib
-       env var, also written by ``_configure_ssl_environment`` so a
-       run that imported the LLM provider first is picked up here.
-    4. ``certifi.where()`` — bundled Mozilla CA list. This branch is
-       what fixes plain Windows Python: the CPython ``python.org``
-       distribution ships no default CA bundle and does not consult
-       the Windows trust store, so a bare ``urlopen`` raises
-       ``CERTIFICATE_VERIFY_FAILED`` against any HTTPS host.
-    5. System default — last resort when nothing above resolves.
+       Diagnostic-only escape hatch for hostile networks; mirrors
+       :func:`amx.llm.provider._configure_ssl_environment`'s contract.
+    2. ``AMX_CA_BUNDLE`` or ``SSL_CERT_FILE`` set to an existing file
+       — corporate CA bundle override; the typical fix for
+       Zscaler / Netskope / on-prem MITM proxies when the OS trust
+       store does NOT contain the corporate CA.
+    3. Otherwise — plain ``ssl.create_default_context()``. Python's
+       :func:`SSLContext.load_default_certs` (called by the default
+       context constructor) pulls in the OS trust store on every
+       supported platform: ``enum_certificates("ROOT")`` on Windows,
+       ``SecTrustCopyAnchorCertificates`` on macOS, the system
+       ``ca-certificates`` packages on Linux/BSD. The startup helper
+       ``amx.utils.network_trust.configure_trust_store`` additionally
+       injects ``truststore`` (when available) so the OS store is
+       consulted through first-class OS APIs instead of OpenSSL's
+       built-in resolution, which catches edge-cases like partial
+       chains and unusual Linux store layouts.
+
+    Earlier revisions of this function forced
+    ``ssl.create_default_context(cafile=certifi.where())`` whenever no
+    env var was set. That branch was intended to paper over Python
+    <= 3.3 on Windows (which shipped no default CA bundle), but on
+    Python 3.10+ — AMX's minimum — passing ``cafile=`` actively
+    *replaces* the default chain and prevents
+    ``load_default_certs()`` from reading the OS trust store, so the
+    corporate CA that browsers / curl already trust never reaches
+    the verifier. Removing the certifi forcing is the entire fix for
+    "Refresh prices returns CERTIFICATE_VERIFY_FAILED behind a
+    corporate proxy where curl works fine".
     """
     insecure = os.getenv("AMX_INSECURE_SSL", "").strip().lower()
     if insecure in ("1", "true", "yes", "on"):
         return ssl._create_unverified_context()
 
-    cafile: str | None = None
     for env_var in ("AMX_CA_BUNDLE", "SSL_CERT_FILE"):
         candidate = os.getenv(env_var, "").strip()
         if candidate and os.path.isfile(candidate):
-            cafile = candidate
-            break
+            return ssl.create_default_context(cafile=candidate)
 
-    if cafile is None:
-        try:
-            import certifi
-        except ImportError:
-            certifi = None  # type: ignore[assignment]
-        if certifi is not None:
-            bundled = certifi.where()
-            if bundled and os.path.isfile(bundled):
-                cafile = bundled
-
-    if cafile is not None:
-        return ssl.create_default_context(cafile=cafile)
     return ssl.create_default_context()
+
+
+def _is_cert_verify_error(exc: BaseException) -> bool:
+    """True when *exc* is (or wraps) a TLS certificate-verification failure.
+
+    Walks ``__cause__`` and ``URLError.reason`` so the
+    ``CERTIFICATE_VERIFY_FAILED`` signature is detected whether
+    Python surfaced it as ``ssl.SSLCertVerificationError`` directly,
+    wrapped it inside ``urllib.error.URLError``, or stacked it via
+    ``__cause__`` (the chain seen on Python 3.10–3.14).
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, ssl.SSLCertVerificationError):
+            return True
+        reason = getattr(current, "reason", None)
+        if isinstance(reason, BaseException) and id(reason) not in seen:
+            current = reason
+            continue
+        current = current.__cause__
+    return False
+
+
+def _format_fetch_error(source: str, url: str, exc: BaseException) -> str:
+    """Render a fetch failure for the Studio toast / CLI log.
+
+    Specialises the message for TLS verification failures so the user
+    sees one short hint that names the env-var override, instead of a
+    multi-line ``URLError: <urlopen error [SSL:
+    CERTIFICATE_VERIFY_FAILED] ... self-signed certificate in
+    certificate chain ...>`` blob that reads like a crash. Every other
+    failure (genuine outage, JSON parse error, file system error)
+    keeps the existing class-name + message format so real problems
+    still surface plainly.
+    """
+    if _is_cert_verify_error(exc):
+        try:
+            host = urllib.parse.urlparse(url).hostname or url
+        except ValueError:
+            host = url
+        return (
+            f"{source}: TLS verification failed against {host} — usually a corporate proxy. "
+            f"AMX consults the OS trust store automatically; if your company CA is still "
+            f"missing, set AMX_CA_BUNDLE=/path/to/ca.pem and retry."
+        )
+    return f"{source}: {exc.__class__.__name__}: {exc}"
 
 
 def _http_get_json(url: str, *, headers: dict[str, str] | None = None) -> Any:
@@ -396,12 +445,12 @@ def refresh_prices(*, force: bool = False) -> dict[str, Any]:
         new_litellm = fetch_litellm_prices()
     except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
         new_litellm = {}
-        errors.append(f"litellm: {exc.__class__.__name__}: {exc}")
+        errors.append(_format_fetch_error("litellm", _LITELLM_URL, exc))
     try:
         new_openrouter = fetch_openrouter_prices()
     except (urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
         new_openrouter = {}
-        errors.append(f"openrouter: {exc.__class__.__name__}: {exc}")
+        errors.append(_format_fetch_error("openrouter", _OPENROUTER_URL, exc))
 
     with _PRICING_LOCK:
         if new_litellm:

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -24,26 +24,26 @@ _litellm_module: ModuleType | None = None
 
 
 def _configure_ssl_environment() -> None:
-    """Honor ``AMX_CA_BUNDLE`` / ``AMX_INSECURE_SSL`` so corporate networks work.
+    """Apply ``AMX_INSECURE_SSL`` to the litellm / httpx stack.
 
-    Corporate environments routinely run TLS-inspecting proxies (Zscaler,
-    Netskope, etc.) that re-sign every HTTPS connection with an internal
-    root CA. Out of the box, ``httpx`` / ``openai`` / ``litellm`` don't
-    trust that CA → "self-signed certificate in certificate chain" and
-    every LLM call fails. We expose two env vars to make this fixable
-    without touching code:
+    Corporate environments routinely run TLS-inspecting proxies
+    (Zscaler, Netskope, etc.) that re-sign every HTTPS connection
+    with an internal root CA. The general fix lives in
+    :mod:`amx.utils.network_trust`: the startup helper there injects
+    ``truststore`` so Python's ``ssl`` module consults the OS trust
+    store (where the corporate CA is almost always already
+    installed), and fans ``AMX_CA_BUNDLE`` out to
+    ``REQUESTS_CA_BUNDLE`` / ``SSL_CERT_FILE`` / ``CURL_CA_BUNDLE``
+    for the third-party HTTP clients that read those env vars.
 
-    - ``AMX_CA_BUNDLE=/path/to/corp_root.pem`` — point requests / httpx /
-      curl at the corporate CA bundle. Most reliable fix.
-    - ``AMX_INSECURE_SSL=1`` — disable SSL verification entirely. Useful
-      for a one-shot test; do NOT use in production.
+    This function is now the litellm-specific extension of that
+    contract: when the user sets ``AMX_INSECURE_SSL=1`` for a
+    one-shot diagnostic, AMX flips litellm's own ``ssl_verify``
+    flag and the cross-library ``PYTHONHTTPSVERIFY`` env var so the
+    underlying httpx clients used by openai / anthropic SDKs also
+    bypass verification. ``AMX_INSECURE_SSL`` should never be set in
+    production.
     """
-    ca_bundle = os.getenv("AMX_CA_BUNDLE", "").strip()
-    if ca_bundle and os.path.exists(ca_bundle):
-        # ``requests`` / ``httpx`` / ``urllib3`` / ``curl`` all read these.
-        for var in ("REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "CURL_CA_BUNDLE"):
-            os.environ.setdefault(var, ca_bundle)
-
     insecure = os.getenv("AMX_INSECURE_SSL", "").strip().lower()
     if insecure in ("1", "true", "yes", "on"):
         try:

--- a/amx/utils/network_trust.py
+++ b/amx/utils/network_trust.py
@@ -1,0 +1,103 @@
+"""Process-wide trust-store wiring for AMX's HTTPS calls.
+
+Why this module exists
+----------------------
+
+Every AMX HTTPS call — the pricing fetcher in ``amx/llm/pricing.py``,
+the document downloads in ``amx/docs/scanner.py``, the litellm /
+openai / anthropic SDKs called from ``amx/llm/provider.py`` — has to
+agree on how to verify TLS certificates. On a corporate or
+school-managed laptop, the certificate chain is rewritten by a
+TLS-intercepting middlebox (Zscaler, Netskope, Cloudflare WARP, an
+on-prem inspection appliance). The middlebox's CA is installed in
+the OS trust store so browsers, ``curl``, and Edge accept it; Python's
+``ssl`` module can reach it via ``ssl.SSLContext.load_default_certs()``,
+but only when no explicit ``cafile=`` is forced — and the underlying
+OpenSSL resolution does fall over in edge cases (partial chains,
+unusual Linux store layouts, certain WSL configs).
+
+This module solves both halves by:
+
+1. **Injecting ``truststore`` once per process.** ``truststore`` is a
+   small, PyPA-endorsed package (used by ``pip`` 24.2+) that replaces
+   the underlying CA resolution with first-class OS APIs
+   (``enum_certificates`` on Windows, ``SecTrustEvaluateWithError`` on
+   macOS, the system ``ca-certificates`` packages on Linux). After
+   ``truststore.inject_into_ssl()``, every later
+   ``ssl.create_default_context()`` — used by ``urllib`` AND
+   ``requests`` via urllib3 AND ``httpx`` — is routed through the OS
+   store. The injection is best-effort: ``ImportError`` /
+   ``NotImplementedError`` / ``OSError`` are swallowed so an
+   unsupported interpreter cannot crash the CLI.
+
+2. **Fanning ``AMX_CA_BUNDLE`` out to the env vars third-party HTTP
+   clients read.** Users who already set ``AMX_CA_BUNDLE`` for the
+   LLM provider get the same override for ``requests``,
+   ``urllib3``, ``httpx``, and curl-via-subprocess without having to
+   set four env vars themselves.
+
+This helper is idempotent — every call after the first is a no-op,
+so it can safely run at every CLI entrypoint and every Studio request
+worker.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+_INJECTED_LOCK = threading.Lock()
+_INJECTED = False
+
+
+def configure_trust_store() -> None:
+    """Wire AMX's HTTPS calls through the OS trust store.
+
+    Safe to call multiple times — the actual ``truststore`` inject
+    runs once and subsequent calls are O(1).
+    """
+    global _INJECTED
+    if _INJECTED:
+        # Still fan out AMX_CA_BUNDLE on every call: the env var can
+        # be set late (e.g. by ``set AMX_CA_BUNDLE=...`` between two
+        # /studio refreshes in the same process).
+        _fan_out_ca_bundle_env()
+        return
+
+    with _INJECTED_LOCK:
+        if _INJECTED:
+            _fan_out_ca_bundle_env()
+            return
+
+        try:
+            import truststore  # type: ignore[import-not-found]
+
+            truststore.inject_into_ssl()
+        except (ImportError, NotImplementedError, OSError):
+            # Leaving the default ``ssl`` resolution in place is a
+            # fully working fallback — Python 3.10+ already pulls the
+            # OS trust store via ``load_default_certs()`` whenever
+            # ``ssl.create_default_context()`` is called without a
+            # ``cafile=`` argument. The injection just widens the
+            # success surface for edge-case Linux / WSL layouts.
+            pass
+
+        _fan_out_ca_bundle_env()
+        _INJECTED = True
+
+
+def _fan_out_ca_bundle_env() -> None:
+    """Mirror ``AMX_CA_BUNDLE`` into the third-party-recognised env vars.
+
+    ``requests`` reads ``REQUESTS_CA_BUNDLE``; ``urllib3`` /
+    ``httpx`` / Python's ``ssl`` module read ``SSL_CERT_FILE``; ``curl``
+    invoked from a subprocess reads ``CURL_CA_BUNDLE``. Setting them
+    here is a strict no-op when ``AMX_CA_BUNDLE`` is unset, and
+    ``setdefault`` semantics mean a user who already pinned one of
+    these vars explicitly keeps their value.
+    """
+    ca_bundle = os.environ.get("AMX_CA_BUNDLE", "").strip()
+    if not ca_bundle or not os.path.exists(ca_bundle):
+        return
+    for var in ("REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "CURL_CA_BUNDLE"):
+        os.environ.setdefault(var, ca_bundle)

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -77,6 +77,14 @@ def create_app(
         users get the pre-built dist; tests point it at a temp dir
         with stub files.
     """
+    # Route HTTPS calls made from Studio worker threads (pricing
+    # refresh, doc scanner, batch API SDKs) through the OS trust
+    # store. ``configure_trust_store`` is idempotent so the CLI entry
+    # point and Studio bootstrap can both call it safely.
+    from amx.utils.network_trust import configure_trust_store
+
+    configure_trust_store()
+
     app = FastAPI(
         title="AMX Studio",
         version=AMX_VERSION,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,13 @@ dependencies = [
     "litellm>=1.83.7",
     "requests>=2.31",
     "keyring>=24.0",
+    # ``truststore`` lets Python's ``ssl`` module consult the OS
+    # trust store (Windows Cert Store / macOS Keychain / Linux
+    # system bundle) through first-class OS APIs. AMX injects it at
+    # startup so corporate-CA-only certificates already imported into
+    # the OS for browsers / curl also work for AMX's HTTPS calls,
+    # without forcing the user to set ``AMX_CA_BUNDLE`` by hand.
+    "truststore>=0.10",
     "fastapi>=0.110",
     "uvicorn[standard]>=0.27",
     "sse-starlette>=2.0",

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -84,22 +84,45 @@ def _clear_pricing_ssl_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(var, raising=False)
 
 
-def test_build_ssl_context_uses_certifi_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Regression: plain Windows Python ships no default CA bundle, so a
-    bare ``urlopen`` raises CERTIFICATE_VERIFY_FAILED. The helper must
-    fall back to ``certifi.where()`` so the price fetch succeeds out of
-    the box without any user env-var configuration."""
-    pytest.importorskip("certifi")
+def test_build_ssl_context_defers_to_os_trust_store_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When neither ``AMX_CA_BUNDLE`` nor ``SSL_CERT_FILE`` is set the
+    helper must return ``ssl.create_default_context()`` with NO
+    ``cafile=`` argument so Python's ``load_default_certs()``
+    consults the OS trust store (Windows Cert Store / macOS Keychain
+    / Linux ``ca-certificates``).
 
+    The earlier behavior forced ``cafile=certifi.where()`` which
+    silently replaced the OS chain — exactly the failure mode users
+    reported behind a corporate TLS proxy where the corporate CA is
+    installed in the OS but not in certifi. Locking ``cafile`` to
+    None pins the fix against an innocent-looking edit that
+    re-introduces certifi forcing.
+    """
     _clear_pricing_ssl_env(monkeypatch)
+
+    captured: dict[str, object] = {}
+    real = ssl.create_default_context
+
+    def _spy(*args: object, **kwargs: object) -> ssl.SSLContext:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(ssl, "create_default_context", _spy)
+
     ctx = _build_ssl_context()
 
     assert isinstance(ctx, ssl.SSLContext)
     assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is True
-    # Loaded a non-empty CA list — the certifi branch only "works" if
-    # the bundled bundle actually populates the context.
-    assert ctx.get_ca_certs(), "expected certifi CA bundle to populate context"
+    assert captured["args"] == ()
+    assert "cafile" not in captured["kwargs"], (
+        "regression: _build_ssl_context forced an explicit cafile= and bypassed "
+        "the OS trust store; revert to plain ssl.create_default_context() so "
+        "load_default_certs() can read the system store."
+    )
 
 
 def test_build_ssl_context_honours_amx_ca_bundle(
@@ -386,6 +409,72 @@ def test_refresh_records_errors_without_raising(monkeypatch: pytest.MonkeyPatch)
     out = refresh_prices(force=True)
     assert any("litellm" in e for e in out["errors"])
     assert out["openrouter"] == 1
+
+
+def test_refresh_emits_actionable_hint_on_tls_verify_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Behind a corporate TLS proxy ``urlopen`` raises a ``URLError``
+    whose ``reason`` is an ``ssl.SSLCertVerificationError``. The
+    Studio toast was rendering the raw ``URLError: <urlopen error
+    [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
+    self-signed certificate in certificate chain (_ssl.c:1032)>``
+    blob, which reads like a crash. The helper must specialise on
+    that case and emit one short hint per source that names the
+    ``AMX_CA_BUNDLE`` escape hatch.
+
+    Locking this in keeps the message from regressing to the raw
+    URLError repr through an innocent-looking refactor in the
+    exception handler.
+    """
+    import urllib.error
+
+    verify_failure = ssl.SSLCertVerificationError(
+        1, "[SSL: CERTIFICATE_VERIFY_FAILED] self-signed certificate in certificate chain"
+    )
+
+    def boom() -> dict[str, ModelPrice]:
+        raise urllib.error.URLError(verify_failure)
+
+    monkeypatch.setattr(pricing_mod, "fetch_litellm_prices", boom)
+    monkeypatch.setattr(pricing_mod, "fetch_openrouter_prices", boom)
+
+    out = refresh_prices(force=True)
+
+    assert len(out["errors"]) == 2
+    for msg in out["errors"]:
+        assert "TLS verification failed" in msg
+        assert "AMX_CA_BUNDLE" in msg
+        # Crucially the raw "URLError: <urlopen error ...>" repr must
+        # NOT leak into the user-facing toast — that was the bug.
+        assert "urlopen error" not in msg
+        assert "CERTIFICATE_VERIFY_FAILED" not in msg
+    # Source labels still routed correctly.
+    sources = {msg.split(":", 1)[0] for msg in out["errors"]}
+    assert sources == {"litellm", "openrouter"}
+
+
+def test_refresh_keeps_raw_format_for_non_ssl_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Genuine outages, JSON parse errors, and OS errors still get
+    the existing ``ClassName: message`` format so real problems
+    surface plainly rather than being masked by the friendly SSL
+    hint.
+    """
+    import urllib.error
+
+    def boom() -> dict[str, ModelPrice]:
+        raise urllib.error.URLError("Network is unreachable")
+
+    monkeypatch.setattr(pricing_mod, "fetch_litellm_prices", boom)
+    monkeypatch.setattr(pricing_mod, "fetch_openrouter_prices", boom)
+
+    out = refresh_prices(force=True)
+    for msg in out["errors"]:
+        assert "URLError" in msg
+        assert "Network is unreachable" in msg
+        assert "TLS verification" not in msg
 
 
 def test_cache_age_reports_none_before_first_fetch() -> None:


### PR DESCRIPTION
## Summary

- ``_build_ssl_context`` (``amx/llm/pricing.py``) no longer forces ``ssl.create_default_context(cafile=certifi.where())`` when neither ``AMX_CA_BUNDLE`` nor ``SSL_CERT_FILE`` is set. The certifi forcing replaced the platform default chain and prevented ``load_default_certs()`` from reading the OS trust store — exactly the failure mode users reported behind a corporate TLS-inspecting proxy (Zscaler / Netskope / Cloudflare WARP) where the OS already trusts the corporate CA.
- New ``amx.utils.network_trust.configure_trust_store`` helper injects the PyPA-endorsed ``truststore`` package (added as a core dependency) so the OS trust store is consulted through first-class OS APIs on Windows / macOS / Linux. Called at the top of ``run_cli`` and ``create_app`` (idempotent); the same helper fans ``AMX_CA_BUNDLE`` out to ``REQUESTS_CA_BUNDLE`` / ``SSL_CERT_FILE`` / ``CURL_CA_BUNDLE``. The CA-bundle fan-out moved out of ``provider._configure_ssl_environment``, which is now just the litellm-specific ``AMX_INSECURE_SSL`` knob.
- ``refresh_prices`` (``amx/llm/pricing.py``) now detects ``ssl.SSLCertVerificationError`` specifically and emits one short actionable hint per source instead of rendering the raw ``URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] ...>`` blob in the Studio toast. Non-TLS failures keep the existing ``ClassName: message`` format.

## Test plan

- [x] ``pytest -q`` — 1334 pass (1332 before + 2 new tests).
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [x] Sanity smoke: ``python -c \"from amx.utils.network_trust import configure_trust_store; configure_trust_store(); import ssl; print(type(ssl.create_default_context()).__module__)\"`` prints ``truststore._api``.
- [x] End-to-end fetch smoke: ``fetch_litellm_prices()`` returned 2253 models from the live LiteLLM JSON on a clean run.
- [ ] Reproduce the user's failure on the corporate proxy (Windows + PowerShell): toast should go away on this branch, Prices listing should show hundreds of models with source = ``litellm`` / ``openrouter`` instead of all ``Fallback``.
- [ ] Same proxied environment: ``set AMX_CA_BUNDLE=...`` override still routes the fetcher at the explicit on-disk PEM. ``set AMX_INSECURE_SSL=1`` still bypasses verification.
- [ ] mitmproxy with an untrusted root CA confirms the new toast shape ("TLS verification failed against <host> — usually a corporate proxy. AMX consults the OS trust store automatically; set AMX_CA_BUNDLE=/path/to/ca.pem if your company CA is still missing") rather than the raw URLError.