### PR TITLE
fix(pricing): legible toast when OpenRouter is blocked at the network layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **``Refresh prices`` toast read like AMX was broken when the
+  corporate proxy blanket-blocked OpenRouter.** Studio surfaced
+  ``openrouter: HTTPError: HTTP Error 403: Forbidden`` — the raw
+  ``HTTPError`` repr from stdlib — which looks like a crash to a
+  first-time user even though LiteLLM kept loading and AMX is fully
+  usable on the LiteLLM catalog alone. ``_format_fetch_error`` in
+  ``amx/llm/pricing.py`` now detects ``urllib.error.HTTPError`` with
+  a 4xx status and emits a one-line hint that names the host, the
+  status code, and reassures the user that the cached / fallback
+  catalog still loaded ("``<host>`` returned HTTP 403 — likely
+  blocked by a network policy …; AMX kept the cached / fallback
+  catalog for this source; ask your network admin to allow ``<host>``
+  if you need its model list"). The non-4xx and non-SSL paths keep
+  the existing ``ClassName: message`` format so genuine outages
+  still surface plainly.
+
 - **Pricing refresh failed with ``CERTIFICATE_VERIFY_FAILED`` on a
   fresh install behind a corporate TLS-inspecting proxy** (Zscaler /
   Netskope / Cloudflare WARP / similar). Studio rendered the toast

--- a/amx/llm/pricing.py
+++ b/amx/llm/pricing.py
@@ -218,25 +218,46 @@ def _is_cert_verify_error(exc: BaseException) -> bool:
 def _format_fetch_error(source: str, url: str, exc: BaseException) -> str:
     """Render a fetch failure for the Studio toast / CLI log.
 
-    Specialises the message for TLS verification failures so the user
-    sees one short hint that names the env-var override, instead of a
-    multi-line ``URLError: <urlopen error [SSL:
-    CERTIFICATE_VERIFY_FAILED] ... self-signed certificate in
-    certificate chain ...>`` blob that reads like a crash. Every other
-    failure (genuine outage, JSON parse error, file system error)
-    keeps the existing class-name + message format so real problems
-    still surface plainly.
+    Specialises the message for the two failure modes that confuse
+    first-time users the most:
+
+    1. **TLS verification failure** (``ssl.SSLCertVerificationError``
+       — typical behind a corporate TLS-inspecting proxy). The raw
+       ``URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]
+       ... self-signed certificate in certificate chain ...>`` blob
+       reads like a crash; the hint names the
+       ``AMX_CA_BUNDLE`` override.
+    2. **HTTP 4xx Forbidden / blocked** (``urllib.error.HTTPError``
+       with a 4xx status). On corporate networks ``openrouter.ai``
+       is commonly classed as an LLM endpoint and blanket-blocked by
+       the proxy, surfacing as ``HTTP Error 403: Forbidden``. The
+       hint reassures the user that LiteLLM kept loading and the
+       block is on their network, not AMX.
+
+    Every other failure (genuine outage, JSON parse error, file
+    system error) keeps the existing class-name + message format so
+    real problems still surface plainly.
     """
+    try:
+        host = urllib.parse.urlparse(url).hostname or url
+    except ValueError:
+        host = url
+
     if _is_cert_verify_error(exc):
-        try:
-            host = urllib.parse.urlparse(url).hostname or url
-        except ValueError:
-            host = url
         return (
             f"{source}: TLS verification failed against {host} — usually a corporate proxy. "
             f"AMX consults the OS trust store automatically; if your company CA is still "
             f"missing, set AMX_CA_BUNDLE=/path/to/ca.pem and retry."
         )
+
+    if isinstance(exc, urllib.error.HTTPError) and 400 <= exc.code < 500:
+        return (
+            f"{source}: {host} returned HTTP {exc.code} — likely blocked by a network policy "
+            f"(corporate proxy, firewall, or rate limit). AMX kept the cached / fallback "
+            f"catalog for this source; ask your network admin to allow {host} if you need "
+            f"its model list."
+        )
+
     return f"{source}: {exc.__class__.__name__}: {exc}"
 
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -477,6 +477,43 @@ def test_refresh_keeps_raw_format_for_non_ssl_failures(
         assert "TLS verification" not in msg
 
 
+def test_refresh_emits_actionable_hint_on_http_4xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Corporate networks frequently blanket-block LLM endpoints at
+    the proxy layer, so ``fetch_openrouter_prices`` surfaces as
+    ``urllib.error.HTTPError: HTTP Error 403: Forbidden``. The
+    earlier toast rendered that string verbatim, which reads like
+    AMX is broken; the helper must produce a short hint that names
+    the host, the status code, and reassures the user that the
+    cached / fallback catalog still loaded.
+    """
+    import io
+    import urllib.error
+
+    def boom() -> dict[str, ModelPrice]:
+        raise urllib.error.HTTPError(
+            url=pricing_mod._OPENROUTER_URL,
+            code=403,
+            msg="Forbidden",
+            hdrs={},  # type: ignore[arg-type]
+            fp=io.BytesIO(b""),
+        )
+
+    monkeypatch.setattr(pricing_mod, "fetch_litellm_prices", boom)
+    monkeypatch.setattr(pricing_mod, "fetch_openrouter_prices", boom)
+
+    out = refresh_prices(force=True)
+
+    assert len(out["errors"]) == 2
+    for msg in out["errors"]:
+        assert "HTTP 403" in msg
+        assert "blocked by a network policy" in msg
+        # The raw "HTTPError: HTTP Error 403: Forbidden" string —
+        # which is what users saw before this fix — must NOT leak.
+        assert "HTTPError:" not in msg
+
+
 def test_cache_age_reports_none_before_first_fetch() -> None:
     assert cache_age_seconds() is None
     assert cache_info()["is_stale"] is True


### PR DESCRIPTION
## Summary

- Behind a corporate proxy that blanket-blocks LLM endpoints, ``fetch_openrouter_prices`` surfaces as ``urllib.error.HTTPError: HTTP Error 403: Forbidden`` and Studio's refresh toast rendered that raw repr, which reads like AMX crashed even though LiteLLM (2253 models) kept loading and AMX is fully usable on it alone.
- ``_format_fetch_error`` (``amx/llm/pricing.py``) now detects ``urllib.error.HTTPError`` with a 4xx status and emits a one-line hint per source: "``<host>`` returned HTTP <code> — likely blocked by a network policy (corporate proxy, firewall, or rate limit). AMX kept the cached / fallback catalog for this source; ask your network admin to allow ``<host>`` if you need its model list".
- Non-4xx and non-SSL paths keep the existing ``ClassName: message`` format so genuine outages and parse errors still surface plainly.

## Context

PR #298 already fixed the SSL-side problem and pricing fetch starts working on corporate networks where the OS trust store contains the proxy CA. A user on a Windows + PowerShell + Astronomer corp network then hit the remaining surface: ``curl.exe https://openrouter.ai/api/v1/models`` returns 403 system-wide, so the proxy is blocking the OpenRouter API endpoint deliberately. AMX cannot make that endpoint reachable from the user's network; this PR is purely a UX fix so the toast no longer reads like an AMX bug.

## Test plan

- [x] ``pytest -q`` — 1335 pass (1334 before + 1 new test).
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [x] New ``test_refresh_emits_actionable_hint_on_http_4xx`` synthesizes ``HTTPError(403, "Forbidden")`` and asserts the toast contains "HTTP 403" + "blocked by a network policy" while the raw "HTTPError:" prefix never leaks.
- [ ] User reproduces from the same corporate network: ``Refresh prices`` in Studio shows the new short hint instead of "openrouter: HTTPError: HTTP Error 403: Forbidden". LiteLLM source label still populates the listing with hundreds of models.