### PR TITLE
fix(pricing): match catalog keys by bare-model suffix when provider field is wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **Sidebar Live LLM price disappeared, ``/cost`` reported $0, and
+  per-run cost columns showed ``unknown`` for models whose profile
+  ``provider`` field did not match the LiteLLM catalog's vendor
+  prefix.** A user with a Databricks-served Llama configured the
+  profile model as ``databricks-meta-llama-3-3-70b-instruct``
+  (Databricks's own format, no slash) while LiteLLM keys the same
+  model as ``databricks/databricks-meta-llama-3-3-70b-instruct``.
+  When the profile's ``provider`` field correctly read ``databricks``,
+  ``_normalize_model_id`` already prefixed the catalog key and the
+  lookup hit. But the same physical endpoint can be configured under
+  ``provider=openai_compatible`` (or ``vllm``, ``databricks_genai``,
+  …) when accessed through an OpenAI-compatible adapter, and in that
+  case the prefix step generated a vendor that the catalog does not
+  use — so the lookup missed and the sidebar's
+  ``LlmProfilePriceLine`` rendered ``null`` (``source === "unknown"``
+  branch), giving the impression that "Refresh prices" had not
+  worked. ``lookup_price`` in ``amx/llm/pricing.py`` now adds a
+  bare-model suffix fallback: after the strict ``_normalize_model_id``
+  candidates are exhausted, it scans each source's keys for a key
+  that ends with ``"/" + model`` (or equals ``model`` outright) and
+  returns the first hit. ``user_override`` and the strict-match path
+  still win when they apply, so existing behaviour for correctly-
+  prefixed providers is unchanged.
+
 - **``Refresh prices`` toast read like AMX was broken when the
   corporate proxy blanket-blocked OpenRouter.** Studio surfaced
   ``openrouter: HTTPError: HTTP Error 403: Forbidden`` — the raw

--- a/amx/llm/pricing.py
+++ b/amx/llm/pricing.py
@@ -603,6 +603,28 @@ def lookup_price(
     import). Pass ``profile_name`` to target a specific LLM profile —
     the wizard / Settings hint reads this when the user has not
     activated the profile yet.
+
+    Resolution chain:
+
+    1. ``_user_override`` — the profile's own ``custom_*_cost_per_mtok``
+       fields. Wins over every catalog hit.
+    2. Exact-match candidates from :func:`_normalize_model_id` walked
+       across the three catalog sources in priority order
+       (``litellm`` → ``openrouter`` → ``fallback``). Covers the common
+       case where the profile's ``provider`` field correctly tells us
+       which prefix the catalog uses.
+    3. Bare-model suffix fallback: when the profile's ``provider``
+       field is wrong, missing, or set to a generic adapter name (the
+       same Databricks endpoint may be configured as ``openai_compatible``
+       on one machine and ``databricks`` on another), the normalize
+       step prefixes the wrong vendor and the candidate list misses
+       even though the catalog DOES have a ``<vendor>/<model>`` key
+       that matches the bare model id verbatim. The fallback scans
+       each source for a key that ends in ``"/" + model`` (or is the
+       bare model itself) and returns the first hit. This keeps the
+       sidebar's Live LLM price line, ``/cost``, and per-run cost
+       columns working for users whose profile providers we cannot
+       interrogate at lookup time.
     """
     _ensure_loaded()
     override = _user_override(cfg, profile_name)
@@ -615,6 +637,16 @@ def lookup_price(
             hit = table.get(cand)
             if hit is not None:
                 return hit
+
+    bare = (model or "").strip().lower()
+    if bare:
+        suffix = "/" + bare
+        for source_key in ("litellm", "openrouter", "fallback"):
+            table = _PRICES.get(source_key) or {}
+            for key_id, price in table.items():
+                if key_id == bare or key_id.endswith(suffix):
+                    return price
+
     key = f"{(provider or '').lower()}|{(model or '').lower()}"
     if key not in _UNKNOWN_PRICE_WARNED:
         _UNKNOWN_PRICE_WARNED.add(key)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -276,6 +276,63 @@ def test_unknown_model_returns_zero_with_unknown_source() -> None:
     assert price.output_per_mtok == 0.0
 
 
+def test_lookup_matches_bare_model_id_when_provider_field_is_wrong(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same physical endpoint (e.g. a Databricks model-serving
+    endpoint exposed via an OpenAI-compatible adapter) can be
+    configured with very different ``provider`` strings on different
+    machines: ``databricks`` on one, ``openai_compatible`` on another,
+    ``vllm`` on a third. LiteLLM's catalog keys are always shaped
+    ``<vendor>/<model>`` (e.g. ``databricks/databricks-meta-llama-3-3-70b-instruct``),
+    so the strict candidate list from ``_normalize_model_id`` only
+    hits when the profile's ``provider`` field happens to match the
+    catalog's vendor prefix.
+
+    Without this fallback, a user who configured the same model under
+    ``provider=openai_compatible`` would see the sidebar's Live LLM
+    price line disappear and ``/cost`` report $0 even though LiteLLM
+    has a perfectly good entry for that exact model id. The fallback
+    matches the bare model id against the ``<anything>/<model>``
+    suffix of every catalog key as a last resort.
+    """
+    monkeypatch.setitem(
+        pricing_mod._PRICES,
+        "litellm",
+        {
+            "databricks/databricks-meta-llama-3-3-70b-instruct": ModelPrice(
+                input_per_mtok=0.5,
+                output_per_mtok=1.5,
+                source="litellm",
+                fetched_at=time.time(),
+            ),
+        },
+    )
+
+    # provider field tells us the wrong prefix — normalize will try
+    # ``openai_compatible/databricks-meta-...`` which is not in the
+    # catalog, but the bare-id fallback still recovers.
+    price = lookup_price(
+        None,
+        provider="openai_compatible",
+        model="databricks-meta-llama-3-3-70b-instruct",
+    )
+    assert price.source == "litellm"
+    assert price.input_per_mtok == 0.5
+    assert price.output_per_mtok == 1.5
+
+    # And of course the strict-match path keeps working when the
+    # provider field is correct — the fallback never gets a chance
+    # to substitute a wrong key.
+    correct = lookup_price(
+        None,
+        provider="databricks",
+        model="databricks-meta-llama-3-3-70b-instruct",
+    )
+    assert correct.source == "litellm"
+    assert correct.input_per_mtok == 0.5
+
+
 # ── list_all_models — flat catalog for Studio + CLI browsers ───────────────
 
 


### PR DESCRIPTION
## Summary

- A user configured a Databricks Llama profile with model ``databricks-meta-llama-3-3-70b-instruct`` (Databricks's own format, no slash). LiteLLM keys the same model as ``databricks/databricks-meta-llama-3-3-70b-instruct``.
- When the profile's ``provider`` field reads ``databricks`` the existing ``_normalize_model_id`` correctly prefixes the candidate and the lookup hits. But the same physical endpoint can be configured under ``provider=openai_compatible`` / ``vllm`` / ``databricks_genai`` when accessed via an OpenAI-compatible adapter, and in that case the normalize step synthesises a vendor prefix the catalog does not use. The strict candidate list misses, ``lookup_price`` returns ``source="unknown"``, the sidebar's ``LlmProfilePriceLine`` renders ``null`` (the ``data.source === "unknown"`` branch), and the user concludes that "Refresh prices" did not actually work.
- ``lookup_price`` (``amx/llm/pricing.py``) now adds a bare-model suffix fallback: after the strict ``_normalize_model_id`` candidates are exhausted, scan each source's keys for one that ends with ``"/" + model`` (or equals ``model`` outright) and return the first hit. Order stays ``user_override → strict candidates → bare suffix → unknown``, so user overrides still win and exact-vendor matches are still preferred over heuristic fallback.

## Test plan

- [x] ``pytest -q`` — 1336 pass (1335 before + 1 new test).
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [x] New ``test_lookup_matches_bare_model_id_when_provider_field_is_wrong`` seeds the catalog with the Databricks-prefixed key and asserts (a) ``lookup_price(provider="openai_compatible", model="databricks-meta-llama-3-3-70b-instruct")`` now returns the LiteLLM rate via the suffix fallback, and (b) ``lookup_price(provider="databricks", ...)`` still hits via the strict path (the fallback never gets a chance to substitute).
- [ ] User reproduces from the same Databricks profile on the corporate network: the sidebar's "Live LLM price" line now renders the LiteLLM rate, ``/cost`` reports non-zero, and per-run cost columns populate.