### PR TITLE
fix(doctor): empty config is FAIL, not OK, and survives --skip-network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **``amx doctor`` / Studio doctor view rendered all-green on a
+  brand-new install even though no DB or LLM profile had been
+  configured yet.** ``_check_active_db_profile`` and
+  ``_check_active_llm_profile`` in ``amx/cli_support/commands/doctor.py``
+  treated "no profile saved" as ``ok=True`` with the polite detail
+  "(none configured)", and ``collect_doctor_checks`` then dropped
+  both rows entirely whenever ``--skip-network`` was on. Studio
+  always passes ``skip_network=False`` by default, so under the
+  remaining ``ok=True`` branch the SPA painted every check green
+  and the user concluded "all systems go" before they had plugged
+  in anything.
+
+  Both rows now FAIL on a fresh install with one of three actionable
+  detail strings depending on which setup gap is in play — "no DB
+  profile saved yet" (no profile at all), "saved profile(s) [...]
+  but none activated" (profile exists but is not the active one),
+  or "(incomplete — missing api_key / model / base_url)" (profile
+  is active but missing required fields). The matching ``hint``
+  field tells the user exactly which Settings page or CLI command
+  to run. ``--skip-network`` now only suppresses the live
+  ``test_connection`` / ``test_result`` probes — the setup-state
+  rows always run because they are config questions, not network
+  ones. ``run_doctor`` returns a non-zero exit code in any of these
+  states so Studio renders the red badge and the CLI surfaces the
+  failure count.
+
 - **Sidebar Live LLM price disappeared, ``/cost`` reported $0, and
   per-run cost columns showed ``unknown`` for models whose profile
   ``provider`` field did not match the LiteLLM catalog's vendor

--- a/amx/cli_support/commands/doctor.py
+++ b/amx/cli_support/commands/doctor.py
@@ -249,14 +249,31 @@ def _check_optional_deps(active_backend: str | None = None) -> list[CheckResult]
     return results
 
 
-def _check_active_db_profile(cfg: AMXConfig) -> CheckResult:
-    """Test the active DB connection if one is configured."""
-    if not cfg.active_db_profile or not cfg.db_profiles:
+def _check_active_db_profile(cfg: AMXConfig, *, skip_network: bool = False) -> CheckResult:
+    """Test the active DB connection if one is configured.
+
+    Three setup-state failures (no profile saved, profile saved but
+    not activated, profile activated but incomplete) are surfaced
+    even with ``skip_network=True`` because they are purely config
+    questions — the earlier "skip the whole row when skip_network is
+    on" path is what produced an all-green doctor view on a brand
+    new install. Only the live ``test_connection`` probe is gated
+    behind ``skip_network`` since it is the part that actually hits
+    the wire.
+    """
+    if not cfg.db_profiles:
         return CheckResult(
             name="Active DB profile",
-            ok=True,
-            detail="(none configured)",
-            hint="Run /add-db-profile inside `amx` to add one.",
+            ok=False,
+            detail="(no DB profile saved yet)",
+            hint="Add a DB profile in Settings or run /add-db-profile in the CLI.",
+        )
+    if not cfg.active_db_profile:
+        return CheckResult(
+            name="Active DB profile",
+            ok=False,
+            detail=f"saved profile(s) {sorted(cfg.db_profiles)} but none activated",
+            hint="Pick one as the active profile in Settings or with /set-db-profile.",
         )
     if not cfg.db.is_connection_configured():
         return CheckResult(
@@ -264,6 +281,13 @@ def _check_active_db_profile(cfg: AMXConfig) -> CheckResult:
             ok=False,
             detail=f"profile '{cfg.active_db_profile}' (incomplete)",
             hint="Run /add-db-profile to fill in connection details.",
+        )
+    if skip_network:
+        label = f"{cfg.db.backend} · {cfg.db.display_summary}"
+        return CheckResult(
+            name="Active DB profile",
+            ok=True,
+            detail=f"profile '{cfg.active_db_profile}' → {label} (connection probe skipped)",
         )
     # Lazy import — DatabaseConnector pulls in heavy backend deps.
     from amx.db.connector import DatabaseConnector
@@ -287,14 +311,41 @@ def _check_active_db_profile(cfg: AMXConfig) -> CheckResult:
     )
 
 
-def _check_active_llm_profile(cfg: AMXConfig) -> CheckResult:
-    """Probe the active LLM endpoint if one is configured."""
-    if not cfg.active_llm_profile or not cfg.llm_profiles or not cfg.llm.is_configured():
+def _check_active_llm_profile(cfg: AMXConfig, *, skip_network: bool = False) -> CheckResult:
+    """Probe the active LLM endpoint if one is configured.
+
+    Setup-state checks (no profile saved, profile saved but not
+    activated, profile activated but missing required fields) run
+    even with ``skip_network=True`` — they are config questions, not
+    network ones. Only the live ``test_result`` probe is gated.
+    """
+    if not cfg.llm_profiles:
+        return CheckResult(
+            name="Active LLM profile",
+            ok=False,
+            detail="(no LLM profile saved yet)",
+            hint="Add an LLM profile in Settings or run /add-llm-profile in the CLI.",
+        )
+    if not cfg.active_llm_profile:
+        return CheckResult(
+            name="Active LLM profile",
+            ok=False,
+            detail=f"saved profile(s) {sorted(cfg.llm_profiles)} but none activated",
+            hint="Pick one as the active profile in Settings or with /set-llm-profile.",
+        )
+    if not cfg.llm.is_configured():
+        return CheckResult(
+            name="Active LLM profile",
+            ok=False,
+            detail=f"profile '{cfg.active_llm_profile}' (incomplete — missing api_key / model / base_url)",
+            hint="Open the profile in Settings and finish filling it in.",
+        )
+    if skip_network:
+        label = f"{cfg.llm.provider}/{cfg.llm.model}"
         return CheckResult(
             name="Active LLM profile",
             ok=True,
-            detail="(none configured)",
-            hint="Run /add-llm-profile inside `amx` to add one.",
+            detail=f"profile '{cfg.active_llm_profile}' → {label} (round-trip probe skipped)",
         )
     from amx.llm.provider import LLMProvider
 
@@ -378,9 +429,14 @@ def collect_doctor_checks(
     if cfg.active_db_profile and cfg.db_profiles:
         active_backend = getattr(cfg.db, "backend", None) or None
     results.extend(_check_optional_deps(active_backend))
-    if not skip_network:
-        results.append(_check_active_db_profile(cfg))
-        results.append(_check_active_llm_profile(cfg))
+    # DB and LLM profile rows always run — the setup-state branches
+    # (no profile / not activated / incomplete) are config questions,
+    # not network ones. The check helpers themselves honour
+    # ``skip_network`` for the actual on-the-wire probe so
+    # ``--skip-network`` keeps its meaning of "do not contact the DB
+    # or the LLM endpoint".
+    results.append(_check_active_db_profile(cfg, skip_network=skip_network))
+    results.append(_check_active_llm_profile(cfg, skip_network=skip_network))
     return results
 
 

--- a/tests/test_doctor_and_schema.py
+++ b/tests/test_doctor_and_schema.py
@@ -224,15 +224,48 @@ class DoctorRendererTests(unittest.TestCase):
 
 
 class DoctorEndToEndTests(unittest.TestCase):
-    def test_run_doctor_skip_network_completes_on_fresh_config(self) -> None:
+    def test_run_doctor_reports_empty_config_as_failure(self) -> None:
+        """A fresh install with zero DB / LLM profiles is NOT a healthy
+        state — it is "needs setup". Earlier doctor returned ``ok=True``
+        on those rows with detail "(none configured)", and Studio's
+        doctor view painted everything green on day one, telling the
+        user "all systems go" before they had plugged in any data
+        source. ``run_doctor`` must now return a non-zero exit code on
+        an empty config so the SPA renders the red badge and the user
+        knows they have setup to do.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             cfg = AMXConfig()
             cfg.CONFIG_DIR = tmp  # type: ignore[misc]
-            # No DB / LLM configured → those checks short-circuit. With
-            # --skip-network the run should always be 0 regardless of
-            # network reachability.
             exit_code = run_doctor(cfg, skip_network=True)
-            self.assertEqual(exit_code, 0)
+            self.assertGreater(
+                exit_code,
+                0,
+                "fresh config (no DB / LLM profile) must report failures",
+            )
+
+    def test_doctor_check_results_name_specific_setup_paths(self) -> None:
+        """The Studio doctor card lists individual check rows; each must
+        be actionable on its own. Fresh-config failures point the user at
+        a specific next step rather than dumping a generic
+        "configuration incomplete" line.
+        """
+        from amx.cli_support.commands.doctor import collect_doctor_checks
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = AMXConfig()
+            cfg.CONFIG_DIR = tmp  # type: ignore[misc]
+            results = collect_doctor_checks(cfg, skip_network=True)
+
+        by_name = {r.name: r for r in results}
+        db_row = by_name["Active DB profile"]
+        llm_row = by_name["Active LLM profile"]
+        self.assertFalse(db_row.ok, "empty config must FAIL the DB-profile row")
+        self.assertFalse(llm_row.ok, "empty config must FAIL the LLM-profile row")
+        self.assertIn("no DB profile", db_row.detail)
+        self.assertIn("no LLM profile", llm_row.detail)
+        self.assertTrue(db_row.hint, "DB row must surface an actionable hint")
+        self.assertTrue(llm_row.hint, "LLM row must surface an actionable hint")
 
     def test_doctor_command_renders_report(self) -> None:
         runner = CliRunner()
@@ -245,7 +278,10 @@ class DoctorEndToEndTests(unittest.TestCase):
                 ["--config", str(path), "doctor", "--skip-network"],
                 catch_exceptions=False,
             )
-            self.assertEqual(result.exit_code, 0, msg=result.output)
+            # Fresh config -> non-zero exit (empty-config rows fail) but
+            # the report itself must still render so the user sees which
+            # rows need their attention.
+            self.assertGreater(result.exit_code, 0, msg=result.output)
             self.assertIn("AMX doctor report", result.output)
             self.assertIn("AMX version", result.output)
             self.assertIn("Python runtime", result.output)


### PR DESCRIPTION
## Summary

- The Studio doctor view rendered all-green on a fresh install with no DB or LLM profile configured. Root cause was two coordinated bugs in ``amx/cli_support/commands/doctor.py``: (1) ``_check_active_db_profile`` / ``_check_active_llm_profile`` returned ``ok=True`` with detail "(none configured)" whenever the active profile was missing, and (2) ``collect_doctor_checks`` dropped both rows entirely behind ``if not skip_network``.
- Both check helpers now FAIL on three setup-state branches — no profile saved, profile saved but not activated, profile activated but incomplete — with detail strings and hints that point at the specific next step.
- ``--skip-network`` now only suppresses the live ``test_connection`` / ``test_result`` probes. The setup-state rows always run because they are pure config questions. When the active profile is fully configured and ``--skip-network`` is on, the row stays ``ok=True`` with detail "… (probe skipped)".

## Test plan

- [x] ``pytest -q`` — 1337 pass (1336 before + 1 new specific check, plus two pre-existing tests re-targeted from asserting the buggy behaviour).
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [x] New ``test_doctor_check_results_name_specific_setup_paths`` builds a fresh ``AMXConfig``, runs ``collect_doctor_checks(skip_network=True)``, and asserts both DB and LLM rows are present with ``ok=False``, the expected "(no DB/LLM profile)" detail, and a non-empty hint.
- [x] ``test_run_doctor_reports_empty_config_as_failure`` asserts a non-zero exit code from ``run_doctor(skip_network=True)`` on the same fresh config.
- [ ] User reproduces in Studio: open the doctor view on a brand-new install — both "Active DB profile" and "Active LLM profile" rows now render red with the actionable hint, status banner is red, and ``failed`` count is at least 2.