### PR TITLE
fix(cli): skip eager embeddings-module import for default-MiniLM users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **Opening the ``amx`` REPL on a fresh install still triggered a
+  second wave of pip subprocesses (chromadb + langchain-text-splitters
+  + tiktoken) even though PR #296 was supposed to make the bring-up
+  single-stage.** Root cause: ``amx/cli.py`` called
+  ``_install_embedding_provider(cfg)`` during the Click ``main``
+  callback so every ``amx`` invocation — including a bare ``amx``
+  that just opens the interactive session — imported
+  ``amx.search.embeddings``. That module runs a module-level
+  ``_ensure("rag")`` (the RAG bundle: chromadb, langchain-text-splitters,
+  tiktoken) before its class bodies can execute, because the three
+  ``EmbeddingFunction`` subclasses defined further down need
+  ``chromadb.api.types`` resolved at class-definition time.
+  Default-MiniLM users (the overwhelming majority on day one) thus
+  paid a multi-minute chromadb install at the very moment they
+  finally got to a working ``amx`` prompt, having just sat through
+  the first wave from ``pip install amx-cli``.
+
+  ``_install_embedding_provider`` now short-circuits without
+  importing ``amx.search.embeddings`` when the active
+  ``cfg.embedding.kind`` is the default MiniLM (or one of its
+  common spellings: ``""``, ``"default"``, ``"minilm-l6-v2"``,
+  case-insensitive). The default-MiniLM provider is exactly the
+  factory Chroma's ``SearchIndex`` falls back to when no
+  process-wide factory is installed, so taking the shortcut produces
+  the same runtime behaviour as the old eager path — just without
+  pulling 150 MB of wheels for a REPL that may never reach a RAG
+  feature. Custom-embedding users still hit the configure path
+  (and the chromadb install along with it) because they are by
+  definition heading for a RAG flow that would have required
+  chromadb regardless. Three new tests pin the boundary: the
+  default-kind shortcut, the alias variants of the default kind,
+  and the must-still-import path for custom kinds.
+
 - **Databricks profiles added through AMX Studio failed at first
   connect on corporate TLS-inspecting networks because the Studio
   form did not expose the two TLS fields the CLI wizard already

--- a/amx/cli.py
+++ b/amx/cli.py
@@ -148,7 +148,28 @@ def _install_embedding_provider(cfg: AMXConfig) -> None:
     that wires the themed ``warn()`` console helper into the
     ``on_warning`` hook so misconfigured providers surface as a themed
     one-line warning rather than a stack trace.
+
+    Default-kind shortcut: when the user has not customised
+    ``cfg.embedding`` (or has explicitly picked the MiniLM default),
+    skip importing ``amx.search.embeddings`` entirely. That module
+    runs a module-level ``_ensure("rag")`` which on a fresh install
+    triggers a chromadb pip download — and the default-MiniLM path
+    does not need a custom factory anyway (``SearchIndex.__init__``
+    falls back to Chroma's bundled MiniLM when no factory is
+    installed). So a user whose only intent on ``amx`` open is
+    ``/db``, ``/llm``, ``/metadata``, ``/ask`` etc. never has to
+    pay a chromadb install at REPL bootstrap. Custom-embedding users
+    still pay it here, but they are by definition heading for a
+    RAG flow that would have triggered the install on first use
+    regardless.
     """
+    embedding = getattr(cfg, "embedding", None)
+    if embedding is None:
+        return
+    kind = (getattr(embedding, "kind", "") or "").lower().strip()
+    if kind in {"", "minilm", "default", "minilm-l6-v2"}:
+        return
+
     from amx.search.embeddings import configure_from_amx_config
 
     configure_from_amx_config(cfg, on_warning=warn)

--- a/tests/test_cli_lazy_embedding.py
+++ b/tests/test_cli_lazy_embedding.py
@@ -1,0 +1,107 @@
+"""Regression: ``amx`` REPL open must not pip-install chromadb.
+
+The pricing fetcher (PR #298) and the install-flow refactor (PR #296)
+both relied on the principle that a fresh ``pip install amx-cli``
+followed by a bare ``amx`` should complete without a second wave of
+pip subprocesses. ``amx/cli.py`` then re-broke that contract by
+calling ``_install_embedding_provider(cfg)`` during the
+:func:`amx.cli.main` callback, which imports
+``amx.search.embeddings`` — a module that runs a module-level
+``_ensure("rag")`` (chromadb + langchain-text-splitters + tiktoken)
+before its class bodies can execute. Default-MiniLM users (the
+overwhelming majority on day one) therefore paid a multi-minute
+chromadb install at the moment they ran ``amx`` for the first time,
+even when they only intended to touch ``/db``, ``/llm``, ``/ask``.
+
+The fix is to short-circuit ``_install_embedding_provider`` for the
+default-kind case: no custom factory is needed (Chroma's bundled
+MiniLM is the same provider AMX would have configured anyway), so
+the embeddings module can stay un-imported until the user actually
+reaches a RAG entry point.
+
+These tests pin that boundary against an innocent-looking edit
+re-introducing an eager import.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from amx.cli import _install_embedding_provider
+from amx.config import AMXConfig
+
+
+def _drop_embeddings_module() -> None:
+    """Force a fresh import check by evicting the cached module."""
+    sys.modules.pop("amx.search.embeddings", None)
+
+
+def test_default_embedding_kind_does_not_import_search_embeddings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A default-kind ``AMXConfig`` (``embedding.kind == "minilm"``) must
+    take the no-op shortcut. Importing ``amx.search.embeddings`` here
+    would re-trigger the chromadb-pulling ``_ensure("rag")`` on every
+    fresh-install REPL open, even though Chroma's bundled MiniLM is
+    the exact provider AMX would have configured.
+    """
+    _drop_embeddings_module()
+    cfg = AMXConfig()  # default kind = "minilm"
+    assert cfg.embedding.kind == "minilm"
+
+    _install_embedding_provider(cfg)
+
+    assert "amx.search.embeddings" not in sys.modules, (
+        "regression: default-kind embedding triggered an eager import of "
+        "amx.search.embeddings, which would chain into chromadb pip install "
+        "on a fresh ``amx`` open."
+    )
+
+
+@pytest.mark.parametrize("default_alias", ["", "default", "minilm-l6-v2", "MINILM"])
+def test_default_kind_aliases_all_take_the_shortcut(
+    default_alias: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shortcut accepts the common spellings users (and historical
+    configs) might leave in ``cfg.embedding.kind``: empty string,
+    ``default``, ``minilm-l6-v2``, and capitalisation variants. Without
+    this normalisation a tiny typo flips the user into the
+    eager-import path and tanks first-launch UX.
+    """
+    _drop_embeddings_module()
+    cfg = AMXConfig()
+    cfg.embedding.kind = default_alias
+
+    _install_embedding_provider(cfg)
+
+    assert "amx.search.embeddings" not in sys.modules, (
+        f"regression: kind={default_alias!r} did not take the shortcut"
+    )
+
+
+def test_custom_embedding_kind_still_imports_search_embeddings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Custom-embedding users opt in to a non-default factory and are
+    by definition heading for a RAG flow that would have required
+    chromadb anyway. The shortcut must not silently swallow their
+    custom config — the embeddings module is imported (so
+    ``configure_from_amx_config`` writes the user's preferred
+    factory) when the kind is anything other than the recognised
+    default aliases.
+    """
+    _drop_embeddings_module()
+    cfg = AMXConfig()
+    cfg.embedding.kind = "openai_compatible"
+
+    _install_embedding_provider(cfg)
+
+    assert "amx.search.embeddings" in sys.modules, (
+        "regression: custom-kind embedding config silently skipped the "
+        "configure_from_amx_config call; the user's factory would never "
+        "be installed and every RAG operation would silently fall back "
+        "to MiniLM."
+    )


### PR DESCRIPTION
## Summary

- Opening the ``amx`` REPL on a fresh install still triggered a second wave of pip subprocesses (chromadb + langchain-text-splitters + tiktoken) even though PR #296 was supposed to end the staged-install UX.
- Trace: ``amx/cli.py:307`` ``_install_embedding_provider(cfg)`` → ``amx/cli.py:152`` ``from amx.search.embeddings import configure_from_amx_config`` → ``amx/search/embeddings.py:40`` module-level ``_ensure("rag")``. The embeddings module runs that ensure before its class bodies because three ``EmbeddingFunction`` subclasses defined further down need ``chromadb.api.types`` at class-definition time.
- ``_install_embedding_provider`` now short-circuits without importing ``amx.search.embeddings`` when ``cfg.embedding.kind`` is the default MiniLM (or one of its common spellings: ``""``, ``"default"``, ``"minilm-l6-v2"``, case-insensitive). Default-MiniLM users get the same runtime behaviour they would have gotten through the eager path — Chroma's ``SearchIndex`` falls back to the bundled MiniLM whenever no factory is installed, which is exactly the provider AMX would have configured.
- Custom-embedding users still hit the configure path (and the chromadb install along with it) because they are by definition heading for a RAG flow that needs chromadb regardless.

## Test plan

- [x] ``pytest -q`` — 1343 pass (1337 before + 6 new).
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [x] Manual repro: ``ensure()`` spy over a bare ``amx`` REPL bootstrap now records ``0`` invocations on this branch vs. ``1`` (``"rag"``) on ``main``.
- [x] New ``tests/test_cli_lazy_embedding.py`` covers the default-kind shortcut, four aliases (``""`` / ``"default"`` / ``"minilm-l6-v2"`` / ``"MINILM"`` via parametrize), and asserts the custom-kind path still imports the embeddings module so the user's factory actually gets installed.
- [ ] User reproduces from a clean venv: ``pip install --upgrade --force-reinstall git+...@main`` followed by a bare ``amx`` opens the REPL without any chromadb / langchain pip output.