### PR TITLE
fix(db): correctness sweep across backend adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,54 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **Backend correctness sweep (PR 1 / 4 of the connector audit).**
+  Closes the highest-impact "the connector says it works but the
+  result is wrong" findings from the per-backend audit:
+
+  - **Oracle / Snowflake identifier folding** —
+    ``DatabaseAdapter.normalize_identifier`` is a new hook with a
+    pass-through default and an UPPER override on the two backends
+    that fold unquoted identifiers at storage time. The connector
+    folds user-supplied ``schema`` / ``table`` arguments at every
+    metadata entry point (``list_tables``, ``list_views``,
+    ``list_materialized_views``, ``list_column_profiles``,
+    ``get_table_comment``, ``get_column_comments``,
+    ``resolve_asset_kind``, ``profile_table``,
+    ``get_incoming_foreign_keys``). Before the fix, typing
+    ``scott.employees`` on an Oracle profile returned an empty
+    listing because the SQLAlchemy inspector queried
+    ``ALL_TABLES`` with the literal lowercase predicate while
+    Oracle had stored the names as ``SCOTT.EMPLOYEES``.
+    Explicitly-quoted identifiers (``"MixedCase"``) are passed
+    through unchanged so power users can still target
+    case-sensitive objects.
+
+  - **Snowflake 3-level fully qualified names.** When the profile
+    binds a database, ``SnowflakeAdapter.fully_qualified_name``
+    now emits ``"db"."schema"."table"``. Comment-write DDL and the
+    cross-database agent path used to silently fall back to the
+    connection's active database; the new form makes the target
+    explicit and matches the comment-test fixture's expectation
+    (``test_comment_sql_generation_per_backend``).
+
+  - **Databricks Unity Catalog field is required at wizard time.**
+    ``/add-db-profile`` for Databricks profiles now refuses to
+    save when the Unity Catalog field is left blank — the legacy
+    code path returned ``None`` from
+    ``DatabricksAdapter.list_schemas`` for empty catalog and fell
+    back to SQLAlchemy's UC-incompatible inspector, which
+    produced the user-reported "fresh profile, listing returns
+    nothing" failure. Legacy hive-metastore-only workspaces type
+    ``hive_metastore`` explicitly so the choice is visible in the
+    saved YAML rather than hidden behind a silent fallback.
+
+  - **PostgreSQL surface friendly hint on wrong password.**
+    ``PostgreSQLAdapter.actionable_profile_error`` now matches
+    ``password authentication failed`` /
+    ``fe_sendauth: no password supplied`` / SQLSTATE ``28P01`` and
+    points the user at ``/edit``, instead of letting libpq's raw
+    ``OperationalError`` traceback bubble through ``/db test``.
+
 - **Studio's collapsed-sidebar icons were inert** — when the user
   hid the left sidebar (via the topbar's ``PanelLeft`` chevron),
   the three icons that remained visible on the narrow rail

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -777,17 +777,25 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
                 tls_trusted_ca_file=tls_trusted_ca_file,
                 tls_no_verify=tls_no_verify,
             )
+            # Catalog is required because the adapter's catalog-less
+            # ``SHOW SCHEMAS`` path falls back to SQLAlchemy's inspector,
+            # which on Unity Catalog returns ambiguous (or empty) results
+            # — the bug surfaced as "fresh profile, listing returns
+            # nothing" on every UC workspace. Legacy hive_metastore-only
+            # workspaces should type ``hive_metastore`` here explicitly.
             catalog = _ask_catalog_or_database_with_picker(
                 label="Unity Catalog",
                 current_value=defaults.catalog or "",
-                optional=True,
+                optional=False,
                 probe_cfg=probe_cfg_for_catalog,
                 listing_kind="catalogs",
             )
         else:
             catalog = _ask_update_text(
-                "Unity Catalog (optional)",
+                "Unity Catalog (required; type 'hive_metastore' for legacy workspaces)",
                 defaults.catalog or "",
+                required=True,
+                allow_clear=False,
             )
         database = _ask_update_text("Schema / database (optional)", defaults.database or "")
         return replace(

--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -113,6 +113,22 @@ class DatabaseAdapter(ABC):
         """Quote a single identifier for use in raw SQL."""
         return f'"{name}"'
 
+    def normalize_identifier(self, value: str) -> str:
+        """Return *value* folded to the case the backend stores by default.
+
+        Most dialects preserve the user's casing (MySQL, MSSQL, PG when
+        the object was quoted at create time). Oracle and Snowflake fold
+        *unquoted* identifiers to UPPER and then store them that way, so a
+        user typing ``scott.employees`` into the wizard does not match
+        the stored ``SCOTT.EMPLOYEES`` rows on listing / get_columns
+        queries — the previous behavior returned empty results silently.
+
+        Adapters override to apply the backend's fold rule. Values that
+        are already explicitly quoted (``"MixedCase"``) are returned
+        unchanged so power users can still target case-sensitive objects.
+        """
+        return value
+
     def quote_literal(self, value: str) -> str:
         """Quote a SQL string literal for dialects that do not allow binds in metadata commands."""
         return "'" + str(value).replace("'", "''") + "'"

--- a/amx/db/adapters/oracle.py
+++ b/amx/db/adapters/oracle.py
@@ -175,6 +175,13 @@ class OracleAdapter(DatabaseAdapter):
     def system_schemas(self) -> frozenset[str]:
         return _ORACLE_SYSTEM_SCHEMAS
 
+    def normalize_identifier(self, value: str) -> str:
+        if not value:
+            return value
+        if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+            return value
+        return value.upper()
+
     def list_databases(self, engine: Engine) -> list[str]:
         # Oracle's "schema = user" model means there's no separate
         # database list; surface the user-visible schemas (owners with

--- a/amx/db/adapters/postgresql.py
+++ b/amx/db/adapters/postgresql.py
@@ -39,6 +39,22 @@ class PostgreSQLAdapter(DatabaseAdapter):
             )
         if "permission denied" in msg:
             return "Insufficient privileges for profiling. Grant SELECT on this object or use a higher-privileged role."
+        # libpq surfaces a wrong/missing password as ``FATAL: password
+        # authentication failed for user "<name>"`` (or
+        # ``28P01`` SQLSTATE). Without this branch the user sees the raw
+        # SQLAlchemy ``OperationalError`` traceback — the same UX gap
+        # the wizard's TLS-cert branch closes for Databricks.
+        if (
+            "password authentication failed" in msg
+            or "no password supplied" in msg
+            or "28p01" in msg
+        ):
+            return (
+                "PostgreSQL refused the credentials. Check the username and "
+                "password on this profile (open it with /edit). If the server "
+                "uses peer/ident auth, the user must match the OS account or "
+                "be remapped in pg_hba.conf."
+            )
         # Catch a missing-database error from the server. When the
         # ``database`` profile field is blank, AMX falls back to the
         # ``postgres`` system database (see ``DBConfig.url`` for

--- a/amx/db/adapters/snowflake.py
+++ b/amx/db/adapters/snowflake.py
@@ -66,6 +66,13 @@ class SnowflakeAdapter(DatabaseAdapter):
     def system_schemas(self) -> frozenset[str]:
         return frozenset({"INFORMATION_SCHEMA", "information_schema"})
 
+    def normalize_identifier(self, value: str) -> str:
+        if not value:
+            return value
+        if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+            return value
+        return value.upper()
+
     def list_databases(self, engine: Engine) -> list[str]:
         """Return user-visible Snowflake databases via ``SHOW DATABASES``.
 
@@ -130,6 +137,30 @@ class SnowflakeAdapter(DatabaseAdapter):
 
     def quote_identifier(self, name: str) -> str:
         return f'"{name}"'
+
+    def fully_qualified_name(self, schema: str, table: str) -> str:
+        """Emit a 3-level ``"db"."schema"."table"`` name when the profile
+        pins a database.
+
+        Snowflake binds the active database at connection time, so
+        ``"schema"."table"`` is valid for sample / profiling queries that
+        run against the current database. Comment-write DDL
+        (``COMMENT ON TABLE``) is also fine without the database when
+        the writer is connected with the right DB. The 3-level form is
+        required only when a query references an object in a *different*
+        database than the active one — but emitting it whenever the
+        profile names a database is a no-op for the active-DB case and
+        avoids "object does not exist" errors when the user runs
+        cross-database lookups via the agent.
+        """
+        db = getattr(self.cfg, "database", "") or ""
+        if db:
+            return (
+                f"{self.quote_identifier(db)}."
+                f"{self.quote_identifier(schema)}."
+                f"{self.quote_identifier(table)}"
+            )
+        return f"{self.quote_identifier(schema)}.{self.quote_identifier(table)}"
 
     # ── Column profiling ──────────────────────────────────────────────────
 

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -259,6 +259,22 @@ class DatabaseConnector:
     def capabilities(self) -> BackendCapabilities:
         return getattr(self._adapter, "capabilities", BackendCapabilities())
 
+    def _normalize_id(self, value: str) -> str:
+        """Fold a user-supplied identifier into the form the backend stores.
+
+        Delegated to ``adapter.normalize_identifier`` (pass-through on
+        most backends; UPPER on Oracle and Snowflake). Test fakes that
+        skip the method get a safe identity fallback — defensive because
+        the connector is exercised heavily with stub adapters.
+        """
+        normaliser = getattr(self._adapter, "normalize_identifier", None)
+        if normaliser is None:
+            return value
+        try:
+            return normaliser(value)
+        except Exception:
+            return value
+
     def test_connection_result(self) -> ConnectionTestResult:
         """Test the active connection, retrying once on transient failures.
 
@@ -387,6 +403,7 @@ class DatabaseConnector:
         # Unity Catalog ``SHOW TABLES IN <catalog>.<schema>``). When
         # the override returns None we fall back to the SQLAlchemy
         # inspector — same contract as ``list_schemas``.
+        schema = self._normalize_id(schema)
         catalog = getattr(self.cfg, "catalog", "") or ""
         try:
             adapter_result = self._adapter.list_tables(
@@ -402,6 +419,7 @@ class DatabaseConnector:
         return insp.get_table_names(schema=schema)
 
     def list_views(self, schema: str) -> list[str]:
+        schema = self._normalize_id(schema)
         catalog = getattr(self.cfg, "catalog", "") or ""
         try:
             adapter_result = self._adapter.list_views(
@@ -419,6 +437,7 @@ class DatabaseConnector:
     def list_materialized_views(self, schema: str) -> list[str]:
         if not self.capabilities.materialized_views:
             return []
+        schema = self._normalize_id(schema)
         return self._adapter.list_materialized_views(self.engine, schema)
 
     # ── Extended object types ─────────────────────────────────────────────
@@ -562,6 +581,8 @@ class DatabaseConnector:
 
     def list_column_profiles(self, schema: str, table: str) -> list[ColumnProfile]:
         """Return column names/types/nullability without scanning table data."""
+        schema = self._normalize_id(schema)
+        table = self._normalize_id(table)
         insp = inspect(self.engine)
         return [
             ColumnProfile(
@@ -574,6 +595,8 @@ class DatabaseConnector:
 
     def resolve_asset_kind(self, schema: str, name: str) -> AssetKind:
         """Determine whether *name* is a table, view, or materialized view."""
+        schema = self._normalize_id(schema)
+        name = self._normalize_id(name)
         tables = set(self.list_tables(schema))
         if name in tables:
             return AssetKind.TABLE
@@ -590,6 +613,8 @@ class DatabaseConnector:
     def get_table_comment(self, schema: str, table: str) -> str | None:
         if not self.capabilities.table_comments and not self.capabilities.view_comments:
             return None
+        schema = self._normalize_id(schema)
+        table = self._normalize_id(table)
         insp = inspect(self.engine)
         try:
             info = insp.get_table_comment(table, schema=schema)
@@ -600,6 +625,8 @@ class DatabaseConnector:
     def get_column_comments(self, schema: str, table: str) -> dict[str, str | None]:
         if not self.capabilities.column_comments:
             return {}
+        schema = self._normalize_id(schema)
+        table = self._normalize_id(table)
         insp = inspect(self.engine)
         cols = insp.get_columns(table, schema=schema)
         return {c["name"]: c.get("comment") for c in cols}
@@ -647,6 +674,13 @@ class DatabaseConnector:
         sample_size: int | None = None,
         asset_kind: AssetKind | None = None,
     ) -> TableProfile:
+        # Fold *once* at the entry point so every downstream
+        # inspector/adapter call (get_pk_constraint, get_columns,
+        # fully_qualified_name, etc.) sees identifiers in the form the
+        # backend stores them. Oracle / Snowflake fold to upper; other
+        # backends pass through unchanged.
+        schema = self._normalize_id(schema)
+        table = self._normalize_id(table)
         if asset_kind is None:
             asset_kind = self.resolve_asset_kind(schema, table)
         log.info("Profiling %s.%s (%s) via %s", schema, table, asset_kind.label, self.backend)
@@ -1126,6 +1160,8 @@ class DatabaseConnector:
     def get_incoming_foreign_keys(self, schema: str, table: str) -> list[dict[str, Any]]:
         if not self.capabilities.relationships:
             return []
+        schema = self._normalize_id(schema)
+        table = self._normalize_id(table)
         try:
             return self._adapter.get_incoming_foreign_keys(self.engine, schema, table)
         except Exception as exc:

--- a/tests/test_connector_identifier_normalization.py
+++ b/tests/test_connector_identifier_normalization.py
@@ -1,0 +1,115 @@
+"""Connector entry points fold user-supplied identifiers via the adapter.
+
+A lowercase ``scott.employees`` typed into ``/db sample`` used to reach
+the SQLAlchemy inspector unchanged, miss the upper-case Oracle/Snowflake
+storage, and return empty results. The connector now calls
+``adapter.normalize_identifier`` before any inspector call.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from amx.config import DBConfig
+from amx.db.adapters.base import BackendCapabilities
+from amx.db.connector import DatabaseConnector
+
+
+class _FakeInspector:
+    def __init__(self) -> None:
+        self.table_calls: list[tuple[str, ...]] = []
+        self.view_calls: list[str] = []
+        self.column_calls: list[tuple[str, str]] = []
+
+    def get_table_names(self, schema: str) -> list[str]:  # noqa: D401
+        self.table_calls.append(schema)
+        return ["EMPLOYEES"] if schema == "SCOTT" else []
+
+    def get_view_names(self, schema: str) -> list[str]:
+        self.view_calls.append(schema)
+        return []
+
+    def get_columns(self, table: str, schema: str) -> list[dict]:
+        self.column_calls.append((schema, table))
+        return [{"name": "ID", "type": "INTEGER", "nullable": False, "comment": None}]
+
+    def get_table_comment(self, table: str, schema: str) -> dict:
+        return {"text": None}
+
+
+class _UpperFoldAdapter:
+    """Stub adapter that mimics Oracle's UPPER-folding behaviour."""
+
+    name = "fake_oracle"
+    capabilities = BackendCapabilities(column_comments=True)
+
+    def normalize_identifier(self, value: str) -> str:
+        if not value:
+            return value
+        if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+            return value
+        return value.upper()
+
+    # Connector falls back to SQLAlchemy inspector when these return None.
+    def list_tables(self, engine, schema, catalog=""):
+        return None
+
+    def list_views(self, engine, schema, catalog=""):
+        return None
+
+
+def _connector_with(adapter) -> DatabaseConnector:
+    db = object.__new__(DatabaseConnector)
+    db.cfg = DBConfig(backend="postgresql")
+    db._engine = SimpleNamespace()
+    db._adapter = adapter
+    return db
+
+
+class ConnectorNormalizationTests(unittest.TestCase):
+    def test_list_tables_folds_schema_for_inspector(self) -> None:
+        adapter = _UpperFoldAdapter()
+        connector = _connector_with(adapter)
+        insp = _FakeInspector()
+        with patch("amx.db.connector.inspect", return_value=insp):
+            result = connector.list_tables("scott")
+        self.assertEqual(insp.table_calls, ["SCOTT"])
+        self.assertEqual(result, ["EMPLOYEES"])
+
+    def test_list_views_folds_schema(self) -> None:
+        adapter = _UpperFoldAdapter()
+        connector = _connector_with(adapter)
+        insp = _FakeInspector()
+        with patch("amx.db.connector.inspect", return_value=insp):
+            connector.list_views("scott")
+        self.assertEqual(insp.view_calls, ["SCOTT"])
+
+    def test_get_column_comments_folds_both(self) -> None:
+        adapter = _UpperFoldAdapter()
+        connector = _connector_with(adapter)
+        insp = _FakeInspector()
+        with patch("amx.db.connector.inspect", return_value=insp):
+            connector.get_column_comments("scott", "employees")
+        self.assertEqual(insp.column_calls, [("SCOTT", "EMPLOYEES")])
+
+    def test_missing_method_falls_back_to_identity(self) -> None:
+        """Test fakes without ``normalize_identifier`` must not crash."""
+
+        class _MinimalAdapter:
+            name = "minimal"
+            capabilities = BackendCapabilities()
+
+            def list_tables(self, engine, schema, catalog=""):
+                return None
+
+        connector = _connector_with(_MinimalAdapter())
+        insp = _FakeInspector()
+        with patch("amx.db.connector.inspect", return_value=insp):
+            connector.list_tables("public")
+        self.assertEqual(insp.table_calls, ["public"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_databricks_wizard_catalog_required.py
+++ b/tests/test_databricks_wizard_catalog_required.py
@@ -1,0 +1,85 @@
+"""Databricks Unity Catalog must be set when the wizard saves a new profile.
+
+The adapter's catalog-less ``SHOW SCHEMAS`` path falls back to
+SQLAlchemy's inspector, which on Unity Catalog returns empty results —
+the user filed a "fresh profile, listing returns nothing" report. The
+wizard now requires the catalog field; legacy hive_metastore-only
+workspaces must type ``hive_metastore`` explicitly so the choice is
+visible in the saved profile.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from amx.cli_support.commands.db import interactive_db_block
+from amx.config import DBConfig
+
+
+class DatabricksWizardCatalogRequiredTests(unittest.TestCase):
+    def test_blank_catalog_is_reprompted_until_filled(self) -> None:
+        defaults = DBConfig(
+            backend="databricks",
+            host="",
+            http_path="",
+            access_token="",
+            catalog="",
+            database="",
+            tls_no_verify=False,
+            tls_trusted_ca_file="",
+        )
+
+        # Probe-gate answers "no", so the wizard falls through to the
+        # free-form ``Unity Catalog (required; ...)`` prompt. We answer
+        # blank once (the wizard must reject and re-prompt), then with
+        # ``hive_metastore`` to escape.
+        ask_values = iter(
+            [
+                "host.example",  # Workspace host
+                "/sql/x",  # SQL warehouse HTTP path
+                "",  # Trusted CA bundle path (empty is fine)
+                "",  # Unity Catalog — first attempt: blank
+                "hive_metastore",  # Unity Catalog — second attempt: legacy literal
+                "",  # Schema / database optional, keep blank
+            ]
+        )
+        choice_values = iter(
+            [
+                "databricks",  # Select backend
+                "no",  # Disable TLS verify? no
+                "no",  # Probe catalogs? no
+            ]
+        )
+
+        warns: list[str] = []
+
+        with (
+            patch(
+                "amx.cli_support.commands.db.ask_choice",
+                side_effect=lambda *a, **kw: next(choice_values),
+            ),
+            patch(
+                "amx.cli_support.commands.db.ask",
+                side_effect=lambda *a, **kw: next(ask_values),
+            ),
+            patch(
+                "amx.cli_support.commands.db.ask_password",
+                side_effect=lambda *a, **kw: "tok",
+            ),
+            patch(
+                "amx.cli_support.commands.db.warn",
+                side_effect=lambda msg, *a, **kw: warns.append(str(msg)),
+            ),
+        ):
+            updated = interactive_db_block(defaults)
+
+        self.assertEqual(updated.catalog, "hive_metastore")
+        self.assertTrue(
+            any("Unity Catalog" in w and "required" in w for w in warns),
+            f"Expected a 'Unity Catalog is required' warning, got {warns!r}",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_db_identifier_folding.py
+++ b/tests/test_db_identifier_folding.py
@@ -1,0 +1,56 @@
+"""Tests for ``DatabaseAdapter.normalize_identifier``.
+
+Background: Oracle and Snowflake fold *unquoted* identifiers to UPPER and
+then store them that way. A user typing ``scott.employees`` into the
+wizard or ``/db sample`` used to silently receive an empty result on
+those backends because the SQLAlchemy inspector and adapter metadata
+queries were called with the raw lowercase value. The connector now
+normalizes user-supplied schema/table names via the adapter hook before
+any inspector call.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from amx.config import DBConfig
+from amx.db.adapters.base import DatabaseAdapter
+from amx.db.adapters.oracle import OracleAdapter
+from amx.db.adapters.postgresql import PostgreSQLAdapter
+from amx.db.adapters.snowflake import SnowflakeAdapter
+
+
+def _make(adapter_cls: type[DatabaseAdapter], **cfg_kwargs: object) -> DatabaseAdapter:
+    cfg = DBConfig(backend=adapter_cls.name, **cfg_kwargs)  # type: ignore[arg-type]
+    return adapter_cls(cfg)
+
+
+class IdentifierFoldingTests(unittest.TestCase):
+    def test_oracle_folds_unquoted_to_upper(self) -> None:
+        adapter = _make(OracleAdapter)
+        self.assertEqual(adapter.normalize_identifier("scott"), "SCOTT")
+        self.assertEqual(adapter.normalize_identifier("employees"), "EMPLOYEES")
+        self.assertEqual(adapter.normalize_identifier("MixedCase"), "MIXEDCASE")
+
+    def test_oracle_preserves_quoted_identifier(self) -> None:
+        adapter = _make(OracleAdapter)
+        self.assertEqual(adapter.normalize_identifier('"scott"'), '"scott"')
+        self.assertEqual(adapter.normalize_identifier('"MixedCase"'), '"MixedCase"')
+
+    def test_oracle_passes_through_empty(self) -> None:
+        adapter = _make(OracleAdapter)
+        self.assertEqual(adapter.normalize_identifier(""), "")
+
+    def test_snowflake_folds_unquoted_to_upper(self) -> None:
+        adapter = _make(SnowflakeAdapter)
+        self.assertEqual(adapter.normalize_identifier("analytics"), "ANALYTICS")
+        self.assertEqual(adapter.normalize_identifier('"analytics"'), '"analytics"')
+
+    def test_postgres_passes_value_through(self) -> None:
+        adapter = _make(PostgreSQLAdapter)
+        self.assertEqual(adapter.normalize_identifier("public"), "public")
+        self.assertEqual(adapter.normalize_identifier("MixedCase"), "MixedCase")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_postgresql_credential_error_hint.py
+++ b/tests/test_postgresql_credential_error_hint.py
@@ -1,0 +1,43 @@
+"""PostgreSQL adapter surfaces a friendly hint on credential failure.
+
+Without this branch, ``OperationalError: FATAL: password authentication
+failed for user "amx"`` bubbled raw through the connector, prompting
+support tickets that looked like ``/db test`` was broken when really the
+profile just had a wrong password.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from amx.config import DBConfig
+from amx.db.adapters.postgresql import PostgreSQLAdapter
+
+
+class PostgreSQLCredentialErrorHintTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.adapter = PostgreSQLAdapter(DBConfig(backend="postgresql"))
+
+    def test_password_auth_failed_returns_hint(self) -> None:
+        exc = Exception('FATAL:  password authentication failed for user "amx"')
+        hint = self.adapter.actionable_profile_error(exc)
+        self.assertIsNotNone(hint)
+        assert hint is not None  # for type-checkers
+        self.assertIn("credentials", hint.lower())
+        self.assertIn("/edit", hint)
+
+    def test_sqlstate_28p01_returns_hint(self) -> None:
+        exc = Exception("connection failed: SQLSTATE 28P01")
+        self.assertIsNotNone(self.adapter.actionable_profile_error(exc))
+
+    def test_no_password_supplied_returns_hint(self) -> None:
+        exc = Exception("fe_sendauth: no password supplied")
+        self.assertIsNotNone(self.adapter.actionable_profile_error(exc))
+
+    def test_unrelated_error_returns_none(self) -> None:
+        exc = Exception('relation "orders" already exists')
+        self.assertIsNone(self.adapter.actionable_profile_error(exc))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -592,9 +592,12 @@ class BackendCapabilityTests(unittest.TestCase):
             pg.set_table_comment_sql("public", "orders", "MATERIALIZED VIEW"),
             'COMMENT ON MATERIALIZED VIEW "public"."orders" IS :cmt',
         )
+        # Snowflake now emits a 3-level FQN when the profile binds a
+        # database; the 2-level form remains the fallback for unbound
+        # profiles (see ``test_snowflake_fully_qualified_name``).
         self.assertEqual(
             sf.set_column_comment_sql("PUBLIC", "ORDERS", "ID"),
-            'COMMENT ON COLUMN "PUBLIC"."ORDERS"."ID" IS :cmt',
+            'COMMENT ON COLUMN "sap"."PUBLIC"."ORDERS"."ID" IS :cmt',
         )
         self.assertEqual(
             dbx.set_database_comment_sql(),
@@ -1296,7 +1299,7 @@ class ProfilingGuardrailTests(unittest.TestCase):
         probe_gate_idx = next(
             i for i, p in enumerate(prompts) if "List the available Unity Catalog catalogs" in p
         )
-        catalog_idx = next(i for i, p in enumerate(prompts) if "Unity Catalog (optional)" in p)
+        catalog_idx = next(i for i, p in enumerate(prompts) if p.startswith("Unity Catalog"))
         self.assertLess(tls_ca_idx, probe_gate_idx, "TLS CA must precede probe gate")
         self.assertLess(tls_verify_idx, probe_gate_idx, "TLS verify must precede probe gate")
         self.assertLess(probe_gate_idx, catalog_idx, "Probe gate must precede catalog")

--- a/tests/test_snowflake_fully_qualified_name.py
+++ b/tests/test_snowflake_fully_qualified_name.py
@@ -1,0 +1,42 @@
+"""Snowflake adapter emits a 3-level FQN when the profile pins a database.
+
+Background: ``fully_qualified_name`` returned ``"schema"."table"`` regardless
+of whether the profile bound a database. Comment-write DDL
+(``COMMENT ON TABLE``) silently targeted the connection's active database,
+which broke once an agent / cross-database query needed to reference an
+object outside the active DB. The fix emits a 3-level
+``"db"."schema"."table"`` whenever ``cfg.database`` is non-empty.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from amx.config import DBConfig
+from amx.db.adapters.snowflake import SnowflakeAdapter
+
+
+class SnowflakeFullyQualifiedNameTests(unittest.TestCase):
+    def test_three_level_when_database_set(self) -> None:
+        adapter = SnowflakeAdapter(DBConfig(backend="snowflake", database="ANALYTICS"))
+        self.assertEqual(
+            adapter.fully_qualified_name("public", "orders"),
+            '"ANALYTICS"."public"."orders"',
+        )
+
+    def test_two_level_when_database_blank(self) -> None:
+        adapter = SnowflakeAdapter(DBConfig(backend="snowflake", database=""))
+        self.assertEqual(
+            adapter.fully_qualified_name("public", "orders"),
+            '"public"."orders"',
+        )
+
+    def test_set_table_comment_sql_uses_three_level(self) -> None:
+        adapter = SnowflakeAdapter(DBConfig(backend="snowflake", database="DW"))
+        stmt = adapter.set_table_comment_sql("sales", "orders", "TABLE")
+        self.assertIn('"DW"."sales"."orders"', stmt)
+        self.assertIn(":cmt", stmt)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 1 of the multi-PR connector audit roadmap. Closes the highest-severity "the connector says it works but the result is wrong" findings — companion PRs for TLS / billing controls / UX polish follow.

- **Oracle / Snowflake identifier folding.** New `DatabaseAdapter.normalize_identifier` hook (pass-through default, UPPER on Oracle + Snowflake). The connector folds user-supplied `schema` / `table` arguments at every metadata entry point (`list_tables`, `list_views`, `list_materialized_views`, `list_column_profiles`, `get_table_comment`, `get_column_comments`, `resolve_asset_kind`, `profile_table`, `get_incoming_foreign_keys`). Fixes the "scott.employees returns empty" failure on Oracle. Explicitly-quoted identifiers (`"MixedCase"`) pass through unchanged.
- **Snowflake 3-level fully qualified names.** When the profile binds a database, `fully_qualified_name` emits `"db"."schema"."table"`. Comment-write DDL and the cross-database agent path used to silently retarget the active database.
- **Databricks Unity Catalog required at wizard time.** `/add-db-profile` refuses to save a Databricks profile with a blank catalog; legacy hive-metastore-only workspaces type `hive_metastore` explicitly. The old `None` fallback ran the UC-incompatible SQLAlchemy inspector and produced the user-reported "fresh profile, listing returns nothing" failure.
- **PostgreSQL credential-failure friendly hint.** `actionable_profile_error` matches `password authentication failed`, `fe_sendauth: no password supplied`, and SQLSTATE `28P01`, surfacing a `/edit` pointer instead of libpq's raw `OperationalError` traceback.

5 new test modules + 1 existing fixture updated for the 3-level FQN rollover. `make test` passes 1360 tests.

## Test plan

- [ ] `pytest tests/test_db_identifier_folding.py tests/test_snowflake_fully_qualified_name.py tests/test_postgresql_credential_error_hint.py tests/test_connector_identifier_normalization.py tests/test_databricks_wizard_catalog_required.py`
- [ ] `pytest tests/test_regressions.py`
- [ ] `pytest tests/` (full suite)
- [ ] `ruff check amx tests && ruff format --check amx tests`
- [ ] Manual: on an Oracle profile, type a lowercase schema in `/db list-tables <schema>` — listing should now match the upper-case stored schema.
- [ ] Manual: edit a Snowflake profile to pin a `database`, run `/db comment` on a table — emitted SQL should be 3-level `"db"."schema"."table"`.
- [ ] Manual: `/add-db-profile databricks` — leave the Unity Catalog blank; wizard must re-prompt with "Unity Catalog is required."
- [ ] Manual: on a PG profile, deliberately set the wrong password, run `/db test` — friendly hint should appear, no raw stack trace.