### PR TITLE
feat(db): approximate distinct counts on metered backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Added
 
+- **Approximate distinct counts for metered backends (PR 3 / 4 of
+  the connector audit).** A new ``profiling_approximate`` flag on
+  ``DBConfig`` (default ``False``) switches the per-column and bulk
+  profiling SQL on BigQuery / Snowflake / Databricks from the exact
+  ``COUNT(DISTINCT col)`` to the backend's native HyperLogLog
+  variant:
+
+  - BigQuery: ``APPROX_COUNT_DISTINCT(col)``
+  - Snowflake: ``APPROX_COUNT_DISTINCT(col)``
+  - Databricks Spark SQL: ``approx_count_distinct(col)``
+
+  The exact aggregate hashes every row in the sampled slice
+  regardless of ``TABLESAMPLE`` / ``SAMPLE`` clauses, so wide /
+  high-cardinality tables racked up surprise credits even with the
+  1 % slice the adapters use today. HLL is within 1–2 % of the exact
+  value on realistic data and bills a tiny fraction of the credits.
+  Defaults preserve existing behaviour; flip the flag with
+  ``/profiling <mode> [max_rows] [sample_size] approximate`` (the
+  fourth positional argument is new) or save it via the profile YAML.
+
 - **TLS / SSL controls for every backend (PR 2 / 4 of the connector
   audit).** Surfaces driver-level TLS knobs in both the CLI wizard
   and the Studio Add-profile form for the backends that needed them.

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -1544,12 +1544,15 @@ def cmd_profiling(cfg: AMXConfig, rest: list[str]) -> None:
     if not rest:
         max_rows = int(getattr(cfg.db, "profiling_max_rows", 1_000_000) or 0)
         max_label = "off" if max_rows <= 0 else f"{max_rows:,}"
+        approx = bool(getattr(cfg.db, "profiling_approximate", False))
         info(
             "Current profiling guardrails: "
             f"mode=[info]{cfg.db.profiling_mode}[/info], "
             f"max_full_scan_rows=[info]{max_label}[/info], "
-            f"sample_size=[info]{cfg.db.profiling_sample_size}[/info]. "
-            "Use /profiling <full|sampled|metadata> [max_rows|off] [sample_size]."
+            f"sample_size=[info]{cfg.db.profiling_sample_size}[/info], "
+            f"approximate=[info]{approx}[/info]. "
+            "Use /profiling <full|sampled|metadata> [max_rows|off] "
+            "[sample_size] [approximate]."
         )
         return
 
@@ -1584,19 +1587,35 @@ def cmd_profiling(cfg: AMXConfig, rest: list[str]) -> None:
             error("Sample size must be >= 0.")
             return
 
+    approximate = bool(getattr(cfg.db, "profiling_approximate", False))
+    if len(rest) >= 4:
+        raw = rest[3].lower().strip()
+        truthy = {"on", "true", "yes", "y", "1", "approx", "approximate"}
+        falsy = {"off", "false", "no", "n", "0", "exact"}
+        if raw in truthy:
+            approximate = True
+        elif raw in falsy:
+            approximate = False
+        else:
+            error(f"Expected approximate flag as on/off, got: {rest[3]!r}.")
+            return
+
     cfg.db.profiling_mode = mode
     cfg.db.profiling_max_rows = max_rows
     cfg.db.profiling_sample_size = sample_size
+    cfg.db.profiling_approximate = approximate
     if cfg.active_db_profile and cfg.active_db_profile in cfg.db_profiles:
         cfg.db_profiles[cfg.active_db_profile].profiling_mode = mode
         cfg.db_profiles[cfg.active_db_profile].profiling_max_rows = max_rows
         cfg.db_profiles[cfg.active_db_profile].profiling_sample_size = sample_size
+        cfg.db_profiles[cfg.active_db_profile].profiling_approximate = approximate
     cfg.save()
 
     max_label = "off" if max_rows <= 0 else f"{max_rows:,}"
     success(
         f"Profiling guardrails saved: mode={mode}, "
-        f"max_full_scan_rows={max_label}, sample_size={sample_size}."
+        f"max_full_scan_rows={max_label}, sample_size={sample_size}, "
+        f"approximate={approximate}."
     )
 
 

--- a/amx/config.py
+++ b/amx/config.py
@@ -549,6 +549,16 @@ class DBConfig(_ObservableConfig):
     profiling_mode: str = "full"  # full | sampled | metadata
     profiling_max_rows: int = 1_000_000  # skip full column scans above this row estimate (0=off)
     profiling_sample_size: int = 5
+    # When True, metered backends (BigQuery / Snowflake / Databricks)
+    # emit ``APPROX_COUNT_DISTINCT`` / ``approx_count_distinct`` instead
+    # of ``COUNT(DISTINCT col)``. The exact aggregate scans every row in
+    # the sampled slice (TABLESAMPLE / SAMPLE only narrows the input,
+    # not the COUNT-DISTINCT hash), so wide tables with high-cardinality
+    # columns can rack up credits even with the 1% sample. The
+    # HyperLogLog approximation is within ~1-2% on realistic data and
+    # bills a small fraction of the credits. Defaults to False so
+    # existing behaviour is preserved.
+    profiling_approximate: bool = False
     # How many columns to compute null/distinct/min/max for in a single
     # bulk query. The connector chunks wide tables into batches of this
     # size — fewer queries on warehouse-billed backends, less memory
@@ -944,6 +954,7 @@ def _db_from_mapping(m: dict[str, Any]) -> DBConfig:
         profiling_max_rows=int(m.get("profiling_max_rows", 1_000_000)),
         profiling_sample_size=int(m.get("profiling_sample_size", 5)),
         profiling_stats_batch_size=int(m.get("profiling_stats_batch_size", 50)),
+        profiling_approximate=bool(m.get("profiling_approximate", False)),
     )
 
 
@@ -1077,6 +1088,7 @@ def _db_to_mapping(db: DBConfig) -> dict[str, Any]:
             "profiling_max_rows": int(db.profiling_max_rows),
             "profiling_sample_size": int(db.profiling_sample_size),
             "profiling_stats_batch_size": int(db.profiling_stats_batch_size),
+            "profiling_approximate": bool(db.profiling_approximate),
         }
     )
     return base

--- a/amx/db/adapters/bigquery.py
+++ b/amx/db/adapters/bigquery.py
@@ -86,7 +86,7 @@ class BigQueryAdapter(DatabaseAdapter):
         return (
             f"SELECT "
             f"  COUNTIF({quoted_col} IS NULL) AS null_cnt, "
-            f"  COUNT(DISTINCT {quoted_col}) AS dist_cnt, "
+            f"  {self._distinct_count_expr(quoted_col)} AS dist_cnt, "
             f"  MIN(CAST({quoted_col} AS STRING)) AS min_val, "
             f"  MAX(CAST({quoted_col} AS STRING)) AS max_val "
             f"FROM {fqn}"
@@ -100,6 +100,19 @@ class BigQueryAdapter(DatabaseAdapter):
 
     def _null_count_expr(self, quoted_col: str) -> str:
         return f"COUNTIF({quoted_col} IS NULL)"
+
+    def _distinct_count_expr(self, quoted_col: str) -> str:
+        # BigQuery's APPROX_COUNT_DISTINCT uses HyperLogLog++ and bills a
+        # tiny fraction of an exact COUNT(DISTINCT) on wide / high-
+        # cardinality columns. The exact aggregate scans every row in
+        # the sampled slice — TABLESAMPLE SYSTEM (1 PERCENT) narrows
+        # the input but the distinct-hash itself still touches each
+        # sampled row, which is what produces the surprise credit
+        # spikes the profiling-billing fix targets. Default behaviour
+        # is unchanged (cfg flag defaults to False).
+        if getattr(self.cfg, "profiling_approximate", False):
+            return f"APPROX_COUNT_DISTINCT({quoted_col})"
+        return f"COUNT(DISTINCT {quoted_col})"
 
     def _aggregate_text_expr(self, agg: str, quoted_col: str) -> str:
         return f"{agg}(CAST({quoted_col} AS STRING))"

--- a/amx/db/adapters/databricks.py
+++ b/amx/db/adapters/databricks.py
@@ -197,7 +197,7 @@ class DatabricksAdapter(DatabaseAdapter):
         return (
             f"SELECT "
             f"  SUM(CASE WHEN {quoted_col} IS NULL THEN 1 ELSE 0 END) AS null_cnt, "
-            f"  COUNT(DISTINCT {quoted_col}) AS dist_cnt, "
+            f"  {self._distinct_count_expr(quoted_col)} AS dist_cnt, "
             f"  MIN(CAST({quoted_col} AS STRING)) AS min_val, "
             f"  MAX(CAST({quoted_col} AS STRING)) AS max_val "
             f"FROM {fqn}"
@@ -213,6 +213,14 @@ class DatabricksAdapter(DatabaseAdapter):
         # Databricks Spark SQL has no ``FILTER (WHERE …)`` aggregate
         # modifier — use SUM(CASE) like the per-column path.
         return f"SUM(CASE WHEN {quoted_col} IS NULL THEN 1 ELSE 0 END)"
+
+    def _distinct_count_expr(self, quoted_col: str) -> str:
+        # Databricks Spark SQL exposes ``approx_count_distinct`` (HLL).
+        # Same billing logic as the BigQuery / Snowflake overrides — see
+        # ``DBConfig.profiling_approximate``. Default unchanged.
+        if getattr(self.cfg, "profiling_approximate", False):
+            return f"approx_count_distinct({quoted_col})"
+        return f"COUNT(DISTINCT {quoted_col})"
 
     def _aggregate_text_expr(self, agg: str, quoted_col: str) -> str:
         # Databricks uses ``STRING`` rather than ``VARCHAR``.

--- a/amx/db/adapters/snowflake.py
+++ b/amx/db/adapters/snowflake.py
@@ -168,7 +168,7 @@ class SnowflakeAdapter(DatabaseAdapter):
         return (
             f"SELECT "
             f"  SUM(CASE WHEN {quoted_col} IS NULL THEN 1 ELSE 0 END) AS null_cnt, "
-            f"  COUNT(DISTINCT {quoted_col}) AS dist_cnt, "
+            f"  {self._distinct_count_expr(quoted_col)} AS dist_cnt, "
             f"  MIN({quoted_col}::VARCHAR) AS min_val, "
             f"  MAX({quoted_col}::VARCHAR) AS max_val "
             f"FROM {fqn}"
@@ -184,6 +184,15 @@ class SnowflakeAdapter(DatabaseAdapter):
         # Snowflake doesn't accept ``COUNT(*) FILTER (WHERE …)``; use the
         # SUM(CASE) form that the per-column path also uses.
         return f"SUM(CASE WHEN {quoted_col} IS NULL THEN 1 ELSE 0 END)"
+
+    def _distinct_count_expr(self, quoted_col: str) -> str:
+        # Snowflake's APPROX_COUNT_DISTINCT is an HLL implementation and
+        # bills a small fraction of an exact COUNT(DISTINCT) on wide
+        # / high-cardinality columns. Default behaviour unchanged
+        # (cfg flag defaults to False).
+        if getattr(self.cfg, "profiling_approximate", False):
+            return f"APPROX_COUNT_DISTINCT({quoted_col})"
+        return f"COUNT(DISTINCT {quoted_col})"
 
     def _aggregate_text_expr(self, agg: str, quoted_col: str) -> str:
         return f"{agg}({quoted_col}::VARCHAR)"

--- a/tests/test_profiling_approximate.py
+++ b/tests/test_profiling_approximate.py
@@ -1,0 +1,86 @@
+"""``profiling_approximate`` swaps COUNT(DISTINCT) for HLL on metered backends.
+
+BigQuery, Snowflake, and Databricks all bill per row scanned. The
+exact ``COUNT(DISTINCT col)`` aggregate hashes every sampled row
+regardless of TABLESAMPLE / SAMPLE, which on wide / high-cardinality
+columns racks up credits even with a 1 % slice. Setting
+``DBConfig.profiling_approximate = True`` switches the per-column
+and bulk profile queries to the backend's native HyperLogLog variant:
+
+* BigQuery: ``APPROX_COUNT_DISTINCT(col)``
+* Snowflake: ``APPROX_COUNT_DISTINCT(col)``
+* Databricks Spark SQL: ``approx_count_distinct(col)``
+
+The default is False so existing behaviour is preserved for users who
+were happy with the exact-but-expensive path.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from amx.config import DBConfig
+from amx.db.adapters.bigquery import BigQueryAdapter
+from amx.db.adapters.databricks import DatabricksAdapter
+from amx.db.adapters.snowflake import SnowflakeAdapter
+
+
+class ApproximateProfilingDistinctSqlTests(unittest.TestCase):
+    def test_bigquery_uses_approx_when_flag_on(self) -> None:
+        cfg = DBConfig(backend="bigquery", project="p", profiling_approximate=True)
+        adapter = BigQueryAdapter(cfg)
+        col = adapter.quote_identifier("amount")
+
+        per_col = adapter.column_stats_sql("`p`.`ds`.`orders`", col)
+        bulk = adapter.column_stats_bulk_sql("`p`.`ds`.`orders`", [col])
+
+        self.assertIn("APPROX_COUNT_DISTINCT", per_col)
+        self.assertIn("APPROX_COUNT_DISTINCT", bulk)
+        self.assertNotIn("COUNT(DISTINCT", per_col)
+        self.assertNotIn("COUNT(DISTINCT", bulk)
+
+    def test_bigquery_uses_exact_when_flag_off(self) -> None:
+        cfg = DBConfig(backend="bigquery", project="p", profiling_approximate=False)
+        adapter = BigQueryAdapter(cfg)
+        col = adapter.quote_identifier("amount")
+        per_col = adapter.column_stats_sql("`p`.`ds`.`orders`", col)
+        bulk = adapter.column_stats_bulk_sql("`p`.`ds`.`orders`", [col])
+        self.assertIn("COUNT(DISTINCT", per_col)
+        self.assertIn("COUNT(DISTINCT", bulk)
+        self.assertNotIn("APPROX_COUNT_DISTINCT", per_col)
+        self.assertNotIn("APPROX_COUNT_DISTINCT", bulk)
+
+    def test_snowflake_uses_approx_when_flag_on(self) -> None:
+        cfg = DBConfig(backend="snowflake", account="a", profiling_approximate=True)
+        adapter = SnowflakeAdapter(cfg)
+        col = adapter.quote_identifier("amount")
+        bulk = adapter.column_stats_bulk_sql('"db"."s"."t"', [col])
+        per_col = adapter.column_stats_sql('"db"."s"."t"', col)
+        self.assertIn("APPROX_COUNT_DISTINCT", per_col)
+        self.assertIn("APPROX_COUNT_DISTINCT", bulk)
+
+    def test_databricks_uses_approx_when_flag_on(self) -> None:
+        cfg = DBConfig(
+            backend="databricks",
+            host="dbx",
+            catalog="main",
+            profiling_approximate=True,
+        )
+        adapter = DatabricksAdapter(cfg)
+        col = adapter.quote_identifier("amount")
+        bulk = adapter.column_stats_bulk_sql("`main`.`s`.`t`", [col])
+        per_col = adapter.column_stats_sql("`main`.`s`.`t`", col)
+        # Databricks Spark SQL exposes the function with lower-case
+        # identifier — match exactly so we don't accidentally also pass
+        # for the Snowflake / BigQuery upper-case name.
+        self.assertIn("approx_count_distinct", per_col)
+        self.assertIn("approx_count_distinct", bulk)
+
+    def test_default_flag_value_is_false(self) -> None:
+        # Existing profiles loaded from YAML without the new key must
+        # keep the exact-count behaviour.
+        self.assertFalse(DBConfig().profiling_approximate)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_profiling_cli_approximate.py
+++ b/tests/test_profiling_cli_approximate.py
@@ -1,0 +1,61 @@
+"""The ``/profiling`` CLI command persists the new ``approximate`` flag.
+
+PR 3 extends the four-arg form to ``/profiling <mode> [max_rows]
+[sample_size] [approximate]`` so users can flip the metered-backend
+billing toggle without editing YAML.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from amx.cli_support.commands.db import cmd_profiling
+from amx.config import AMXConfig, DBConfig
+
+
+class ProfilingCommandApproximateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cfg = AMXConfig()
+        self.cfg.db = DBConfig(backend="bigquery", project="p")
+        self.cfg.active_db_profile = "default"
+        self.cfg.db_profiles = {"default": self.cfg.db}
+
+    def test_four_args_set_approximate(self) -> None:
+        with patch.object(self.cfg, "save"):
+            cmd_profiling(self.cfg, ["sampled", "5000000", "10", "on"])
+        self.assertTrue(self.cfg.db.profiling_approximate)
+        self.assertEqual(self.cfg.db.profiling_mode, "sampled")
+        self.assertEqual(self.cfg.db.profiling_max_rows, 5_000_000)
+        self.assertEqual(self.cfg.db.profiling_sample_size, 10)
+
+    def test_three_args_leaves_approximate_alone(self) -> None:
+        self.cfg.db.profiling_approximate = True
+        with patch.object(self.cfg, "save"):
+            cmd_profiling(self.cfg, ["full", "1000000", "5"])
+        self.assertTrue(self.cfg.db.profiling_approximate)
+
+    def test_off_keyword_disables_approximate(self) -> None:
+        self.cfg.db.profiling_approximate = True
+        with patch.object(self.cfg, "save"):
+            cmd_profiling(self.cfg, ["full", "1000000", "5", "off"])
+        self.assertFalse(self.cfg.db.profiling_approximate)
+
+    def test_bad_approximate_arg_errors(self) -> None:
+        errors: list[str] = []
+        with (
+            patch.object(self.cfg, "save"),
+            patch(
+                "amx.cli_support.commands.db.error",
+                side_effect=lambda msg, *a, **kw: errors.append(str(msg)),
+            ),
+        ):
+            cmd_profiling(self.cfg, ["full", "1000000", "5", "maybe"])
+        self.assertTrue(
+            any("approximate" in e.lower() for e in errors),
+            f"Expected an approximate-flag error, got {errors!r}",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

PR 3 of the connector audit roadmap (P2 — billing controls). Stops profiling runs from blowing up Snowflake / BigQuery / Databricks credits on wide tables.

The user-facing change is one boolean flag — `DBConfig.profiling_approximate` (default `False`). When True, the per-column and bulk profile queries on the three metered backends swap `COUNT(DISTINCT col)` for the backend's native HyperLogLog variant:

- BigQuery: `APPROX_COUNT_DISTINCT(col)`
- Snowflake: `APPROX_COUNT_DISTINCT(col)`
- Databricks Spark SQL: `approx_count_distinct(col)`

The exact `COUNT(DISTINCT)` hashes every row in the sampled slice regardless of the `TABLESAMPLE (1 PERCENT)` / `SAMPLE (1)` clauses — wide / high-cardinality tables therefore racked up credits even with the 1 % sample. HLL is within 1–2 % of the exact value on realistic data and bills a fraction of the credits.

Implementation:

- `_distinct_count_expr` override on each metered adapter, gated on `cfg.profiling_approximate`.
- `column_stats_sql` per-column path on each adapter now routes through `_distinct_count_expr` so the bulk and per-column paths stay in sync.
- `/profiling` CLI command accepts a fourth positional arg: `/profiling <mode> [max_rows|off] [sample_size] [approximate]`. Bool tokens accepted: `on/off`, `yes/no`, `true/false`, `approx/exact`.
- YAML round-trip via the existing `_db_to_mapping` / `_db_from_mapping` whitelist.
- Defaults unchanged for every existing profile — opt-in only.

Out of scope:

- TABLESAMPLE percent is still hardcoded at 1 %. The original plan proposed plumbing `profiling_sample_size` into the bulk SQL signature, but that field already has a different semantic (per-column distinct sample target), and conflating the two would have introduced an API break for marginal benefit. If users hit the 1 % limit a future PR can add a separate `profiling_sample_pct` knob.

## Test plan

- [ ] `pytest tests/test_profiling_approximate.py tests/test_profiling_cli_approximate.py` — 9 new cases pass (per-column + bulk SQL containing the right function name, default-False sanity, `/profiling` CLI persistence + bad-arg handling).
- [ ] `pytest tests/` — full suite 1377 cases.
- [ ] `ruff check amx tests && ruff format --check amx tests` — clean.
- [ ] Manual: on a real Snowflake / BigQuery profile, `/profiling sampled 1000000 5 approx`; run profiling; verify the warehouse / billing dashboard shows the function name in the query history.