### PR TITLE
docs(readme): hide video filename header, swap ASCII flow for amx-flow.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <p align="center">
-
-https://github.com/user-attachments/assets/fdcb7498-928a-4250-b257-7d5aef5521bb
-
+  <video src="https://github.com/user-attachments/assets/fdcb7498-928a-4250-b257-7d5aef5521bb" controls muted playsinline width="760"></video>
 </p>
 
 <p align="center">
@@ -68,22 +66,9 @@ Full walkthrough at [`/studio`](https://omeryasirkucuk.github.io/amx-docs/cli/st
 
 ## How it works
 
-```
-   ┌──────────────┐
-   │   Profile    │  schema, types, keys,
-   │    agent     │  cardinality, samples
-   └──────┬───────┘
-          │
-   ┌──────┴───────┐      ┌──────────────┐      ┌──────────────┐
-   │     RAG      │ ───▶ │ Orchestrator │ ───▶ │  You review  │
-   │    agent     │      │   (LLM rank)  │      │  accept/edit │
-   └──────┬───────┘      └──────────────┘      └──────┬───────┘
-          │                                            │
-   ┌──────┴───────┐                                    ▼
-   │     Code     │                            COMMENT ON COLUMN …
-   │    agent     │                          (native DDL on the engine)
-   └──────────────┘
-```
+<p align="center">
+  <img src="https://amxcli.com/assets/amx-flow.png" alt="AMX flow — Profile, RAG, and Code agents feed evidence to an orchestrator that ranks suggestions; you review accept/edit/skip and AMX writes the approved text back as COMMENT ON COLUMN native DDL" width="900">
+</p>
 
 Each agent runs independently, surfaces its own evidence, and assigns its own confidence. The orchestrator picks the narrower, defensible description and ranks up to N alternatives. You never apply anything you didn't approve.
 


### PR DESCRIPTION
Follow-up to #311. Two README fixes that didn't make it into the original merge.

## Summary

- **Video filename header.** The hero intro video was embedded as a bare `user-attachments` URL, which GitHub auto-wraps with a dropdown header showing the original filename (`AMX.Intro.mp4 ▾`). Switching to an explicit `<video src="…" controls muted playsinline width="760">` tag points at the same asset and renders the native player without the wrapper.
- **"How it works" diagram.** The ASCII box-drawing version of the three-agent flow rendered as a misaligned wrapped code block on GitHub. Replace it with the rendered `amx-flow.png` hosted on `amxcli.com` (`curl -I` returned `HTTP/2 200`, served from `GitHub.com` Pages with `access-control-allow-origin: *`).

No other content changes.

## Test plan

- [ ] On the rendered PR diff, confirm the video player no longer shows the `AMX.Intro.mp4` filename row above it.
- [ ] Confirm the "How it works" section now renders the `amx-flow.png` image inline instead of the ASCII box-drawing block.
- [ ] Confirm the caption paragraph ("Each agent runs independently…") still appears immediately after the image.