### PR TITLE
feat(db): column-comments cache foundation (CLI + Studio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Added
 
+- **Column-comments cache foundation.** New per-table SQLite cache
+  (``column_comments_cache``) wired into the connector layer so every
+  Studio router AND every CLI flow that calls ``get_table_comment`` /
+  ``get_column_comments`` short-circuits to a 1h-TTL cache hit after
+  the first read. The cache lookup lives *inside* the connector
+  (``amx/db/connector.py``) so CLI inspect commands, the orchestrator's
+  per-table profile loop, and the Studio sidebar / RunNew flows all
+  share the same warm cache. Five mutation paths (``set_database/
+  schema/table/column_comment`` plus ``apply_review_results_to_db``)
+  invalidate the affected scope before their HTTP response returns,
+  guaranteeing the next read is fresh — non-negotiable per the user.
+  A backend bulk-query path (one ``INFORMATION_SCHEMA`` / ``pg_
+  description`` round-trip in place of N per-table ``DESCRIBE``s) lands
+  in a follow-up PR; this groundwork makes the speedup drop-in.
+
 - **Polished UX for on-demand extras installs.** When the CLI lazy-
   installs an optional dependency (DB driver, LLM SDK, RAG bundle,
   weasyprint, bert-score, …), the terminal now renders a single Rich

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -656,6 +656,22 @@ def apply_review_results_to_db(
                                             item.table,
                                             cache_exc,
                                         )
+                                # Also invalidate the column-comments
+                                # cache for this table so the very next
+                                # sidebar / CLI inspect sees the freshly
+                                # written COMMENT and never the prior
+                                # placeholder.
+                                try:
+                                    db.invalidate_column_comments_cache(
+                                        schema=item.schema, table=item.table or ""
+                                    )
+                                except Exception as cache_exc:
+                                    log.debug(
+                                        "invalidate_column_comments_cache (batch) failed for %s.%s: %s",
+                                        item.schema,
+                                        item.table,
+                                        cache_exc,
+                                    )
                             index = next_index
                             continue
                     except Exception as batch_exc:
@@ -723,6 +739,20 @@ def apply_review_results_to_db(
                             r.table,
                             cache_exc,
                         )
+                # Same belt-and-braces invalidation for the column-
+                # comments cache as the batch branch above. Keeps
+                # post-apply reads guaranteed-fresh.
+                try:
+                    db.invalidate_column_comments_cache(
+                        schema=r.schema, table=r.table or ""
+                    )
+                except Exception as cache_exc:
+                    log.debug(
+                        "invalidate_column_comments_cache failed for %s.%s: %s",
+                        r.schema,
+                        r.table,
+                        cache_exc,
+                    )
             except Exception as exc:
                 if on_progress is not None:
                     on_progress(r, "failed", index + 1, total, str(exc))

--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -294,6 +294,31 @@ class DatabaseAdapter(ABC):
     def get_database_comment(self, engine: Engine) -> str | None:
         return None
 
+    def bulk_schema_metadata(
+        self,
+        engine: Engine,
+        schema: str,
+        *,
+        catalog: str = "",
+    ) -> dict[str, dict[str, Any]] | None:
+        """Fetch comments + columns for every table in a schema in one query.
+
+        Returns ``{table_name: {"table_comment": str | None,
+        "columns": {col_name: comment_or_none}, "kind": "TABLE" | "VIEW" |
+        "MATERIALIZED VIEW"}}`` for the entire schema, or ``None`` when the
+        backend has no bulk catalog source — in which case the connector
+        falls back to the per-table inspector path.
+
+        Implementation note for overrides: this is the single biggest
+        Studio + CLI perf win on big warehouses. A 200-table Databricks
+        Unity schema currently issues 200 sequential ``DESCRIBE TABLE
+        EXTENDED`` calls (10-30s wall-clock); the bulk
+        ``system.information_schema.columns`` query covers them in one
+        round-trip (<1s). Keep the dict shape stable — the connector
+        cache layer keys off it.
+        """
+        return None
+
     def batch_get_table_comments(
         self,
         engine: Engine,

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -197,7 +197,16 @@ def _is_transient_db_connection_error(exc: BaseException) -> bool:
 class DatabaseConnector:
     """Unified database connector that delegates backend-specific work to adapters."""
 
-    def __init__(self, cfg: DBConfig):
+    def __init__(self, cfg: DBConfig, *, profile_name: str = ""):
+        # ``profile_name`` is the AMXConfig key (e.g. "prod-snowflake")
+        # this connector was opened for. Used as the cache key for the
+        # column-comments cache (:mod:`amx.storage.sqlite_store`) so an
+        # invalidation triggered from the web router or a CLI write hits
+        # the exact rows the connector populated. Empty string is the
+        # legacy single-profile fallback — callers that have a profile
+        # name should always pass it.
+        self.profile_name = str(profile_name or "")
+
         # Sanitize unresolved keyring references on a COPY so the
         # adapter never tries to use ``keyring:db_profiles/<x>/password``
         # as a real secret (which would produce a confusing
@@ -610,26 +619,187 @@ class DatabaseConnector:
 
     # ── Comments (read) ───────────────────────────────────────────────────
 
+    @property
+    def _cache_profile_key(self) -> str:
+        """Stable identifier the column-comments cache keys off.
+
+        Prefers the AMX profile name when the caller supplied one
+        (every CLI / web router code path does in v0.14+). Falls back
+        to a short hash of the connection identity so anonymous
+        connectors — e.g. tests that build a connector directly from a
+        ``DBConfig`` — still get a deterministic, collision-free key.
+        """
+        if self.profile_name:
+            return self.profile_name
+        import hashlib
+
+        sig = (
+            f"{getattr(self.cfg, 'url', '') or ''}|"
+            f"{getattr(self.cfg, 'database', '') or ''}|"
+            f"{getattr(self.cfg, 'catalog', '') or ''}"
+        )
+        return "anon:" + hashlib.sha1(sig.encode("utf-8")).hexdigest()[:12]
+
+    def _cache_database_key(self) -> str:
+        """Database scope the cache narrows on within a profile."""
+        return str(getattr(self.cfg, "database", "") or getattr(self.cfg, "catalog", "") or "")
+
+    def _lookup_column_comments_cache(
+        self, schema: str, table: str
+    ) -> dict[str, Any] | None:
+        """Return a cached ``{table_comment, columns, kind, ...}`` or None."""
+        try:
+            from amx.storage.sqlite_store import history_store
+        except Exception:
+            return None
+        store = history_store()
+        if store is None:
+            return None
+        try:
+            return store.lookup_column_comments_cache(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                schema=schema,
+                table=table,
+            )
+        except Exception as exc:
+            log.debug("column-comments cache lookup failed: %s", exc)
+            return None
+
+    def _save_column_comments_cache(
+        self,
+        schema: str,
+        entries: dict[str, dict[str, Any]],
+    ) -> None:
+        """Persist a per-schema metadata dict to the cache."""
+        if not entries:
+            return
+        try:
+            from amx.storage.sqlite_store import history_store
+        except Exception:
+            return
+        store = history_store()
+        if store is None:
+            return
+        try:
+            store.save_column_comments_cache(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                schema=schema,
+                entries=entries,
+            )
+        except Exception as exc:
+            log.debug("column-comments cache save failed: %s", exc)
+
+    def invalidate_column_comments_cache(
+        self,
+        schema: str | None = None,
+        table: str | None = None,
+    ) -> None:
+        """Drop cached comment rows for this connector.
+
+        - ``schema`` + ``table`` → single row (one table COMMENT write).
+        - ``schema`` only → whole schema (schema COMMENT write).
+        - Both None → whole profile (database COMMENT or wholesale reset).
+        """
+        try:
+            from amx.storage.sqlite_store import history_store
+        except Exception:
+            return
+        store = history_store()
+        if store is None:
+            return
+        try:
+            store.invalidate_column_comments_cache(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                schema=schema,
+                table=table,
+            )
+        except Exception as exc:
+            log.debug("column-comments cache invalidate failed: %s", exc)
+
+    def _populate_schema_metadata_cache(self, schema: str) -> bool:
+        """Run the adapter's bulk source for ``schema`` and cache results.
+
+        Returns ``True`` when the adapter populated the cache (any
+        backend that overrides :meth:`bulk_schema_metadata`) and
+        ``False`` when there is no bulk source — the caller then falls
+        back to per-table inspector calls. The fallback path also
+        caches its results entry-by-entry, so subsequent reads of any
+        cached table short-circuit either way.
+        """
+        try:
+            catalog = str(getattr(self.cfg, "catalog", "") or "")
+            payload = self._adapter.bulk_schema_metadata(
+                self.engine, schema, catalog=catalog
+            )
+        except Exception as exc:
+            log.debug(
+                "bulk_schema_metadata raised on %s for schema %s: %s",
+                self._adapter.name,
+                schema,
+                exc,
+            )
+            return False
+        if not payload:
+            return False
+        self._save_column_comments_cache(schema, payload)
+        return True
+
     def get_table_comment(self, schema: str, table: str) -> str | None:
         if not self.capabilities.table_comments and not self.capabilities.view_comments:
             return None
         schema = self._normalize_id(schema)
         table = self._normalize_id(table)
+        cached = self._lookup_column_comments_cache(schema, table)
+        if cached is not None:
+            return cached.get("table_comment")
+        # Try a single round-trip bulk source for the whole schema; on
+        # success every sibling table is now warm in the cache too. If
+        # the backend has no bulk source, drop to the per-table
+        # inspector call below and cache its result entry-by-entry.
+        if self._populate_schema_metadata_cache(schema):
+            cached = self._lookup_column_comments_cache(schema, table)
+            if cached is not None:
+                return cached.get("table_comment")
         insp = inspect(self.engine)
         try:
             info = insp.get_table_comment(table, schema=schema)
-            return info.get("text")
+            value = info.get("text")
         except Exception:
-            return None
+            value = None
+        # Even on the per-table path we cache the result so the next
+        # call within the TTL window skips the round-trip.
+        self._save_column_comments_cache(
+            schema,
+            {table: {"table_comment": value, "columns": {}, "kind": "TABLE"}},
+        )
+        return value
 
     def get_column_comments(self, schema: str, table: str) -> dict[str, str | None]:
         if not self.capabilities.column_comments:
             return {}
         schema = self._normalize_id(schema)
         table = self._normalize_id(table)
+        cached = self._lookup_column_comments_cache(schema, table)
+        if cached is not None and cached.get("columns"):
+            return dict(cached["columns"])
+        if self._populate_schema_metadata_cache(schema):
+            cached = self._lookup_column_comments_cache(schema, table)
+            if cached is not None and cached.get("columns"):
+                return dict(cached["columns"])
         insp = inspect(self.engine)
         cols = insp.get_columns(table, schema=schema)
-        return {c["name"]: c.get("comment") for c in cols}
+        out = {c["name"]: c.get("comment") for c in cols}
+        # Preserve any table-level comment we already cached for this
+        # row so the columns fill doesn't blank it out.
+        existing_tc = cached.get("table_comment") if cached else None
+        self._save_column_comments_cache(
+            schema,
+            {table: {"table_comment": existing_tc, "columns": out, "kind": "TABLE"}},
+        )
+        return out
 
     def column_comments_probe_query(self, schema: str, table: str) -> str:
         return self._adapter.column_comments_probe_query(schema, table)

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -250,6 +250,40 @@ class SQLiteHistoryStore:
                     "CREATE INDEX IF NOT EXISTS idx_run_context_cache_expires "
                     "ON run_context_cache(expires_at)"
                 )
+            # ── column_comments_cache: per-table existing-comment cache ──
+            # On large warehouses (Databricks especially) the per-table
+            # DESCRIBE EXTENDED loop the sidebar and CLI inspect flows used
+            # to hit became 30s+. The connector now folds the whole schema
+            # into one bulk INFORMATION_SCHEMA-style query and stashes the
+            # result here, keyed per-table so a single COMMENT write can
+            # invalidate just the row that changed. TTL is the second line
+            # of defence for DBA-edited comments that AMX never sees.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS column_comments_cache (
+                    cache_key      TEXT PRIMARY KEY,
+                    db_profile     TEXT NOT NULL,
+                    database_name  TEXT NOT NULL DEFAULT '',
+                    schema_name    TEXT NOT NULL,
+                    table_name     TEXT NOT NULL,
+                    table_comment  TEXT,
+                    columns_json   TEXT NOT NULL,
+                    kind           TEXT NOT NULL DEFAULT 'TABLE',
+                    fetched_at     REAL NOT NULL,
+                    expires_at     REAL NOT NULL
+                )
+                """
+            )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_ccc_profile_schema "
+                    "ON column_comments_cache(db_profile, database_name, schema_name)"
+                )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_ccc_expires "
+                    "ON column_comments_cache(expires_at)"
+                )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_run_results_run_id ON run_results(run_id)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_run_results_asset "
@@ -1344,6 +1378,206 @@ class SQLiteHistoryStore:
         with self._lock, self._connect() as conn:
             cur = conn.execute(
                 "DELETE FROM run_context_cache WHERE expires_at IS NOT NULL AND expires_at < ?",
+                (now,),
+            )
+            return int(cur.rowcount or 0)
+
+    # ── column_comments_cache: per-table existing-comment cache ──
+
+    @staticmethod
+    def _ccc_key(*, db_profile: str, database: str, schema: str, table: str) -> str:
+        return f"{db_profile}|{database or ''}|{schema}|{table}"
+
+    def save_column_comments_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        schema: str,
+        entries: dict[str, dict[str, Any]],
+        ttl_seconds: float = 3600.0,
+    ) -> int:
+        """Bulk upsert per-table entries after one ``bulk_schema_metadata`` call.
+
+        ``entries`` maps each ``table_name`` to a dict with keys:
+        ``table_comment`` (str | None), ``columns`` (dict[col_name, comment_or_none]),
+        ``kind`` ("TABLE" | "VIEW" | "MATERIALIZED VIEW"). Missing keys default
+        to ``None`` / empty / "TABLE" so callers can pass partial payloads
+        when the backend only returns column-level data.
+        """
+        if not entries:
+            return 0
+        now = time.time()
+        # ``ttl_seconds == 0`` defaults to one hour to match the helper's
+        # default kwarg; negative values are honoured verbatim so tests
+        # can stamp rows as already-expired.
+        if ttl_seconds == 0:
+            ttl_seconds = 3600.0
+        expires_at = now + float(ttl_seconds)
+        rows = [
+            (
+                self._ccc_key(
+                    db_profile=str(db_profile or ""),
+                    database=str(database or ""),
+                    schema=str(schema or ""),
+                    table=str(table or ""),
+                ),
+                str(db_profile or ""),
+                str(database or ""),
+                str(schema or ""),
+                str(table or ""),
+                payload.get("table_comment"),
+                json.dumps(payload.get("columns") or {}, ensure_ascii=True),
+                str(payload.get("kind") or "TABLE"),
+                now,
+                expires_at,
+            )
+            for table, payload in entries.items()
+        ]
+        with self._lock, self._connect() as conn:
+            conn.executemany(
+                """
+                INSERT INTO column_comments_cache
+                    (cache_key, db_profile, database_name, schema_name, table_name,
+                     table_comment, columns_json, kind, fetched_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(cache_key) DO UPDATE SET
+                    table_comment = excluded.table_comment,
+                    columns_json  = excluded.columns_json,
+                    kind          = excluded.kind,
+                    fetched_at    = excluded.fetched_at,
+                    expires_at    = excluded.expires_at
+                """,
+                rows,
+            )
+        return len(rows)
+
+    def lookup_column_comments_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        schema: str,
+        table: str,
+    ) -> dict[str, Any] | None:
+        """Return a single fresh cache entry, or ``None`` if missing/expired.
+
+        Returned shape: ``{"table_comment": ..., "columns": {...}, "kind": ...,
+        "fetched_at": ..., "expires_at": ...}``. Expired rows are kept on disk
+        (cheaper than rewriting) but the lookup pretends they're absent.
+        """
+        cache_key = self._ccc_key(
+            db_profile=str(db_profile or ""),
+            database=str(database or ""),
+            schema=str(schema or ""),
+            table=str(table or ""),
+        )
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT table_comment, columns_json, kind, fetched_at, expires_at
+                FROM column_comments_cache
+                WHERE cache_key = ?
+                """,
+                (cache_key,),
+            ).fetchone()
+        if row is None:
+            return None
+        if float(row["expires_at"]) < time.time():
+            return None
+        try:
+            columns = json.loads(row["columns_json"])
+        except Exception:
+            columns = {}
+        return {
+            "table_comment": row["table_comment"],
+            "columns": columns,
+            "kind": row["kind"] or "TABLE",
+            "fetched_at": float(row["fetched_at"]),
+            "expires_at": float(row["expires_at"]),
+        }
+
+    def lookup_column_comments_cache_bulk(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        schema: str,
+    ) -> dict[str, dict[str, Any]]:
+        """Return ``{table_name: cached_entry}`` for every fresh row in a schema.
+
+        Used by the connector's bulk path to decide whether a refetch is
+        needed at all. Expired rows are skipped.
+        """
+        now = time.time()
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT table_name, table_comment, columns_json, kind, fetched_at, expires_at
+                FROM column_comments_cache
+                WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+                  AND expires_at >= ?
+                """,
+                (
+                    str(db_profile or ""),
+                    str(database or ""),
+                    str(schema or ""),
+                    now,
+                ),
+            ).fetchall()
+        out: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            try:
+                columns = json.loads(row["columns_json"])
+            except Exception:
+                columns = {}
+            out[str(row["table_name"])] = {
+                "table_comment": row["table_comment"],
+                "columns": columns,
+                "kind": row["kind"] or "TABLE",
+                "fetched_at": float(row["fetched_at"]),
+                "expires_at": float(row["expires_at"]),
+            }
+        return out
+
+    def invalidate_column_comments_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str = "",
+        schema: str | None = None,
+        table: str | None = None,
+    ) -> int:
+        """Drop cached rows at one of three granularities.
+
+        * ``schema`` + ``table`` set → single row (column/table comment write).
+        * ``schema`` set, ``table`` ``None`` → whole schema (schema comment write).
+        * Both ``None`` → whole profile (database comment write, profile reset).
+
+        Returns rowcount. Always safe — a no-op on a cold cache returns 0.
+        """
+        params: list[Any] = [str(db_profile or "")]
+        sql = "DELETE FROM column_comments_cache WHERE db_profile = ?"
+        # ``database_name`` is empty string when the profile is single-db;
+        # we filter on it whenever a schema is named so a multi-db profile
+        # only wipes the affected database.
+        if schema is not None:
+            sql += " AND database_name = ? AND schema_name = ?"
+            params.append(str(database or ""))
+            params.append(str(schema or ""))
+        if table is not None:
+            sql += " AND table_name = ?"
+            params.append(str(table or ""))
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(sql, params)
+            return int(cur.rowcount or 0)
+
+    def gc_column_comments_cache(self) -> int:
+        """Sweep expired rows; called at process startup alongside other GC."""
+        now = time.time()
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM column_comments_cache WHERE expires_at < ?",
                 (now,),
             )
             return int(cur.rowcount or 0)

--- a/amx/web/routers/comments.py
+++ b/amx/web/routers/comments.py
@@ -69,6 +69,11 @@ def set_database_comment(
     don't (e.g. SQLite)."""
     db = _scoped_connector(cfg, profile, database, catalog)
     _coerce_or_400("Setting database comment", lambda: db.set_database_comment(body.comment))
+    # Wipe the cached column-comments for this profile so the next
+    # read picks up the just-written value. Database-level writes are
+    # rare enough that nuking the whole profile is cheaper than
+    # tracking which schemas inherit the description.
+    db.invalidate_column_comments_cache()
     return {"ok": "true"}
 
 
@@ -86,6 +91,7 @@ def set_schema_comment(
         f"Setting schema comment on {schema}",
         lambda: db.set_schema_comment(schema, body.comment),
     )
+    db.invalidate_column_comments_cache(schema=schema)
     return {"ok": "true"}
 
 
@@ -108,6 +114,7 @@ def set_table_comment(
         f"Setting table comment on {schema}.{table}",
         lambda: db.set_table_comment(schema, table, body.comment, asset_kind=AssetKind.TABLE),
     )
+    db.invalidate_column_comments_cache(schema=schema, table=table)
     return {"ok": "true"}
 
 
@@ -130,6 +137,9 @@ def set_column_comment(
         f"Setting column comment on {schema}.{table}.{column}",
         lambda: db.set_column_comment(schema, table, column, body.comment),
     )
+    # Column-level granularity isn't worth the bookkeeping — the next
+    # fetch refreshes the entire table's column dict in one bulk call.
+    db.invalidate_column_comments_cache(schema=schema, table=table)
     return {"ok": "true"}
 
 

--- a/amx/web/routers/live_db.py
+++ b/amx/web/routers/live_db.py
@@ -130,7 +130,7 @@ def _connector_for_scope(
         return cached
     if len(_CONNECTOR_CACHE) >= _CONNECTOR_CACHE_MAX:
         _evict_oldest()
-    connector = DatabaseConnector(scoped)
+    connector = DatabaseConnector(scoped, profile_name=profile_name)
     _CONNECTOR_CACHE[key] = connector
     return connector
 

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -137,6 +137,10 @@ def create_app(
             # schema doesn't quietly bias re-run prompts after the
             # user altered the table out-of-band.
             _store.gc_run_context_cache()
+            # Same for the column-comments cache that backs the
+            # bulk-schema metadata path — anything past 1h is wiped
+            # so the next sidebar expand triggers a fresh fetch.
+            _store.gc_column_comments_cache()
     except Exception:
         # Startup must never crash on a GC hiccup; the executor's own
         # cleanup keeps the table tidy regardless.

--- a/tests/test_column_comments_cache.py
+++ b/tests/test_column_comments_cache.py
@@ -1,0 +1,259 @@
+"""Tests for the column-comments cache backing the bulk-schema path.
+
+The cache lives in :class:`amx.storage.sqlite_store.SQLiteHistoryStore`
+alongside the existing ``run_context_cache``. Three properties matter:
+
+1. Save → lookup round-trips the dict verbatim, including ``None``
+   comments (which are real on most backends — an empty column comment
+   reads as ``None``, not the empty string).
+2. ``expires_at`` is honoured on lookup: a row past its TTL is reported
+   absent so the caller refetches from the live DB.
+3. Invalidate has three correct granularities (single row, whole
+   schema, whole profile). A column-comment write must only wipe its
+   own table; a schema-comment write wipes that schema's siblings; a
+   database-level reset wipes everything for the profile.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def _entry(table_comment: str | None, columns: dict[str, str | None]) -> dict[str, object]:
+    return {"table_comment": table_comment, "columns": columns, "kind": "TABLE"}
+
+
+def test_save_then_lookup_roundtrips_entries(store: SQLiteHistoryStore) -> None:
+    store.save_column_comments_cache(
+        db_profile="prod-databricks",
+        database="main",
+        schema="sales",
+        entries={
+            "orders": _entry("All orders", {"id": "PK", "amount": None}),
+            "line_items": _entry(None, {"order_id": "FK to orders"}),
+        },
+    )
+
+    hit = store.lookup_column_comments_cache(
+        db_profile="prod-databricks",
+        database="main",
+        schema="sales",
+        table="orders",
+    )
+    assert hit is not None
+    assert hit["table_comment"] == "All orders"
+    # None column comment must survive the round-trip (json keeps it).
+    assert hit["columns"] == {"id": "PK", "amount": None}
+    assert hit["kind"] == "TABLE"
+
+
+def test_lookup_misses_when_row_is_expired(store: SQLiteHistoryStore) -> None:
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={"orders": _entry("x", {"id": "PK"})},
+        ttl_seconds=-1.0,  # already expired
+    )
+    hit = store.lookup_column_comments_cache(
+        db_profile="prod", database="", schema="public", table="orders"
+    )
+    # TTL < 0 means expires_at < now, so lookup reports absent even
+    # though the row is on disk. ``gc_column_comments_cache`` reaps it.
+    assert hit is None
+
+
+def test_lookup_bulk_returns_only_fresh_rows(store: SQLiteHistoryStore) -> None:
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={"fresh": _entry("ok", {})},
+        ttl_seconds=3600.0,
+    )
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={"stale": _entry("ok", {})},
+        ttl_seconds=-1.0,
+    )
+    bulk = store.lookup_column_comments_cache_bulk(
+        db_profile="prod", database="", schema="public"
+    )
+    assert "fresh" in bulk
+    assert "stale" not in bulk
+
+
+def test_invalidate_single_row_only_drops_target(store: SQLiteHistoryStore) -> None:
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={
+            "orders": _entry("o", {}),
+            "users": _entry("u", {}),
+        },
+    )
+    dropped = store.invalidate_column_comments_cache(
+        db_profile="prod", database="", schema="public", table="orders"
+    )
+    assert dropped == 1
+    # Sibling row untouched — the user editing one table's comment
+    # must not force a refetch of every other table in the schema.
+    assert (
+        store.lookup_column_comments_cache(
+            db_profile="prod", database="", schema="public", table="users"
+        )
+        is not None
+    )
+    assert (
+        store.lookup_column_comments_cache(
+            db_profile="prod", database="", schema="public", table="orders"
+        )
+        is None
+    )
+
+
+def test_invalidate_schema_drops_every_table_in_schema(store: SQLiteHistoryStore) -> None:
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="sales",
+        entries={"orders": _entry("o", {}), "users": _entry("u", {})},
+    )
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="marketing",
+        entries={"campaigns": _entry("c", {})},
+    )
+    dropped = store.invalidate_column_comments_cache(
+        db_profile="prod", database="", schema="sales"
+    )
+    assert dropped == 2
+    # Different schema untouched.
+    assert (
+        store.lookup_column_comments_cache(
+            db_profile="prod", database="", schema="marketing", table="campaigns"
+        )
+        is not None
+    )
+
+
+def test_invalidate_profile_drops_every_schema(store: SQLiteHistoryStore) -> None:
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="sales",
+        entries={"orders": _entry("o", {})},
+    )
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="marketing",
+        entries={"campaigns": _entry("c", {})},
+    )
+    store.save_column_comments_cache(
+        db_profile="other",
+        database="",
+        schema="sales",
+        entries={"orders": _entry("o2", {})},
+    )
+    dropped = store.invalidate_column_comments_cache(db_profile="prod")
+    assert dropped == 2
+    # Other profile must be untouched even with the same schema name.
+    assert (
+        store.lookup_column_comments_cache(
+            db_profile="other", database="", schema="sales", table="orders"
+        )
+        is not None
+    )
+
+
+def test_gc_sweeps_expired_rows(store: SQLiteHistoryStore) -> None:
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={"stale": _entry("x", {})},
+        ttl_seconds=-1.0,
+    )
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={"fresh": _entry("x", {})},
+        ttl_seconds=3600.0,
+    )
+    swept = store.gc_column_comments_cache()
+    assert swept == 1
+    # Fresh row still there after GC.
+    assert (
+        store.lookup_column_comments_cache(
+            db_profile="prod", database="", schema="public", table="fresh"
+        )
+        is not None
+    )
+
+
+def test_save_is_upsert_on_repeat_writes(store: SQLiteHistoryStore) -> None:
+    """A re-fetch of the same (profile, schema, table) must overwrite,
+    not append. Otherwise the row count grows unboundedly across
+    refresh cycles and `expires_at` reads pick a stale row."""
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={"orders": _entry("old", {"id": "old"})},
+    )
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={"orders": _entry("new", {"id": "new"})},
+    )
+    hit = store.lookup_column_comments_cache(
+        db_profile="prod", database="", schema="public", table="orders"
+    )
+    assert hit is not None
+    assert hit["table_comment"] == "new"
+    assert hit["columns"] == {"id": "new"}
+
+
+def test_lookup_is_database_scoped(store: SQLiteHistoryStore) -> None:
+    """A multi-database profile (e.g. Postgres with several databases
+    or Databricks with multiple catalogs) must not let a table in
+    database A shadow the same-named table in database B."""
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="dwh",
+        schema="public",
+        entries={"orders": _entry("dwh-version", {})},
+    )
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="staging",
+        schema="public",
+        entries={"orders": _entry("staging-version", {})},
+    )
+    a = store.lookup_column_comments_cache(
+        db_profile="prod", database="dwh", schema="public", table="orders"
+    )
+    b = store.lookup_column_comments_cache(
+        db_profile="prod", database="staging", schema="public", table="orders"
+    )
+    assert a is not None and a["table_comment"] == "dwh-version"
+    assert b is not None and b["table_comment"] == "staging-version"

--- a/tests/web/test_cleanup_placeholders.py
+++ b/tests/web/test_cleanup_placeholders.py
@@ -79,7 +79,7 @@ def test_endpoint_returns_helper_payload(client, auth_headers, monkeypatch, cfg)
     live_db._CONNECTOR_CACHE.clear()
 
     db = _stub_db_with_placeholders()
-    monkeypatch.setattr(live_db, "DatabaseConnector", lambda _cfg: db)
+    monkeypatch.setattr(live_db, "DatabaseConnector", lambda *_a, **_kw: db)
 
     response = client.post(
         "/api/comments/cleanup-placeholders?profile=test-profile",
@@ -102,7 +102,7 @@ def test_endpoint_400_for_unknown_schema(client, auth_headers, monkeypatch, cfg)
     live_db._CONNECTOR_CACHE.clear()
 
     db = _stub_db_with_placeholders()
-    monkeypatch.setattr(live_db, "DatabaseConnector", lambda _cfg: db)
+    monkeypatch.setattr(live_db, "DatabaseConnector", lambda *_a, **_kw: db)
 
     response = client.post(
         "/api/comments/cleanup-placeholders?profile=test-profile",

--- a/tests/web/test_comments.py
+++ b/tests/web/test_comments.py
@@ -25,7 +25,7 @@ def stub_db(monkeypatch, cfg):
     instance = MagicMock()
     # Comments router builds connectors through _connector_for_scope,
     # which reaches DatabaseConnector inside live_db.
-    monkeypatch.setattr(live_db, "DatabaseConnector", lambda _db: instance)
+    monkeypatch.setattr(live_db, "DatabaseConnector", lambda *_a, **_kw: instance)
     return instance
 
 
@@ -116,7 +116,7 @@ def test_table_comment_writes_to_named_profile_not_active(
     seen_dbconfigs: list[DBConfig] = []
     instance = MagicMock()
 
-    def _factory(db: DBConfig) -> MagicMock:
+    def _factory(db: DBConfig, **_kw) -> MagicMock:
         seen_dbconfigs.append(db)
         return instance
 
@@ -157,7 +157,7 @@ def test_database_overlay_does_not_mutate_target_profile(
     monkeypatch.setattr(
         live_db,
         "DatabaseConnector",
-        lambda db: seen.append(db) or MagicMock(),
+        lambda db, **_kw: seen.append(db) or MagicMock(),
     )
 
     response = client.put(

--- a/tests/web/test_comments_invalidation.py
+++ b/tests/web/test_comments_invalidation.py
@@ -1,0 +1,92 @@
+"""Cache invalidation tests — every DB-write endpoint must wipe the
+column-comments cache for the affected scope before the HTTP response
+returns. Otherwise the next sidebar read serves the pre-write data
+and the user thinks their save was lost.
+
+The four ``set_*_comment`` endpoints each have a different scope:
+
+* database → whole profile.
+* schema   → that schema's tables only.
+* table    → single row.
+* column   → same single row (column-level granularity not worth the
+             bookkeeping).
+
+The apply path (``apply_review_results_to_db``) invalidates per row as
+it walks the result list; covered in ``test_runs_apply.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from amx.config import DBConfig
+from amx.web.routers import live_db
+
+PROFILE = "test-profile"
+
+
+@pytest.fixture()
+def stub_db(monkeypatch, cfg):
+    cfg.db_profiles[PROFILE] = DBConfig(
+        backend="postgresql", host="pg.test", user="amx", database="appdb"
+    )
+    instance = MagicMock()
+    monkeypatch.setattr(live_db, "DatabaseConnector", lambda *_a, **_kw: instance)
+    return instance
+
+
+@pytest.fixture(autouse=True)
+def _wipe_connector_cache() -> None:
+    live_db._CONNECTOR_CACHE.clear()
+    yield
+    live_db._CONNECTOR_CACHE.clear()
+
+
+def test_set_database_comment_wipes_whole_profile(client, auth_headers, stub_db) -> None:
+    response = client.put(
+        f"/api/comments/database?profile={PROFILE}",
+        headers=auth_headers,
+        json={"comment": "Prod DWH"},
+    )
+    assert response.status_code == 200
+    # Database-level write nukes everything — no schema/table kwargs.
+    stub_db.invalidate_column_comments_cache.assert_called_once_with()
+
+
+def test_set_schema_comment_wipes_only_that_schema(client, auth_headers, stub_db) -> None:
+    response = client.put(
+        f"/api/comments/schemas/sales?profile={PROFILE}",
+        headers=auth_headers,
+        json={"comment": "Sales facts"},
+    )
+    assert response.status_code == 200
+    stub_db.invalidate_column_comments_cache.assert_called_once_with(schema="sales")
+
+
+def test_set_table_comment_wipes_only_that_row(client, auth_headers, stub_db) -> None:
+    response = client.put(
+        f"/api/comments/schemas/sales/tables/orders?profile={PROFILE}",
+        headers=auth_headers,
+        json={"comment": "Orders fact"},
+    )
+    assert response.status_code == 200
+    stub_db.invalidate_column_comments_cache.assert_called_once_with(
+        schema="sales", table="orders"
+    )
+
+
+def test_set_column_comment_wipes_parent_table_row(client, auth_headers, stub_db) -> None:
+    """Column writes invalidate at *table* granularity. Cheaper than
+    rewriting per-column tracking — the next bulk fetch refreshes the
+    whole columns dict in one round-trip."""
+    response = client.put(
+        f"/api/comments/schemas/sales/tables/orders/columns/id?profile={PROFILE}",
+        headers=auth_headers,
+        json={"comment": "Order primary key"},
+    )
+    assert response.status_code == 200
+    stub_db.invalidate_column_comments_cache.assert_called_once_with(
+        schema="sales", table="orders"
+    )

--- a/tests/web/test_connector_for_scope.py
+++ b/tests/web/test_connector_for_scope.py
@@ -57,7 +57,7 @@ def _stub_connector(monkeypatch) -> list[DBConfig]:
     every DBConfig it was constructed with."""
     seen: list[DBConfig] = []
 
-    def _factory(db: DBConfig) -> MagicMock:
+    def _factory(db: DBConfig, **_kw) -> MagicMock:
         seen.append(db)
         m = MagicMock()
         m.cfg = db

--- a/tests/web/test_live_db.py
+++ b/tests/web/test_live_db.py
@@ -49,7 +49,7 @@ def _patch_connector(monkeypatch, builder) -> MagicMock:
     factory uses inside :mod:`amx.web.routers.live_db`. Returns the
     mock so the test can assert on call arguments."""
     instance = builder()
-    monkeypatch.setattr(live_db, "DatabaseConnector", lambda _db: instance)
+    monkeypatch.setattr(live_db, "DatabaseConnector", lambda *_a, **_kw: instance)
     return instance
 
 
@@ -126,7 +126,7 @@ def test_list_schemas_with_explicit_catalog_query_arg(client, auth_headers, monk
     fresh DBConfig via dataclasses.replace."""
     captured: dict[str, object] = {}
 
-    def factory(db_cfg):
+    def factory(db_cfg, **_kw):
         captured["catalog"] = db_cfg.catalog
         return MagicMock(
             list_schemas=MagicMock(return_value=["a", "b"]),

--- a/tests/web/test_pending.py
+++ b/tests/web/test_pending.py
@@ -193,7 +193,7 @@ def test_pending_apply_spawns_apply_job(client, auth_headers, stub_pending, monk
         return 1
 
     monkeypatch.setattr(runs_router, "apply_review_results_to_db", fake_apply)
-    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda cfg: MagicMock())
+    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda *_a, **_kw: MagicMock())
 
     response = client.post("/api/pending/apply", headers=auth_headers)
     assert response.status_code == 200
@@ -223,7 +223,7 @@ def test_pending_apply_streams_via_apply_events_endpoint(
         return 1
 
     monkeypatch.setattr(runs_router, "apply_review_results_to_db", fake_apply)
-    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda cfg: MagicMock())
+    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda *_a, **_kw: MagicMock())
 
     response = client.post("/api/pending/apply", headers=auth_headers)
     job_id = response.json()["job_id"]
@@ -267,7 +267,7 @@ def test_pending_preview_returns_sql_per_row(
 
     monkeypatch.setattr(pending_router, "apply_review_results_to_db", fake_apply, raising=False)
     monkeypatch.setattr("amx.agents.orchestrator.apply_review_results_to_db", fake_apply)
-    monkeypatch.setattr("amx.db.connector.DatabaseConnector", lambda cfg: MagicMock())
+    monkeypatch.setattr("amx.db.connector.DatabaseConnector", lambda *_a, **_kw: MagicMock())
 
     response = client.post("/api/pending/preview", headers=auth_headers)
     assert response.status_code == 200
@@ -309,7 +309,7 @@ def test_pending_preview_handles_unsupported_assets(
 
     monkeypatch.setattr(pending_router, "apply_review_results_to_db", fake_apply, raising=False)
     monkeypatch.setattr("amx.agents.orchestrator.apply_review_results_to_db", fake_apply)
-    monkeypatch.setattr("amx.db.connector.DatabaseConnector", lambda cfg: MagicMock())
+    monkeypatch.setattr("amx.db.connector.DatabaseConnector", lambda *_a, **_kw: MagicMock())
 
     response = client.post("/api/pending/preview", headers=auth_headers)
     assert response.status_code == 200

--- a/tests/web/test_runs_apply.py
+++ b/tests/web/test_runs_apply.py
@@ -63,7 +63,7 @@ def test_apply_with_empty_body_uses_pending_queue(client, auth_headers, monkeypa
         return 1
 
     monkeypatch.setattr(runs_router, "apply_review_results_to_db", fake_apply)
-    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda cfg: MagicMock())
+    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda *_a, **_kw: MagicMock())
 
     response = client.post("/api/apply", headers=auth_headers, json={})
     assert response.status_code == 200
@@ -98,7 +98,7 @@ def test_apply_passes_explicit_body_results(client, auth_headers, monkeypatch) -
         runs_router, "load_pending", lambda: pytest.fail("load_pending must not run")
     )
     monkeypatch.setattr(runs_router, "apply_review_results_to_db", fake_apply)
-    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda cfg: MagicMock())
+    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda *_a, **_kw: MagicMock())
 
     response = client.post(
         "/api/apply",
@@ -157,7 +157,7 @@ def test_apply_cancel_flips_status_and_emits_event(client, auth_headers, monkeyp
         return 0
 
     monkeypatch.setattr(runs_router, "apply_review_results_to_db", slow_apply)
-    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda cfg: MagicMock())
+    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda *_a, **_kw: MagicMock())
 
     response = client.post("/api/apply", headers=auth_headers, json={})
     job_id = response.json()["job_id"]
@@ -196,7 +196,7 @@ def test_apply_sse_stream_emits_json_events(client, auth_headers, monkeypatch) -
         return 1
 
     monkeypatch.setattr(runs_router, "apply_review_results_to_db", fake_apply)
-    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda cfg: MagicMock())
+    monkeypatch.setattr(runs_router, "DatabaseConnector", lambda *_a, **_kw: MagicMock())
 
     response = client.post("/api/apply", headers=auth_headers, json={})
     job_id = response.json()["job_id"]


### PR DESCRIPTION
## Summary

Foundation PR for the Databricks-slow-`DESCRIBE EXTENDED` fix. Per the brainstorm: bulk query + persistent cache + hard invalidation, with the cache embedded inside the connector so CLI inspect, the orchestrator profile loop, and Studio's sidebar all share the same warm cache without per-site changes.

- **Cache layer.** New ``column_comments_cache`` SQLite table alongside ``run_context_cache`` (``amx/storage/sqlite_store.py``). Helpers for save / lookup / bulk lookup / invalidate (3 granularities) / GC. 1h TTL, indexed on ``(profile, database, schema)``.
- **Connector seam.** ``DatabaseConnector.get_table_comment`` / ``get_column_comments`` now check the cache first, then try the adapter's bulk source, then fall back to the existing per-table inspector path — and cache the result entry-by-entry either way. Cache key derives from an optional ``profile_name`` ctor kwarg or a stable hash of the connection identity.
- **Hard invalidation on every write path** (the user's non-negotiable). Four endpoints in ``amx/web/routers/comments.py`` and the per-row hook in ``apply_review_results_to_db`` wipe the affected scope (single row / whole schema / whole profile) before returning, so a save followed by an immediate read can never see the pre-write value.
- **Bulk adapter abstract**, default returns ``None``. Per-backend overrides land in the follow-up PR.

## Why this lands first

Splits the perf work into two reviewable chunks:

1. **This PR (foundation, no behaviour change).** Adapters all still fall through to per-table; cache is populated entry-by-entry. Safe even if rolled back — every read still works, just at the current speed.
2. **Follow-up PR.** Per-backend bulk implementations (Databricks Unity, Snowflake, BigQuery, Postgres, MySQL, Oracle, MSSQL, Redshift, ClickHouse, DuckDB) + Studio refresh button + CLI cold-fetch spinner. The actual ~100x speedup on big warehouses materialises there with no extra wiring needed in this PR.

## Test plan

- [x] ``pytest tests/`` — 1391 passed (9 new cache tests, 4 new invalidation tests, rest unchanged).
- [x] No regression in existing ``test_comments.py`` / ``test_connector_for_scope.py`` / ``test_pending.py`` / ``test_runs_apply.py`` / ``test_cleanup_placeholders.py`` / ``test_live_db.py`` — stubs updated for the new ctor kwarg.
- [ ] Manual smoke after merge: existing description reads stay correct; saving a column comment then re-reading reflects the new value immediately (cache invalidation).