### PR TITLE
fix(cli): honour pinned catalog without re-prompting on every run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
   just above the `/studio` section so it captions the REPL walkthrough
   rather than serving as a generic hero.
 
+### Fixed
+
+- **Catalog picker no longer re-prompts on every run when the profile
+  already pinned one.** A Databricks profile with ``catalog=main`` was
+  showing the "Current catalog: 'main'. Press Enter to keep it" prompt
+  on every ``/run``, every ``/search sync``, every REPL boot — the
+  user had already chosen the catalog at profile-creation time and
+  the repeat ask was pure friction. ``ensure_catalog_selected`` now
+  defaults to ``silent_when_set=True``, mirroring the 2-level
+  ``ensure_database_selected`` behaviour that has always been silent
+  for pinned ``cfg.database``. The picker still fires when the
+  catalog is unpinned, or when the pinned value is no longer visible
+  in ``SHOW CATALOGS`` (e.g. archived in Unity, or the role lost
+  access) — in both cases the user has a real decision to make.
+
 ### Added
 
 - **Bulk column-comment metadata across all 10 backends.** Replaces

--- a/amx/cli_support/catalog_picker.py
+++ b/amx/cli_support/catalog_picker.py
@@ -5,11 +5,15 @@ BigQuery projects, etc.).
 Lives at the package level rather than inside ``commands/manual.py``
 so every flow that lists schemas / tables before knowing the
 catalog (``/connect``, ``/run``, ``/run-apply``, ``/search sync``,
-``/edit``) can call the same helper. Per the v0.10.13 UX rule the
-picker is always shown when the backend supports catalogs — the
-existing ``cfg.catalog`` seeds the default so a user happy with
-their previous pick just presses Enter, and a user who wants to
-switch catalogs picks a different one.
+``/edit``) can call the same helper.
+
+UX rule (revised post-v0.13): when the profile already has a
+``cfg.catalog`` pinned, use it silently — same as the 2-level
+``ensure_database_selected`` already does for ``cfg.database``.
+Prompting on every run for a value the user has already chosen at
+profile-creation time was noise; the original "always prompt with
+Enter to keep" rule was rolled back. To explicitly change the pin,
+the user re-runs ``/db`` and edits the profile.
 
 The helper is intentionally a pure function with no side effects
 beyond updating ``db.cfg.catalog`` for the active in-memory
@@ -30,26 +34,27 @@ log = get_logger("cli.catalog_picker")
 def ensure_catalog_selected(
     db: Any,
     *,
-    silent_when_set: bool = False,
+    silent_when_set: bool = True,
 ) -> str:
-    """Prompt the user for a catalog, defaulting to the current pick.
+    """Prompt the user for a catalog only when nothing is pinned.
 
     Args:
         db: A live :class:`DatabaseConnector`. The helper checks
             ``db.supports_catalogs()`` and short-circuits when False
             so PG / Snowflake / BigQuery (without project switching)
             connections are unaffected.
-        silent_when_set: When True, skip the prompt entirely if
-            ``cfg.catalog`` is already populated and the catalog
-            list is non-empty. Useful for non-interactive flows
-            where the user has already pinned a catalog and any
-            extra prompt would be noise. Default False — the picker
-            shows every time, mirroring the v0.10.13 UX rule.
+        silent_when_set: When True (the default since v0.13), skip
+            the prompt entirely if ``cfg.catalog`` is already pinned
+            in the profile AND visible in ``list_catalogs()``. This
+            mirrors what :func:`ensure_database_selected` already
+            does for 2-level backends — pinned == use directly, no
+            re-ask on every run. Pass False to force the picker
+            (e.g. an explicit "switch catalog" sub-command).
 
     Returns:
-        The selected catalog name (or the existing one when the
-        user pressed Enter to keep it). Returns "" when the
-        backend doesn't support catalogs or when the user cancelled.
+        The selected catalog name (the pinned value when silent,
+        the user's pick otherwise). Returns "" when the backend
+        doesn't support catalogs or when the user cancelled.
     """
     # Lazy import to avoid coupling cli_support → commands.manual at
     # import time. The text-prompt helpers come from utils.console

--- a/tests/test_runtime_pickers.py
+++ b/tests/test_runtime_pickers.py
@@ -156,3 +156,46 @@ def test_ensure_hierarchy_resolved_falls_through_to_database_picker(patch_picker
         chosen = ensure_hierarchy_resolved(db)
     assert chosen == "app"
     assert db.cfg.database == "app"
+
+
+def test_pinned_catalog_is_used_silently_on_every_run(patch_picker_choice) -> None:
+    """Profile with ``cfg.catalog`` already set must not re-prompt on
+    every ``/run``. Mirrors what the 2-level database picker already
+    does for ``cfg.database`` — pinned == use directly, no re-ask.
+
+    Regression guard for the user-reported friction: a Databricks
+    profile with ``catalog=main`` was showing the picker on every
+    run, forcing the user to press Enter even though they had already
+    pinned a catalog at profile-creation time.
+    """
+    db = _FakeDB(
+        cfg=_FakeCfg(backend="databricks", catalog="main"),
+        _catalogs=["main", "analytics"],
+        _supports_catalogs=True,
+    )
+    # The picker primitive must NOT be invoked at all when the
+    # catalog is pinned. Asserting the choice fn was never called is
+    # the strongest form of "no prompt shown to the user".
+    with patch(
+        "amx.cli_support.commands.manual._ask_choice_or_cancel"
+    ) as choice_mock:
+        chosen = ensure_hierarchy_resolved(db)
+    assert chosen == "main"
+    assert db.cfg.catalog == "main"
+    choice_mock.assert_not_called()
+
+
+def test_pinned_catalog_no_longer_visible_falls_back_to_picker(patch_picker_choice) -> None:
+    """Defence: if the pinned catalog has been dropped on the server
+    (or the role lost access), the silent path can't honour the pin
+    — show the picker so the user can choose a still-valid catalog
+    instead of returning a name the next list_schemas would 404 on."""
+    db = _FakeDB(
+        cfg=_FakeCfg(backend="databricks", catalog="archived"),
+        _catalogs=["main", "analytics"],
+        _supports_catalogs=True,
+    )
+    with patch_picker_choice("main"):
+        chosen = ensure_hierarchy_resolved(db)
+    assert chosen == "main"
+    assert db.cfg.catalog == "main"


### PR DESCRIPTION
## Symptom

A Databricks profile with ``catalog=main`` pinned at ``/db`` profile-creation time still triggered the catalog picker on every ``/run``, every ``/search sync``, every REPL boot:

```
Current catalog: 'main'. Press Enter to keep it, or pick a different one.
> _
```

The user has to press Enter once per run for a decision they already made. Pure friction.

## Cause

``ensure_catalog_selected`` defaulted to ``silent_when_set=False``, encoded as the deliberate "always prompt with Enter to keep" rule from v0.10.13. Meanwhile ``ensure_database_selected`` (the 2-level counterpart for Postgres/Snowflake/MySQL/etc.) has always short-circuited when ``cfg.database`` is pinned — same logical condition, opposite default. The asymmetry was the bug.

## Fix

Flip ``silent_when_set`` to default-True so the catalog picker matches the database picker's behaviour: pinned == use directly, no re-ask. The picker still fires when:

- The catalog is unpinned (``cfg.catalog == ""``); or
- The pinned catalog is no longer visible in ``SHOW CATALOGS`` (dropped in Unity, role lost access).

Both cases represent real decisions the user needs to make — those prompts are signal, not noise.

## Test plan

- [x] ``pytest tests/test_runtime_pickers.py`` — 14 passed (12 existing + 2 new):
  - ``test_pinned_catalog_is_used_silently_on_every_run`` asserts the picker primitive is **never invoked** when ``cfg.catalog=main`` and ``main ∈ list_catalogs()``.
  - ``test_pinned_catalog_no_longer_visible_falls_back_to_picker`` asserts the safety fallback when the pinned name vanished from the server side.
- [x] ``pytest tests/`` — 1399 passed.
- [ ] Manual: open Databricks profile with pinned catalog, run ``/run`` — catalog picker MUST NOT appear; the run starts immediately on the pinned catalog.