### PR TITLE
feat(db): cache the asset list and per-schema metadata (not just column comments)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **Cache now actually covers ``list_assets`` and the per-schema
+  ``DESCRIBE SCHEMA`` loop.** The v0.13 cache short-circuited
+  ``get_table_comment`` and ``get_column_comments`` but left the
+  upstream SHOW TABLES / per-schema DESCRIBE SCHEMA queries firing
+  on every sidebar visit. Two fixes:
+  - ``column_comments_cache`` now records *how* an entry was written
+    (``bulk_filled=1`` for adapter-bulk fetches, ``0`` for per-table
+    inspector fallback). ``connector.list_assets`` reads the asset
+    list directly from the cache when at least one bulk-filled row
+    exists for the schema, so a re-visit no longer issues SHOW
+    TABLES at all.
+  - New ``schemas_cache`` table + per-backend ``bulk_catalog_
+    metadata`` (Databricks Unity, Snowflake, Postgres, BigQuery,
+    MySQL, Oracle, MSSQL, Redshift, ClickHouse, DuckDB) so expanding
+    a catalog in the sidebar runs **one** ``INFORMATION_SCHEMA.
+    SCHEMATA`` query instead of N per-schema DESCRIBE SCHEMA round-
+    trips. ``connector.list_schemas`` and ``get_schema_comment``
+    both read off this cache. The invalidation hooks in
+    ``set_schema_comment`` / ``set_database_comment`` were extended
+    to drop the matching schemas_cache rows so a post-write read is
+    guaranteed fresh.
+
 - **Catalog picker no longer re-prompts on every run when the profile
   already pinned one.** A Databricks profile with ``catalog=main`` was
   showing the "Current catalog: 'main'. Press Enter to keep it" prompt

--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -294,6 +294,27 @@ class DatabaseAdapter(ABC):
     def get_database_comment(self, engine: Engine) -> str | None:
         return None
 
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """Fetch ``{schema_name: schema_comment_or_none}`` for a whole catalog.
+
+        Backends that organise schemas under a catalog/database (every
+        backend AMX supports, in practice) can answer "what schemas
+        exist + what's their comment" in a single round-trip against
+        ``INFORMATION_SCHEMA.SCHEMATA`` / ``pg_namespace`` /
+        ``system.databases`` etc. The connector folds this into its
+        ``schemas_cache`` so subsequent sidebar expands skip the DB
+        entirely until TTL or a schema-write invalidation.
+
+        Returning ``None`` leaves the existing per-schema
+        ``get_schema_comment`` fallback in place — no regression for
+        backends that don't override this.
+        """
+        return None
+
     def bulk_schema_metadata(
         self,
         engine: Engine,

--- a/amx/db/adapters/bigquery.py
+++ b/amx/db/adapters/bigquery.py
@@ -150,6 +150,36 @@ class BigQueryAdapter(DatabaseAdapter):
     def stats_label(self) -> str:
         return "INFORMATION_SCHEMA.TABLES"
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """BigQuery doesn't store a free-text dataset description in
+        ``INFORMATION_SCHEMA.SCHEMATA`` — descriptions live on the
+        dataset resource itself, fetched via the Google client. The
+        bulk query still wins because it replaces one
+        ``SELECT … FROM `project`.INFORMATION_SCHEMA.SCHEMATA`` for
+        the schema list with N per-dataset client calls the legacy
+        path would make.
+        """
+        project = (catalog or getattr(self.cfg, "project", "") or "").strip()
+        info_path = (
+            f"`{project}`.INFORMATION_SCHEMA.SCHEMATA"
+            if project
+            else "INFORMATION_SCHEMA.SCHEMATA"
+        )
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(f"SELECT schema_name FROM {info_path}")
+                ).fetchall()
+            return {str(r[0]): None for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/adapters/clickhouse.py
+++ b/amx/db/adapters/clickhouse.py
@@ -213,6 +213,31 @@ class ClickHouseAdapter(DatabaseAdapter):
     def stats_label(self) -> str:
         return "system.parts (active parts only)"
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """``system.databases`` covers every CH "schema" + its comment.
+
+        ClickHouse 22.5+ ships the ``comment`` column on this view; on
+        older builds we degrade silently (the ``except`` branch fires)
+        and the connector falls back to its per-schema path.
+        """
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT name, comment FROM system.databases "
+                        "WHERE name NOT IN ('system','INFORMATION_SCHEMA','information_schema')"
+                    )
+                ).fetchall()
+            return {str(r[0]): (str(r[1]) if r[1] else None) for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/adapters/databricks.py
+++ b/amx/db/adapters/databricks.py
@@ -345,6 +345,39 @@ class DatabricksAdapter(DatabaseAdapter):
         except Exception:
             return None
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """Unity Catalog: every schema in ``catalog`` + its comment in
+        one ``system.information_schema.schemata`` query.
+
+        Replaces the sidebar's per-schema ``DESCRIBE SCHEMA`` loop on
+        Databricks, which is the single most expensive bit of metadata
+        polish when expanding a catalog with many schemas. Legacy Hive
+        metastore profiles return ``None`` (no ``system.information_
+        schema``) and fall back to per-schema fetch.
+        """
+        cat = (catalog or getattr(self.cfg, "catalog", "") or "").strip()
+        if not cat:
+            return None
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT schema_name, comment "
+                        "FROM system.information_schema.schemata "
+                        "WHERE catalog_name = :cat AND schema_name <> 'information_schema'"
+                    ),
+                    {"cat": cat},
+                ).fetchall()
+            return {str(r[0]): (str(r[1]) if r[1] else None) for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/adapters/duckdb.py
+++ b/amx/db/adapters/duckdb.py
@@ -159,6 +159,26 @@ class DuckDBAdapter(DatabaseAdapter):
     def stats_label(self) -> str:
         return "row count (no scan counters)"
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """All user-visible schemas + their comments via ``duckdb_schemas()``."""
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT schema_name, comment FROM duckdb_schemas() "
+                        "WHERE NOT internal"
+                    )
+                ).fetchall()
+            return {str(r[0]): (str(r[1]) if r[1] else None) for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/adapters/mssql.py
+++ b/amx/db/adapters/mssql.py
@@ -226,6 +226,38 @@ class MSSQLAdapter(DatabaseAdapter):
     def stats_label(self) -> str:
         return "sys.dm_db_partition_stats (estimate)"
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """``sys.schemas`` joined to ``sys.extended_properties`` for the
+        ``MS_Description`` extended property on schema-level (class=3).
+        Skips the built-in ``dbo``-adjacent system schemas the sidebar
+        already filters.
+        """
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT s.name, CAST(ep.value AS NVARCHAR(MAX)) "
+                        "FROM sys.schemas s "
+                        "LEFT JOIN sys.extended_properties ep "
+                        "  ON ep.major_id = s.schema_id "
+                        "  AND ep.class = 3 AND ep.name = 'MS_Description' "
+                        "WHERE s.name NOT IN ("
+                        "'sys','INFORMATION_SCHEMA','guest','db_accessadmin',"
+                        "'db_backupoperator','db_datareader','db_datawriter',"
+                        "'db_ddladmin','db_denydatareader','db_denydatawriter',"
+                        "'db_owner','db_securityadmin')"
+                    )
+                ).fetchall()
+            return {str(r[0]): (str(r[1]) if r[1] else None) for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/adapters/mysql.py
+++ b/amx/db/adapters/mysql.py
@@ -417,6 +417,32 @@ class MySQLAdapter(DatabaseAdapter):
             out["warnings"] = warnings
         return out
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """MySQL stores schemas in ``INFORMATION_SCHEMA.SCHEMATA``; no
+        schema-level comment exists in the protocol, so every entry's
+        comment is ``None``. The bulk path still wins because we avoid
+        per-schema DESCRIBE round-trips driven by the sidebar's
+        expand-all loop.
+        """
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA "
+                        "WHERE SCHEMA_NAME NOT IN "
+                        "('information_schema','mysql','performance_schema','sys')"
+                    )
+                ).fetchall()
+            return {str(r[0]): None for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/adapters/oracle.py
+++ b/amx/db/adapters/oracle.py
@@ -271,6 +271,35 @@ class OracleAdapter(DatabaseAdapter):
     def stats_label(self) -> str:
         return "ALL_TABLES.NUM_ROWS (optimiser stats; may be stale)"
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """Oracle has no schema-level COMMENT (schemas are users). Use
+        ``ALL_USERS`` as the schema source; every entry carries
+        ``None`` as the comment so the bulk path purely saves the
+        sidebar's per-schema enumeration round-trips, no comment polish.
+        """
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT USERNAME FROM ALL_USERS "
+                        "WHERE USERNAME NOT IN ("
+                        "'SYS','SYSTEM','OUTLN','XS$NULL','DBSNMP','APPQOSSYS',"
+                        "'ANONYMOUS','XDB','GSMADMIN_INTERNAL','GSMCATUSER','GSMUSER',"
+                        "'DIP','REMOTE_SCHEDULER_AGENT','SI_INFORMTN_SCHEMA',"
+                        "'ORDDATA','ORDPLUGINS','ORDSYS','OJVMSYS','LBACSYS',"
+                        "'CTXSYS','MDSYS','MDDATA','OLAPSYS','WMSYS','EXFSYS')"
+                    )
+                ).fetchall()
+            return {str(r[0]): None for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/adapters/postgresql.py
+++ b/amx/db/adapters/postgresql.py
@@ -171,6 +171,35 @@ class PostgreSQLAdapter(DatabaseAdapter):
     def stats_label(self) -> str:
         return "pg_stat_user_tables"
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """Pull every user schema + its comment in one ``pg_namespace`` scan.
+
+        Skips the system catalogs (``pg_*`` + ``information_schema``)
+        that ``DatabaseConnector.list_schemas`` would already filter
+        out — keeps the bulk result aligned with what the sidebar
+        actually shows.
+        """
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT n.nspname, "
+                        "       obj_description(n.oid, 'pg_namespace') "
+                        "FROM pg_namespace n "
+                        "WHERE n.nspname NOT LIKE 'pg_%' "
+                        "  AND n.nspname <> 'information_schema'"
+                    )
+                ).fetchall()
+            return {str(r[0]): (str(r[1]) if r[1] else None) for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/adapters/redshift.py
+++ b/amx/db/adapters/redshift.py
@@ -146,6 +146,30 @@ class RedshiftAdapter(DatabaseAdapter):
             ).fetchall()
         return [str(r[0]) for r in rows]
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """Same shape as Postgres' ``bulk_catalog_metadata`` since
+        Redshift forks ``pg_namespace`` / ``obj_description``."""
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT n.nspname, "
+                        "       obj_description(n.oid, 'pg_namespace') "
+                        "FROM pg_namespace n "
+                        "WHERE n.nspname NOT LIKE 'pg_%' "
+                        "  AND n.nspname <> 'information_schema'"
+                    )
+                ).fetchall()
+            return {str(r[0]): (str(r[1]) if r[1] else None) for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/adapters/snowflake.py
+++ b/amx/db/adapters/snowflake.py
@@ -215,6 +215,31 @@ class SnowflakeAdapter(DatabaseAdapter):
     def stats_label(self) -> str:
         return "INFORMATION_SCHEMA.TABLES"
 
+    # ── Bulk catalog metadata ─────────────────────────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """``INFORMATION_SCHEMA.SCHEMATA`` is database-scoped on
+        Snowflake; the active connection's database implicitly bounds
+        the result. Skips the always-empty ``INFORMATION_SCHEMA``
+        schema itself so the sidebar doesn't show it.
+        """
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT SCHEMA_NAME, COMMENT "
+                        "FROM INFORMATION_SCHEMA.SCHEMATA "
+                        "WHERE SCHEMA_NAME <> 'INFORMATION_SCHEMA'"
+                    )
+                ).fetchall()
+            return {str(r[0]): (str(r[1]) if r[1] else None) for r in rows}
+        except Exception:
+            return None
+
     # ── Bulk schema metadata ──────────────────────────────────────────────
 
     def bulk_schema_metadata(

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -392,11 +392,26 @@ class DatabaseConnector:
         self._engine = None
 
     def list_schemas(self) -> list[str]:
+        # Cache fast path: the schemas_cache holds (schema, comment)
+        # pairs per (profile, database, catalog). Reading here lets the
+        # sidebar's catalog-expand short-circuit BOTH the schema
+        # enumeration AND the per-schema get_schema_comment loop the
+        # router fires right after — see _populate_catalogs_cache for
+        # the bulk fill that warms this state.
+        catalog = getattr(self.cfg, "catalog", "") or ""
+        if self._catalog_bulk_cache_is_fresh(catalog):
+            cached = self._list_schemas_from_cache(catalog)
+            if cached:
+                return [name for name, _ in cached]
+        if self._populate_catalogs_cache(catalog):
+            cached = self._list_schemas_from_cache(catalog)
+            if cached:
+                return [name for name, _ in cached]
+
         # Adapter-specific override (e.g. Databricks ``SHOW SCHEMAS IN
         # <catalog>``) takes precedence so catalog-scoped backends
         # don't fall through to the SQLAlchemy inspector — which
         # ignores catalog and returns ambiguous results.
-        catalog = getattr(self.cfg, "catalog", "") or ""
         try:
             adapter_result = self._adapter.list_schemas(self.engine, catalog)
         except Exception:
@@ -577,7 +592,68 @@ class DatabaseConnector:
         return self._list_extended("external_tables", "list_external_tables", schema)
 
     def list_assets(self, schema: str) -> list[tuple[str, AssetKind]]:
-        """All analyzable assets (tables, views, materialized views) in a schema."""
+        """All analyzable assets (tables, views, materialized views) in a schema.
+
+        Cache fast path: when the column-comments cache for this
+        schema is bulk-filled (the adapter's ``bulk_schema_metadata``
+        ran for it within the TTL window), we already know every table
+        + view + MV name and their kinds — return them without
+        re-issuing SHOW TABLES / SHOW VIEWS. This is the difference
+        the user observed between "expand schema" hitting the DB
+        every time and a true warm cache.
+
+        Cold path: try the bulk fetch via
+        ``_populate_schema_metadata_cache`` to also fill the cache for
+        every sibling read in the same session. If the backend has no
+        bulk source (or it fails), fall through to the existing
+        per-list inspector calls and DO NOT pretend the result is
+        bulk-filled — that flag is reserved for the adapter path that
+        promises an exhaustive enumeration.
+        """
+        normalised = self._normalize_id(schema)
+        # Fast path — cache covers the schema; derive list from rows.
+        if self._schema_bulk_cache_is_fresh(normalised):
+            cached = self._lookup_column_comments_cache_bulk(normalised)
+            if cached:
+                kind_map = {
+                    "TABLE": AssetKind.TABLE,
+                    "VIEW": AssetKind.VIEW,
+                    "MATERIALIZED VIEW": AssetKind.MATERIALIZED_VIEW,
+                }
+                assets = [
+                    (
+                        name,
+                        kind_map.get(
+                            str(entry.get("kind", "TABLE")).upper(),
+                            AssetKind.TABLE,
+                        ),
+                    )
+                    for name, entry in cached.items()
+                ]
+                assets.sort(key=lambda x: x[0])
+                return assets
+        # Cold path — try the bulk adapter so the next call is warm.
+        if self._populate_schema_metadata_cache(normalised):
+            cached = self._lookup_column_comments_cache_bulk(normalised)
+            if cached:
+                kind_map = {
+                    "TABLE": AssetKind.TABLE,
+                    "VIEW": AssetKind.VIEW,
+                    "MATERIALIZED VIEW": AssetKind.MATERIALIZED_VIEW,
+                }
+                assets = [
+                    (
+                        name,
+                        kind_map.get(
+                            str(entry.get("kind", "TABLE")).upper(),
+                            AssetKind.TABLE,
+                        ),
+                    )
+                    for name, entry in cached.items()
+                ]
+                assets.sort(key=lambda x: x[0])
+                return assets
+        # Fallback — inspector-driven enumeration (legacy path).
         assets: list[tuple[str, AssetKind]] = []
         for t in self.list_tables(schema):
             assets.append((t, AssetKind.TABLE))
@@ -670,8 +746,17 @@ class DatabaseConnector:
         self,
         schema: str,
         entries: dict[str, dict[str, Any]],
+        *,
+        bulk_filled: bool = False,
     ) -> None:
-        """Persist a per-schema metadata dict to the cache."""
+        """Persist a per-schema metadata dict to the cache.
+
+        ``bulk_filled`` is ``True`` only when the entries dict came
+        from the adapter's bulk source — i.e. covers every table in
+        the schema. Per-table fallback writes pass ``False`` so the
+        cache row is usable for column-comment short-circuits but not
+        for ``list_assets``.
+        """
         if not entries:
             return
         try:
@@ -687,9 +772,47 @@ class DatabaseConnector:
                 database=self._cache_database_key(),
                 schema=schema,
                 entries=entries,
+                bulk_filled=bulk_filled,
             )
         except Exception as exc:
             log.debug("column-comments cache save failed: %s", exc)
+
+    def _schema_bulk_cache_is_fresh(self, schema: str) -> bool:
+        """Cheap check used by ``list_assets`` before re-running SHOW TABLES."""
+        try:
+            from amx.storage.sqlite_store import history_store
+        except Exception:
+            return False
+        store = history_store()
+        if store is None:
+            return False
+        try:
+            return store.schema_has_bulk_filled_cache(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                schema=schema,
+            )
+        except Exception:
+            return False
+
+    def _lookup_column_comments_cache_bulk(
+        self, schema: str
+    ) -> dict[str, dict[str, Any]]:
+        try:
+            from amx.storage.sqlite_store import history_store
+        except Exception:
+            return {}
+        store = history_store()
+        if store is None:
+            return {}
+        try:
+            return store.lookup_column_comments_cache_bulk(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                schema=schema,
+            )
+        except Exception:
+            return {}
 
     def invalidate_column_comments_cache(
         self,
@@ -701,6 +824,10 @@ class DatabaseConnector:
         - ``schema`` + ``table`` → single row (one table COMMENT write).
         - ``schema`` only → whole schema (schema COMMENT write).
         - Both None → whole profile (database COMMENT or wholesale reset).
+
+        Schema-level invalidations also wipe the matching
+        ``schemas_cache`` row so a re-read of ``get_schema_comment``
+        sees the fresh value, not the pre-write copy.
         """
         try:
             from amx.storage.sqlite_store import history_store
@@ -718,6 +845,132 @@ class DatabaseConnector:
             )
         except Exception as exc:
             log.debug("column-comments cache invalidate failed: %s", exc)
+        # Mirror the invalidation into the schemas_cache. Granularity
+        # mapping: ``table`` writes don't touch schema metadata so we
+        # skip them; ``schema`` writes wipe that one schema row; whole-
+        # profile invalidations (both None) wipe everything in the
+        # catalog cache too.
+        if table is not None:
+            return
+        try:
+            store.invalidate_schemas_cache(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                catalog=str(getattr(self.cfg, "catalog", "") or ""),
+                schema=schema,
+            ) if schema is not None else store.invalidate_schemas_cache(
+                db_profile=self._cache_profile_key,
+            )
+        except Exception as exc:
+            log.debug("schemas cache invalidate failed: %s", exc)
+
+    # ── schemas_cache helpers ─────────────────────────────────────────────
+
+    def _lookup_schemas_cache(
+        self, catalog: str, schema: str
+    ) -> dict[str, Any] | None:
+        try:
+            from amx.storage.sqlite_store import history_store
+        except Exception:
+            return None
+        store = history_store()
+        if store is None:
+            return None
+        try:
+            return store.lookup_schemas_cache(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                catalog=catalog,
+                schema=schema,
+            )
+        except Exception:
+            return None
+
+    def _catalog_bulk_cache_is_fresh(self, catalog: str) -> bool:
+        try:
+            from amx.storage.sqlite_store import history_store
+        except Exception:
+            return False
+        store = history_store()
+        if store is None:
+            return False
+        try:
+            return store.catalog_has_bulk_filled_cache(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                catalog=catalog,
+            )
+        except Exception:
+            return False
+
+    def _list_schemas_from_cache(
+        self, catalog: str
+    ) -> list[tuple[str, str | None]]:
+        try:
+            from amx.storage.sqlite_store import history_store
+        except Exception:
+            return []
+        store = history_store()
+        if store is None:
+            return []
+        try:
+            return store.list_schemas_from_cache(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                catalog=catalog,
+            )
+        except Exception:
+            return []
+
+    def _save_schemas_cache(
+        self,
+        catalog: str,
+        entries: dict[str, str | None],
+        *,
+        bulk_filled: bool = False,
+    ) -> None:
+        if not entries:
+            return
+        try:
+            from amx.storage.sqlite_store import history_store
+        except Exception:
+            return
+        store = history_store()
+        if store is None:
+            return
+        try:
+            store.save_schemas_cache(
+                db_profile=self._cache_profile_key,
+                database=self._cache_database_key(),
+                catalog=catalog,
+                entries=entries,
+                bulk_filled=bulk_filled,
+            )
+        except Exception as exc:
+            log.debug("schemas cache save failed: %s", exc)
+
+    def _populate_catalogs_cache(self, catalog: str) -> bool:
+        """Run the adapter's ``bulk_catalog_metadata`` and cache it.
+
+        Returns ``True`` when the adapter delivered a non-empty dict
+        (every reachable schema in the catalog) and ``False`` when the
+        backend has no bulk source — the caller then falls back to
+        per-schema enumeration + per-schema comment lookups.
+        """
+        try:
+            payload = self._adapter.bulk_catalog_metadata(self.engine, catalog)
+        except Exception as exc:
+            log.debug(
+                "bulk_catalog_metadata raised on %s for catalog %r: %s",
+                self._adapter.name,
+                catalog,
+                exc,
+            )
+            return False
+        if not payload:
+            return False
+        self._save_schemas_cache(catalog, payload, bulk_filled=True)
+        return True
 
     def _populate_schema_metadata_cache(self, schema: str) -> bool:
         """Run the adapter's bulk source for ``schema`` and cache results.
@@ -777,7 +1030,7 @@ class DatabaseConnector:
             return False
         if not payload:
             return False
-        self._save_column_comments_cache(schema, payload)
+        self._save_column_comments_cache(schema, payload, bulk_filled=True)
         return True
 
     def get_table_comment(self, schema: str, table: str) -> str | None:
@@ -861,7 +1114,24 @@ class DatabaseConnector:
     def get_schema_comment(self, schema: str) -> str | None:
         if not self.capabilities.schema_comments:
             return None
-        return self._adapter.get_schema_comment(self.engine, schema)
+        catalog = str(getattr(self.cfg, "catalog", "") or "")
+        # Cache fast path: hit the schemas_cache before any DB call.
+        cached = self._lookup_schemas_cache(catalog, schema)
+        if cached is not None:
+            return cached.get("schema_comment")
+        # Cold path: bulk-fill the whole catalog in one shot so the
+        # sidebar's per-schema loop becomes O(1) cache hits after the
+        # first call. If the adapter has no bulk source, drop to the
+        # legacy per-schema call and cache its single-row result.
+        if self._populate_catalogs_cache(catalog):
+            cached = self._lookup_schemas_cache(catalog, schema)
+            if cached is not None:
+                return cached.get("schema_comment")
+        value = self._adapter.get_schema_comment(self.engine, schema)
+        self._save_schemas_cache(
+            catalog, {schema: value}, bulk_filled=False
+        )
+        return value
 
     def get_database_comment(self) -> str | None:
         if not self.capabilities.database_comments:

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -284,6 +284,56 @@ class SQLiteHistoryStore:
                     "CREATE INDEX IF NOT EXISTS idx_ccc_expires "
                     "ON column_comments_cache(expires_at)"
                 )
+            # ``bulk_filled`` differentiates two write paths:
+            #   - ``1`` — entry came from a successful
+            #     ``adapter.bulk_schema_metadata`` call, which by
+            #     contract returns EVERY table in the schema. Presence
+            #     of any such row for a schema means the cache covers
+            #     the whole schema and ``list_assets`` can read from it
+            #     directly without re-issuing SHOW TABLES.
+            #   - ``0`` — entry came from the per-table inspector
+            #     fallback. The schema may have other uncached tables;
+            #     ``list_assets`` must NOT trust this state.
+            # Added as a migration so existing histories pick it up.
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "ALTER TABLE column_comments_cache "
+                    "ADD COLUMN bulk_filled INTEGER NOT NULL DEFAULT 0"
+                )
+            # ── schemas_cache: per-catalog schema-level metadata ──
+            # Catalog expand in the sidebar fires ``list_schemas`` (one
+            # query — fast) and then ``get_schema_comment`` per schema
+            # (DESCRIBE SCHEMA / pg_namespace lookup — slow loop).
+            # This table absorbs both: a single ``bulk_catalog_metadata``
+            # query fills schema names + comments for the whole catalog
+            # in one round-trip, and the result lives here under a
+            # ``(profile, database, catalog)`` scope. The freshness
+            # marker on individual rows mirrors the column cache.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schemas_cache (
+                    cache_key       TEXT PRIMARY KEY,
+                    db_profile      TEXT NOT NULL,
+                    database_name   TEXT NOT NULL DEFAULT '',
+                    catalog_name    TEXT NOT NULL DEFAULT '',
+                    schema_name     TEXT NOT NULL,
+                    schema_comment  TEXT,
+                    bulk_filled     INTEGER NOT NULL DEFAULT 0,
+                    fetched_at      REAL NOT NULL,
+                    expires_at      REAL NOT NULL
+                )
+                """
+            )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_sc_profile_catalog "
+                    "ON schemas_cache(db_profile, database_name, catalog_name)"
+                )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_sc_expires "
+                    "ON schemas_cache(expires_at)"
+                )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_run_results_run_id ON run_results(run_id)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_run_results_asset "
@@ -1396,6 +1446,7 @@ class SQLiteHistoryStore:
         schema: str,
         entries: dict[str, dict[str, Any]],
         ttl_seconds: float = 3600.0,
+        bulk_filled: bool = False,
     ) -> int:
         """Bulk upsert per-table entries after one ``bulk_schema_metadata`` call.
 
@@ -1404,6 +1455,12 @@ class SQLiteHistoryStore:
         ``kind`` ("TABLE" | "VIEW" | "MATERIALIZED VIEW"). Missing keys default
         to ``None`` / empty / "TABLE" so callers can pass partial payloads
         when the backend only returns column-level data.
+
+        ``bulk_filled`` records *how* the entries arrived: ``True`` for a
+        successful bulk-adapter call (the dict covers every table in the
+        schema by contract), ``False`` for per-table fallback writes. The
+        flag is what lets ``list_assets`` know whether the cache is safe
+        to read instead of re-issuing SHOW TABLES.
         """
         if not entries:
             return 0
@@ -1414,6 +1471,7 @@ class SQLiteHistoryStore:
         if ttl_seconds == 0:
             ttl_seconds = 3600.0
         expires_at = now + float(ttl_seconds)
+        flag = 1 if bulk_filled else 0
         rows = [
             (
                 self._ccc_key(
@@ -1431,6 +1489,7 @@ class SQLiteHistoryStore:
                 str(payload.get("kind") or "TABLE"),
                 now,
                 expires_at,
+                flag,
             )
             for table, payload in entries.items()
         ]
@@ -1439,18 +1498,53 @@ class SQLiteHistoryStore:
                 """
                 INSERT INTO column_comments_cache
                     (cache_key, db_profile, database_name, schema_name, table_name,
-                     table_comment, columns_json, kind, fetched_at, expires_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     table_comment, columns_json, kind, fetched_at, expires_at, bulk_filled)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(cache_key) DO UPDATE SET
                     table_comment = excluded.table_comment,
                     columns_json  = excluded.columns_json,
                     kind          = excluded.kind,
                     fetched_at    = excluded.fetched_at,
-                    expires_at    = excluded.expires_at
+                    expires_at    = excluded.expires_at,
+                    bulk_filled   = MAX(column_comments_cache.bulk_filled, excluded.bulk_filled)
                 """,
                 rows,
             )
         return len(rows)
+
+    def schema_has_bulk_filled_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        schema: str,
+    ) -> bool:
+        """``True`` when at least one fresh ``bulk_filled=1`` row exists
+        for ``(profile, database, schema)``.
+
+        Presence of one bulk-filled row implies the whole schema is
+        covered by the cache (bulk_schema_metadata returns every table
+        in the schema by contract). ``list_assets`` keys off this flag
+        to decide whether reading from cache is safe — partial caches
+        produced by the per-table fallback path are not.
+        """
+        now = time.time()
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT 1 FROM column_comments_cache
+                WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+                  AND bulk_filled = 1 AND expires_at >= ?
+                LIMIT 1
+                """,
+                (
+                    str(db_profile or ""),
+                    str(database or ""),
+                    str(schema or ""),
+                    now,
+                ),
+            ).fetchone()
+        return row is not None
 
     def lookup_column_comments_cache(
         self,
@@ -1578,6 +1672,204 @@ class SQLiteHistoryStore:
         with self._lock, self._connect() as conn:
             cur = conn.execute(
                 "DELETE FROM column_comments_cache WHERE expires_at < ?",
+                (now,),
+            )
+            return int(cur.rowcount or 0)
+
+    # ── schemas_cache: per-catalog schema-level cache ─────────────
+
+    @staticmethod
+    def _sc_key(*, db_profile: str, database: str, catalog: str, schema: str) -> str:
+        return f"{db_profile}|{database or ''}|{catalog or ''}|{schema}"
+
+    def save_schemas_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        catalog: str,
+        entries: dict[str, str | None],
+        ttl_seconds: float = 3600.0,
+        bulk_filled: bool = False,
+    ) -> int:
+        """Bulk upsert schema-level entries for one catalog.
+
+        ``entries`` maps schema name → schema comment (``None`` when the
+        schema has no comment). ``bulk_filled`` mirrors the column
+        cache's flag: ``True`` when a single ``bulk_catalog_metadata``
+        call produced the dict (covers every schema in the catalog),
+        ``False`` for per-schema fallback writes.
+        """
+        if not entries:
+            return 0
+        now = time.time()
+        if ttl_seconds == 0:
+            ttl_seconds = 3600.0
+        expires_at = now + float(ttl_seconds)
+        flag = 1 if bulk_filled else 0
+        rows = [
+            (
+                self._sc_key(
+                    db_profile=str(db_profile or ""),
+                    database=str(database or ""),
+                    catalog=str(catalog or ""),
+                    schema=str(schema or ""),
+                ),
+                str(db_profile or ""),
+                str(database or ""),
+                str(catalog or ""),
+                str(schema or ""),
+                comment,
+                flag,
+                now,
+                expires_at,
+            )
+            for schema, comment in entries.items()
+        ]
+        with self._lock, self._connect() as conn:
+            conn.executemany(
+                """
+                INSERT INTO schemas_cache
+                    (cache_key, db_profile, database_name, catalog_name, schema_name,
+                     schema_comment, bulk_filled, fetched_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(cache_key) DO UPDATE SET
+                    schema_comment = excluded.schema_comment,
+                    bulk_filled    = MAX(schemas_cache.bulk_filled, excluded.bulk_filled),
+                    fetched_at     = excluded.fetched_at,
+                    expires_at     = excluded.expires_at
+                """,
+                rows,
+            )
+        return len(rows)
+
+    def lookup_schemas_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        catalog: str,
+        schema: str,
+    ) -> dict[str, Any] | None:
+        """Return one fresh schema entry or ``None`` if missing/expired."""
+        cache_key = self._sc_key(
+            db_profile=str(db_profile or ""),
+            database=str(database or ""),
+            catalog=str(catalog or ""),
+            schema=str(schema or ""),
+        )
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT schema_comment, bulk_filled, fetched_at, expires_at
+                FROM schemas_cache WHERE cache_key = ?
+                """,
+                (cache_key,),
+            ).fetchone()
+        if row is None or float(row["expires_at"]) < time.time():
+            return None
+        return {
+            "schema_comment": row["schema_comment"],
+            "bulk_filled": bool(row["bulk_filled"]),
+            "fetched_at": float(row["fetched_at"]),
+            "expires_at": float(row["expires_at"]),
+        }
+
+    def catalog_has_bulk_filled_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        catalog: str,
+    ) -> bool:
+        """``True`` when at least one fresh ``bulk_filled=1`` row exists
+        for ``(profile, database, catalog)``.
+
+        ``list_schemas`` keys off this flag to decide whether reading
+        schema names from the cache is safe instead of re-issuing
+        SHOW SCHEMAS / pg_namespace lookups.
+        """
+        now = time.time()
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT 1 FROM schemas_cache
+                WHERE db_profile = ? AND database_name = ? AND catalog_name = ?
+                  AND bulk_filled = 1 AND expires_at >= ?
+                LIMIT 1
+                """,
+                (
+                    str(db_profile or ""),
+                    str(database or ""),
+                    str(catalog or ""),
+                    now,
+                ),
+            ).fetchone()
+        return row is not None
+
+    def list_schemas_from_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str,
+        catalog: str,
+    ) -> list[tuple[str, str | None]]:
+        """Return ``[(schema_name, schema_comment), …]`` for every fresh
+        row of this catalog. Caller is responsible for checking
+        ``catalog_has_bulk_filled_cache`` first if it needs to know
+        whether the list is exhaustive.
+        """
+        now = time.time()
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT schema_name, schema_comment FROM schemas_cache
+                WHERE db_profile = ? AND database_name = ? AND catalog_name = ?
+                  AND expires_at >= ?
+                ORDER BY schema_name
+                """,
+                (
+                    str(db_profile or ""),
+                    str(database or ""),
+                    str(catalog or ""),
+                    now,
+                ),
+            ).fetchall()
+        return [(str(r[0]), r[1]) for r in rows]
+
+    def invalidate_schemas_cache(
+        self,
+        *,
+        db_profile: str,
+        database: str = "",
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> int:
+        """Drop schema-cache rows at one of three granularities.
+
+        * ``catalog`` + ``schema`` set → single schema row.
+        * ``catalog`` only → whole catalog.
+        * Both ``None`` → whole profile.
+        """
+        params: list[Any] = [str(db_profile or "")]
+        sql = "DELETE FROM schemas_cache WHERE db_profile = ?"
+        if catalog is not None:
+            sql += " AND database_name = ? AND catalog_name = ?"
+            params.append(str(database or ""))
+            params.append(str(catalog or ""))
+        if schema is not None:
+            sql += " AND schema_name = ?"
+            params.append(str(schema or ""))
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(sql, params)
+            return int(cur.rowcount or 0)
+
+    def gc_schemas_cache(self) -> int:
+        """Sweep expired schemas_cache rows."""
+        now = time.time()
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM schemas_cache WHERE expires_at < ?",
                 (now,),
             )
             return int(cur.rowcount or 0)

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -141,6 +141,9 @@ def create_app(
             # bulk-schema metadata path — anything past 1h is wiped
             # so the next sidebar expand triggers a fresh fetch.
             _store.gc_column_comments_cache()
+            # And the schemas_cache that backs the catalog-expand
+            # bulk path.
+            _store.gc_schemas_cache()
     except Exception:
         # Startup must never crash on a GC hiccup; the executor's own
         # cleanup keeps the table tidy regardless.

--- a/tests/test_bulk_schema_metadata_duckdb.py
+++ b/tests/test_bulk_schema_metadata_duckdb.py
@@ -110,3 +110,65 @@ def test_invalidation_forces_refetch(duckdb_profile) -> None:
     # Without invalidation the cache would still serve the old value.
     db.invalidate_column_comments_cache(schema="sales", table="orders")
     assert db.get_table_comment("sales", "orders") == "Updated comment"
+
+
+def test_list_assets_uses_cache_after_first_call(duckdb_profile) -> None:
+    """The user's reported friction: ``list_assets`` was hitting
+    SHOW TABLES every sidebar expand because the v0.13 cache only
+    covered column comments, not the asset list itself. After the
+    bulk_filled-aware cache lands, the second ``list_assets`` for the
+    same schema must NOT touch the engine.
+    """
+    db = DatabaseConnector(duckdb_profile, profile_name="duckdb-test")
+    # First call — cold path, bulk fetch populates the cache.
+    assets = db.list_assets("sales")
+    names = sorted([n for n, _ in assets])
+    assert names == ["line_items", "orders"]
+    # Trap the engine so any DB hit on the second call raises loudly.
+    real_engine = db._engine
+
+    class _Trap:
+        def __getattr__(self, _name):  # pragma: no cover - guard
+            raise AssertionError("expected cache hit; engine was reached")
+
+    db._engine = _Trap()  # type: ignore[assignment]
+    try:
+        cached_assets = db.list_assets("sales")
+    finally:
+        db._engine = real_engine
+    assert sorted([n for n, _ in cached_assets]) == ["line_items", "orders"]
+
+
+def test_list_schemas_uses_cache_after_first_call(tmp_path) -> None:
+    """Catalog expand: ``list_schemas`` must NOT re-query the DB on
+    repeat visits. DuckDB can't carry schema-level comments (the
+    backend NotImplementedException's COMMENT ON SCHEMA), but the
+    schema enumeration itself absolutely must be cache-served — that
+    is the reported friction on the catalog-expand path.
+    """
+    db_path = tmp_path / "schemas.duckdb"
+    engine = sqlalchemy.create_engine(f"duckdb:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(sqlalchemy.text("CREATE SCHEMA finance"))
+        conn.execute(sqlalchemy.text("CREATE SCHEMA marketing"))
+    engine.dispose()
+
+    db = DatabaseConnector(
+        DBConfig(backend="duckdb", database=str(db_path)),
+        profile_name="duckdb-schemas-test",
+    )
+    schemas = db.list_schemas()
+    assert {"finance", "marketing"} <= set(schemas)
+
+    real_engine = db._engine
+
+    class _Trap:
+        def __getattr__(self, _name):  # pragma: no cover - guard
+            raise AssertionError("expected cache hit; engine was reached")
+
+    db._engine = _Trap()  # type: ignore[assignment]
+    try:
+        again = db.list_schemas()
+    finally:
+        db._engine = real_engine
+    assert {"finance", "marketing"} <= set(again)

--- a/tests/test_column_comments_cache.py
+++ b/tests/test_column_comments_cache.py
@@ -233,6 +233,124 @@ def test_save_is_upsert_on_repeat_writes(store: SQLiteHistoryStore) -> None:
     assert hit["columns"] == {"id": "new"}
 
 
+def test_bulk_filled_flag_separates_full_from_partial_caches(
+    store: SQLiteHistoryStore,
+) -> None:
+    """``list_assets`` can only trust the cache when a bulk fetch
+    populated it (the adapter promises every table in the schema).
+    Per-table fallback writes leave the flag off, so the helper
+    returns ``False`` until a bulk fill lands.
+    """
+    # Per-table fallback write — single entry, bulk_filled=0.
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={"orders": _entry("o", {})},
+        bulk_filled=False,
+    )
+    assert (
+        store.schema_has_bulk_filled_cache(
+            db_profile="prod", database="", schema="public"
+        )
+        is False
+    )
+    # Now a bulk fill drops in. ON CONFLICT promotes the flag to 1
+    # via MAX(); a later bulk fill must never demote a partial row.
+    store.save_column_comments_cache(
+        db_profile="prod",
+        database="",
+        schema="public",
+        entries={"orders": _entry("o", {}), "users": _entry("u", {})},
+        bulk_filled=True,
+    )
+    assert (
+        store.schema_has_bulk_filled_cache(
+            db_profile="prod", database="", schema="public"
+        )
+        is True
+    )
+
+
+def test_schemas_cache_roundtrip_and_invalidation(store: SQLiteHistoryStore) -> None:
+    """``schemas_cache`` mirrors ``column_comments_cache`` shape:
+    save → lookup with same scope returns the entry; invalidating
+    a catalog wipes all schemas under it but leaves siblings alone.
+    """
+    store.save_schemas_cache(
+        db_profile="prod-databricks",
+        database="main",
+        catalog="warehouse",
+        entries={"sales": "GL + AR + AP", "marketing": None},
+        bulk_filled=True,
+    )
+    store.save_schemas_cache(
+        db_profile="prod-databricks",
+        database="main",
+        catalog="archive",
+        entries={"old_sales": None},
+        bulk_filled=True,
+    )
+
+    hit = store.lookup_schemas_cache(
+        db_profile="prod-databricks",
+        database="main",
+        catalog="warehouse",
+        schema="sales",
+    )
+    assert hit is not None and hit["schema_comment"] == "GL + AR + AP"
+    assert hit["bulk_filled"] is True
+
+    # Catalog-level invalidate drops all schemas under that catalog.
+    dropped = store.invalidate_schemas_cache(
+        db_profile="prod-databricks",
+        database="main",
+        catalog="warehouse",
+    )
+    assert dropped == 2
+    # Sibling catalog untouched.
+    assert (
+        store.lookup_schemas_cache(
+            db_profile="prod-databricks",
+            database="main",
+            catalog="archive",
+            schema="old_sales",
+        )
+        is not None
+    )
+
+
+def test_catalog_has_bulk_filled_cache_gate(store: SQLiteHistoryStore) -> None:
+    """``list_schemas`` may only short-circuit the DB when the catalog
+    cache was filled in bulk — same invariant the column cache has."""
+    store.save_schemas_cache(
+        db_profile="prod",
+        database="",
+        catalog="warehouse",
+        entries={"sales": None},
+        bulk_filled=False,
+    )
+    assert (
+        store.catalog_has_bulk_filled_cache(
+            db_profile="prod", database="", catalog="warehouse"
+        )
+        is False
+    )
+    store.save_schemas_cache(
+        db_profile="prod",
+        database="",
+        catalog="warehouse",
+        entries={"sales": None, "marketing": None},
+        bulk_filled=True,
+    )
+    assert (
+        store.catalog_has_bulk_filled_cache(
+            db_profile="prod", database="", catalog="warehouse"
+        )
+        is True
+    )
+
+
 def test_lookup_is_database_scoped(store: SQLiteHistoryStore) -> None:
     """A multi-database profile (e.g. Postgres with several databases
     or Databricks with multiple catalogs) must not let a table in


### PR DESCRIPTION
## Symptom (user report)

> Bir önceki PR'larda yaptığımız cache mekanizmamız çalışmıyor. Çünkü ben gidip bir schema'nın altında tablolara bakıyorum. Fakat sonra tekrar baktığımda arkada SHOW TABLES sorgusu atıyor. Ya da bir catalog'u expand ediyorum arkada bakıyorum ki altındaki her schema için DESCRIBE SCHEMA atmış.

Two upstream loops were never cached:

1. **Sidebar schema expand → SHOW TABLES still firing on repeat visits.** ``connector.list_assets`` walked ``list_tables`` / ``list_views`` / ``list_materialized_views`` against the inspector, ignoring the bulk metadata that was already in the column-comments cache for the schema.
2. **Catalog expand → DESCRIBE SCHEMA per schema.** ``get_schema_comment`` had no cache and the router calls it in a per-schema loop right after ``list_schemas``.

## What this PR adds

### 1. ``list_assets`` cache fast-path

- New ``bulk_filled INTEGER`` column on ``column_comments_cache`` (added as a migration so existing histories pick it up).
- ``bulk_filled=1`` is set only when the adapter's ``bulk_schema_metadata`` returned an exhaustive dict; per-table inspector fallback writes leave it at ``0``.
- ``DatabaseConnector.list_assets`` now reads the asset list directly from cache rows when at least one bulk-filled row exists for the schema. Re-visiting an expanded schema no longer issues SHOW TABLES.

### 2. New ``schemas_cache`` + per-backend ``bulk_catalog_metadata``

- New SQLite table keyed by ``(profile, database, catalog, schema)`` storing ``schema_comment`` + ``bulk_filled``.
- New adapter abstract ``bulk_catalog_metadata(engine, catalog)`` returning ``{schema_name: comment_or_none}``. Default returns ``None`` so backends without an override degrade gracefully.
- All 10 backends override:
  - Databricks Unity → ``system.information_schema.schemata WHERE catalog_name = ?``
  - Snowflake → ``INFORMATION_SCHEMA.SCHEMATA``
  - Postgres / Redshift → ``pg_namespace`` + ``obj_description``
  - BigQuery → ``INFORMATION_SCHEMA.SCHEMATA``
  - MySQL → ``INFORMATION_SCHEMA.SCHEMATA``
  - Oracle → ``ALL_USERS``
  - MSSQL → ``sys.schemas`` + ``sys.extended_properties (class=3)``
  - ClickHouse → ``system.databases``
  - DuckDB → ``duckdb_schemas() WHERE NOT internal``
- ``connector.list_schemas`` + ``connector.get_schema_comment`` both short-circuit through this cache. Expanding a catalog with 50 schemas runs **one** ``INFORMATION_SCHEMA.SCHEMATA`` query instead of 50 ``DESCRIBE SCHEMA`` calls.

### 3. Invalidation hooks extended

The existing invalidation path in ``connector.invalidate_column_comments_cache`` now also wipes the matching ``schemas_cache`` rows when ``schema`` (whole-schema) or both args are ``None`` (whole-profile) — so ``set_schema_comment`` and ``set_database_comment`` writes still leave the cache guaranteed-fresh on the very next read.

## Test plan

- [x] ``pytest tests/`` — 1404 passed (4 new tests + all existing).
- [x] New tests pin:
  - ``bulk_filled`` flag transitions correctly when a per-table fallback row is upgraded by a later bulk fill.
  - ``schemas_cache`` round-trip + catalog-level invalidation drops siblings cleanly.
  - DuckDB integration: ``list_assets`` second call serves from cache without touching the engine.
  - DuckDB integration: ``list_schemas`` second call serves from cache without touching the engine.
- [ ] Manual smoke on Databricks profile: expand a catalog → DevTools / warehouse query history should show ONE ``system.information_schema.schemata`` query, not N ``DESCRIBE SCHEMA``s. Expand a schema → ONE ``system.information_schema.columns`` query, not SHOW TABLES + N DESCRIBE TABLE EXTENDED.