### PR TITLE
fix(studio): stop CLI spinner leak + raise Databricks retry budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,30 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **CLI no longer leaks Studio activity into the foreground terminal.**
+  ``_populate_schema_metadata_cache`` was painting a ``step_spinner``
+  ("Cached column descriptions for X") whenever it was invoked with a
+  TTY stdout, regardless of which thread asked. Studio's uvicorn
+  worker threads were therefore drawing spinner lines into the shell
+  the user launched ``/studio`` from. The guard now skips the spinner
+  unless we're on the main thread AND ``is_quiet()`` is off — the
+  worker-thread / Studio-mode cases satisfy neither, so the CLI stays
+  clean while sidebar reads run silently in the background.
+
+- **Databricks retry budget raised + internal retry chatter silenced
+  in Studio mode.** ``connect_retry_duration_seconds`` was 20s, which
+  the databricks-sql-connector applies to BOTH connection
+  establishment and every query retry. On a slow / serverless
+  warehouse a real bulk metadata query (``system.information_
+  schema.columns`` over a 1000-table schema) was bumping the cap and
+  surfacing a noisy "Retry request would exceed Retry policy max
+  retry duration of 20.0 seconds" log line. Bumped to 120s. Also
+  added ``databricks.sql`` / ``databricks.sqlalchemy`` to the
+  Studio-mode log mute list so even when the cap *is* hit on an
+  unhealthy warehouse, the connector's internal chatter doesn't bleed
+  into the CLI — the real failure still surfaces as an exception
+  through the request handler.
+
 - **Cache now actually covers ``list_assets`` and the per-schema
   ``DESCRIBE SCHEMA`` loop.** The v0.13 cache short-circuited
   ``get_table_comment`` and ``get_column_comments`` but left the

--- a/amx/db/adapters/databricks.py
+++ b/amx/db/adapters/databricks.py
@@ -20,7 +20,17 @@ class DatabricksAdapter(DatabaseAdapter):
     name = "databricks"
     connect_timeout_seconds = 15
     connect_retry_attempts = 3
-    connect_retry_duration_seconds = 20
+    # ``_retry_stop_after_attempts_duration`` is the total budget the
+    # databricks-sql-connector spends retrying a single request. It
+    # caps connection-establishment retries AND query retries with the
+    # same value, so on a slow/serverless warehouse a real-world bulk
+    # metadata query (e.g. ``system.information_schema.columns`` over
+    # a 1000-table schema) was hitting the previous 20s cap and
+    # surfacing as a noisy "Retry request would exceed Retry policy
+    # max retry duration" log line. 120s covers transient hiccups
+    # without masking a genuinely dead warehouse — the per-attempt
+    # socket timeout above (15s) still bites individual round-trips.
+    connect_retry_duration_seconds = 120
     capabilities = BackendCapabilities(
         database_comments=True,
         materialized_view_comments=False,

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -995,12 +995,29 @@ class DatabaseConnector:
         spinner_ctx = None
         try:
             import sys as _sys
+            import threading as _threading
 
+            from amx.utils.console import is_quiet
             from amx.utils.live_display import get_display
 
             display = get_display()
             display_active = display is not None and getattr(display, "_live", None) is not None
-            if _sys.stdout.isatty() and not display_active:
+            # Only paint a spinner when this call comes from the CLI's
+            # foreground REPL — i.e. main thread, TTY, no Rich Live
+            # region already active, and the thread-local quiet flag
+            # the Studio worker installs is off. Without these guards
+            # a Studio sidebar expand (which runs on a uvicorn worker
+            # thread) was bleeding "Cached column descriptions for X"
+            # lines into the user's CLI shell.
+            on_main_thread = (
+                _threading.current_thread() is _threading.main_thread()
+            )
+            if (
+                _sys.stdout.isatty()
+                and not display_active
+                and on_main_thread
+                and not is_quiet()
+            ):
                 from amx.utils.console import step_spinner
 
                 spinner_ctx = step_spinner(

--- a/amx/utils/logging.py
+++ b/amx/utils/logging.py
@@ -267,6 +267,20 @@ def mute_root_logger_for_studio() -> None:
         if logger_name == "amx" or logger_name.startswith("amx."):
             existing.propagate = False
 
+    # The databricks-sql-connector library emits an ERROR-level record
+    # ("Retry request would exceed Retry policy max retry duration of
+    # N seconds") every time its internal retry budget runs down on a
+    # single request, EVEN WHEN the request later succeeds via a fresh
+    # connection. That chatter has no actionable value for the user —
+    # genuine failures still surface as exceptions through the
+    # connector layer above. Suppress at the library's root logger so
+    # the CLI terminal stays clean while Studio is serving requests
+    # against a busy / serverless warehouse.
+    for noisy in ("databricks.sql", "databricks.sqlalchemy"):
+        lib_logger = logging.getLogger(noisy)
+        lib_logger.setLevel(logging.CRITICAL)
+        lib_logger.propagate = False
+
 
 def log_event(event_type: str, /, **fields: Any) -> None:
     """Write a structured event line to the rotating JSON log.

--- a/tests/test_bulk_schema_metadata_duckdb.py
+++ b/tests/test_bulk_schema_metadata_duckdb.py
@@ -139,6 +139,52 @@ def test_list_assets_uses_cache_after_first_call(duckdb_profile) -> None:
     assert sorted([n for n, _ in cached_assets]) == ["line_items", "orders"]
 
 
+def test_spinner_suppressed_off_main_thread(duckdb_profile, monkeypatch) -> None:
+    """Regression for the Studio leak: ``_populate_schema_metadata_cache``
+    used to paint a Rich ``step_spinner`` whenever stdout was a TTY,
+    no matter which thread invoked it. Studio's uvicorn worker
+    threads were therefore drawing "Cached column descriptions for X"
+    lines into the CLI shell the user launched ``/studio`` from. The
+    guard now skips the spinner unless we're on the main thread AND
+    not inside a ``quiet_console()`` context — Studio worker threads
+    satisfy neither.
+    """
+    import threading
+
+    # Force the TTY branch on so the only suppression in play is the
+    # thread + quiet guards. Without the fix this monkeypatch would
+    # make the worker-thread test attempt to render Rich output.
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    db = DatabaseConnector(duckdb_profile, profile_name="duckdb-test")
+
+    step_spinner_calls: list[str] = []
+
+    def _track_step_spinner(label, **_kw):
+        step_spinner_calls.append(label)
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _noop():
+            yield
+
+        return _noop()
+
+    import amx.utils.console as console_mod
+
+    monkeypatch.setattr(console_mod, "step_spinner", _track_step_spinner)
+
+    def _worker():
+        db.get_table_comment("sales", "orders")
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    t.join()
+
+    assert step_spinner_calls == [], (
+        f"step_spinner must not be invoked from a non-main thread; was {step_spinner_calls}"
+    )
+
+
 def test_list_schemas_uses_cache_after_first_call(tmp_path) -> None:
     """Catalog expand: ``list_schemas`` must NOT re-query the DB on
     repeat visits. DuckDB can't carry schema-level comments (the


### PR DESCRIPTION
## Two unrelated annoyances, same Studio session

### 1. CLI spinner leak while Studio is the active surface

While the user was clicking around in the Studio browser tab, the CLI shell (where ``/studio`` was launched) kept printing:

```
Cached column descriptions for sales
Cached column descriptions for marketing
Cached column descriptions for finance
…
```

Source: ``_populate_schema_metadata_cache`` was wrapping its bulk fetch in ``step_spinner`` whenever stdout was a TTY. Studio's uvicorn worker threads inherit the same stdout, so every sidebar expand drew lines into the foreground terminal.

**Fix:** Only paint the spinner when the call is on the **main thread** AND ``is_quiet()`` is off. Studio worker threads fail both checks (not main, often inside a ``quiet_console()`` block per-endpoint), so the spinner is suppressed silently. CLI ``/db inspect`` style commands still get the spinner because they run on the main thread with quiet off.

### 2. Databricks "Retry policy max retry duration of 20.0 seconds" noise

``connect_retry_duration_seconds = 20`` was used as the single budget the databricks-sql-connector spends on retries for **any** request — connect AND query. On a slow / serverless warehouse a bulk ``system.information_schema.columns`` query over a large schema bumped the cap and emitted a noisy WARNING.

**Fix:**
- Raise the budget to 120s. Long enough for transient warehouse hiccups; the per-attempt 15s socket timeout still bites individual round-trips so a genuinely dead warehouse fails fast.
- Add ``databricks.sql`` / ``databricks.sqlalchemy`` to the Studio-mode log mute (``mute_root_logger_for_studio``) so even when the cap IS hit on a degraded warehouse, the library's internal retry chatter no longer leaks to the CLI. Real failures still surface as exceptions through the request handler.

## Test plan

- [x] New ``test_spinner_suppressed_off_main_thread`` asserts that calling ``get_table_comment`` from a worker thread (with TTY stdout forced on) never invokes ``step_spinner``.
- [x] ``pytest tests/`` — 1405 passed.
- [ ] Manual: while Studio is running, expand a schema in the sidebar — CLI shell stays silent. Run ``/db inspect`` directly in the CLI — spinner appears as before.
- [ ] Manual on Databricks: a bulk metadata query that previously emitted the 20s retry warning either completes silently (budget covered it) OR fails as a clean exception in the Studio banner (real failure).