### PR TITLE
fix(studio): show the AMX Studio logo on the offline page

### DIFF
--- a/amx/web/static/offline.html
+++ b/amx/web/static/offline.html
@@ -91,22 +91,22 @@
         border-color: rgba(244, 185, 66, 0.7);
         background: rgba(244, 185, 66, 0.07);
       }
-      .badge {
-        display: inline-block;
-        font-size: 11px;
-        letter-spacing: 0.06em;
-        text-transform: uppercase;
-        color: #a8a39a;
-        padding: 4px 10px;
-        border: 1px solid rgba(231, 227, 218, 0.12);
-        border-radius: 999px;
-        margin-bottom: 18px;
+      .logo {
+        display: block;
+        margin: 0 auto 22px auto;
+        height: 56px;
+        width: auto;
+        /*
+         * The Service Worker pre-caches this image so it renders even
+         * when the local CLI is down. ``alt`` keeps the layout sane if
+         * the asset is ever evicted before the page is served.
+         */
       }
     </style>
   </head>
   <body>
     <main>
-      <div class="badge">AMX Studio</div>
+      <img class="logo" src="/amx-logo.png" alt="AMX Studio" />
       <h1>Connection to the AMX CLI was lost.</h1>
       <p>
         Studio runs locally — the page you were on is served by your CLI

--- a/amx/web/static/sw.js
+++ b/amx/web/static/sw.js
@@ -13,9 +13,12 @@
 // HTTP layer; over-caching at the SW would mean stale chunks on
 // every Studio upgrade). The Service Worker handles offline UX only.
 
-const CACHE_NAME = 'amx-studio-offline-v1';
+// Bump the cache name when changing PRECACHE_URLS so the ``activate``
+// handler wipes the old cache and the new payload (e.g. the AMX logo
+// added in v2) is fetched on the next install.
+const CACHE_NAME = 'amx-studio-offline-v2';
 const OFFLINE_URL = '/offline.html';
-const PRECACHE_URLS = [OFFLINE_URL, '/favicon.png'];
+const PRECACHE_URLS = [OFFLINE_URL, '/favicon.png', '/amx-logo.png'];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -91,22 +91,22 @@
         border-color: rgba(244, 185, 66, 0.7);
         background: rgba(244, 185, 66, 0.07);
       }
-      .badge {
-        display: inline-block;
-        font-size: 11px;
-        letter-spacing: 0.06em;
-        text-transform: uppercase;
-        color: #a8a39a;
-        padding: 4px 10px;
-        border: 1px solid rgba(231, 227, 218, 0.12);
-        border-radius: 999px;
-        margin-bottom: 18px;
+      .logo {
+        display: block;
+        margin: 0 auto 22px auto;
+        height: 56px;
+        width: auto;
+        /*
+         * The Service Worker pre-caches this image so it renders even
+         * when the local CLI is down. ``alt`` keeps the layout sane if
+         * the asset is ever evicted before the page is served.
+         */
       }
     </style>
   </head>
   <body>
     <main>
-      <div class="badge">AMX Studio</div>
+      <img class="logo" src="/amx-logo.png" alt="AMX Studio" />
       <h1>Connection to the AMX CLI was lost.</h1>
       <p>
         Studio runs locally — the page you were on is served by your CLI

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -13,9 +13,12 @@
 // HTTP layer; over-caching at the SW would mean stale chunks on
 // every Studio upgrade). The Service Worker handles offline UX only.
 
-const CACHE_NAME = 'amx-studio-offline-v1';
+// Bump the cache name when changing PRECACHE_URLS so the ``activate``
+// handler wipes the old cache and the new payload (e.g. the AMX logo
+// added in v2) is fetched on the next install.
+const CACHE_NAME = 'amx-studio-offline-v2';
 const OFFLINE_URL = '/offline.html';
-const PRECACHE_URLS = [OFFLINE_URL, '/favicon.png'];
+const PRECACHE_URLS = [OFFLINE_URL, '/favicon.png', '/amx-logo.png'];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(


### PR DESCRIPTION
## Symptom

The offline fallback page (added in #322) opened with a text badge reading "AMX STUDIO" — looked unfinished next to the brand mark the rest of Studio uses.

## Fix

Replace the badge with ``/amx-logo.png`` (same asset rendered by the in-app ``<Logo />`` component). Added the logo to the Service Worker precache so it loads even when the local CLI is down. Bumped the cache name to ``amx-studio-offline-v2`` so existing installs evict the v1 payload and fetch the new one on activate.

## Test plan

- [x] ``npm run build`` clean.
- [ ] Manual: stop the CLI, refresh the tab — offline page now shows the logo above the headline, not the badge.