### PR TITLE
fix(studio): offline page favicon + Try-reconnecting now actually probes the CLI

### DIFF
--- a/amx/web/static/offline.html
+++ b/amx/web/static/offline.html
@@ -91,6 +91,13 @@
         border-color: rgba(244, 185, 66, 0.7);
         background: rgba(244, 185, 66, 0.07);
       }
+      .status {
+        font-size: 12px;
+        color: #f4b942;
+        text-align: center;
+        margin-top: -4px;
+        line-height: 1.45;
+      }
       .logo {
         display: block;
         margin: 0 auto 22px auto;
@@ -122,9 +129,10 @@
         disk — nothing was lost.
       </p>
       <div class="stack">
-        <button class="action primary" onclick="window.location.reload()">
+        <button id="reconnect" class="action primary" type="button">
           Try reconnecting
         </button>
+        <div id="status" class="status" hidden></div>
         <a
           class="action"
           href="https://amxcli.com"
@@ -135,5 +143,64 @@
         </a>
       </div>
     </main>
+    <script>
+      // ``Try reconnecting`` used to call ``window.location.reload()``
+      // unconditionally. The reload would re-enter the Service Worker
+      // immediately, the SW would re-detect the dead CLI, and bounce
+      // back to this same offline page — the user clicked the button
+      // and nothing visible changed, so it looked broken. The script
+      // below probes ``/api/system/healthz`` (the same lightweight
+      // health endpoint the CLI exposes) BEFORE reloading and surfaces
+      // a "still offline" hint when the probe fails. ``cache: 'no-store'``
+      // + the timestamp query param sidestep the SW so the probe sees
+      // the live network, not our cached offline response.
+      const button = document.getElementById('reconnect');
+      const status = document.getElementById('status');
+
+      function setBusy(busy) {
+        button.disabled = busy;
+        button.textContent = busy ? 'Reconnecting…' : 'Try reconnecting';
+      }
+
+      async function probe() {
+        // ``/`` is auth-free (the catch-all serves index.html with no
+        // bearer check). Using a JS ``fetch`` keeps the request out of
+        // ``navigate`` mode so the Service Worker doesn't intercept it
+        // and serve the cached offline page — the probe always sees
+        // the real network status. The bust query nudges any
+        // intermediary proxy to revalidate.
+        const url = '/?__amx_probe=' + Date.now();
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 4000);
+        try {
+          const r = await fetch(url, {
+            cache: 'no-store',
+            signal: controller.signal,
+          });
+          return r.ok;
+        } catch (_err) {
+          return false;
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+
+      button.addEventListener('click', async () => {
+        setBusy(true);
+        status.hidden = true;
+        const alive = await probe();
+        if (alive) {
+          // CLI is back — let the browser fetch the live page. The
+          // SW will see a successful response from network and pass
+          // it through instead of serving the cached offline page.
+          window.location.reload();
+          return;
+        }
+        setBusy(false);
+        status.hidden = false;
+        status.textContent =
+          'Still offline. Run "amx /studio" in your terminal, then click again.';
+      });
+    </script>
   </body>
 </html>

--- a/amx/web/static/sw.js
+++ b/amx/web/static/sw.js
@@ -13,12 +13,17 @@
 // HTTP layer; over-caching at the SW would mean stale chunks on
 // every Studio upgrade). The Service Worker handles offline UX only.
 
-// Bump the cache name when changing PRECACHE_URLS so the ``activate``
-// handler wipes the old cache and the new payload (e.g. the AMX logo
-// added in v2) is fetched on the next install.
-const CACHE_NAME = 'amx-studio-offline-v2';
+// Bump the cache name when changing PRECACHE_URLS or fetch logic so
+// the ``activate`` handler wipes the old cache and the new payload
+// is fetched on the next install.
+const CACHE_NAME = 'amx-studio-offline-v3';
 const OFFLINE_URL = '/offline.html';
-const PRECACHE_URLS = [OFFLINE_URL, '/favicon.png', '/amx-logo.png'];
+const PRECACHE_URLS = [
+  OFFLINE_URL,
+  '/favicon.png',
+  '/favicon.svg',
+  '/amx-logo.png',
+];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -44,27 +49,63 @@ self.addEventListener('activate', (event) => {
   );
 });
 
+// Precached asset URLs as an absolute-path Set for cheap lookup.
+const PRECACHED_PATHS = new Set(PRECACHE_URLS);
+
+function isPrecachedAsset(url) {
+  try {
+    const u = new URL(url);
+    return PRECACHED_PATHS.has(u.pathname);
+  } catch (_err) {
+    return false;
+  }
+}
+
 self.addEventListener('fetch', (event) => {
   const { request } = event;
-  // Only intercept navigation requests. Other resources (JS chunks,
-  // API calls, images) bubble up to the SPA's own error handling —
-  // a failed ``/api/runs`` call should still surface as a toast or
-  // banner inside the SPA when it's loaded, not be silently masked
-  // by the offline page.
-  if (request.mode !== 'navigate') {
+  const url = request.url;
+
+  // 1. Navigation requests — serve the offline page when network fails.
+  //    This is the headline UX: the user refreshes a Studio tab whose
+  //    CLI has died and lands on our branded page instead of Chrome's
+  //    "site can't be reached".
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() =>
+        caches
+          .match(OFFLINE_URL, { cacheName: CACHE_NAME })
+          .then((cached) =>
+            cached ||
+            new Response(
+              '<h1>AMX Studio is offline</h1><p>Run <code>amx /studio</code> to restart.</p>',
+              { status: 503, headers: { 'Content-Type': 'text/html' } },
+            ),
+          ),
+      ),
+    );
     return;
   }
-  event.respondWith(
-    fetch(request).catch(() =>
-      caches
-        .match(OFFLINE_URL, { cacheName: CACHE_NAME })
-        .then((cached) =>
-          cached ||
-          new Response(
-            '<h1>AMX Studio is offline</h1><p>Run <code>amx /studio</code> to restart.</p>',
-            { status: 503, headers: { 'Content-Type': 'text/html' } },
-          ),
+
+  // 2. Precached static assets (favicon, logo) — these are loaded by
+  //    the offline page itself, so they must resolve even when the
+  //    CLI is down. Try network first (so an updated logo lands
+  //    naturally on the next visit) and fall back to cache. Without
+  //    this branch the offline page would show a broken-image icon
+  //    for the logo and the browser tab would show a blank favicon
+  //    while the CLI is offline.
+  if (isPrecachedAsset(url)) {
+    event.respondWith(
+      fetch(request).catch(() =>
+        caches.match(request, { cacheName: CACHE_NAME }).then(
+          (cached) => cached || new Response('', { status: 504 }),
         ),
-    ),
-  );
+      ),
+    );
+    return;
+  }
+
+  // 3. Everything else (JS chunks, API calls) — bubble up to the
+  //    SPA's own error handling. A failed ``/api/runs`` should still
+  //    surface as a toast in the SPA when it's loaded, not be
+  //    silently masked by the offline page.
 });

--- a/frontend/public/offline.html
+++ b/frontend/public/offline.html
@@ -91,6 +91,13 @@
         border-color: rgba(244, 185, 66, 0.7);
         background: rgba(244, 185, 66, 0.07);
       }
+      .status {
+        font-size: 12px;
+        color: #f4b942;
+        text-align: center;
+        margin-top: -4px;
+        line-height: 1.45;
+      }
       .logo {
         display: block;
         margin: 0 auto 22px auto;
@@ -122,9 +129,10 @@
         disk — nothing was lost.
       </p>
       <div class="stack">
-        <button class="action primary" onclick="window.location.reload()">
+        <button id="reconnect" class="action primary" type="button">
           Try reconnecting
         </button>
+        <div id="status" class="status" hidden></div>
         <a
           class="action"
           href="https://amxcli.com"
@@ -135,5 +143,64 @@
         </a>
       </div>
     </main>
+    <script>
+      // ``Try reconnecting`` used to call ``window.location.reload()``
+      // unconditionally. The reload would re-enter the Service Worker
+      // immediately, the SW would re-detect the dead CLI, and bounce
+      // back to this same offline page — the user clicked the button
+      // and nothing visible changed, so it looked broken. The script
+      // below probes ``/api/system/healthz`` (the same lightweight
+      // health endpoint the CLI exposes) BEFORE reloading and surfaces
+      // a "still offline" hint when the probe fails. ``cache: 'no-store'``
+      // + the timestamp query param sidestep the SW so the probe sees
+      // the live network, not our cached offline response.
+      const button = document.getElementById('reconnect');
+      const status = document.getElementById('status');
+
+      function setBusy(busy) {
+        button.disabled = busy;
+        button.textContent = busy ? 'Reconnecting…' : 'Try reconnecting';
+      }
+
+      async function probe() {
+        // ``/`` is auth-free (the catch-all serves index.html with no
+        // bearer check). Using a JS ``fetch`` keeps the request out of
+        // ``navigate`` mode so the Service Worker doesn't intercept it
+        // and serve the cached offline page — the probe always sees
+        // the real network status. The bust query nudges any
+        // intermediary proxy to revalidate.
+        const url = '/?__amx_probe=' + Date.now();
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 4000);
+        try {
+          const r = await fetch(url, {
+            cache: 'no-store',
+            signal: controller.signal,
+          });
+          return r.ok;
+        } catch (_err) {
+          return false;
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+
+      button.addEventListener('click', async () => {
+        setBusy(true);
+        status.hidden = true;
+        const alive = await probe();
+        if (alive) {
+          // CLI is back — let the browser fetch the live page. The
+          // SW will see a successful response from network and pass
+          // it through instead of serving the cached offline page.
+          window.location.reload();
+          return;
+        }
+        setBusy(false);
+        status.hidden = false;
+        status.textContent =
+          'Still offline. Run "amx /studio" in your terminal, then click again.';
+      });
+    </script>
   </body>
 </html>

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -13,12 +13,17 @@
 // HTTP layer; over-caching at the SW would mean stale chunks on
 // every Studio upgrade). The Service Worker handles offline UX only.
 
-// Bump the cache name when changing PRECACHE_URLS so the ``activate``
-// handler wipes the old cache and the new payload (e.g. the AMX logo
-// added in v2) is fetched on the next install.
-const CACHE_NAME = 'amx-studio-offline-v2';
+// Bump the cache name when changing PRECACHE_URLS or fetch logic so
+// the ``activate`` handler wipes the old cache and the new payload
+// is fetched on the next install.
+const CACHE_NAME = 'amx-studio-offline-v3';
 const OFFLINE_URL = '/offline.html';
-const PRECACHE_URLS = [OFFLINE_URL, '/favicon.png', '/amx-logo.png'];
+const PRECACHE_URLS = [
+  OFFLINE_URL,
+  '/favicon.png',
+  '/favicon.svg',
+  '/amx-logo.png',
+];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -44,27 +49,63 @@ self.addEventListener('activate', (event) => {
   );
 });
 
+// Precached asset URLs as an absolute-path Set for cheap lookup.
+const PRECACHED_PATHS = new Set(PRECACHE_URLS);
+
+function isPrecachedAsset(url) {
+  try {
+    const u = new URL(url);
+    return PRECACHED_PATHS.has(u.pathname);
+  } catch (_err) {
+    return false;
+  }
+}
+
 self.addEventListener('fetch', (event) => {
   const { request } = event;
-  // Only intercept navigation requests. Other resources (JS chunks,
-  // API calls, images) bubble up to the SPA's own error handling —
-  // a failed ``/api/runs`` call should still surface as a toast or
-  // banner inside the SPA when it's loaded, not be silently masked
-  // by the offline page.
-  if (request.mode !== 'navigate') {
+  const url = request.url;
+
+  // 1. Navigation requests — serve the offline page when network fails.
+  //    This is the headline UX: the user refreshes a Studio tab whose
+  //    CLI has died and lands on our branded page instead of Chrome's
+  //    "site can't be reached".
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() =>
+        caches
+          .match(OFFLINE_URL, { cacheName: CACHE_NAME })
+          .then((cached) =>
+            cached ||
+            new Response(
+              '<h1>AMX Studio is offline</h1><p>Run <code>amx /studio</code> to restart.</p>',
+              { status: 503, headers: { 'Content-Type': 'text/html' } },
+            ),
+          ),
+      ),
+    );
     return;
   }
-  event.respondWith(
-    fetch(request).catch(() =>
-      caches
-        .match(OFFLINE_URL, { cacheName: CACHE_NAME })
-        .then((cached) =>
-          cached ||
-          new Response(
-            '<h1>AMX Studio is offline</h1><p>Run <code>amx /studio</code> to restart.</p>',
-            { status: 503, headers: { 'Content-Type': 'text/html' } },
-          ),
+
+  // 2. Precached static assets (favicon, logo) — these are loaded by
+  //    the offline page itself, so they must resolve even when the
+  //    CLI is down. Try network first (so an updated logo lands
+  //    naturally on the next visit) and fall back to cache. Without
+  //    this branch the offline page would show a broken-image icon
+  //    for the logo and the browser tab would show a blank favicon
+  //    while the CLI is offline.
+  if (isPrecachedAsset(url)) {
+    event.respondWith(
+      fetch(request).catch(() =>
+        caches.match(request, { cacheName: CACHE_NAME }).then(
+          (cached) => cached || new Response('', { status: 504 }),
         ),
-    ),
-  );
+      ),
+    );
+    return;
+  }
+
+  // 3. Everything else (JS chunks, API calls) — bubble up to the
+  //    SPA's own error handling. A failed ``/api/runs`` should still
+  //    surface as a toast in the SPA when it's loaded, not be
+  //    silently masked by the offline page.
 });


### PR DESCRIPTION
## Two issues on the offline page

### 1. Favicon disappeared while offline

The Service Worker's fetch handler only intercepted ``navigate`` requests, so when the offline page was shown the browser still tried network for ``/favicon.png`` and that fetch failed (CLI is the only thing serving static files). Result: browser tab dropped the AMX brand mark.

**Fix:** new branch in the SW fetch handler intercepts precached asset URLs (``/favicon.png``, ``/favicon.svg``, ``/amx-logo.png``) with a network-first + cache-fallback strategy. Browser tab keeps the AMX favicon throughout the offline state. Cache name bumped to v3 so existing installations evict the v2 payload.

### 2. "Try reconnecting" did nothing visible

The button used to call ``window.location.reload()`` unconditionally. When the CLI was still down the reload re-entered the SW, the SW re-detected the dead socket, and bounced straight back to the offline page — same URL, same content, no visible feedback. Looked broken even though it was technically working.

**Fix:** Replace the inline ``onclick`` with a small script that:

1. Probes ``/`` via a plain ``fetch`` (auth-free catch-all + ``cache: 'no-store'`` + 4s ``AbortController`` timeout). Because the probe is not ``navigate`` mode the SW doesn't intercept it — the probe always sees the real network status.
2. On success → reload, live SPA renders.
3. On failure → button re-enables and surfaces ``Still offline. Run "amx /studio" in your terminal, then click again.`` under it.

## Test plan

- [x] ``npm run build`` clean.
- [ ] Manual: open Studio → DevTools Application → Service Workers shows ``v3`` active. Stop CLI (Ctrl-C) → refresh tab → offline page renders WITH the AMX favicon in the browser tab. Click "Try reconnecting" → it spins for up to 4s → shows the "Still offline" hint. Restart ``amx /studio`` → click again → live SPA loads.