### PR TITLE
fix(llm): flatten list-shaped Message.content directly on the class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **LLM call no longer fails on Responses-API-shaped reasoning
+  models.** Some hosted endpoints return ``message.content`` as a
+  list of typed parts (``[{"type": "reasoning", "summary": [...]},
+  {"type": "text", "text": "OK"}]``) instead of a plain string. The
+  v0.13 flatten shim that wrapped ``convert_to_model_response_object``
+  was being bypassed by litellm's own internal call paths, which
+  imported the function under a local alias before our shim ran —
+  the wrapped module-level symbol was rebound but the local alias
+  still pointed at the original function. The fix adds a second
+  layer that patches ``litellm.types.utils.Message.__init__``
+  directly: every code path eventually instantiates the same Message
+  class, so flattening in the constructor catches the list shape
+  regardless of which import path got us there. Surfaces as a
+  ``litellm.InternalServerError: Invalid response object`` /
+  ``ValidationError: content Input should be a valid string`` going
+  away on reasoning-capable hosted models that return Responses-API
+  content shapes.
+
 - **Runs list + Compare picker now show the actual asset, not just
   the schema-level scope.** ``scope_json`` only carries the schemas
   + tables the user originally picked, so a ``/rerun --column

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -177,32 +177,80 @@ def _normalize_response_dict_in_place(response_obj: Any) -> None:
 
 
 def _install_structured_content_shim(lm: ModuleType) -> None:
-    """Wrap ``litellm.litellm_core_utils...convert_to_model_response_object``
-    so it auto-flattens structured ``content`` lists before pydantic
-    validation. Idempotent — safe to call once per LiteLLM import.
+    """Belt-and-suspenders flatten of list-shaped ``message.content``.
+
+    Two layers because patching ``convert_to_model_response_object``
+    alone leaks: callers that did ``from … convert_dict_to_response
+    import convert_to_model_response_object`` at module load time hold
+    a frozen reference to the original function, and our module-level
+    rebind doesn't reach them. Patching the ``Message`` pydantic class
+    closes that gap because every code path eventually constructs the
+    same ``Message`` object — there's only one class.
+
+    Layer 1: wrap ``convert_to_model_response_object`` so the raw
+    response dict is normalised before the function ever builds a
+    Message. Cheap and covers the common path.
+
+    Layer 2: wrap ``Message.__init__`` so any direct Message(content=
+    [...]) construction also flattens. This is what actually defends
+    against the user-reported ``InternalServerError: Invalid response
+    object`` from Databricks Foundation Models (gpt-oss family) and
+    similar Responses-API-shaped endpoints — the first layer was
+    silently bypassed because litellm internally imports the
+    converter under a local alias.
+
+    Both layers are idempotent so repeat ``litellm()`` lookups never
+    install the wrapper twice.
     """
     try:
         from litellm.litellm_core_utils.llm_response_utils import (
             convert_dict_to_response as _conv_mod,
         )
     except Exception:  # pragma: no cover - defensive against LiteLLM internals shifting
-        return
-    if getattr(_conv_mod, "_amx_structured_content_shim", False):
-        return
-    original = _conv_mod.convert_to_model_response_object
+        _conv_mod = None  # type: ignore[assignment]
+    if _conv_mod is not None and not getattr(_conv_mod, "_amx_structured_content_shim", False):
+        original = _conv_mod.convert_to_model_response_object
 
-    def _patched(*args: Any, **kwargs: Any):
-        response_object = kwargs.get("response_object")
-        if response_object is None and args:
-            response_object = args[0]
-        try:
-            _normalize_response_dict_in_place(response_object)
-        except Exception:  # pragma: no cover - never block a real response on a flatten error
-            pass
-        return original(*args, **kwargs)
+        def _patched(*args: Any, **kwargs: Any):
+            response_object = kwargs.get("response_object")
+            if response_object is None and args:
+                response_object = args[0]
+            try:
+                _normalize_response_dict_in_place(response_object)
+            except Exception:  # pragma: no cover - never block on a flatten error
+                pass
+            return original(*args, **kwargs)
 
-    _conv_mod.convert_to_model_response_object = _patched
-    _conv_mod._amx_structured_content_shim = True
+        _conv_mod.convert_to_model_response_object = _patched
+        _conv_mod._amx_structured_content_shim = True
+
+    # Layer 2 — class-level Message patch. Captures every Message
+    # construction across litellm regardless of which module imported
+    # ``convert_to_model_response_object`` under what alias.
+    try:
+        from litellm.types.utils import Message as _LiteLLMMessage  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - litellm typing module relocated upstream
+        return
+    if getattr(_LiteLLMMessage, "_amx_structured_content_shim", False):
+        return
+    _orig_init = _LiteLLMMessage.__init__
+
+    def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        # Flatten BEFORE pydantic validation runs. The Responses-API
+        # output (reasoning + text typed parts) needs to collapse to
+        # the single text string Message's content field expects;
+        # reasoning is dropped here because the provider layer surfaces
+        # it through ``on_thinking`` already and embedding it in the
+        # content string would corrupt downstream JSON parsers.
+        content = kwargs.get("content")
+        if isinstance(content, list):
+            flattened = _flatten_structured_content(content)
+            if flattened is not None:
+                kwargs["content"] = flattened
+        return _orig_init(self, *args, **kwargs)
+
+    _LiteLLMMessage.__init__ = _patched_init  # type: ignore[assignment]
+    _LiteLLMMessage._amx_structured_content_shim = True  # type: ignore[attr-defined]
 
 
 PROVIDER_MODEL_PREFIX = {

--- a/tests/test_llm_structured_content.py
+++ b/tests/test_llm_structured_content.py
@@ -216,5 +216,79 @@ class LiteLLMShimInstallationTests(unittest.TestCase):
         self.assertEqual(int(result.usage.completion_tokens or 0), 1)
 
 
+class MessageConstructorShimTests(unittest.TestCase):
+    """Layer-2 of the structured-content fix.
+
+    The Layer-1 patch on ``convert_to_model_response_object`` only
+    intercepts calls that go through the module-level symbol AFTER our
+    shim installed. LiteLLM has internal modules that did ``from …
+    import convert_to_model_response_object`` at THEIR module load
+    time, before our shim ran — those callers hold a frozen reference
+    to the original function and bypass the rebind. The bug surfaced
+    as a real ``ValidationError`` on Databricks gpt-oss-120b in the
+    field even though the Layer-1 tests above were green.
+
+    Patching ``Message.__init__`` directly closes the gap because
+    every code path eventually instantiates the same ``Message``
+    class. These tests pin that the patched constructor accepts a
+    list-content payload without raising.
+    """
+
+    def test_message_with_list_content_accepted_after_shim(self) -> None:
+        """``Message(content=[...])`` would raise a pydantic
+        ``ValidationError`` upstream without our patch. After the
+        shim installs the layer-2 wrapper, the same construction
+        must succeed and ``content`` becomes the flattened string."""
+        from amx.llm.provider import _litellm
+
+        _litellm()  # install the shim
+        from litellm.types.utils import Message
+
+        message = Message(
+            content=[
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "say OK"}]},
+                {"type": "text", "text": "OK"},
+            ],
+            role="assistant",
+        )
+        self.assertEqual(message.content, "OK")
+
+    def test_message_with_string_content_passes_through(self) -> None:
+        """The shim must NOT touch string content — that would be a
+        regression for the 99% case where the upstream API already
+        returned a clean string."""
+        from amx.llm.provider import _litellm
+
+        _litellm()
+        from litellm.types.utils import Message
+
+        message = Message(content="already a string", role="assistant")
+        self.assertEqual(message.content, "already a string")
+
+    def test_message_with_none_content_passes_through(self) -> None:
+        """``content=None`` is also valid (tool-only responses); the
+        shim must not coerce it to an empty string."""
+        from amx.llm.provider import _litellm
+
+        _litellm()
+        from litellm.types.utils import Message
+
+        message = Message(content=None, role="assistant")
+        self.assertIsNone(message.content)
+
+    def test_double_litellm_call_keeps_shim_idempotent(self) -> None:
+        """Re-importing ``_litellm`` must not stack the wrapper twice
+        — otherwise every Message construction would flatten the
+        same content two times with no extra benefit but visible cost."""
+        from amx.llm.provider import _litellm
+
+        _litellm()
+        from litellm.types.utils import Message
+
+        first_init = Message.__init__
+        _litellm()
+        self.assertIs(Message.__init__, first_init)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Symptom

Selecting a reasoning-capable hosted model whose API returns Responses-API output (a ``reasoning`` summary followed by the actual ``text`` answer, shape ``[{"type": "reasoning", ...}, {"type": "text", "text": "..."}]``) every LLM call surfaces as:

```
litellm.InternalServerError: InternalServerError: OpenAIException - Invalid response object
ValidationError: 1 validation error for Message
content: Input should be a valid string [type=string_type, input_value=[{'type': 'reasoning', ...}], input_type=list]
```

Upstream API returned a perfectly valid answer; litellm's pydantic ``Message`` field declares ``content: str`` so the list payload fails validation before our provider layer can use it.

## Why the existing shim wasn't enough

A flatten shim that wraps ``convert_to_model_response_object`` was already in place (covers the ``message.content`` and ``delta.content`` slots before validation). But litellm's own internal modules import that converter under a local alias **at their module load time**, BEFORE our shim runs. Rebinding the canonical module symbol doesn't reach those cached aliases — calls flowing through them hit the original function and the list slips straight to pydantic.

## Fix

Add a second flatten layer that patches ``litellm.types.utils.Message.__init__`` directly. There is exactly one ``Message`` class, and every code path eventually instantiates it — wrapping the constructor catches the list shape no matter which import alias got us there. Reasoning parts are dropped (they're surfaced separately via ``on_thinking``), text parts collapse to the single string the field expects.

Both shim layers stay (idempotent install, ``_amx_structured_content_shim`` markers on each). Belt-and-suspenders: the first layer keeps the cost down for the common ``convert_to_model_response_object`` path; the second layer is the guarantee.

## Test plan

- [x] ``pytest tests/test_llm_structured_content.py`` — 17 passed (4 new ``MessageConstructorShimTests``). Critical new test instantiates ``Message(content=[...])`` directly, asserting the constructor flattens to ``"OK"`` without raising.
- [x] ``pytest tests/`` — 1435 passed.
- [x] ``ruff check`` + ``ruff format --check`` clean.
- [ ] Manual: a profile pointing at a reasoning-capable hosted model whose API returns Responses-style content runs end-to-end without the ``InternalServerError: Invalid response object`` retry loop.