### PR TITLE
fix(runs): cancel reaches the next LLM call + final status reflects reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,36 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- **Cancel button in Studio now short-circuits the next LLM call,
+  and runs that produce nothing no longer flip to ``success``.** Two
+  user reports rolled up:
+  - **Cancel observed late.** The orchestrator's table-level loop
+    checks the cancel token between phases (profile / filters /
+    agents / apply), but the inner LLM-call retry loop in
+    ``amx.llm.provider`` had no view of the token — so a mid-table
+    cancel waited for the whole agent fan-out before the click took
+    effect. On slow reasoning models (Databricks Serving, OpenAI o-
+    series) the user could click Cancel and see no change for many
+    minutes. New ``amx/utils/cancel.py`` exposes the active token
+    through a ``ContextVar``; the run worker binds ``job.cancel``
+    once on entry, the provider's retry loop calls
+    ``raise_if_cancelled`` before every attempt. Next call after the
+    click bails immediately with ``RunCancelled``.
+  - **All-failed-and-cancel-late status.** The final-status logic
+    defaulted to ``success`` whenever no top-level exception fired.
+    Two paths slipped through: (a) every table raised inside
+    ``process_table`` and was swallowed by the per-table ``except``,
+    leaving the worker to exit "cleanly" with zero processed assets;
+    (b) the user clicked Cancel AFTER the last table finished but
+    BEFORE the worker reached the status assignment, so no
+    ``RunCancelled`` ever propagated. Both now flip ``final_status``
+    away from ``success`` — ``failed`` when assets failed without
+    any succeeding, ``cancelled`` when ``job.cancel.is_set()`` at
+    the end. The terminal SSE emit was generalised to dispatch the
+    matching ``job.cancelled`` / ``job.failed`` event, so the
+    Studio's SSE consumer never hangs waiting for a frame that the
+    worker forgot to send.
+
 - **LLM call no longer fails on Responses-API-shaped reasoning
   models.** Some hosted endpoints return ``message.content`` as a
   list of typed parts (``[{"type": "reasoning", "summary": [...]},

--- a/amx/llm/provider.py
+++ b/amx/llm/provider.py
@@ -1361,6 +1361,17 @@ class LLMProvider:
         resp = None
         last_exc: BaseException | None = None
         for attempt in range(MAX_LLM_RETRIES + 1):
+            # Cancel short-circuit. The orchestrator binds the active
+            # job's ``cancel_token`` via ``bind_cancel_token`` in the
+            # run worker; checking here means a Studio Cancel click
+            # bails out of the NEXT LLM call instead of waiting for
+            # the current chain of retries to complete naturally. The
+            # in-flight HTTP request can't be interrupted mid-call
+            # (litellm is synchronous), but every retry budget the
+            # token saves is many seconds the user no longer waits.
+            from amx.utils.cancel import raise_if_cancelled
+
+            raise_if_cancelled(phase=f"LLM call (attempt {attempt + 1})")
             try:
                 resp = _do_completion(call_api_base)
                 last_exc = None

--- a/amx/utils/cancel.py
+++ b/amx/utils/cancel.py
@@ -1,0 +1,86 @@
+"""Process-wide cancel-token propagation.
+
+The orchestrator's table-level loop already checks
+``cancel_token.is_set()`` between phases (profile fetch, filter chain,
+agent fan-out, apply/review dispatch). That works for short tables —
+the worker exits within a few seconds of the user clicking Cancel.
+But on a slow LLM (Databricks Serving + a reasoning model can take 30-
+60s per column) a single table's agent phase blocks the cancel signal
+for many minutes, and the Studio user sees the row keep marching
+forward long after they pressed the button.
+
+The fix is to also check the cancel token **before each LLM call**, so
+the next ``litellm.completion(...)`` is short-circuited. Threading the
+token through every agent → provider call signature would touch
+dozens of files; this module exposes the token as a ``ContextVar``
+that the run worker sets once and the provider reads on each call.
+Same pattern AMX already uses for the live-display subscriber bus
+(:mod:`amx.utils.live_display`).
+
+The provider raises
+:class:`amx.agents.orchestrator.RunCancelled` when it observes the
+token; the orchestrator's existing per-table try/except surfaces that
+as the run's final ``cancelled`` status.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections.abc import Generator
+from contextvars import ContextVar
+
+_active_cancel_token: ContextVar[threading.Event | None] = ContextVar(
+    "amx_active_cancel_token", default=None
+)
+
+
+def get_active_cancel_token() -> threading.Event | None:
+    """Return the cancel-token bound to the current task, or ``None``.
+
+    Code paths that want to be cancellation-aware without an explicit
+    parameter (e.g. :func:`amx.llm.provider.LLMProvider.complete`) read
+    this and short-circuit when the token is set.
+    """
+    return _active_cancel_token.get()
+
+
+def is_cancelled() -> bool:
+    """``True`` when there is an active token AND it has been signalled."""
+    tok = _active_cancel_token.get()
+    return tok is not None and tok.is_set()
+
+
+@contextlib.contextmanager
+def bind_cancel_token(
+    token: threading.Event | None,
+) -> Generator[None, None, None]:
+    """Bind ``token`` for the duration of the ``with`` block.
+
+    The run worker wraps its main body with this so every nested
+    agent / provider call inherits the binding. The token is restored
+    on exit so a worker thread re-used by the next job sees the new
+    job's cancel state, not the previous one's.
+
+    Passing ``None`` is valid and explicitly clears any inherited
+    binding — useful for tests that want to assert "no token was
+    propagated".
+    """
+    sentinel = _active_cancel_token.set(token)
+    try:
+        yield
+    finally:
+        _active_cancel_token.reset(sentinel)
+
+
+def raise_if_cancelled(*, phase: str = "llm call") -> None:
+    """Raise :class:`RunCancelled` when the active token has been set.
+
+    Lazy-imports the exception class so this module stays free of any
+    dependency on the orchestrator package — keeps the provider's
+    import graph clean and prevents a circular import.
+    """
+    if is_cancelled():
+        from amx.agents.orchestrator import RunCancelled
+
+        raise RunCancelled(f"Cancelled before {phase}")

--- a/amx/web/routers/runs.py
+++ b/amx/web/routers/runs.py
@@ -612,6 +612,19 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
     )
     _push_display_subscriber(_display_to_sse)
 
+    # Make ``job.cancel`` visible to every nested LLM call via a
+    # ContextVar. The orchestrator's table-level cancel checks fire at
+    # phase boundaries (profile / filters / agents / apply), so a
+    # mid-table cancel had to wait for the whole agent fan-out to
+    # finish before observing the click. The provider now reads this
+    # same token and short-circuits the next ``litellm.completion()``
+    # — many minutes saved on slow reasoning models. The token is
+    # bound here and explicitly reset on the finally below so a
+    # worker thread re-used by a future job sees the new job's state.
+    from amx.utils.cancel import _active_cancel_token
+
+    _cancel_token_sentinel = _active_cancel_token.set(job.cancel)
+
     try:
         if use_batch:
             _process_scope_batch(
@@ -704,6 +717,13 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
             _display.stop_headless()
         except Exception:  # pragma: no cover - defensive
             pass
+        # Restore the cancel-token ContextVar to whatever it was bound
+        # to before this job — required so a worker thread re-used by
+        # the next job doesn't observe this job's token as "active".
+        try:
+            _active_cancel_token.reset(_cancel_token_sentinel)
+        except Exception:  # pragma: no cover - defensive
+            pass
 
     # Persist deferred review results into the pending queue regardless
     # of cancellation — the user may want to review what *did* finish.
@@ -756,6 +776,31 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
             log.warning("Auto-apply after run failed: %s", exc)
             final_error_text = f"Auto-apply failed: {exc}"
 
+    # Late-cancel override. If the user clicked Cancel after the
+    # last table finished but BEFORE the worker reached this line —
+    # or any other window where the cancel set without a ``Run-
+    # Cancelled`` ever being raised — the run's true outcome is
+    # ``cancelled``, not ``success``. The token check here is what
+    # made the difference for the user-reported "I cancelled but it
+    # still flipped to success" case.
+    if final_status == "success" and job.cancel.is_set():
+        final_status = "cancelled"
+
+    # When no tables were actually processed but some failed, the run
+    # is a failure — surfacing it as ``success`` (the default) had
+    # been misleading users who saw zero output but a green pill. The
+    # cancelled / failed status branches above remain authoritative;
+    # this only fires when the worker exited cleanly with no produced
+    # results AND at least one table raised inside ``orchestrator.
+    # process_table``.
+    if final_status == "success" and len(processed_assets) == 0 and len(failed_assets) > 0:
+        final_status = "failed"
+        if not final_error_text:
+            first_path, first_err = failed_assets[0]
+            final_error_text = (
+                f"{len(failed_assets)} asset(s) failed; first: {first_path} → {first_err}"
+            )
+
     # Demote successful runs to ``ready_for_review`` when nothing was
     # actually written to the catalog. The worker finished cleanly but
     # 119/119 suggestions still sitting in the pending queue is not a
@@ -795,22 +840,45 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
         except Exception as exc:
             log.warning("finish_run failed: %s", exc)
 
+    # Dispatch the terminal SSE event based on the FINAL status (after
+    # all the demotion / late-cancel / all-failed overrides above).
+    # Before this, the worker only emitted ``job.done`` for success /
+    # ready_for_review and relied on the ``RunCancelled`` exception
+    # handler to emit ``job.cancelled``. The late-cancel and all-
+    # failed overrides above don't raise — they only flip ``final_
+    # status`` — so without this branch the SPA's SSE consumer was
+    # left waiting indefinitely for a terminal event that never came.
+    summary = {
+        "run_id": run_id,
+        "processed": len(processed_assets),
+        "failed": len(failed_assets),
+        "pending": pending_count,
+        "applied": int(applied),
+        "run_status": final_status,
+    }
+    job.summary = summary
+    job.ended_at = time.time()
     if final_status in ("success", "ready_for_review"):
-        # Both terminal states close the job from the worker side; the
-        # SSE consumer treats ``job.done`` as "worker exited" and reads
-        # the persisted run status to decide whether the run actually
-        # succeeded or merely landed suggestions in the pending queue.
         job.status = "done"
-        job.summary = {
-            "run_id": run_id,
-            "processed": len(processed_assets),
-            "failed": len(failed_assets),
-            "pending": pending_count,
-            "applied": int(applied),
-            "run_status": final_status,
-        }
-        job.ended_at = time.time()
-        emit_terminal(job.queue, "job.done", {"summary": job.summary})
+        emit_terminal(job.queue, "job.done", {"summary": summary})
+    elif final_status == "cancelled":
+        # ``job.status`` may already be ``cancelled`` from the
+        # RunCancelled handler; setting it again is a no-op. The SSE
+        # emit, however, is gated on whether the handler fired — we
+        # only emit here when no terminal event was sent earlier, to
+        # avoid the consumer seeing two ``job.cancelled`` frames.
+        if job.status != "cancelled":
+            job.status = "cancelled"
+            emit_terminal(job.queue, "job.cancelled", {"summary": summary})
+    elif final_status == "failed":
+        if job.status != "failed":
+            job.status = "failed"
+            job.error = final_error_text or job.error
+            emit_terminal(
+                job.queue,
+                "job.failed",
+                {"error": final_error_text or "Run failed", "summary": summary},
+            )
 
 
 def _fail_job(job: Job, message: str) -> None:

--- a/tests/test_cancel_propagation.py
+++ b/tests/test_cancel_propagation.py
@@ -1,0 +1,104 @@
+"""``amx.utils.cancel`` propagates the run's cancel token to nested
+LLM calls so a Studio Cancel click short-circuits the next
+``litellm.completion(...)`` instead of waiting for the whole agent
+fan-out to finish.
+
+Three behaviours pinned here:
+
+1. The ContextVar starts unbound — code that didn't opt-in stays
+   silent (matches the CLI's programmatic-call shape).
+2. ``bind_cancel_token`` makes the token visible to nested code AND
+   restores the previous binding on exit. Critical for worker threads
+   that are re-used across jobs.
+3. ``raise_if_cancelled`` raises ``RunCancelled`` when the bound
+   token has been set, and is a no-op otherwise. The provider's
+   retry loop uses this on every attempt to short-circuit the next
+   call.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from amx.utils.cancel import (
+    bind_cancel_token,
+    get_active_cancel_token,
+    is_cancelled,
+    raise_if_cancelled,
+)
+
+
+def test_no_token_by_default():
+    """A fresh process starts with no binding — preserves the
+    no-cancellation behaviour for callers that never installed one."""
+    assert get_active_cancel_token() is None
+    assert is_cancelled() is False
+    # ``raise_if_cancelled`` is a no-op when no token is bound.
+    raise_if_cancelled(phase="test")
+
+
+def test_bind_cancel_token_makes_it_visible_inside_block():
+    token = threading.Event()
+    with bind_cancel_token(token):
+        assert get_active_cancel_token() is token
+    # Restored on exit.
+    assert get_active_cancel_token() is None
+
+
+def test_bind_cancel_token_restores_previous_binding():
+    outer = threading.Event()
+    inner = threading.Event()
+    with bind_cancel_token(outer):
+        assert get_active_cancel_token() is outer
+        with bind_cancel_token(inner):
+            assert get_active_cancel_token() is inner
+        # Outer binding restored, NOT cleared to None.
+        assert get_active_cancel_token() is outer
+    assert get_active_cancel_token() is None
+
+
+def test_is_cancelled_reflects_set_state():
+    token = threading.Event()
+    with bind_cancel_token(token):
+        assert is_cancelled() is False
+        token.set()
+        assert is_cancelled() is True
+
+
+def test_raise_if_cancelled_raises_RunCancelled_when_set():
+    from amx.agents.orchestrator import RunCancelled
+
+    token = threading.Event()
+    token.set()
+    with bind_cancel_token(token):
+        try:
+            raise_if_cancelled(phase="probe")
+        except RunCancelled as exc:
+            assert "probe" in str(exc)
+        else:
+            raise AssertionError("RunCancelled was not raised")
+
+
+def test_raise_if_cancelled_silent_when_token_unset():
+    """Token bound but unset → still a no-op. Matches the path the
+    provider takes when no Cancel button has been clicked."""
+    token = threading.Event()
+    with bind_cancel_token(token):
+        # Should NOT raise.
+        raise_if_cancelled(phase="probe")
+
+
+def test_bind_with_none_clears_inherited_binding():
+    """Useful for tests / nested contexts that want to assert
+    "no cancel token visible here". Passing ``None`` is an explicit
+    clear, not a re-use of the parent binding."""
+    outer = threading.Event()
+    outer.set()
+    with bind_cancel_token(outer):
+        assert is_cancelled() is True
+        with bind_cancel_token(None):
+            # Cleared inside the inner block.
+            assert get_active_cancel_token() is None
+            assert is_cancelled() is False
+        # Outer binding restored.
+        assert is_cancelled() is True


### PR DESCRIPTION
## Symptom (rolled-up user report)

> Studio'da bir run yaparken cancel'a basıyorum. O ana kadar gelenleri tutup hemen yazması sonrasında hemen cancellaması gerekir. Ben cancel'a basıyorum, ama running olmaya devam ediyor. İşin daha kötü tarafı hiçbir çıktı görünmemesine rağmen bu çıktı sonunda "success" görünüyor.

Two related bugs:
1. **Cancel observed late** — on a slow reasoning model each table's agent fan-out takes minutes; the orchestrator only checks the cancel token at phase boundaries (profile / filters / agents / apply), so a mid-fan-out click is observed minutes after the user pressed it.
2. **Final status reports "success" with no output** — the run worker defaulted ``final_status = "success"`` and only demoted it on a top-level exception. Per-table failures swallowed by the table loop's ``except``, and a Cancel click landing after the last table finished, both slipped through and the row flipped green.

## Fix

### Cancel propagation
New ``amx/utils/cancel.py`` exposes the active cancel token through a ``ContextVar``:

```python
@contextlib.contextmanager
def bind_cancel_token(token): ...
def raise_if_cancelled(*, phase): ...
```

The run worker binds ``job.cancel`` once on entry, restoring on ``finally``. The provider's per-attempt retry loop in ``_complete`` calls ``raise_if_cancelled`` before every ``litellm.completion`` — so the **next LLM call** after the Cancel click bails out with ``RunCancelled`` instead of waiting for the whole agent chain. The in-flight HTTP request still can't be interrupted mid-call (litellm is synchronous), but every saved retry is seconds the user no longer waits.

### Final status accuracy
``runs.py``'s status-finalisation block now demotes ``success`` to:
- **``cancelled``** when ``job.cancel.is_set()`` at the bottom of the worker. Covers the late-cancel window where no ``RunCancelled`` was raised because the loop already exited.
- **``failed``** when ``len(processed_assets) == 0 and len(failed_assets) > 0``. Covers the all-tables-raised-but-each-was-swallowed case (e.g. previously: the upstream API returned the list-content shape the v0.13 shim missed; every table raised and the worker exited "cleanly").

The terminal SSE emit was generalised so ``job.cancelled`` / ``job.failed`` is sent whenever the status ends up there. Previously only ``job.done`` was emitted for success / ready_for_review and the SSE consumer was left hanging on the late-cancel / all-failed paths waiting for a terminal frame that never came.

## Test plan

- [x] ``pytest tests/`` — 1442 passed (7 new in ``test_cancel_propagation.py`` pinning the ContextVar bind / nest / restore / clear / silent-when-unset / raise-when-set behaviour).
- [x] ``ruff check`` + ``ruff format --check`` clean.
- [ ] Manual: kick off a slow run, click Cancel mid-table → the run stops within one LLM-call's worth of latency (no longer waits for the table's full agent fan-out). Status pill flips to ``cancelled``, NOT ``success``.
- [ ] Manual: induce a per-table failure on every table (e.g. with the v0.13 list-content bug before #328) → row lands as ``failed``, not ``success``.

Part 2 of 2 with #328 (the list-content fix that unblocks the rest).