### PR TITLE
docs: link README hero video to YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <p align="center">
-  <a href="https://www.youtube.com/watch?v=NmEVxqkfZdI">
-    <img src="https://img.youtube.com/vi/NmEVxqkfZdI/maxresdefault.jpg" alt="Watch AMX in action on YouTube" width="760">
-  </a>
+  <video src="https://www.youtube.com/watch?v=NmEVxqkfZdI" controls muted playsinline width="760"></video>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <p align="center">
-  <video src="https://github.com/user-attachments/assets/fdcb7498-928a-4250-b257-7d5aef5521bb" controls muted playsinline width="760"></video>
+  <a href="https://www.youtube.com/watch?v=NmEVxqkfZdI">
+    <img src="https://img.youtube.com/vi/NmEVxqkfZdI/maxresdefault.jpg" alt="Watch AMX in action on YouTube" width="760">
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Swap the inline `<video>` block for a clickable YouTube thumbnail (https://www.youtube.com/watch?v=NmEVxqkfZdI).
- GitHub sanitizes `<iframe>` so a true in-page embed is not possible; the thumbnail+link pattern is the standard OSS idiom and keeps a single asset (the thumbnail) in flight on first paint.

## Test plan
- [ ] Confirm the thumbnail renders on the rendered README (GitHub PR Preview)
- [ ] Confirm clicking the thumbnail opens the YouTube video