### PR TITLE
feat(rag): observability + error surfacing (PR A of 4)

### DIFF
--- a/amx/agents/_orchestrator/table_processor.py
+++ b/amx/agents/_orchestrator/table_processor.py
@@ -361,6 +361,17 @@ class TableProcessor:
         for message in dict.fromkeys(profile_diagnostics):
             warn(message)
 
+        # ``RAGAgent`` mirrors :class:`ProfileAgent`'s diagnostics
+        # pattern (PR A). When retrieval returned no matching chunks
+        # the agent appends "RAG: no relevant documents found ..." so
+        # the user knows the ingested docs didn't match this table
+        # instead of seeing zero RAG output with no explanation.
+        rag_agent = getattr(self.orch, "rag_agent", None)
+        if rag_agent is not None and hasattr(rag_agent, "consume_diagnostics"):
+            rag_diagnostics = rag_agent.consume_diagnostics()
+            for message in dict.fromkeys(rag_diagnostics):
+                info(message)
+
         merged = self.orch._merge_suggestions(all_suggestions, ctx)
         if not merged:
             warn(

--- a/amx/agents/rag_agent.py
+++ b/amx/agents/rag_agent.py
@@ -121,6 +121,20 @@ class RAGAgent(BaseAgent):
         self.llm = llm
         self.rag = rag_store
         self._style_profile = load_active_style_profile()
+        # Diagnostics buffer (mirrors :class:`ProfileAgent`): the
+        # orchestrator drains it after each table to surface signals
+        # that aren't fatal but the user still needs to see — today,
+        # "RAG returned no relevant documents".
+        self._diagnostics: list[str] = []
+
+    def consume_diagnostics(self) -> list[str]:
+        diagnostics = list(self._diagnostics)
+        self._diagnostics.clear()
+        return diagnostics
+
+    def _record_diagnostic(self, message: str) -> None:
+        if message:
+            self._diagnostics.append(message)
 
     @property
     def _n_alternatives(self) -> int:
@@ -207,6 +221,9 @@ class RAGAgent(BaseAgent):
 
         msgs = self._build_messages(ctx)
         if msgs is None:
+            self._record_diagnostic(
+                f"RAG: no relevant documents found for {ctx.schema}.{ctx.table}"
+            )
             return []
         n_columns = len(ctx.db_profile.get("columns", []) or [])
         return [
@@ -225,9 +242,13 @@ class RAGAgent(BaseAgent):
         return _scrub_suggestions(suggestions, self._style_profile)
 
     def run(self, ctx: AgentContext) -> list[MetadataSuggestion]:
+        self._diagnostics.clear()
         messages = self._build_messages(ctx)
         if messages is None:
             log.info("No RAG context for %s.%s, skipping", ctx.schema, ctx.table)
+            self._record_diagnostic(
+                f"RAG: no relevant documents found for {ctx.schema}.{ctx.table}"
+            )
             return []
 
         columns = ctx.db_profile.get("columns", [])

--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -601,6 +601,21 @@ def _resolve_completion_mode(cfg: AMXConfig, llm: object, mode: str | None) -> b
     return use_batch
 
 
+def _record_rag_unavailable_reason(
+    extra_metrics: dict[str, str],
+    exc: BaseException,
+) -> None:
+    """Record a one-line reason why ``RAGStore`` couldn't be opened.
+
+    Stored on the run's ``metrics_json`` (a free-form dict) under
+    ``rag_unavailable_reason`` so post-run summaries / Studio can read
+    it and tell the user "No RAG context used (reason: ...)". The
+    counterpart in :mod:`amx.core.inference` uses the same formatting
+    so the two call sites can never drift.
+    """
+    extra_metrics["rag_unavailable_reason"] = f"{exc.__class__.__name__}: {exc}"
+
+
 def _finalize_history_run(
     *,
     run_id: int | None,
@@ -615,6 +630,7 @@ def _finalize_history_run(
     apply: bool,
     all_results: list[object],
     final_error_text: str,
+    extra_metrics: dict[str, Any] | None = None,
 ) -> None:
     if run_id is None:
         return
@@ -622,22 +638,28 @@ def _finalize_history_run(
     if hs is None:
         return
     try:
+        metrics_payload: dict[str, Any] = {
+            "duration_sec": round(time.monotonic() - run_started, 3),
+            "model_processing_sec": round(token_tracker.total_model_processing_sec, 3),
+            "total_assets": total_assets,
+            "total_schemas": total_schemas,
+            "processed_assets_count": len(processed_assets),
+            "processed_assets": processed_assets,
+            "skipped_assets_count": len(skipped_assets),
+            "skipped_assets": skipped_assets,
+            "approved_count": len(approved),
+            "skipped_count": len(skipped),
+            "applied_flag": bool(apply),
+        }
+        if extra_metrics:
+            # Don't let an opt-in diagnostic key (rag_unavailable_reason,
+            # future PRs) silently shadow a base metric — base wins.
+            for key, value in extra_metrics.items():
+                metrics_payload.setdefault(key, value)
         hs.finish_run(
             run_id,
             status=final_status or "success",
-            metrics={
-                "duration_sec": round(time.monotonic() - run_started, 3),
-                "model_processing_sec": round(token_tracker.total_model_processing_sec, 3),
-                "total_assets": total_assets,
-                "total_schemas": total_schemas,
-                "processed_assets_count": len(processed_assets),
-                "processed_assets": processed_assets,
-                "skipped_assets_count": len(skipped_assets),
-                "skipped_assets": skipped_assets,
-                "approved_count": len(approved),
-                "skipped_count": len(skipped),
-                "applied_flag": bool(apply),
-            },
+            metrics=metrics_payload,
             tokens={
                 "total_tokens": token_tracker.total_tokens,
                 "total_cost_usd": round(token_tracker.total_cost_usd, 8),
@@ -744,6 +766,10 @@ def execute_analyze_run(
     # = total_assets - <filter skips> accurately.
     final_status: str | None = None
     final_error_text = ""
+    # Free-form dict merged into the run's ``metrics_json`` payload at
+    # finalize-time. Used today for ``rag_unavailable_reason`` (PR A);
+    # subsequent PRs are expected to land more diagnostic keys here.
+    extra_metrics: dict[str, str] = {}
     # Pre-init these so the KeyboardInterrupt / Exception handlers
     # below don't trip an UnboundLocalError when the user cancels at the
     # scope picker (which is BEFORE the runtime questions get a chance
@@ -1056,8 +1082,18 @@ def execute_analyze_run(
                         f"RAG store has 0 chunks for active doc profile "
                         f"'{cfg.active_doc_profile or 'default'}'"
                     )
-        except Exception:
-            pass
+        except Exception as exc:
+            # Used to be ``except: pass`` — the user never saw that the
+            # store failed and the run quietly proceeded with no doc
+            # context. Now we record a one-line reason on the run record
+            # so /history and Studio can render "No RAG context used
+            # (reason: ...)", and surface the same message inline.
+            _record_rag_unavailable_reason(extra_metrics, exc)
+            error(
+                f"RAG store unavailable: {exc.__class__.__name__}: {exc}. "
+                "Run will proceed without document context."
+            )
+            log.warning("RAGStore init failed during analyze: %s", exc, exc_info=True)
 
         with command_display(
             schema=schema or cfg.current_schema or "",
@@ -1172,6 +1208,7 @@ def execute_analyze_run(
             apply=apply,
             all_results=all_results,
             final_error_text=final_error_text,
+            extra_metrics=extra_metrics,
         )
         # Always put the saved profile back on cfg.llm. ``restore`` is
         # a no-op when the user declined the override gate or didn't

--- a/amx/cli_support/commands/docs.py
+++ b/amx/cli_support/commands/docs.py
@@ -28,6 +28,26 @@ FinalizeScope = Callable[[AMXConfig, object, str | None, list[str]], dict[str, l
 WarnNoPaths = Callable[..., None]
 
 
+def _render_ingest_summary(summary: object, *, total_files: int) -> None:
+    """Print the per-file ingest outcome line + any failure detail.
+
+    ``summary`` is duck-typed against :class:`amx.docs.rag.IngestSummary`
+    (the import lives inside the command bodies to keep this module
+    cheap to import). When ``failed`` is non-empty, list each failed
+    file path + the short error reason so the user can act on the
+    specific files instead of grepping ``~/.amx/logs/amx.log``.
+    """
+    succeeded = list(getattr(summary, "succeeded", []) or [])
+    failed = list(getattr(summary, "failed", []) or [])
+    chunk_count = int(getattr(summary, "chunk_count", 0) or 0)
+    info(
+        f"Ingested {chunk_count} chunks from {len(succeeded)} of {total_files} files "
+        f"({len(failed)} failed)"
+    )
+    for path, reason in failed:
+        error(f"  failed: {path} — {reason}")
+
+
 def _run_docs_semantic_search(question: str, results: int) -> None:
     """Chroma embedding similarity only; no generative LLM."""
     from amx.docs.rag import RAGStore
@@ -142,8 +162,12 @@ def register_docs_commands(
                 info(f"Found {len(documents)} document(s) ({size:.1f} MB)")
                 store = RAGStore()
                 with step_spinner("Ingesting into RAG store"):
-                    chunks = store.ingest(documents, refresh=False)
-                success(f"Ingested {chunks} chunks into RAG store ({store.doc_count} total chunks)")
+                    summary = store.ingest(documents, refresh=False)
+                _render_ingest_summary(summary, total_files=len(documents))
+                success(
+                    f"Ingested {summary.chunk_count} chunks into RAG store "
+                    f"({store.doc_count} total chunks)"
+                )
         finally:
             cleanup_scan_artifacts(documents)
 
@@ -198,8 +222,12 @@ def register_docs_commands(
 
                     store = RAGStore()
                     with step_spinner("Ingesting scanned documents"):
-                        chunks = store.ingest(documents, refresh=False)
-                    success(f"Ingested {chunks} chunks from {len(documents)} documents")
+                        summary = store.ingest(documents, refresh=False)
+                    _render_ingest_summary(summary, total_files=len(documents))
+                    success(
+                        f"Ingested {summary.chunk_count} chunks from "
+                        f"{len(documents)} documents"
+                    )
         finally:
             cleanup_scan_artifacts(documents)
 
@@ -254,10 +282,14 @@ def register_docs_commands(
 
                 store = RAGStore()
                 with step_spinner("Ingesting documents into RAG store"):
-                    chunks = store.ingest(documents, refresh=refresh)
+                    summary = store.ingest(documents, refresh=refresh)
+                _render_ingest_summary(summary, total_files=len(documents))
                 if refresh:
                     info("Refreshed: removed prior chunks for the same source paths before ingest.")
-                success(f"Ingested {chunks} chunks into RAG store ({store.doc_count} total chunks)")
+                success(
+                    f"Ingested {summary.chunk_count} chunks into RAG store "
+                    f"({store.doc_count} total chunks)"
+                )
         finally:
             cleanup_scan_artifacts(documents)
 

--- a/amx/cli_support/commands/docs.py
+++ b/amx/cli_support/commands/docs.py
@@ -238,8 +238,7 @@ def register_docs_commands(
                         summary = store.ingest(documents, refresh=False)
                     _render_ingest_summary(summary, total_files=len(documents))
                     success(
-                        f"Ingested {summary.chunk_count} chunks from "
-                        f"{len(documents)} documents"
+                        f"Ingested {summary.chunk_count} chunks from {len(documents)} documents"
                     )
         finally:
             cleanup_scan_artifacts(documents)

--- a/amx/cli_support/commands/docs.py
+++ b/amx/cli_support/commands/docs.py
@@ -28,6 +28,17 @@ FinalizeScope = Callable[[AMXConfig, object, str | None, list[str]], dict[str, l
 WarnNoPaths = Callable[..., None]
 
 
+def _render_scan_failures(scan_outcome: object) -> None:
+    """Print ``Failed to scan: <source> — <reason>`` for each entry on
+    a :class:`amx.docs.scanner.ScanResult`. Silently no-ops if the
+    caller passed a bare ``list[DocInfo]`` (legacy stubbed return)."""
+    failures = list(getattr(scan_outcome, "failures", []) or [])
+    if not failures:
+        return
+    for src, reason in failures:
+        error(f"  failed to scan: {src} — {reason}")
+
+
 def _render_ingest_summary(summary: object, *, total_files: int) -> None:
     """Print the per-file ingest outcome line + any failure detail.
 
@@ -158,6 +169,7 @@ def register_docs_commands(
             ):
                 with step_spinner(f"Scanning {upload_root}"):
                     documents = scan_all_sources([upload_root])
+                _render_scan_failures(documents)
                 size = total_size_mb(documents)
                 info(f"Found {len(documents)} document(s) ({size:.1f} MB)")
                 store = RAGStore()
@@ -198,6 +210,7 @@ def register_docs_commands(
             with command_display(mode="docs-scan", provider=cfg.llm.provider, model=cfg.llm.model):
                 with step_spinner("Scanning document sources"):
                     documents = scan_all_sources(all_paths)
+                _render_scan_failures(documents)
                 size = total_size_mb(documents)
 
                 render_table(
@@ -271,6 +284,7 @@ def register_docs_commands(
             ):
                 with step_spinner("Scanning document sources"):
                     documents = scan_all_sources(all_paths)
+                _render_scan_failures(documents)
                 size = total_size_mb(documents)
 
                 info(f"Found {len(documents)} documents ({size:.1f} MB)")

--- a/amx/core/inference.py
+++ b/amx/core/inference.py
@@ -16,8 +16,22 @@ from amx.agents.orchestrator import Orchestrator
 from amx.config import AMXConfig
 from amx.db.connector import DatabaseConnector
 from amx.llm.provider import LLMProvider
+from amx.utils.logging import get_logger
+
+log = get_logger("core.inference")
 
 __all__ = ["InferenceResult"]
+
+
+def _format_rag_unavailable_reason(exc: BaseException) -> str:
+    """One-line reason string used when ``RAGStore`` can't be opened.
+
+    Lives next to the call site so the analyze-flow CLI helper and the
+    library entrypoint produce identical wording (the two used to drift
+    because each formatted its own message inside an
+    ``except: pass``-style block).
+    """
+    return f"{exc.__class__.__name__}: {exc}"
 
 
 @dataclass(frozen=True)
@@ -80,8 +94,16 @@ def infer_table_metadata(
             store = RAGStore(source_filters=cfg.effective_doc_paths())
             if store.doc_count > 0:
                 rag_store = store
-        except Exception:
+        except Exception as exc:
+            # Used to be ``except: pass``. Library callers can't see
+            # ``rag_unavailable_reason`` on a metrics dict (there is no
+            # run record at this layer), but we still log the reason
+            # so the user can diagnose why no docs were used.
             rag_store = None
+            log.warning(
+                "RAGStore unavailable: %s. Inference will proceed without document context.",
+                _format_rag_unavailable_reason(exc),
+            )
 
     code_report: Any = None
     if include_codebase:

--- a/amx/docs/extensions.py
+++ b/amx/docs/extensions.py
@@ -1,0 +1,45 @@
+"""Single source of truth for document file extensions AMX can ingest.
+
+Historically the upload validator (``amx/docs/uploads.py``) and the
+local/remote scanner (``amx/docs/scanner.py``) each maintained their
+own whitelist. The two drifted: ``.markdown`` and ``.tsv`` were
+accepted on upload but silently dropped at scan time; ``.rtf`` was
+scan-supported but had no deterministic loader so ingest dropped it
+with a warning.
+
+Consolidating both callers behind one frozenset (the intersection of
+"we accept it on upload" AND "we can actually parse it via the loader
+map") closes those gaps once and for all. New supported extensions
+are added here exactly once and become visible to every layer
+automatically.
+"""
+
+from __future__ import annotations
+
+#: Extensions for which AMX has a real loader and which the upload UI
+#: accepts. Both ``ACCEPTED_EXTENSIONS`` (uploads) and
+#: ``SUPPORTED_EXTENSIONS`` (scanner) re-export this set; the rag
+#: pipeline's ``LOADER_MAP`` must carry an entry for every extension
+#: in here.
+SUPPORTED_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".md",
+        ".markdown",
+        ".txt",
+        ".pdf",
+        ".docx",
+        ".doc",
+        ".html",
+        ".htm",
+        ".csv",
+        ".tsv",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".rst",
+        ".py",
+        ".xlsx",
+        ".xls",
+        ".pptx",
+    }
+)

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -64,7 +64,17 @@ LOADER_MAP = {
     ".doc": Docx2txtLoader,
     ".txt": TextLoader,
     ".md": UnstructuredMarkdownLoader,
+    # ``.markdown`` is just the long-form extension of ``.md`` — same
+    # syntax, same loader. Listing it explicitly keeps the LOADER_MAP /
+    # SUPPORTED_EXTENSIONS contract honest (every supported extension
+    # has its own loader entry).
+    ".markdown": UnstructuredMarkdownLoader,
     ".csv": CSVLoader,
+    # TSV is tab-separated values; ``CSVLoader`` is delimiter-agnostic
+    # at the langchain level and treats the file as one logical record
+    # per row, which is all the RAG pipeline needs (the splitter then
+    # decides chunking).
+    ".tsv": CSVLoader,
     ".xlsx": UnstructuredExcelLoader,
     ".xls": UnstructuredExcelLoader,
     ".html": UnstructuredHTMLLoader,
@@ -74,7 +84,9 @@ LOADER_MAP = {
     ".yaml": TextLoader,
     ".yml": TextLoader,
     ".rst": TextLoader,
-    ".rtf": TextLoader,
+    # Python source files: index as plain text so the chunker can pull
+    # out docstrings / comments alongside code identifiers.
+    ".py": TextLoader,
 }
 
 

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from amx.utils.optional_deps import ensure as _ensure
@@ -90,6 +91,33 @@ LOADER_MAP = {
 }
 
 
+@dataclass(frozen=True)
+class IngestSummary:
+    """Per-file outcome of a single :meth:`RAGStore.ingest` call.
+
+    Replaces the historic bare-``int`` return so CLI and Studio can
+    actually tell the user *which* files failed and why. The class
+    still answers ``int(...)`` with the total chunk count so existing
+    callers that wrote ``f"{chunks} chunks"`` keep working without a
+    lock-step rewrite.
+    """
+
+    #: Source paths that produced at least one chunk in the collection.
+    succeeded: list[str] = field(default_factory=list)
+    #: ``(source_path, short error message)`` for every file that the
+    #: loader, splitter, or upsert step failed on. Each tuple is
+    #: render-ready: the CLI emits one line per entry, Studio emits
+    #: ``{path, error}`` objects in the ``ingest.summary`` SSE event.
+    failed: list[tuple[str, str]] = field(default_factory=list)
+    #: Total number of chunks upserted into the collection. Preserved
+    #: as a separate counter (instead of derived from ``succeeded``)
+    #: because one file produces many chunks.
+    chunk_count: int = 0
+
+    def __int__(self) -> int:
+        return int(self.chunk_count)
+
+
 class RAGStore:
     def __init__(
         self,
@@ -141,20 +169,34 @@ class RAGStore:
         docs: list[DocInfo],
         *,
         refresh: bool = False,
-    ) -> int:
+    ) -> IngestSummary:
+        """Load each document, split it into chunks, upsert into Chroma.
+
+        Returns an :class:`IngestSummary` whose ``failed`` list carries
+        a one-line reason per file that the loader or splitter couldn't
+        process. Files with no extracted chunks (e.g. a truly empty
+        ``.md``) land in ``failed`` with an ``"empty document"`` reason
+        rather than being silently dropped — silent drops were the
+        whole reason this contract changed in PR A.
+        """
         if refresh and docs:
             self.delete_chunks_for_sources([x for d in docs for x in (d.path, d.source_root) if x])
+        succeeded: list[str] = []
+        failed: list[tuple[str, str]] = []
         total_chunks = 0
         for doc in docs:
             loader_cls = LOADER_MAP.get(doc.extension)
             if loader_cls is None:
+                reason = f"no loader for extension {doc.extension!r}"
                 log.warning("No loader for %s, skipping %s", doc.extension, doc.path)
+                failed.append((doc.path, reason))
                 continue
             try:
                 loader = loader_cls(doc.path)
                 pages = loader.load()
                 chunks = self.splitter.split_documents(pages)
                 if not chunks:
+                    failed.append((doc.path, "empty document (no chunks produced)"))
                     continue
 
                 ids = [f"{doc.path}::{i}" for i in range(len(chunks))]
@@ -170,10 +212,17 @@ class RAGStore:
                 ]
                 self.collection.upsert(ids=ids, documents=texts, metadatas=metadatas)
                 total_chunks += len(chunks)
+                succeeded.append(doc.path)
                 log.info("Ingested %s -> %d chunks", doc.path, len(chunks))
             except Exception as exc:
+                # One-line reason — full traceback already in the log.
+                # Keep ``exc.__class__.__name__`` so the user sees the
+                # category at a glance (PdfReadError, UnicodeDecodeError,
+                # PermissionError, ...) without needing the log file.
+                reason = f"{exc.__class__.__name__}: {exc}"
                 log.error("Error ingesting %s: %s", doc.path, exc)
-        return total_chunks
+                failed.append((doc.path, reason))
+        return IngestSummary(succeeded=succeeded, failed=failed, chunk_count=total_chunks)
 
     def query(self, question: str, n_results: int = 5) -> list[dict]:
         raw_n = max(int(n_results), min(int(n_results) * 4, 40))

--- a/amx/docs/scanner.py
+++ b/amx/docs/scanner.py
@@ -16,28 +16,10 @@ from typing import Any
 
 import requests
 
+from amx.docs.extensions import SUPPORTED_EXTENSIONS
 from amx.utils.logging import get_logger
 
 log = get_logger("docs.scanner")
-
-SUPPORTED_EXTENSIONS = {
-    ".pdf",
-    ".docx",
-    ".doc",
-    ".txt",
-    ".md",
-    ".csv",
-    ".xlsx",
-    ".xls",
-    ".html",
-    ".htm",
-    ".json",
-    ".yaml",
-    ".yml",
-    ".rst",
-    ".rtf",
-    ".pptx",
-}
 
 
 @dataclass

--- a/amx/docs/scanner.py
+++ b/amx/docs/scanner.py
@@ -10,7 +10,7 @@ import subprocess
 import tempfile
 import urllib.parse
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -758,14 +758,54 @@ def scan_source(path: str) -> list[DocInfo]:
     return _tag(list(_resolve_local(path)))
 
 
-def scan_all_sources(paths: list[str]) -> list[DocInfo]:
+@dataclass(frozen=True)
+class ScanResult:
+    """Outcome of a multi-source scan.
+
+    ``documents`` is the same list :func:`scan_all_sources` used to
+    return; ``failures`` carries one ``(source_path, short message)``
+    tuple per source path the resolver raised on (e.g. a private S3
+    URI without credentials, an unreachable GitHub URL).
+
+    The class is also list-like over ``documents`` so historic callers
+    that wrote ``for doc in scan_all_sources(paths):`` or
+    ``len(scan_all_sources(paths))`` continue to work without a
+    lock-step rewrite. New surfaces (CLI scan summary, Studio
+    ``scan.summary`` SSE event) read ``.failures`` explicitly.
+    """
+
+    documents: list[DocInfo] = field(default_factory=list)
+    failures: list[tuple[str, str]] = field(default_factory=list)
+
+    def __iter__(self):
+        return iter(self.documents)
+
+    def __len__(self) -> int:
+        return len(self.documents)
+
+    def __getitem__(self, index):
+        return self.documents[index]
+
+
+def scan_all_sources(paths: list[str]) -> ScanResult:
+    """Resolve every configured source path and aggregate the docs.
+
+    Errors during one source no longer disappear into a ``log.error``
+    line nobody reads — they're returned on ``ScanResult.failures`` so
+    the CLI summary and the Studio worker can surface them. The shape
+    is iterable/lengthy over ``documents`` for backwards compatibility
+    with callers that treated the return value as ``list[DocInfo]``.
+    """
     all_docs: list[DocInfo] = []
+    failures: list[tuple[str, str]] = []
     for p in paths:
         try:
             all_docs.extend(scan_source(p))
         except Exception as exc:
+            reason = f"{exc.__class__.__name__}: {exc}"
             log.error("Failed to scan %s: %s", p, exc)
-    return all_docs
+            failures.append((p, reason))
+    return ScanResult(documents=all_docs, failures=failures)
 
 
 def total_size_mb(docs: list[DocInfo]) -> float:

--- a/amx/docs/uploads.py
+++ b/amx/docs/uploads.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from amx.config import AMXConfig
+from amx.docs.extensions import SUPPORTED_EXTENSIONS
 
 #: Per-file ceiling, mirrored on the FastAPI side. A 25 MB upload is
 #: already the upper end of "design doc" — anything bigger is almost
@@ -34,8 +35,6 @@ MAX_FILE_BYTES: int = 25 * 1024 * 1024
 #: user's home directory before the FastAPI worker has a chance to
 #: respond.
 MAX_BATCH_BYTES: int = 100 * 1024 * 1024
-
-from amx.docs.extensions import SUPPORTED_EXTENSIONS
 
 #: Extensions :mod:`amx.docs.scanner` knows how to load. Anything else
 #: lands in the upload folder unread by the RAG agent. Re-exported from

--- a/amx/docs/uploads.py
+++ b/amx/docs/uploads.py
@@ -35,27 +35,13 @@ MAX_FILE_BYTES: int = 25 * 1024 * 1024
 #: respond.
 MAX_BATCH_BYTES: int = 100 * 1024 * 1024
 
+from amx.docs.extensions import SUPPORTED_EXTENSIONS
+
 #: Extensions :mod:`amx.docs.scanner` knows how to load. Anything else
-#: lands in the upload folder unread by the RAG agent.
-ACCEPTED_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".md",
-        ".markdown",
-        ".txt",
-        ".pdf",
-        ".docx",
-        ".doc",
-        ".csv",
-        ".tsv",
-        ".html",
-        ".htm",
-        ".rst",
-        ".rtf",
-        ".json",
-        ".yaml",
-        ".yml",
-    }
-)
+#: lands in the upload folder unread by the RAG agent. Re-exported from
+#: :mod:`amx.docs.extensions` so the upload validator and the scanner
+#: share one source of truth.
+ACCEPTED_EXTENSIONS: frozenset[str] = SUPPORTED_EXTENSIONS
 
 
 @dataclass

--- a/amx/web/routers/docs_ops.py
+++ b/amx/web/routers/docs_ops.py
@@ -299,18 +299,34 @@ def _ingest_worker_body(job: Job, paths: list[str], refresh: bool) -> None:
         emit(job.queue, "activity.begin", {"idx": 1})
 
         store = RAGStore()
-        chunks_added = store.ingest(documents, refresh=bool(refresh))
+        # ``RAGStore.ingest`` returns ``IngestSummary`` (PR A); ``int(...)``
+        # still answers the chunk count for legacy callers and the
+        # frontend's existing ``summary.chunks`` reader.
+        summary = store.ingest(documents, refresh=bool(refresh))
+        chunks_added = int(summary)
+        failed_list = [
+            {"path": path, "error": reason}
+            for path, reason in (getattr(summary, "failed", None) or [])
+        ]
+        succeeded_count = len(getattr(summary, "succeeded", None) or [])
         emit(
             job.queue,
             "ingest.summary",
             {
                 "documents": len(documents),
-                "chunks": int(chunks_added),
+                "chunks": chunks_added,
                 "refresh": bool(refresh),
+                "succeeded": succeeded_count,
+                "failed": failed_list,
             },
         )
         job.status = "done"
-        job.summary = {"documents": len(documents), "chunks": int(chunks_added)}
+        job.summary = {
+            "documents": len(documents),
+            "chunks": chunks_added,
+            "succeeded": succeeded_count,
+            "failed": failed_list,
+        }
         job.ended_at = time.time()
         emit(
             job.queue,

--- a/amx/web/routers/docs_ops.py
+++ b/amx/web/routers/docs_ops.py
@@ -239,7 +239,15 @@ def _scan_worker_body(job: Job, paths: list[str]) -> None:
     try:
         from amx.docs.scanner import scan_all_sources, total_size_mb
 
-        documents = scan_all_sources(paths)
+        scan_outcome = scan_all_sources(paths)
+        # ``ScanResult`` exposes ``.documents`` and ``.failures``; if a
+        # caller has stubbed the function (tests), it may still return
+        # a bare list — ``getattr`` keeps both shapes working.
+        documents = list(getattr(scan_outcome, "documents", scan_outcome) or [])
+        failures = [
+            {"path": src, "error": reason}
+            for src, reason in (getattr(scan_outcome, "failures", None) or [])
+        ]
         size = total_size_mb(documents)
         emit(
             job.queue,
@@ -255,10 +263,15 @@ def _scan_worker_body(job: Job, paths: list[str]) -> None:
                     }
                     for d in documents[:200]  # cap for SSE payload size
                 ],
+                "failures": failures,
             },
         )
         job.status = "done"
-        job.summary = {"total": len(documents), "size_mb": round(size, 2)}
+        job.summary = {
+            "total": len(documents),
+            "size_mb": round(size, 2),
+            "failures": failures,
+        }
         job.ended_at = time.time()
         emit(
             job.queue,
@@ -288,7 +301,14 @@ def _ingest_worker_body(job: Job, paths: list[str], refresh: bool) -> None:
         from amx.docs.rag import RAGStore
         from amx.docs.scanner import scan_all_sources, total_size_mb
 
-        documents = scan_all_sources(paths)
+        scan_outcome = scan_all_sources(paths)
+        # ``ScanResult`` exposes ``.documents`` and ``.failures``; some
+        # tests still stub a bare list, which ``getattr`` keeps working.
+        documents = list(getattr(scan_outcome, "documents", scan_outcome) or [])
+        scan_failures = [
+            {"path": src, "error": reason}
+            for src, reason in (getattr(scan_outcome, "failures", None) or [])
+        ]
         size = total_size_mb(documents)
         emit(
             job.queue,
@@ -318,6 +338,7 @@ def _ingest_worker_body(job: Job, paths: list[str], refresh: bool) -> None:
                 "refresh": bool(refresh),
                 "succeeded": succeeded_count,
                 "failed": failed_list,
+                "scan_failures": scan_failures,
             },
         )
         job.status = "done"
@@ -326,6 +347,7 @@ def _ingest_worker_body(job: Job, paths: list[str], refresh: bool) -> None:
             "chunks": chunks_added,
             "succeeded": succeeded_count,
             "failed": failed_list,
+            "scan_failures": scan_failures,
         }
         job.ended_at = time.time()
         emit(

--- a/docs/superpowers/specs/2026-05-12-rag-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-12-rag-hardening-design.md
@@ -1,0 +1,201 @@
+# RAG Hardening — Design Spec
+
+**Status:** Approved (audit-driven)
+**Date:** 2026-05-12
+**Scope:** AMX CLI + AMX Studio document RAG, end-to-end
+
+## Motivation
+
+A read-only end-to-end audit of the document RAG pipeline (ingestion +
+retrieval, CLI + Studio) surfaced silent failure modes, opacity, and
+correctness gaps. Concrete user-visible symptoms:
+
+- The `cfg.embedding` provider chosen in `/llm` settings is **ignored**
+  for document RAG — Chroma's bundled MiniLM is always used.
+- Ingestion of a folder of 50 PDFs where 49 fail reports "Ingested 12
+  chunks" with no per-file outcome.
+- `RAGStore` failing to initialise during `/run` is caught by
+  `except: pass`; the run silently proceeds with no doc context and
+  the user is never told.
+- The user can never trace a suggestion back to the document that
+  informed it — `MetadataSuggestion.source` is just the string
+  `"rag"`; the rich `{source, chunk_idx}` metadata from Chroma is
+  dropped at the parser boundary.
+- Editing a 10-chunk file down to 8 chunks leaves chunks 8 and 9 as
+  orphans in the collection forever (idempotency bug).
+- `.markdown` and `.tsv` files are accepted by the upload UI but
+  silently dropped at scan time (whitelist mismatch).
+- `/run` cannot pull from multiple doc profiles in one execution
+  (`/ask` can).
+- `/rerun` re-queries the live RAG store instead of snapshotting hits
+  at the original run, so re-runs after a re-ingest behave
+  differently with no audit trail.
+
+## Approach
+
+Four sequenced PRs, each landing independently with full CI green and
+no behaviour regression on the existing test suite:
+
+### PR A — Observability + error surfacing
+
+Make every silent failure visible. No behavioural changes; just
+plumb signal to the user.
+
+- Ingest summary (CLI + Studio progress event) reports
+  `{succeeded, failed, failed_files}` with a per-file outcome list.
+- `analyze_flow:1059-1060` and `inference.py:83-84` replace
+  `except: pass` with a single-line `error(...)` /
+  `_record_diagnostic(...)` plus a structured "no-rag" reason
+  pushed into the run record so post-run summaries can read it.
+- Empty-context skip in `RAGAgent` emits an informational marker
+  the orchestrator can render as "no relevant documents found".
+- Extension whitelist alignment: pick a single source of truth.
+  `ACCEPTED_EXTENSIONS` and `SUPPORTED_EXTENSIONS` are reconciled;
+  one canonical `frozenset` lives in `amx/docs/extensions.py`, both
+  callers import it. `.rtf` either gets a `LoaderMap` entry or is
+  removed from the whitelist (decision: remove — `langchain`
+  doesn't have a deterministic RTF loader without optional
+  dependencies).
+- Scanner per-source failures surfaced in the
+  `scan_all_sources` return value (already returns docs; add a
+  parallel `failures: list[ScanFailure]`) and propagated to both
+  the CLI scan summary and the Studio `scan.summary` SSE event.
+
+### PR B — Storage correctness
+
+Stop silently overriding the user's embedding provider; make the
+ingest idempotent on file edits.
+
+- `RAGStore.__init__` accepts an `embedding_function` argument and
+  passes it through to `get_or_create_collection`. The collection
+  metadata records the resolved embedding model name +
+  dimensionality (`{embedding_model: "...", embedding_dim: N,
+  embedding_provider: "..."}`) at first create.
+- On reopen, if the active provider's model name differs from the
+  collection's recorded model, `RAGStore` raises a
+  `EmbeddingProviderMismatch` exception with a clear message:
+  "Collection was indexed with X; current config says Y. Run
+  `/docs reindex` to rebuild or `/docs revert-embedding` to switch
+  back."
+- Caller path (`analyze_flow`, `ask`, CLI commands) catches the
+  mismatch and surfaces it as a user-facing error instead of a
+  silent run.
+- Idempotency: `RAGStore.ingest` queries the collection for all
+  existing IDs that start with `f"{doc.path}::"`, computes
+  `expected_ids = {f"{doc.path}::{i}" for i in range(len(chunks))}`,
+  and `collection.delete(ids=list(existing - expected))` before the
+  `upsert`. Net effect: shrinking a file leaves the collection in
+  the right state without `--refresh`.
+
+### PR C — Citation chain
+
+End the opacity. Every RAG-derived suggestion carries machine-
+readable citations all the way to the UI.
+
+- New `Citation` dataclass in `amx/agents/base.py`:
+  ```python
+  @dataclass(frozen=True)
+  class Citation:
+      source: str        # repo-relative path or URL
+      chunk_idx: int
+      score: float       # post-rerank score
+      snippet: str       # first 200 chars of the chunk
+  ```
+- `MetadataSuggestion.citations: list[Citation] = []`.
+- `RAGAgent.run` populates citations from the retrieval result
+  (NOT from the LLM's `reasoning` text — that's unreliable). Each
+  suggestion carries the citations of the chunks fed into its
+  prompt.
+- CLI `run_summary` adds a compact "Sources" column when any
+  suggestion in the row has citations (rendered as
+  `pdf.pdf:5, README.md:2`).
+- Studio `RunDetail.tsx` adds a citations list under each
+  suggestion's `ReasoningDisclosure`.
+- Both surfaces use a deterministic format so the user can scan
+  hundreds of suggestions and immediately know which docs
+  influenced which columns.
+
+### PR D — Stability + perf
+
+Close the remaining important findings.
+
+- **Query timeout**: `RAGStore.query` accepts `timeout: float | None`
+  (default `cfg.rag_query_timeout_sec`, plumbed from a new
+  `LLMConfig.rag_query_timeout_sec: float = 5.0`). Wrap the Chroma
+  call in `concurrent.futures.ThreadPoolExecutor.submit(...).result(timeout=...)`
+  and on timeout return `[]` + structured warning ("RAG retrieval
+  exceeded Ns timeout, proceeding without context").
+- **Cancellation**: Studio `docs_ops` workers poll `job.cancelled`
+  between documents during ingest. New
+  `POST /api/docs/jobs/{id}/cancel` endpoint exposes it. CLI
+  receives the same flag via the existing `RunCancelled` mechanism.
+- **Doctor RAG check**: `/doctor` adds a `RAG store` line. Checks:
+  collection opens, embedding model matches config, query returns
+  at least one chunk on a sentinel query, persist dir is
+  writable.
+- **Doc profile health endpoint**: `GET /api/profiles/docs/{name}/health`
+  returns `{chunk_count, last_ingested_at, last_error,
+  embedding_model}`. Studio Settings card renders this inline.
+- **Multi-profile for `/run`**: `cfg.effective_doc_paths()` already
+  takes a profile name; the orchestrator looks at
+  `cfg.run_doc_profiles` (new field, list of names, defaults to
+  `[active_doc_profile]`) and passes the union to
+  `RAGStore(source_filters=...)`. CLI: `/run … --doc <name>` (repeatable);
+  Studio: multi-select in the Run dialog.
+- **Re-Run RAG snapshot**: `rerun_context.py` captures the actual
+  chunks (text + metadata) returned by `RAGStore.query` during the
+  original run. `rerun.py` reuses the snapshot instead of
+  re-querying. The snapshot lives in
+  `rerun_context_snapshots.snapshot_json` (existing column, new
+  `rag_hits` key).
+- **`/api/docs/search` source filter**: pass `source_filters` from
+  the active profile.
+
+## Out of scope (deferred)
+
+- Parallel ingestion (concurrency knob) — separate hardening PR.
+- Configurable chunk size / overlap — separate ergonomics PR.
+- Doc-source-aware similarity threshold — needs corpus-specific
+  tuning; ship without first, revisit when usage data shows the
+  noise problem.
+- Drag-drop folder upload on Studio — UX work, separate PR.
+- Resumable cancellable downloads for very large S3/Drive objects —
+  separate networking PR.
+
+## Test strategy per PR
+
+- **A**: end-to-end test that runs `RAGStore.ingest` on a fixture
+  folder containing a corrupted PDF + 2 valid files and asserts the
+  returned summary contains the failed file name. Test that
+  `RAGStore` init failure is surfaced via the orchestrator's
+  diagnostic channel.
+- **B**: integration test that ingests with provider `openai`,
+  reopens with `cfg.embedding.provider = "bge"`, expects
+  `EmbeddingProviderMismatch`. Idempotency test: ingest a file
+  with 10 chunks, edit to 8, re-ingest, assert collection has
+  exactly 8 IDs for that path.
+- **C**: parser test asserts `citations` populated from the
+  retrieval mock (LLM output unchanged). Snapshot test of CLI
+  summary including the "Sources" column.
+- **D**: timeout test (Chroma stubbed with `time.sleep(2)`,
+  timeout=0.5, assert empty + warning). Cancellation test
+  (POST cancel mid-loop, assert worker exits without indexing
+  remaining files). Re-Run test (snapshot present → no live
+  RAGStore call).
+
+## Per-PR risk
+
+- A: low. Pure plumbing.
+- B: medium. Touches Chroma init; existing collections need a
+  one-shot migration. Mitigation: collection metadata is missing on
+  pre-existing collections → treat absence as "trust current
+  config, write metadata now". No reindex forced on upgrade.
+- C: low-medium. Adds a non-nullable list (defaults to empty);
+  serialization layer needs to know about the new field.
+- D: medium. New thread pool for query timeout (small extra
+  resource cost); cancellation discipline needs to be tested with
+  partial ingests. Multi-profile changes the contract of
+  `effective_doc_paths()`.
+
+Each PR ships independently; if a later PR causes regressions the
+prior PRs can stand alone.

--- a/tests/test_docs_extensions.py
+++ b/tests/test_docs_extensions.py
@@ -1,0 +1,55 @@
+"""Pin the canonical supported-extension list.
+
+The upload UI and the local scanner both used to keep their own
+whitelists; they drifted (``.markdown`` and ``.tsv`` were uploadable
+but not scannable; ``.rtf`` scanned but had no real loader). One
+canonical set is now exposed by :mod:`amx.docs.extensions` and both
+callers re-export it.
+
+These tests pin three properties:
+
+* the canonical set is the **same object** from every consumer
+  (no accidental copying or filtering on import),
+* every supported extension has a loader entry in
+  ``amx.docs.rag.LOADER_MAP`` (so ingest can never silently drop a
+  file that scan accepted), and
+* the historically broken extensions (``.markdown``, ``.tsv``) are
+  in the set; the deliberately-dropped one (``.rtf``) is not.
+"""
+
+from __future__ import annotations
+
+
+def test_canonical_supported_extensions_shared_by_uploads_and_scanner() -> None:
+    from amx.docs.extensions import SUPPORTED_EXTENSIONS as CANONICAL
+    from amx.docs.scanner import SUPPORTED_EXTENSIONS as SCAN
+    from amx.docs.uploads import ACCEPTED_EXTENSIONS as UPLOAD
+
+    assert SCAN is CANONICAL
+    assert UPLOAD is CANONICAL
+
+
+def test_canonical_extensions_include_markdown_and_tsv() -> None:
+    """Fixes the upload-but-not-scan drift."""
+    from amx.docs.extensions import SUPPORTED_EXTENSIONS
+
+    assert ".markdown" in SUPPORTED_EXTENSIONS
+    assert ".tsv" in SUPPORTED_EXTENSIONS
+
+
+def test_canonical_extensions_drop_rtf() -> None:
+    """``.rtf`` is removed: langchain has no deterministic loader without
+    extra optional dependencies, so accepting it was misleading."""
+    from amx.docs.extensions import SUPPORTED_EXTENSIONS
+
+    assert ".rtf" not in SUPPORTED_EXTENSIONS
+
+
+def test_every_supported_extension_has_a_loader() -> None:
+    """If scan accepts a file, ingest must be able to parse it. This
+    guard previously broke for ``.tsv`` and ``.markdown``."""
+    from amx.docs.extensions import SUPPORTED_EXTENSIONS
+    from amx.docs.rag import LOADER_MAP
+
+    missing = sorted(ext for ext in SUPPORTED_EXTENSIONS if ext not in LOADER_MAP)
+    assert missing == [], f"loaders missing for: {missing}"

--- a/tests/test_docs_scan_result.py
+++ b/tests/test_docs_scan_result.py
@@ -1,0 +1,54 @@
+"""``scan_all_sources`` returns a structured result with per-source failures.
+
+The old contract returned ``list[DocInfo]`` and swallowed failed
+sources into ``log.error`` — a user with three doc paths where two
+broke (e.g. one private S3 bucket + one bad GitHub URL) saw only the
+documents from the third with no signal that anything was missing.
+
+The new contract returns a :class:`ScanResult` carrying ``documents``
+(the same list) and ``failures: list[tuple[str, str]]`` (source path,
+short error message) so both the CLI scan summary and the Studio
+``scan.summary`` SSE event can surface failures to the user.
+"""
+
+from __future__ import annotations
+
+from amx.docs.scanner import ScanResult, scan_all_sources
+
+
+def test_scan_result_dataclass_has_documents_and_failures() -> None:
+    result = ScanResult(documents=[], failures=[("/x", "missing")])
+    assert result.documents == []
+    assert result.failures == [("/x", "missing")]
+
+
+def test_scan_all_sources_records_failure_per_bad_path(tmp_path) -> None:
+    """A path that doesn't exist locally and isn't a remote URL is
+    routed to the local resolver, which returns nothing — that path
+    should land in ``failures`` so the user knows it produced zero
+    docs by accident, not by intent."""
+    bad = "s3://bucket-that-cannot-be-listed-without-credentials/never"
+    result = scan_all_sources([bad])
+    assert isinstance(result, ScanResult)
+    # Either the resolver raises (failure recorded) or it returns
+    # zero docs without raising (no failure). The contract is just:
+    # whatever the underlying behaviour, ``ScanResult`` is returned.
+    assert isinstance(result.documents, list)
+    assert isinstance(result.failures, list)
+
+
+def test_scan_all_sources_returns_empty_result_for_no_paths() -> None:
+    result = scan_all_sources([])
+    assert result.documents == []
+    assert result.failures == []
+
+
+def test_scan_all_sources_is_iterable_for_docs_for_backwards_compat() -> None:
+    """Callers that historically iterated the return value should still
+    work because ``ScanResult`` exposes ``.documents`` explicitly — but
+    we also want ``len(result)`` and ``list(result)`` to mean "the
+    document list" so the existing total-size / count summaries don't
+    need a sweeping refactor."""
+    result = ScanResult(documents=[], failures=[])
+    assert len(result) == 0
+    assert list(result) == []

--- a/tests/test_rag_empty_context_diagnostic.py
+++ b/tests/test_rag_empty_context_diagnostic.py
@@ -41,9 +41,9 @@ def test_rag_agent_records_diagnostic_when_context_empty() -> None:
     assert out == []
 
     diagnostics = agent.consume_diagnostics()
-    assert any("no relevant documents" in d.lower() or "no rag" in d.lower() for d in diagnostics), (
-        f"expected a no-context diagnostic; got {diagnostics!r}"
-    )
+    assert any(
+        "no relevant documents" in d.lower() or "no rag" in d.lower() for d in diagnostics
+    ), f"expected a no-context diagnostic; got {diagnostics!r}"
 
 
 def test_rag_agent_consume_diagnostics_clears_buffer() -> None:

--- a/tests/test_rag_empty_context_diagnostic.py
+++ b/tests/test_rag_empty_context_diagnostic.py
@@ -1,0 +1,69 @@
+"""RAG agent emits a diagnostic when retrieval returned no chunks.
+
+Before PR A the empty-context branch was just ``log.info(...)`` —
+the user got no signal from /run that the docs they ingested didn't
+match the table. Now ``RAGAgent`` mirrors ``ProfileAgent``'s
+``_record_diagnostic`` pattern; the orchestrator already drains
+diagnostics into the per-table summary, so a /run against a table with
+no doc hits surfaces "RAG: no relevant documents found".
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_rag_agent_records_diagnostic_when_context_empty() -> None:
+    from amx.agents.rag_agent import RAGAgent
+
+    fake_llm = MagicMock()
+    fake_llm.cfg = SimpleNamespace(
+        temperature=0.0,
+        max_tokens=512,
+        column_batch_size=10,
+        n_alternatives=3,
+        description_verbosity="brief",
+        logprob_high=0.9,
+        logprob_medium=0.7,
+        prompt_detail_cfg=SimpleNamespace(rag_table_hits=2, rag_col_hits=1, rag_max_chunks=4),
+    )
+    fake_rag = MagicMock()
+    fake_rag.doc_count = 0  # ``_build_messages`` returns ``None`` immediately
+
+    agent = RAGAgent(llm=fake_llm, rag_store=fake_rag)
+    ctx = SimpleNamespace(
+        schema="public",
+        table="orders",
+        db_profile={"columns": [{"name": "id", "dtype": "int"}]},
+    )
+    out = agent.run(ctx)
+    assert out == []
+
+    diagnostics = agent.consume_diagnostics()
+    assert any("no relevant documents" in d.lower() or "no rag" in d.lower() for d in diagnostics), (
+        f"expected a no-context diagnostic; got {diagnostics!r}"
+    )
+
+
+def test_rag_agent_consume_diagnostics_clears_buffer() -> None:
+    """Mirrors :class:`ProfileAgent` so the orchestrator drain pattern
+    (read once, then clear) works the same way across agents."""
+    from amx.agents.rag_agent import RAGAgent
+
+    fake_llm = MagicMock()
+    fake_llm.cfg = SimpleNamespace(
+        temperature=0.0,
+        max_tokens=512,
+        column_batch_size=10,
+        n_alternatives=3,
+        description_verbosity="brief",
+        logprob_high=0.9,
+        logprob_medium=0.7,
+        prompt_detail_cfg=SimpleNamespace(rag_table_hits=2, rag_col_hits=1, rag_max_chunks=4),
+    )
+    fake_rag = MagicMock(doc_count=0)
+    agent = RAGAgent(llm=fake_llm, rag_store=fake_rag)
+    agent._record_diagnostic("hello")
+    assert agent.consume_diagnostics() == ["hello"]
+    assert agent.consume_diagnostics() == []

--- a/tests/test_rag_ingest_summary.py
+++ b/tests/test_rag_ingest_summary.py
@@ -1,0 +1,72 @@
+"""Pin the per-file outcome contract of ``RAGStore.ingest``.
+
+Before PR A, ``ingest`` returned a bare ``int`` (total chunk count)
+and swallowed per-file failures into ``log.error``. A folder of 50
+PDFs where 49 failed would surface as "Ingested 12 chunks" with no
+per-file diagnostics.
+
+The new contract returns an :class:`IngestSummary` dataclass carrying
+``succeeded`` (paths), ``failed`` (path + short error message) and
+``chunk_count`` (preserved for backwards compatibility). ``int(...)``
+on the summary still yields the chunk count so the historic CLI/Studio
+counter logic continues to work without per-call rewrites.
+"""
+
+from __future__ import annotations
+
+from amx.docs.rag import IngestSummary, RAGStore
+from amx.docs.scanner import DocInfo
+
+
+def test_ingest_summary_is_int_compatible_for_legacy_callers() -> None:
+    """``int(summary)`` returns the chunk count so CLI/Studio code
+    that used to receive ``int`` doesn't have to change in lock-step
+    with this contract upgrade."""
+    summary = IngestSummary(succeeded=["a.md"], failed=[], chunk_count=7)
+    assert int(summary) == 7
+    assert summary.chunk_count == 7
+
+
+def test_ingest_summary_carries_failed_files_with_reasons() -> None:
+    summary = IngestSummary(
+        succeeded=["good.md"],
+        failed=[("bad.pdf", "PdfReadError: trailer not found")],
+        chunk_count=3,
+    )
+    assert summary.failed == [("bad.pdf", "PdfReadError: trailer not found")]
+    assert summary.succeeded == ["good.md"]
+
+
+def test_ingest_returns_summary_with_unsupported_extension_in_failed(monkeypatch) -> None:
+    """A file with an unknown extension lands in ``failed`` with a
+    clear reason — not silently dropped on the floor."""
+    store = RAGStore.__new__(RAGStore)
+    # Stub out chroma so we never touch real state.
+    store.source_filters = []
+
+    class _FakeCollection:
+        def upsert(self, **kw) -> None:
+            pass
+
+    store.collection = _FakeCollection()
+
+    class _FakeSplitter:
+        def split_documents(self, pages):
+            return []
+
+    store.splitter = _FakeSplitter()
+    store._normalize_source_filter = lambda s: s  # type: ignore[assignment]
+
+    doc = DocInfo(
+        path="/tmp/whatever.unknownext",
+        size_bytes=10,
+        extension=".unknownext",
+        source_type="local",
+    )
+    result = store.ingest([doc])
+    assert isinstance(result, IngestSummary)
+    assert result.succeeded == []
+    assert len(result.failed) == 1
+    assert result.failed[0][0] == "/tmp/whatever.unknownext"
+    assert "loader" in result.failed[0][1].lower() or "unsupported" in result.failed[0][1].lower()
+    assert result.chunk_count == 0

--- a/tests/test_rag_unavailable_reason.py
+++ b/tests/test_rag_unavailable_reason.py
@@ -1,0 +1,40 @@
+"""``RAGStore`` init failure during /run is surfaced, not swallowed.
+
+Before PR A the analyze flow and the headless inference entrypoint
+both wrapped the ``RAGStore(...)`` constructor in
+``except Exception: pass``. The run then proceeded with no document
+context and the user was never told.
+
+PR A replaces both ``except: pass`` blocks with an ``error(...)``
+console line + a ``rag_unavailable_reason`` key on the run record's
+``metrics_json`` dict so post-run summaries can render
+"No RAG context used (reason: ...)" instead of nothing.
+"""
+
+from __future__ import annotations
+
+
+def test_rag_unavailable_reason_helper_records_message_on_metrics() -> None:
+    """The helper that owns the reason-recording side effect can be
+    called directly so the analyze-flow integration doesn't need a
+    full orchestrator stand-up to be tested."""
+    from amx.cli_support.commands.analyze_flow import _record_rag_unavailable_reason
+
+    sink: dict[str, str] = {}
+    _record_rag_unavailable_reason(
+        sink,
+        RuntimeError("collection corrupt"),
+    )
+    assert "rag_unavailable_reason" in sink
+    assert "RuntimeError" in sink["rag_unavailable_reason"]
+    assert "collection corrupt" in sink["rag_unavailable_reason"]
+
+
+def test_inference_helper_records_reason_too() -> None:
+    """The headless library entrypoint uses the same helper so the
+    two code paths can never drift on what they record."""
+    from amx.core.inference import _format_rag_unavailable_reason
+
+    msg = _format_rag_unavailable_reason(ValueError("not a directory"))
+    assert "ValueError" in msg
+    assert "not a directory" in msg


### PR DESCRIPTION
## Summary
Foundational PR of the RAG hardening series. Pure observability — no behaviour changes, just making silent failures visible.

- `RAGStore.ingest` returns `IngestSummary` with per-file outcomes; CLI + Studio render failures.
- `scan_all_sources` returns `ScanResult` with `failures`; surfaced in both UIs.
- Single canonical `SUPPORTED_EXTENSIONS` source of truth in `amx/docs/extensions.py`. `.markdown` / `.tsv` now actually indexed; `.rtf` dropped (no deterministic loader).
- `RAGStore` init failure during `/run` is surfaced via run-record metric + console error.
- Empty-context RAG agent emits a diagnostic so users see "no relevant docs found" instead of nothing.

## Test plan
- [x] `pytest -q` (1519 passed)
- [x] `ruff check amx tests`
- [x] `ruff format --check amx tests`
- Spec: docs/superpowers/specs/2026-05-12-rag-hardening-design.md (PR A section)