### PR TITLE
feat(rag): storage correctness — embedding provider + idempotency (PR B of 4)

### DIFF
--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -613,7 +613,17 @@ def _record_rag_unavailable_reason(
     counterpart in :mod:`amx.core.inference` uses the same formatting
     so the two call sites can never drift.
     """
-    extra_metrics["rag_unavailable_reason"] = f"{exc.__class__.__name__}: {exc}"
+    # When the user changed embedding providers between runs the
+    # collection is technically intact but unusable with the active
+    # config. Tag that case structurally so /history and Studio can
+    # render a remediation hint ("run /docs reindex") instead of
+    # treating it like a generic init crash.
+    from amx.docs.rag import EmbeddingProviderMismatch
+
+    if isinstance(exc, EmbeddingProviderMismatch):
+        extra_metrics["rag_unavailable_reason"] = f"embedding_mismatch: {exc}"
+    else:
+        extra_metrics["rag_unavailable_reason"] = f"{exc.__class__.__name__}: {exc}"
 
 
 def _finalize_history_run(
@@ -1088,11 +1098,16 @@ def execute_analyze_run(
             # context. Now we record a one-line reason on the run record
             # so /history and Studio can render "No RAG context used
             # (reason: ...)", and surface the same message inline.
+            from amx.docs.rag import EmbeddingProviderMismatch
+
             _record_rag_unavailable_reason(extra_metrics, exc)
-            error(
-                f"RAG store unavailable: {exc.__class__.__name__}: {exc}. "
-                "Run will proceed without document context."
-            )
+            if isinstance(exc, EmbeddingProviderMismatch):
+                error(f"RAG store unavailable: {exc}. Run will proceed without document context.")
+            else:
+                error(
+                    f"RAG store unavailable: {exc.__class__.__name__}: {exc}. "
+                    "Run will proceed without document context."
+                )
             log.warning("RAGStore init failed during analyze: %s", exc, exc_info=True)
 
         with command_display(

--- a/amx/core/inference.py
+++ b/amx/core/inference.py
@@ -31,6 +31,16 @@ def _format_rag_unavailable_reason(exc: BaseException) -> str:
     because each formatted its own message inside an
     ``except: pass``-style block).
     """
+    # Tag the embedding-mismatch case structurally so downstream
+    # tooling (history readers, /doctor) can tell user-config-changed
+    # apart from a genuine init crash. See ``EmbeddingProviderMismatch``
+    # in :mod:`amx.docs.rag`.
+    try:
+        from amx.docs.rag import EmbeddingProviderMismatch
+    except Exception:
+        EmbeddingProviderMismatch = ()  # type: ignore[assignment, misc]
+    if isinstance(exc, EmbeddingProviderMismatch):
+        return f"embedding_mismatch: {exc}"
     return f"{exc.__class__.__name__}: {exc}"
 
 

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from amx.utils.optional_deps import ensure as _ensure
+
+if TYPE_CHECKING:
+    from chromadb.api.types import EmbeddingFunction
 
 # Document-RAG is a heavy cluster (~150 MB across chromadb + the
 # langchain ecosystem + unstructured's parser fleet). It only loads
@@ -34,6 +38,91 @@ from amx.docs.scanner import DocInfo  # noqa: E402
 from amx.utils.logging import get_logger  # noqa: E402
 
 log = get_logger("docs.rag")
+
+
+class EmbeddingProviderMismatch(RuntimeError):
+    """Raised when the active embedding provider does not match the
+    one used to populate the existing Chroma collection.
+
+    The collection metadata records the provider/model used at first
+    create. If the user later switches embedding providers (via
+    ``/embeddings``) the existing vectors are in a different
+    semantic space, so retrieval would silently degrade. Raising
+    here forces an explicit reindex or revert decision.
+    """
+
+    def __init__(
+        self,
+        *,
+        recorded_provider: str,
+        recorded_model: str,
+        active_provider: str,
+        active_model: str,
+    ) -> None:
+        self.recorded_provider = recorded_provider
+        self.recorded_model = recorded_model
+        self.active_provider = active_provider
+        self.active_model = active_model
+        super().__init__(
+            f"Docs RAG collection was indexed with provider={recorded_provider} "
+            f"model={recorded_model}. Current config says provider={active_provider} "
+            f"model={active_model}. "
+            "Run `/docs reindex` to rebuild the collection with the active provider, "
+            "or update the embedding profile to match the indexed model."
+        )
+
+
+# Schema version for the docs RAG collection metadata. Bumped when the
+# metadata shape changes in a way old AMX cannot read.
+_AMX_RAG_SCHEMA_VERSION = 1
+
+
+def _resolve_active_embedding(cfg: Any | None = None) -> tuple[str, str, EmbeddingFunction | None]:
+    """Resolve ``(provider, model, embedding_function)`` from config.
+
+    Falls back to the bundled MiniLM (``embedding_function=None``) when
+    no config is available or the user has the default kind selected.
+    The provider/model strings are what get persisted as collection
+    metadata so a later reopen can detect mismatches.
+    """
+    from amx.search.embeddings import make_embedding_function
+
+    if cfg is None:
+        try:
+            from amx.config import AMXConfig
+
+            cfg = AMXConfig.load()
+        except Exception:
+            cfg = None
+
+    embedding = getattr(cfg, "embedding", None) if cfg is not None else None
+    if embedding is None:
+        return ("minilm", "minilm-l6-v2", None)
+
+    kind = (getattr(embedding, "kind", "") or "minilm").lower().strip()
+    model = getattr(embedding, "model", "") or ""
+    api_key = getattr(embedding, "api_key", "") or ""
+    base_url = getattr(embedding, "base_url", "") or ""
+
+    if kind in {"", "minilm", "default", "minilm-l6-v2"}:
+        return ("minilm", "minilm-l6-v2", None)
+
+    # For non-default kinds the model id IS the unique identifier; if
+    # the user hasn't picked one yet fall back to MiniLM rather than
+    # error here (the embeddings module emits a themed warning at
+    # startup for that case).
+    if not model:
+        return ("minilm", "minilm-l6-v2", None)
+
+    try:
+        ef = make_embedding_function(kind, model=model, api_key=api_key, base_url=base_url)
+    except Exception:
+        # Builder failure (missing optional dep, bad model id) — fall
+        # back to MiniLM so retrieval still works; the mismatch check
+        # later will catch the wrong-provider case explicitly.
+        return ("minilm", "minilm-l6-v2", None)
+    return (kind, model, ef)
+
 
 EXPLANATORY_TERMS = frozenset(
     {
@@ -123,14 +212,86 @@ class RAGStore:
         self,
         persist_dir: str | None = None,
         source_filters: list[str] | None = None,
+        *,
+        embedding_function: EmbeddingFunction | None = None,
+        embedding_provider: str | None = None,
+        embedding_model: str | None = None,
+        cfg: Any | None = None,
     ):
         self.persist_dir = persist_dir or str(Path.home() / ".amx" / "chroma_db")
         Path(self.persist_dir).mkdir(parents=True, exist_ok=True)
         self.client = chromadb.PersistentClient(path=self.persist_dir)
-        self.collection = self.client.get_or_create_collection(
-            name="amx_docs",
-            metadata={"hnsw:space": "cosine"},
-        )
+
+        # Resolve the active embedding provider so we can (a) wire it
+        # into Chroma's ``embedding_function=`` slot — historically
+        # omitted, which silently forced bundled MiniLM regardless of
+        # the user's ``cfg.embedding`` choice — and (b) record it on
+        # the collection metadata for the cross-version mismatch
+        # check below.
+        if embedding_provider is None or embedding_model is None or embedding_function is None:
+            resolved_provider, resolved_model, resolved_ef = _resolve_active_embedding(cfg)
+            if embedding_provider is None:
+                embedding_provider = resolved_provider
+            if embedding_model is None:
+                embedding_model = resolved_model
+            if embedding_function is None:
+                embedding_function = resolved_ef
+
+        self.embedding_provider = embedding_provider
+        self.embedding_model = embedding_model
+        self.embedding_function = embedding_function
+
+        kwargs: dict[str, Any] = {
+            "name": "amx_docs",
+            "metadata": {
+                "hnsw:space": "cosine",
+                "embedding_provider": embedding_provider,
+                "embedding_model": embedding_model,
+                "amx_schema_version": _AMX_RAG_SCHEMA_VERSION,
+            },
+        }
+        if embedding_function is not None:
+            kwargs["embedding_function"] = embedding_function
+        self.collection = self.client.get_or_create_collection(**kwargs)
+
+        # ``get_or_create_collection`` only honours ``metadata=`` on
+        # FIRST create; for an existing collection Chroma drops the
+        # passed-in dict on the floor. So after open we explicitly
+        # reconcile:
+        #
+        # * If the existing collection has recorded provider/model
+        #   that DON'T match the active config → raise mismatch.
+        # * If it has no recorded provider/model (pre-PR-B
+        #   collection) → backfill the metadata now; do NOT force a
+        #   reindex (grandfather rule from the design spec).
+        existing_meta = dict(self.collection.metadata or {})
+        recorded_provider = existing_meta.get("embedding_provider")
+        recorded_model = existing_meta.get("embedding_model")
+        if recorded_provider and recorded_model:
+            if recorded_provider != embedding_provider or recorded_model != embedding_model:
+                raise EmbeddingProviderMismatch(
+                    recorded_provider=str(recorded_provider),
+                    recorded_model=str(recorded_model),
+                    active_provider=str(embedding_provider),
+                    active_model=str(embedding_model),
+                )
+        else:
+            # Pre-existing collection without metadata — write it now
+            # so future opens have something to compare against.
+            # Strip ``hnsw:*`` keys: Chroma treats those as construction-
+            # time parameters and rejects ``modify(metadata=)`` calls
+            # that try to "change" them (even to the same value).
+            merged = {k: v for k, v in existing_meta.items() if not str(k).startswith("hnsw:")}
+            merged["embedding_provider"] = embedding_provider
+            merged["embedding_model"] = embedding_model
+            merged["amx_schema_version"] = _AMX_RAG_SCHEMA_VERSION
+            try:
+                self.collection.modify(metadata=merged)
+            except Exception as exc:
+                # Non-fatal: the collection still works, we just lose
+                # the mismatch check on the next reopen.
+                log.warning("Could not backfill RAG collection metadata: %s", exc)
+
         self.splitter = RecursiveCharacterTextSplitter(
             chunk_size=1000,
             chunk_overlap=200,
@@ -210,6 +371,35 @@ class RAGStore:
                     }
                     for i in range(len(chunks))
                 ]
+
+                # Idempotency on file shrink: if the previous ingest of
+                # this exact path produced N chunks and the new content
+                # only produces M<N, chunks ``::M`` … ``::N-1`` would
+                # otherwise live on in the collection forever. Look up
+                # the existing ID set for this source and delete any
+                # that the new upsert won't cover. Done BEFORE the
+                # upsert so a partial failure leaves the file in a
+                # half-deleted state at worst, never a half-orphaned
+                # one.
+                try:
+                    existing = self.collection.get(where={"source": doc.path}, include=[])
+                    existing_ids = set(existing.get("ids") or [])
+                except Exception as exc:
+                    log.warning("Could not enumerate existing chunks for %s: %s", doc.path, exc)
+                    existing_ids = set()
+                new_id_set = set(ids)
+                orphans = sorted(existing_ids - new_id_set)
+                if orphans:
+                    try:
+                        self.collection.delete(ids=orphans)
+                        log.info(
+                            "Deleted %d orphan chunk(s) for %s before re-ingest",
+                            len(orphans),
+                            doc.path,
+                        )
+                    except Exception as exc:
+                        log.warning("Could not delete orphan chunks for %s: %s", doc.path, exc)
+
                 self.collection.upsert(ids=ids, documents=texts, metadatas=metadatas)
                 total_chunks += len(chunks)
                 succeeded.append(doc.path)

--- a/tests/test_rag_storage_correctness.py
+++ b/tests/test_rag_storage_correctness.py
@@ -1,0 +1,184 @@
+"""Storage correctness for the docs RAG (PR B).
+
+Pins three behaviours that PR B added to ``amx.docs.rag.RAGStore``:
+
+1. The Chroma collection records ``embedding_provider`` and
+   ``embedding_model`` on first create so a later reopen can detect a
+   provider switch.
+2. Reopening with a different provider raises
+   :class:`EmbeddingProviderMismatch`; a pre-existing (PR A and older)
+   collection without those metadata keys is grandfathered in and gets
+   the metadata back-filled silently.
+3. ``RAGStore.ingest`` deletes orphan chunks for a source path before
+   upserting, so editing a 10-chunk file down to 2 no longer leaves
+   chunks 2..9 in the collection forever.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import chromadb
+import pytest
+
+from amx.docs.rag import EmbeddingProviderMismatch, RAGStore
+from amx.docs.scanner import DocInfo
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _make_store(
+    persist_dir: Path,
+    *,
+    provider: str = "minilm",
+    model: str = "minilm-l6-v2",
+) -> RAGStore:
+    """Build a ``RAGStore`` with an explicit provider/model and no real
+    embedding function (MiniLM bundled default). Keeps tests offline
+    and deterministic."""
+    return RAGStore(
+        persist_dir=str(persist_dir),
+        embedding_function=None,
+        embedding_provider=provider,
+        embedding_model=model,
+    )
+
+
+def _make_doc(tmp_path: Path, body: str, name: str = "fixture.txt") -> DocInfo:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return DocInfo(
+        path=str(p),
+        size_bytes=p.stat().st_size,
+        extension=".txt",
+        source_type="local",
+        source_root=str(tmp_path),
+    )
+
+
+# ── Fix 2: metadata recorded on first create ──────────────────────────
+
+
+def test_collection_records_embedding_metadata_on_create(tmp_path: Path) -> None:
+    store = _make_store(tmp_path / "chroma", provider="minilm", model="minilm-l6-v2")
+    meta = dict(store.collection.metadata or {})
+    assert meta.get("embedding_provider") == "minilm"
+    assert meta.get("embedding_model") == "minilm-l6-v2"
+    assert meta.get("amx_schema_version") == 1
+
+
+# ── Fix 3: mismatch raises ────────────────────────────────────────────
+
+
+def test_mismatch_raises_embedding_provider_mismatch(tmp_path: Path) -> None:
+    persist = tmp_path / "chroma"
+    # Seal the collection with provider A.
+    _make_store(persist, provider="openai_compatible", model="text-embedding-3-small")
+    # Reopen with provider B; expect the structured mismatch error.
+    with pytest.raises(EmbeddingProviderMismatch) as excinfo:
+        _make_store(persist, provider="minilm", model="minilm-l6-v2")
+    msg = str(excinfo.value)
+    assert "openai_compatible" in msg
+    assert "text-embedding-3-small" in msg
+    assert "minilm" in msg
+    assert "/docs reindex" in msg
+
+
+# ── Fix 3 (grandfather): pre-PR-B collection has no metadata ──────────
+
+
+def test_pre_existing_collection_without_metadata_is_grandfathered(
+    tmp_path: Path,
+) -> None:
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    # Simulate a pre-PR-B collection: only ``hnsw:space`` in metadata.
+    client = chromadb.PersistentClient(path=str(persist))
+    client.get_or_create_collection(
+        name="amx_docs",
+        metadata={"hnsw:space": "cosine"},
+    )
+    # No assertion on the absence-of-keys here — different chromadb
+    # versions backfill ``hnsw:*`` defaults differently. The real
+    # contract under test is "reopen does not raise even when our
+    # embedding_* keys are missing".
+
+    store = _make_store(persist, provider="minilm", model="minilm-l6-v2")
+    backfilled = dict(store.collection.metadata or {})
+    assert backfilled.get("embedding_provider") == "minilm"
+    assert backfilled.get("embedding_model") == "minilm-l6-v2"
+
+
+# ── Fix 5: idempotency on shrink ──────────────────────────────────────
+
+
+def _ids_for_source(store: RAGStore, source: str) -> list[str]:
+    res = store.collection.get(where={"source": source}, include=[])
+    return list(res.get("ids") or [])
+
+
+def test_ingest_deletes_orphan_chunks_on_shrink(tmp_path: Path) -> None:
+    store = _make_store(tmp_path / "chroma")
+    # Long enough body (with paragraph breaks) to produce multiple
+    # chunks under the default RecursiveCharacterTextSplitter
+    # (chunk_size=1000, overlap=200).
+    long_body = "\n\n".join(["paragraph " + ("x" * 600)] * 8)
+    doc = _make_doc(tmp_path, long_body, name="big.txt")
+    store.ingest([doc])
+    big_count = len(_ids_for_source(store, doc.path))
+    assert big_count >= 2, "fixture should produce at least 2 chunks"
+
+    # Re-ingest the SAME path with a one-chunk body and verify the
+    # orphans got cleaned up rather than lingering forever.
+    Path(doc.path).write_text("tiny single chunk content", encoding="utf-8")
+    store.ingest([doc])
+    final = _ids_for_source(store, doc.path)
+    assert len(final) == 1
+    assert final[0] == f"{doc.path}::0"
+
+
+def test_ingest_idempotent_on_unchanged_file(tmp_path: Path) -> None:
+    store = _make_store(tmp_path / "chroma")
+    doc = _make_doc(tmp_path, "stable content body", name="stable.txt")
+    store.ingest([doc])
+    first = sorted(_ids_for_source(store, doc.path))
+    store.ingest([doc])
+    second = sorted(_ids_for_source(store, doc.path))
+    assert first == second
+
+
+# ── Fix 4: callers surface the mismatch as a run error ────────────────
+
+
+def test_record_rag_unavailable_reason_tags_mismatch(monkeypatch) -> None:
+    """The analyze-flow helper tags the mismatch case with a
+    ``embedding_mismatch:`` prefix so /history and Studio can
+    distinguish it from a generic init crash."""
+    from amx.cli_support.commands.analyze_flow import _record_rag_unavailable_reason
+
+    exc = EmbeddingProviderMismatch(
+        recorded_provider="openai_compatible",
+        recorded_model="text-embedding-3-small",
+        active_provider="minilm",
+        active_model="minilm-l6-v2",
+    )
+    sink: dict[str, str] = {}
+    _record_rag_unavailable_reason(sink, exc)
+    assert sink["rag_unavailable_reason"].startswith("embedding_mismatch:")
+    assert "openai_compatible" in sink["rag_unavailable_reason"]
+
+
+def test_format_rag_unavailable_reason_tags_mismatch() -> None:
+    """The library-side helper used by ``infer_table_metadata`` mirrors
+    the analyze-flow tagging so the two paths never drift."""
+    from amx.core.inference import _format_rag_unavailable_reason
+
+    exc = EmbeddingProviderMismatch(
+        recorded_provider="sentence_transformers",
+        recorded_model="BAAI/bge-large-en-v1.5",
+        active_provider="minilm",
+        active_model="minilm-l6-v2",
+    )
+    msg = _format_rag_unavailable_reason(exc)
+    assert msg.startswith("embedding_mismatch:")
+    assert "bge-large-en-v1.5" in msg


### PR DESCRIPTION
## Summary
Second PR of the RAG hardening series. Two interlocking storage fixes:

- `RAGStore` now passes the configured `cfg.embedding` provider to Chroma via `embedding_function=`. Was silently defaulting to bundled MiniLM regardless of user config.
- Collection metadata records the resolved `embedding_model` / `embedding_provider` on first create. On reopen, a mismatch raises `EmbeddingProviderMismatch`, which propagates to the user via the run-record path PR A added.
- `RAGStore.ingest` now deletes orphan chunks for each file before upserting, so editing a 10-chunk file down to 8 no longer leaves chunks 8 and 9 in the collection forever.
- Grandfather rule: pre-existing collections without metadata are trusted as-is and get metadata written on next access — no forced reindex on AMX upgrade.

## Test plan
- [x] `pytest -q` (1526 passed)
- [x] `ruff check amx tests`
- [x] `ruff format --check amx tests`
- Spec: docs/superpowers/specs/2026-05-12-rag-hardening-design.md (PR B section)