### PR TITLE
feat(rag): stability + perf (PR D of 4 — final)

### DIFF
--- a/amx/agents/_orchestrator/table_processor.py
+++ b/amx/agents/_orchestrator/table_processor.py
@@ -195,6 +195,57 @@ class TableProcessor:
             # cache layer is misconfigured (e.g. SQLite locked).
             pass
 
+    def _cache_rag_hits_for_rerun(self, profile: TableProfile, rag_agent: Any) -> None:
+        """Refresh the run-context cache row with the agent's prompt hits.
+
+        Called after the agent fan-out so the cache reflects the exact
+        chunks that informed this table's suggestions. The cache is
+        keyed on ``(db_profile, database, schema, table)`` — same shape
+        as ``_cache_profile_for_rerun`` — and merges the ``rag_hits``
+        list into the existing payload without overwriting the
+        ``db_profile`` / ``existing_metadata`` already there.
+        """
+        from amx.agents.rerun_context import _serialize_rag_hit
+        from amx.storage.sqlite_store import history_store
+
+        hits_map = getattr(rag_agent, "last_prompt_hits", None) or {}
+        key = (profile.schema or "", profile.name or "")
+        prompt_hits = hits_map.get(key) or []
+        if not prompt_hits:
+            return
+        hs = history_store()
+        if hs is None or self.orch.run_id is None:
+            return
+        run = hs.get_run(int(self.orch.run_id)) or {}
+        db_profile_name = str(run.get("db_profile") or "")
+        if not db_profile_name:
+            return
+        database = str(run.get("database") or "") or (
+            getattr(self.orch.db.cfg, "database", "")
+            or getattr(self.orch.db.cfg, "project", "")
+            or getattr(self.orch.db.cfg, "catalog", "")
+            or ""
+        )
+        existing = (
+            hs.lookup_run_context_cache(
+                db_profile=db_profile_name,
+                database=database,
+                schema=profile.schema or "",
+                table=profile.name or "",
+            )
+            or {}
+        )
+        payload = dict(existing.get("payload") or {})
+        payload["rag_hits"] = [_serialize_rag_hit(h) for h in prompt_hits if h]
+        hs.save_run_context_cache(
+            db_profile=db_profile_name,
+            database=database,
+            schema=profile.schema or "",
+            table=profile.name or "",
+            payload=payload,
+            source_run_id=self.orch.run_id,
+        )
+
     # ── Phase 2: filter chain ──────────────────────────────────────────
 
     def _apply_filters(self, profile: TableProfile) -> bool:
@@ -371,6 +422,17 @@ class TableProcessor:
             rag_diagnostics = rag_agent.consume_diagnostics()
             for message in dict.fromkeys(rag_diagnostics):
                 info(message)
+
+        # Persist the actual RAG chunks the agent fed into the prompt
+        # so a later re-run replays the same retrieval set instead of
+        # hitting Chroma again (deterministic across re-ingests).
+        # Best-effort: cache write failure must never break analyze.
+        rag_agent = getattr(self.orch, "rag_agent", None)
+        if rag_agent is not None:
+            try:
+                self._cache_rag_hits_for_rerun(profile, rag_agent)
+            except Exception as exc:
+                log.debug("rag_hits cache write failed: %s", exc)
 
         merged = self.orch._merge_suggestions(all_suggestions, ctx)
         if not merged:

--- a/amx/agents/base.py
+++ b/amx/agents/base.py
@@ -127,6 +127,13 @@ class AgentContext:
     db_profile: dict[str, Any] = field(default_factory=dict)
     rag_context: list[str] = field(default_factory=list)
     code_context: list[str] = field(default_factory=list)
+    # Actual RAG hits consumed by the original run, snapshotted at
+    # re-run time so the second pass uses the same retrieval set
+    # regardless of intervening re-ingests. Each element is the
+    # ``{text, metadata, score, distance}`` dict produced by
+    # :meth:`RAGStore.query`; an empty list means "no snapshot — fall
+    # back to a live RAGStore query" (the pre-PR-D contract).
+    rag_hits: list[dict[str, Any]] = field(default_factory=list)
     existing_metadata: dict[str, Any] = field(default_factory=dict)
     # Optional free-text addendum from the user, populated by the
     # Re-Run flow. Empty string on normal runs. Each agent's

--- a/amx/agents/rag_agent.py
+++ b/amx/agents/rag_agent.py
@@ -186,6 +186,11 @@ class RAGAgent(BaseAgent):
         # that aren't fatal but the user still needs to see — today,
         # "RAG returned no relevant documents".
         self._diagnostics: list[str] = []
+        # Snapshot of the exact ``prompt_hits`` fed into the most recent
+        # LLM call per ``(schema, table)``. The orchestrator drains this
+        # after each table so the run-context cache (PR D) can persist
+        # the actual chunks for deterministic re-runs.
+        self.last_prompt_hits: dict[tuple[str, str], list[dict]] = {}
 
     def consume_diagnostics(self) -> list[str]:
         diagnostics = list(self._diagnostics)
@@ -214,6 +219,34 @@ class RAGAgent(BaseAgent):
     def _prompt_detail(self) -> PromptDetail:
         return self.llm.cfg.prompt_detail_cfg
 
+    def _rag_query_timeout(self) -> float | None:
+        """Resolved per-query timeout for retrieval (seconds), or ``None`` to disable."""
+        raw = getattr(self.llm.cfg, "rag_query_timeout_sec", 5.0)
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
+
+    def _query_with_timeout(self, question: str, n_results: int) -> tuple[list[dict], bool]:
+        """Run ``RAGStore.query`` honouring the configured timeout.
+
+        Returns ``(hits, timed_out)`` so the caller can branch on the
+        timeout case to record a user-facing diagnostic. The timeout
+        path returns an empty hit list so retrieval falls back to
+        "no docs used" instead of blocking the run on a stalled
+        vector store. ``timeout=None`` (or ``<=0``) on the config
+        runs the query without the executor wrapper.
+        """
+        from amx.docs.rag import RAGQueryTimeout
+
+        timeout = self._rag_query_timeout()
+        try:
+            hits = self.rag.query(question, n_results=n_results, timeout=timeout)
+            return (hits, False)
+        except RAGQueryTimeout:
+            return ([], True)
+
     def _build_messages(self, ctx: AgentContext) -> tuple[list[dict[str, str]], list[dict]] | None:
         """Build the RAG prompt messages and remember the retrieval hits.
 
@@ -225,36 +258,59 @@ class RAGAgent(BaseAgent):
         from a known-good provenance source instead of trusting the
         LLM's free-text reasoning.
         """
-        if self.rag.doc_count == 0:
-            return None
-
         columns = ctx.db_profile.get("columns", [])
         if not columns:
             return None
 
         pd = self._prompt_detail
 
-        table_hits = self.rag.query(
-            f"table {ctx.table} in schema {ctx.schema}", n_results=pd.rag_table_hits
-        )
-        seen_docs: set[str] = set()
-        unique_hits = list(table_hits)
+        # Re-run replay path: when the orchestrator hydrated the
+        # AgentContext from a snapshot that already carries the exact
+        # hits the original run consumed, skip the live Chroma queries
+        # entirely. This makes re-runs deterministic across re-ingests
+        # and avoids re-paying retrieval latency on every re-run.
+        snapshot_hits = list(getattr(ctx, "rag_hits", None) or [])
+        any_timed_out = False
+        if snapshot_hits:
+            unique_hits = snapshot_hits
+        else:
+            if self.rag.doc_count == 0:
+                return None
+            table_hits, table_timed_out = self._query_with_timeout(
+                f"table {ctx.table} in schema {ctx.schema}", pd.rag_table_hits
+            )
+            seen_docs: set[str] = set()
+            unique_hits = list(table_hits)
+            any_timed_out = table_timed_out
 
-        if pd.rag_col_hits > 0:
-            for col in columns:
-                col_hits = self.rag.query(
-                    f"{ctx.table}.{col['name']} column", n_results=pd.rag_col_hits
-                )
-                for h in col_hits:
-                    key = h["text"][:120]
-                    if key not in seen_docs:
-                        seen_docs.add(key)
-                        unique_hits.append(h)
+            if pd.rag_col_hits > 0:
+                for col in columns:
+                    col_hits, col_timed_out = self._query_with_timeout(
+                        f"{ctx.table}.{col['name']} column", pd.rag_col_hits
+                    )
+                    if col_timed_out:
+                        any_timed_out = True
+                    for h in col_hits:
+                        key = h["text"][:120]
+                        if key not in seen_docs:
+                            seen_docs.add(key)
+                            unique_hits.append(h)
+
+        if any_timed_out:
+            timeout = self._rag_query_timeout() or 0.0
+            self._record_diagnostic(
+                f"RAG: retrieval timed out after {timeout:.1f}s for "
+                f"{ctx.schema}.{ctx.table}; no docs used for this table"
+            )
 
         if not unique_hits:
             return None
 
         prompt_hits = list(unique_hits[: pd.rag_max_chunks])
+        # Stash for downstream snapshot writers; keyed by (schema,
+        # table) since the agent is reused across many tables in one
+        # run.
+        self.last_prompt_hits[(ctx.schema, ctx.table)] = list(prompt_hits)
         doc_chunks = [
             f"[{h['metadata'].get('source', 'unknown')}]\n{h['text']}" for h in prompt_hits
         ]

--- a/amx/agents/rerun_context.py
+++ b/amx/agents/rerun_context.py
@@ -52,6 +52,34 @@ class RerunContextError(RuntimeError):
     """
 
 
+def _serialize_rag_hit(hit: dict[str, Any]) -> dict[str, Any]:
+    """Lean JSON projection of one ``RAGStore.query`` hit for the snapshot.
+
+    Keeps ``text``, ``metadata`` (the per-chunk provenance dict
+    written at ingest time — ``source``, ``source_root``,
+    ``source_type``, ``chunk_idx``), ``distance``, and ``score`` so
+    the re-run replay reproduces the same prompt and the citations
+    layer can still attribute alternatives to their original
+    chunks. Other keys (loader-specific debug fields, embedding
+    vectors if any caller ever sticks one in) are intentionally
+    dropped to keep the snapshot small.
+    """
+    meta = hit.get("metadata") or {}
+    return {
+        "text": str(hit.get("text") or ""),
+        "metadata": {
+            "source": str(meta.get("source") or ""),
+            "source_root": str(meta.get("source_root") or ""),
+            "source_type": str(meta.get("source_type") or ""),
+            "chunk_idx": int(meta.get("chunk_idx") or 0)
+            if str(meta.get("chunk_idx") or "0").lstrip("-").isdigit()
+            else 0,
+        },
+        "distance": float(hit.get("distance") or 0.0) if hit.get("distance") is not None else None,
+        "score": float(hit.get("score") or 0.0),
+    }
+
+
 def _connector_for_db_profile(cfg: AMXConfig, profile_name: str) -> DatabaseConnector:
     """Open a fresh ``DatabaseConnector`` against a named DB profile.
 
@@ -248,6 +276,7 @@ def build_context_snapshot(
         "asset_kind": asset_kind_raw,
         "db_profile": {},
         "rag_context": [],
+        "rag_hits": [],
         "code_context": [],
         "existing_metadata": {},
         "user_instructions": (user_instructions or "").strip(),
@@ -306,10 +335,14 @@ def build_context_snapshot(
     )
     db_profile_dict: dict[str, Any] | None = None
     existing_metadata: dict[str, Any] | None = None
+    cached_rag_hits: list[dict[str, Any]] = []
     if cached and isinstance(cached.get("payload"), dict):
         cached_payload = cached["payload"]
         cached_db_profile = cached_payload.get("db_profile")
         cached_existing = cached_payload.get("existing_metadata")
+        cached_rag = cached_payload.get("rag_hits")
+        if isinstance(cached_rag, list):
+            cached_rag_hits = [h for h in cached_rag if isinstance(h, dict)]
         if isinstance(cached_db_profile, dict) and isinstance(cached_existing, dict):
             db_profile_dict = _slice_cached_profile(
                 cached_db_profile, only_column=column if column else None
@@ -339,6 +372,8 @@ def build_context_snapshot(
 
     payload["db_profile"] = db_profile_dict
     payload["existing_metadata"] = existing_metadata
+    if cached_rag_hits:
+        payload["rag_hits"] = cached_rag_hits
 
     snapshot_id = uuid.uuid4().hex
     hs.save_rerun_snapshot(
@@ -363,6 +398,7 @@ def hydrate_context(payload: dict[str, Any]) -> AgentContext:
         asset_kind=str(payload.get("asset_kind") or "table"),
         db_profile=dict(payload.get("db_profile") or {}),
         rag_context=list(payload.get("rag_context") or []),
+        rag_hits=[h for h in (payload.get("rag_hits") or []) if isinstance(h, dict)],
         code_context=list(payload.get("code_context") or []),
         existing_metadata=dict(payload.get("existing_metadata") or {}),
         user_instructions=str(payload.get("user_instructions") or ""),
@@ -385,6 +421,7 @@ def cache_table_profile(
     db_profile_name: str,
     database: str,
     run_id: int | None = None,
+    rag_hits: list[dict[str, Any]] | None = None,
 ) -> bool:
     """Persist the freshly-built table profile for re-use on re-run.
 
@@ -401,10 +438,16 @@ def cache_table_profile(
         return False
     try:
         db_profile_dict, existing_metadata = _table_profile_to_dicts(profile, db)
-        payload = {
+        payload: dict[str, Any] = {
             "db_profile": db_profile_dict,
             "existing_metadata": existing_metadata,
         }
+        if rag_hits:
+            # Persist a lean projection of each hit — just the fields
+            # the re-run replay path needs to reconstruct the prompt.
+            # Dropping the raw distance/score keeps the JSON column
+            # small without losing provenance.
+            payload["rag_hits"] = [_serialize_rag_hit(h) for h in rag_hits if h]
         hs.save_run_context_cache(
             db_profile=str(db_profile_name or ""),
             database=str(database or ""),

--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -1075,7 +1075,7 @@ def execute_analyze_run(
             if cfg.active_doc_profile == DISABLED_PROFILE:
                 info("RAG Agent disabled (document profile: none).")
             else:
-                doc_filters = cfg.effective_doc_paths()
+                doc_filters = cfg.effective_run_doc_paths()
                 store = RAGStore(source_filters=doc_filters)
                 visible_chunks = store.doc_count
                 if visible_chunks > 0:
@@ -1284,6 +1284,17 @@ def register_analyze_run_command(
             "omitted, the persisted scope (set by /use-db) is used."
         ),
     )
+    @click.option(
+        "--doc",
+        "doc_profile_override",
+        multiple=True,
+        help=(
+            "Override the doc profile scope for this run. Pass multiple "
+            "times to union retrieval context from multiple profiles, "
+            "e.g. --doc handbook --doc product-spec. When omitted, "
+            "``active_doc_profile`` (or persisted ``run_doc_profiles``) is used."
+        ),
+    )
     @click.pass_obj
     def analyze_run(
         cfg: AMXConfig,
@@ -1295,9 +1306,32 @@ def register_analyze_run_command(
         code_profile: str | None,
         mode: str | None,
         db_profile_override: tuple[str, ...],
+        doc_profile_override: tuple[str, ...],
     ) -> None:
         """Run all agents to infer metadata for selected assets (tables, views, etc.)."""
         from amx.db.connector import DatabaseConnector
+
+        # Apply --doc multi-profile override for this run only. We
+        # capture the previous value so we can restore it in the
+        # ``finally`` below; the override is scoped to this CLI
+        # invocation and never persists to YAML.
+        doc_override_saved: list[str] | None = None
+        if doc_profile_override:
+            unknown_docs = [n for n in doc_profile_override if n not in cfg.doc_profiles]
+            if unknown_docs:
+                error(
+                    f"Unknown doc profile(s): {', '.join(unknown_docs)}. "
+                    f"Available: {', '.join(sorted(cfg.doc_profiles)) or '(none)'}."
+                )
+                sys.exit(1)
+            doc_override_saved = list(cfg.run_doc_profiles)
+            ordered_docs: list[str] = []
+            seen_docs: set[str] = set()
+            for name in doc_profile_override:
+                if name not in seen_docs:
+                    seen_docs.add(name)
+                    ordered_docs.append(name)
+            cfg.run_doc_profiles = ordered_docs
 
         # 0.11.0: resolve the effective scope for this run.
         # Priority: --db-profile (CLI) > persisted active_db_profiles
@@ -1395,3 +1429,7 @@ def register_analyze_run_command(
             if original_active and original_active in cfg.db_profiles:
                 object.__setattr__(cfg, "active_db_profile", original_active)
                 cfg.db = cfg.db_profiles[original_active]
+            # Roll back the per-run doc profile override so the next
+            # CLI command still sees the user's persisted scope.
+            if doc_override_saved is not None:
+                object.__setattr__(cfg, "run_doc_profiles", doc_override_saved)

--- a/amx/cli_support/commands/doctor.py
+++ b/amx/cli_support/commands/doctor.py
@@ -374,6 +374,75 @@ def _check_active_llm_profile(cfg: AMXConfig, *, skip_network: bool = False) -> 
     )
 
 
+def _check_rag_store(cfg: AMXConfig) -> CheckResult:
+    """Open the docs RAG collection and report its health.
+
+    Three failure modes the user actually cares about:
+
+    1. The active embedding provider/model doesn't match the one the
+       collection was created with — raising
+       :class:`EmbeddingProviderMismatch`. The hint points at the
+       remediation (``/docs reindex``).
+    2. Chroma/Embedding deps aren't installed — surface the
+       :class:`ImportError` instead of a 500 from the inner traceback.
+    3. The collection opens but is empty — pass with a warning-style
+       detail (not an error: an empty collection is "nothing ingested
+       yet", a perfectly normal first-run state).
+    """
+    try:
+        from amx.docs.rag import EmbeddingProviderMismatch, RAGStore
+    except Exception as exc:
+        return CheckResult(
+            name="RAG store",
+            ok=True,
+            detail="RAG dependencies not installed (optional)",
+            hint=f"pip install 'amx-cli[docs]' ({exc.__class__.__name__})",
+        )
+    try:
+        store = RAGStore(cfg=cfg)
+    except EmbeddingProviderMismatch as exc:
+        return CheckResult(
+            name="RAG store",
+            ok=False,
+            detail=str(exc),
+            hint="Run `/docs reindex` to rebuild the collection, or switch the active embedding profile back.",
+        )
+    except Exception as exc:
+        return CheckResult(
+            name="RAG store",
+            ok=False,
+            detail=f"{exc.__class__.__name__}: {exc}",
+            hint="Check ~/.amx/chroma_db permissions and the embedding provider settings.",
+        )
+    try:
+        store.collection.get(limit=1)
+    except Exception as exc:
+        return CheckResult(
+            name="RAG store",
+            ok=False,
+            detail=f"collection.get failed — {exc.__class__.__name__}: {exc}",
+            hint="The persist directory may be unreadable. Re-run with elevated permissions or delete ~/.amx/chroma_db and re-ingest.",
+        )
+    chunk_count = 0
+    try:
+        chunk_count = int(store.collection.count())
+    except Exception:
+        chunk_count = 0
+    embedding = f"{store.embedding_provider}/{store.embedding_model}"
+    if chunk_count == 0:
+        return CheckResult(
+            name="RAG store",
+            ok=True,
+            detail=f"opens with {embedding}, 0 chunks indexed",
+            hint="Empty collection — run `/ingest` (or upload via Studio) to populate it.",
+        )
+    return CheckResult(
+        name="RAG store",
+        ok=True,
+        detail=f"opens with {embedding}, {chunk_count} chunks indexed",
+    )
+
+
 # ── Rendering ───────────────────────────────────────────────────────────────
 
 
@@ -437,6 +506,7 @@ def collect_doctor_checks(
     # or the LLM endpoint".
     results.append(_check_active_db_profile(cfg, skip_network=skip_network))
     results.append(_check_active_llm_profile(cfg, skip_network=skip_network))
+    results.append(_check_rag_store(cfg))
     return results
 
 

--- a/amx/config.py
+++ b/amx/config.py
@@ -1199,6 +1199,13 @@ class LLMConfig(_ObservableConfig):
     # the user at "free input + market output" or vice versa.
     custom_input_cost_per_mtok: float | None = None
     custom_output_cost_per_mtok: float | None = None
+    # Per-query wall-clock cap on Chroma similarity retrieval. When the
+    # underlying ``RAGStore.query`` call exceeds this many seconds AMX
+    # logs a structured warning, surfaces a diagnostic to the
+    # orchestrator, and proceeds with an empty hit list so the run is
+    # not blocked by a stalled vector store. Set to ``0`` (or a negative
+    # value) to disable the timeout entirely.
+    rag_query_timeout_sec: float = 5.0
 
     @property
     def prompt_detail_cfg(self) -> PromptDetail:
@@ -1238,6 +1245,7 @@ def _llm_from_mapping(m: dict[str, Any]) -> LLMConfig:
         thinking_budget=int(m.get("thinking_budget", 1024)),
         custom_input_cost_per_mtok=_optional_nonneg_float(m.get("custom_input_cost_per_mtok")),
         custom_output_cost_per_mtok=_optional_nonneg_float(m.get("custom_output_cost_per_mtok")),
+        rag_query_timeout_sec=float(m.get("rag_query_timeout_sec", 5.0) or 5.0),
     )
 
 
@@ -1284,6 +1292,7 @@ def _llm_to_mapping(llm: LLMConfig) -> dict[str, Any]:
         "thinking_budget": llm.thinking_budget,
         "custom_input_cost_per_mtok": llm.custom_input_cost_per_mtok,
         "custom_output_cost_per_mtok": llm.custom_output_cost_per_mtok,
+        "rag_query_timeout_sec": llm.rag_query_timeout_sec,
     }
 
 
@@ -1400,6 +1409,23 @@ class AMXConfig:
     rag_llm_profile: str = ""
     doc_profiles: dict[str, list[str]] = field(default_factory=dict)
     active_doc_profile: str = ""
+    # Multi-profile override for ``/run``. When non-empty, the
+    # orchestrator unions every named profile's
+    # :meth:`effective_doc_paths` into a single ``RAGStore`` source
+    # filter for the run, so a single ``/run`` can pull context from
+    # multiple doc collections at once. Empty list (the default) means
+    # "use ``active_doc_profile`` exactly like before" — no migration
+    # needed for existing configs.
+    run_doc_profiles: list[str] = field(default_factory=list)
+    # Per-doc-profile health telemetry updated at the end of every
+    # ``RAGStore.ingest`` call. ``last_ingested_at`` is a Unix
+    # timestamp (or ``0.0`` when the profile has never been ingested);
+    # ``last_error`` carries a one-line reason from the most recent
+    # failure (or ``""`` when the last run was clean). Surfaced by
+    # ``GET /api/profiles/docs/{name}/health`` and the Studio Settings
+    # page.
+    doc_profiles_last_ingested_at: dict[str, float] = field(default_factory=dict)
+    doc_profiles_last_error: dict[str, str] = field(default_factory=dict)
     code_profiles: dict[str, str] = field(default_factory=dict)
     active_code_profile: str = ""
     # Map a doc/code profile to the DB profiles it documents. Empty list
@@ -1458,6 +1484,9 @@ class AMXConfig:
             "rag_llm_profile",
             "doc_profiles",
             "active_doc_profile",
+            "run_doc_profiles",
+            "doc_profiles_last_ingested_at",
+            "doc_profiles_last_error",
             "code_profiles",
             "active_code_profile",
             "doc_profile_linked_dbs",
@@ -1569,6 +1598,26 @@ class AMXConfig:
                         cfg.doc_profiles[str(name)] = [paths]
 
             cfg.active_doc_profile = str(data.get("active_doc_profile") or "")
+
+            run_doc_raw = data.get("run_doc_profiles") or []
+            if isinstance(run_doc_raw, list):
+                cfg.run_doc_profiles = [
+                    str(name).strip()
+                    for name in run_doc_raw
+                    if isinstance(name, str) and str(name).strip()
+                ]
+
+            doc_last_ingested_raw = data.get("doc_profiles_last_ingested_at") or {}
+            if isinstance(doc_last_ingested_raw, dict):
+                for name, ts in doc_last_ingested_raw.items():
+                    try:
+                        cfg.doc_profiles_last_ingested_at[str(name)] = float(ts)
+                    except (TypeError, ValueError):
+                        continue
+            doc_last_error_raw = data.get("doc_profiles_last_error") or {}
+            if isinstance(doc_last_error_raw, dict):
+                for name, err in doc_last_error_raw.items():
+                    cfg.doc_profiles_last_error[str(name)] = str(err or "")
 
             code_prof_raw = data.get("code_profiles") or {}
             if isinstance(code_prof_raw, dict):
@@ -1751,6 +1800,13 @@ class AMXConfig:
             data["doc_paths"] = doc_paths_yaml
             data["doc_profiles"] = {k: list(v) for k, v in self.doc_profiles.items()}
             data["active_doc_profile"] = self.active_doc_profile
+            data["run_doc_profiles"] = list(self.run_doc_profiles)
+            data["doc_profiles_last_ingested_at"] = {
+                k: float(v) for k, v in self.doc_profiles_last_ingested_at.items()
+            }
+            data["doc_profiles_last_error"] = {
+                k: str(v) for k, v in self.doc_profiles_last_error.items() if v
+            }
             data["code_paths"] = code_paths_yaml
             data["code_profiles"] = dict(self.code_profiles)
             data["active_code_profile"] = self.active_code_profile
@@ -2180,7 +2236,57 @@ class AMXConfig:
             with suppress(Exception):
                 object.__setattr__(profile, "_amx_owner", self)
 
-    def effective_doc_paths(self) -> list[str]:
+    def record_doc_profile_ingest(self, profile_name: str, *, error: str | None = None) -> None:
+        """Stamp the doc profile's health telemetry after an ingest run.
+
+        Always updates ``last_ingested_at`` so even a failed ingest is
+        reflected in the Studio Settings "Last indexed" line — users
+        need to see that something happened, not that the profile is
+        untouched. ``last_error`` records a one-line reason on
+        failure or clears to ``""`` on success.
+        """
+        name = (profile_name or "").strip()
+        if not name:
+            return
+        import time as _time
+
+        self.doc_profiles_last_ingested_at[name] = _time.time()
+        self.doc_profiles_last_error[name] = str(error or "")
+        with suppress(Exception):
+            self._autosave_nested()
+
+    def effective_run_doc_paths(self) -> list[str]:
+        """Doc paths the orchestrator should pass to ``RAGStore`` for ``/run``.
+
+        When ``run_doc_profiles`` is non-empty (multi-profile override
+        set by ``/run --doc foo --doc bar`` or the Studio Run dialog),
+        return the **union** of every named profile's paths so a single
+        run can pull retrieval context from multiple doc collections.
+        Empty list → fall back to the single active profile, matching
+        the pre-PR-D single-profile behaviour byte-for-byte.
+        """
+        names = [n for n in (self.run_doc_profiles or []) if n]
+        if not names:
+            return self.effective_doc_paths()
+        seen: set[str] = set()
+        out: list[str] = []
+        for name in names:
+            if name == DISABLED_PROFILE:
+                continue
+            paths = self.doc_profiles.get(name) or []
+            for p in paths:
+                if p and p not in seen:
+                    seen.add(p)
+                    out.append(p)
+        return out
+
+    def effective_doc_paths(self, name: str | None = None) -> list[str]:
+        if name is not None:
+            if name == DISABLED_PROFILE:
+                return []
+            if name in self.doc_profiles:
+                return list(self.doc_profiles[name])
+            return []
         if self.doc_profiles:
             name = self.active_doc_profile
             if name == DISABLED_PROFILE:

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -38,6 +39,15 @@ from amx.docs.scanner import DocInfo  # noqa: E402
 from amx.utils.logging import get_logger  # noqa: E402
 
 log = get_logger("docs.rag")
+
+
+class RAGQueryTimeout(TimeoutError):
+    """Raised by :meth:`RAGStore.query` when the per-call wall-clock cap fires.
+
+    The :class:`RAGAgent` catches this to record a diagnostic and fall
+    back to running the table without RAG context; other call sites can
+    treat it as a soft failure and return an empty hit list.
+    """
 
 
 class EmbeddingProviderMismatch(RuntimeError):
@@ -414,9 +424,50 @@ class RAGStore:
                 failed.append((doc.path, reason))
         return IngestSummary(succeeded=succeeded, failed=failed, chunk_count=total_chunks)
 
-    def query(self, question: str, n_results: int = 5) -> list[dict]:
+    def query(
+        self,
+        question: str,
+        n_results: int = 5,
+        *,
+        timeout: float | None = None,
+    ) -> list[dict]:
         raw_n = max(int(n_results), min(int(n_results) * 4, 40))
-        results = self.collection.query(query_texts=[question], n_results=raw_n)
+
+        def _do_query() -> Any:
+            return self.collection.query(query_texts=[question], n_results=raw_n)
+
+        # Honour the optional per-query wall-clock cap. We submit the
+        # Chroma call to a fresh single-thread executor scoped to a
+        # context manager so the worker thread is reaped even on
+        # timeout — a leaked daemon thread per query would pile up
+        # under a slow vector store. ``timeout=None`` or ``timeout<=0``
+        # skips the executor and runs synchronously (matches the pre-
+        # PR-D fast path with zero overhead for callers that opted
+        # out).
+        if timeout is not None and float(timeout) > 0:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(_do_query)
+                try:
+                    results = future.result(timeout=float(timeout))
+                except concurrent.futures.TimeoutError as exc:
+                    log.warning(
+                        "RAG retrieval exceeded %.2fs timeout, proceeding without context",
+                        float(timeout),
+                    )
+                    # Best-effort cancel; the underlying Chroma call
+                    # may still finish in the background thread but
+                    # the executor's context manager joins it before
+                    # we leave this block. Re-raise as a typed
+                    # exception so callers can branch on the timeout
+                    # case (and surface a user-facing diagnostic)
+                    # without inspecting an empty hit list.
+                    future.cancel()
+                    raise RAGQueryTimeout(
+                        f"RAG retrieval exceeded {float(timeout):.2f}s timeout"
+                    ) from exc
+        else:
+            results = _do_query()
+
         hits: list[dict] = []
         for i in range(len(results["documents"][0])):
             meta = results["metadatas"][0][i]

--- a/amx/web/routers/docs_ops.py
+++ b/amx/web/routers/docs_ops.py
@@ -98,15 +98,38 @@ def submit_ingest(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No paths to ingest. Pass paths=[...], profile=<name>, or activate a doc profile.",
         )
+    profile_name = (body.profile or "").strip() or (cfg.active_doc_profile or "").strip()
     job = jobs.new_job("docs_ingest")
     thread = threading.Thread(
         target=_ingest_worker,
-        args=(job, paths, bool(body.refresh)),
+        args=(job, paths, bool(body.refresh), cfg, profile_name),
         name=f"amx-docs-ingest-{job.id}",
         daemon=True,
     )
     thread.start()
     return {"job_id": job.id, "status": job.status, "paths": paths, "refresh": bool(body.refresh)}
+
+
+@router.post("/jobs/{job_id}/cancel")
+def cancel_job(
+    job_id: str,
+    jobs: JobRegistry = Depends(get_jobs),
+) -> dict[str, Any]:
+    """Signal an in-flight docs ingest/scan worker to stop.
+
+    The worker polls ``job.cancel`` between documents (never mid-Chroma
+    write) so cancellation latency is one document at most. Returns 200
+    when the job exists and the flag is set, 404 when the job id is
+    unknown.
+    """
+    job = jobs.get(job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Job {job_id} not found.",
+        )
+    job.cancel.set()
+    return {"job_id": job_id, "cancelled": True, "status": job.status}
 
 
 @router.post("/upload")
@@ -184,7 +207,7 @@ async def upload_docs(
         job = jobs.new_job("docs_ingest")
         thread = threading.Thread(
             target=_ingest_worker,
-            args=(job, [upload_root], False),
+            args=(job, [upload_root], False, cfg, profile_clean),
             name=f"amx-docs-upload-ingest-{job.id}",
             daemon=True,
         )
@@ -194,7 +217,11 @@ async def upload_docs(
 
 
 @router.get("/search")
-def search_docs(q: str, n: int = 5) -> dict[str, Any]:
+def search_docs(
+    q: str,
+    n: int = 5,
+    cfg: AMXConfig = Depends(get_cfg),
+) -> dict[str, Any]:
     """Synchronous embedding-only search (Chroma similarity, no LLM).
     The result set is small (default 5) and the call is cheap, so we
     don't bother with a job/SSE round trip — the SPA renders this
@@ -212,7 +239,13 @@ def search_docs(q: str, n: int = 5) -> dict[str, Any]:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=f"RAG dependencies not installed: {exc}",
         ) from exc
-    store = RAGStore()
+    # Apply the active doc profile's source filter so search results
+    # respect the same scope as ``/run``. Without this, search would
+    # leak chunks from other profiles' documents into the result list
+    # regardless of which profile is active — confusing on its own and
+    # arguably a small information leak in multi-profile setups.
+    source_filters = cfg.effective_doc_paths() or None
+    store = RAGStore(source_filters=source_filters)
     if store.doc_count == 0:
         return {"hits": [], "count": 0, "message": "RAG store is empty — run /ingest first."}
     hits = store.query(query, n_results=max(1, min(int(n), 25)))
@@ -288,12 +321,25 @@ def _scan_worker_body(job: Job, paths: list[str]) -> None:
         emit_terminal(job.queue, "job.failed", {"error": job.error})
 
 
-def _ingest_worker(job: Job, paths: list[str], refresh: bool) -> None:
+def _ingest_worker(
+    job: Job,
+    paths: list[str],
+    refresh: bool,
+    cfg: AMXConfig | None = None,
+    profile_name: str | None = None,
+) -> None:
     with quiet_console():
-        _ingest_worker_body(job, paths, refresh)
+        _ingest_worker_body(job, paths, refresh, cfg=cfg, profile_name=profile_name)
 
 
-def _ingest_worker_body(job: Job, paths: list[str], refresh: bool) -> None:
+def _ingest_worker_body(
+    job: Job,
+    paths: list[str],
+    refresh: bool,
+    *,
+    cfg: AMXConfig | None = None,
+    profile_name: str | None = None,
+) -> None:
     job.status = "running"
     emit(job.queue, "activity.added", {"idx": 0, "label": "Scanning"})
     emit(job.queue, "activity.begin", {"idx": 0})
@@ -319,16 +365,36 @@ def _ingest_worker_body(job: Job, paths: list[str], refresh: bool) -> None:
         emit(job.queue, "activity.begin", {"idx": 1})
 
         store = RAGStore()
-        # ``RAGStore.ingest`` returns ``IngestSummary`` (PR A); ``int(...)``
-        # still answers the chunk count for legacy callers and the
-        # frontend's existing ``summary.chunks`` reader.
-        summary = store.ingest(documents, refresh=bool(refresh))
-        chunks_added = int(summary)
-        failed_list = [
-            {"path": path, "error": reason}
-            for path, reason in (getattr(summary, "failed", None) or [])
-        ]
-        succeeded_count = len(getattr(summary, "succeeded", None) or [])
+        # Iterate documents one at a time so we can poll ``job.cancel``
+        # between docs and exit cleanly mid-batch. Mid-document
+        # cancellation is intentionally NOT supported — interrupting a
+        # Chroma upsert would leave the collection in a half-orphaned
+        # state. One document of latency is the worst case.
+        succeeded: list[str] = []
+        failed_list: list[dict[str, str]] = []
+        chunks_added = 0
+        cancelled = False
+        for idx, doc in enumerate(documents):
+            if job.cancel.is_set():
+                cancelled = True
+                break
+            single_summary = store.ingest([doc], refresh=bool(refresh))
+            succeeded.extend(getattr(single_summary, "succeeded", None) or [])
+            failed_list.extend(
+                {"path": p, "error": r} for p, r in (getattr(single_summary, "failed", None) or [])
+            )
+            chunks_added += int(single_summary)
+            if (idx + 1) % 5 == 0 or idx == len(documents) - 1:
+                emit(
+                    job.queue,
+                    "ingest.progress",
+                    {"done": idx + 1, "total": len(documents), "chunks": chunks_added},
+                )
+        succeeded_count = len(succeeded)
+        status_label = "cancelled" if cancelled else "done"
+        ingest_error: str | None = None
+        if failed_list and not succeeded:
+            ingest_error = "; ".join(f"{f['path']}: {f['error']}" for f in failed_list[:3])
         emit(
             job.queue,
             "ingest.summary",
@@ -339,27 +405,36 @@ def _ingest_worker_body(job: Job, paths: list[str], refresh: bool) -> None:
                 "succeeded": succeeded_count,
                 "failed": failed_list,
                 "scan_failures": scan_failures,
+                "cancelled": cancelled,
+                "status": status_label,
             },
         )
-        job.status = "done"
+        job.status = status_label  # type: ignore[assignment]
         job.summary = {
             "documents": len(documents),
             "chunks": chunks_added,
             "succeeded": succeeded_count,
             "failed": failed_list,
             "scan_failures": scan_failures,
+            "cancelled": cancelled,
         }
         job.ended_at = time.time()
-        emit(
-            job.queue,
-            "activity.complete",
-            {"idx": 1, "detail": f"{chunks_added} chunks ingested"},
+        if cfg is not None and profile_name:
+            cfg.record_doc_profile_ingest(profile_name, error=ingest_error)
+        detail = (
+            f"{chunks_added} chunks ingested ({succeeded_count}/{len(documents)} files) — cancelled"
+            if cancelled
+            else f"{chunks_added} chunks ingested"
         )
-        emit_terminal(job.queue, "job.done", {"summary": job.summary})
+        emit(job.queue, "activity.complete", {"idx": 1, "detail": detail})
+        terminal_event = "job.cancelled" if cancelled else "job.done"
+        emit_terminal(job.queue, terminal_event, {"summary": job.summary})
     except Exception as exc:
         log.exception("docs ingest worker crashed")
         job.status = "failed"
         job.error = f"{exc.__class__.__name__}: {exc}"
         job.ended_at = time.time()
+        if cfg is not None and profile_name:
+            cfg.record_doc_profile_ingest(profile_name, error=job.error)
         emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
         emit_terminal(job.queue, "job.failed", {"error": job.error})

--- a/amx/web/routers/profiles.py
+++ b/amx/web/routers/profiles.py
@@ -390,6 +390,55 @@ def list_docs(cfg: AMXConfig = Depends(get_cfg)) -> dict[str, Any]:
     return {"profiles": items, "active": getattr(cfg, "active_doc_profile", "") or None}
 
 
+@router.get("/docs/{name}/health")
+def doc_profile_health(
+    name: str,
+    cfg: AMXConfig = Depends(get_cfg),
+) -> dict[str, Any]:
+    """Per-doc-profile health card for Studio Settings.
+
+    Combines on-disk Chroma stats (chunk count, embedding metadata)
+    with config-side telemetry (last ingested timestamp, last error
+    one-liner) so the user can see at a glance whether the profile
+    is wired up and indexed without dropping to the CLI.
+
+    Returns 404 when the profile is unknown so the SPA can distinguish
+    "no telemetry yet" (200 with zeros) from a typo in the URL.
+    """
+    if name not in cfg.doc_profiles:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=404, detail=f"Doc profile '{name}' not found.")
+    paths = list(cfg.doc_profiles.get(name) or [])
+    chunk_count = 0
+    embedding_model: str | None = None
+    embedding_provider: str | None = None
+    try:
+        from amx.docs.rag import RAGStore
+
+        store = RAGStore(source_filters=cfg.effective_doc_paths(name) or None)
+        chunk_count = int(store.filtered_doc_count())
+        meta = dict(store.collection.metadata or {})
+        embedding_model = str(meta.get("embedding_model")) if meta.get("embedding_model") else None
+        embedding_provider = (
+            str(meta.get("embedding_provider")) if meta.get("embedding_provider") else None
+        )
+    except Exception as exc:
+        log.debug("doc_profile_health: RAGStore probe failed: %s", exc)
+    last_ingested = cfg.doc_profiles_last_ingested_at.get(name, 0.0) or 0.0
+    last_error = cfg.doc_profiles_last_error.get(name, "") or ""
+    return {
+        "name": name,
+        "chunk_count": chunk_count,
+        "last_ingested_at": float(last_ingested) if last_ingested else None,
+        "last_error": last_error or None,
+        "embedding_model": embedding_model,
+        "embedding_provider": embedding_provider,
+        "paths": paths,
+        "linked_db_profiles": list(cfg.doc_profile_linked_dbs.get(name, []) or []),
+    }
+
+
 @router.get("/code")
 def list_code(cfg: AMXConfig = Depends(get_cfg)) -> dict[str, Any]:
     """Code profiles are ``dict[name -> repo_path_or_url]``."""

--- a/tests/test_doctor_rag_check.py
+++ b/tests/test_doctor_rag_check.py
@@ -1,0 +1,82 @@
+"""PR D — doctor adds a ``RAG store`` check.
+
+Three branches matter to the user:
+
+* fresh persist_dir (collection opens, 0 chunks) → ``ok=True`` with a
+  "0 chunks indexed" detail and a "run /ingest" hint;
+* mismatched embedding (``EmbeddingProviderMismatch``) → ``ok=False``
+  with the mismatch message;
+* arbitrary open failure → ``ok=False`` with the exception name.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from amx.cli_support.commands.doctor import _check_rag_store
+
+
+def test_rag_store_check_passes_on_fresh_collection(monkeypatch, tmp_path):
+    fake_store = MagicMock()
+    fake_store.collection = MagicMock()
+    fake_store.collection.get = MagicMock(return_value={"ids": []})
+    fake_store.collection.count = MagicMock(return_value=0)
+    fake_store.embedding_provider = "minilm"
+    fake_store.embedding_model = "minilm-l6-v2"
+
+    monkeypatch.setattr("amx.docs.rag.RAGStore", lambda *a, **kw: fake_store)
+
+    cfg = MagicMock()
+    result = _check_rag_store(cfg)
+    assert result.ok is True
+    assert "0 chunks" in result.detail
+    assert "minilm" in result.detail
+    assert result.hint  # should suggest running /ingest
+
+
+def test_rag_store_check_fails_on_embedding_mismatch(monkeypatch):
+    from amx.docs.rag import EmbeddingProviderMismatch
+
+    def _raise_mismatch(*a, **kw):
+        raise EmbeddingProviderMismatch(
+            recorded_provider="openai_compatible",
+            recorded_model="text-embedding-3-small",
+            active_provider="minilm",
+            active_model="minilm-l6-v2",
+        )
+
+    monkeypatch.setattr("amx.docs.rag.RAGStore", _raise_mismatch)
+
+    cfg = MagicMock()
+    result = _check_rag_store(cfg)
+    assert result.ok is False
+    assert "text-embedding-3-small" in result.detail
+    assert "reindex" in (result.hint or "").lower()
+
+
+def test_rag_store_check_fails_on_open_error(monkeypatch):
+    def _boom(*a, **kw):
+        raise RuntimeError("chroma_db permission denied")
+
+    monkeypatch.setattr("amx.docs.rag.RAGStore", _boom)
+
+    cfg = MagicMock()
+    result = _check_rag_store(cfg)
+    assert result.ok is False
+    assert "permission denied" in result.detail
+
+
+def test_rag_store_check_passes_with_existing_chunks(monkeypatch):
+    fake_store = MagicMock()
+    fake_store.collection = MagicMock()
+    fake_store.collection.get = MagicMock(return_value={"ids": ["a", "b"]})
+    fake_store.collection.count = MagicMock(return_value=42)
+    fake_store.embedding_provider = "openai_compatible"
+    fake_store.embedding_model = "text-embedding-3-small"
+
+    monkeypatch.setattr("amx.docs.rag.RAGStore", lambda *a, **kw: fake_store)
+
+    cfg = MagicMock()
+    result = _check_rag_store(cfg)
+    assert result.ok is True
+    assert "42 chunks" in result.detail

--- a/tests/test_rag_multi_profile.py
+++ b/tests/test_rag_multi_profile.py
@@ -1,0 +1,61 @@
+"""PR D — multi-profile doc scope for ``/run``.
+
+``AMXConfig.run_doc_profiles`` is a list of doc profile names. When
+non-empty, ``effective_run_doc_paths`` returns the **union** of every
+named profile's paths so a single ``/run`` can pull retrieval context
+from multiple doc collections at once. Empty list falls back to the
+single-active-profile contract — no migration needed.
+"""
+
+from __future__ import annotations
+
+from amx.config import AMXConfig
+
+
+def test_effective_run_doc_paths_falls_back_to_single_profile():
+    cfg = AMXConfig()
+    cfg.doc_profiles = {"handbook": ["/abs/handbook"]}
+    cfg.active_doc_profile = "handbook"
+    assert cfg.run_doc_profiles == []
+    assert cfg.effective_run_doc_paths() == ["/abs/handbook"]
+
+
+def test_effective_run_doc_paths_unions_multiple_profiles():
+    cfg = AMXConfig()
+    cfg.doc_profiles = {
+        "handbook": ["/abs/handbook", "/abs/wiki"],
+        "spec": ["/abs/spec"],
+    }
+    cfg.run_doc_profiles = ["handbook", "spec"]
+    paths = cfg.effective_run_doc_paths()
+    assert paths == ["/abs/handbook", "/abs/wiki", "/abs/spec"]
+
+
+def test_effective_run_doc_paths_deduplicates_overlapping_paths():
+    cfg = AMXConfig()
+    cfg.doc_profiles = {
+        "a": ["/abs/shared", "/abs/a_only"],
+        "b": ["/abs/shared", "/abs/b_only"],
+    }
+    cfg.run_doc_profiles = ["a", "b"]
+    paths = cfg.effective_run_doc_paths()
+    assert paths == ["/abs/shared", "/abs/a_only", "/abs/b_only"]
+
+
+def test_effective_run_doc_paths_skips_disabled_sentinel():
+    from amx.config import DISABLED_PROFILE
+
+    cfg = AMXConfig()
+    cfg.doc_profiles = {"handbook": ["/abs/handbook"]}
+    cfg.run_doc_profiles = [DISABLED_PROFILE, "handbook"]
+    assert cfg.effective_run_doc_paths() == ["/abs/handbook"]
+
+
+def test_effective_doc_paths_by_name_returns_just_that_profile():
+    cfg = AMXConfig()
+    cfg.doc_profiles = {
+        "handbook": ["/abs/handbook"],
+        "spec": ["/abs/spec"],
+    }
+    assert cfg.effective_doc_paths("spec") == ["/abs/spec"]
+    assert cfg.effective_doc_paths("nonexistent") == []

--- a/tests/test_rag_query_timeout.py
+++ b/tests/test_rag_query_timeout.py
@@ -1,0 +1,116 @@
+"""PR D — RAG retrieval timeout.
+
+``RAGStore.query`` accepts a ``timeout: float | None`` kwarg; when the
+underlying Chroma call exceeds the cap, the call raises
+:class:`RAGQueryTimeout` so callers can branch on the timeout case
+(rather than ambiguously returning ``[]``). The :class:`RAGAgent`
+catches the exception, falls back to "no docs used", and records a
+user-facing diagnostic.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _slow_query(*args, **kwargs):
+    time.sleep(0.5)
+    return {
+        "documents": [[]],
+        "metadatas": [[]],
+        "distances": [[]],
+    }
+
+
+def test_ragstore_query_raises_on_timeout(monkeypatch, caplog):
+    """The lower-level ``RAGStore.query`` raises ``RAGQueryTimeout``
+    and logs a structured warning when the Chroma call overruns."""
+    from amx.docs.rag import RAGQueryTimeout, RAGStore
+
+    store = object.__new__(RAGStore)
+    store.collection = SimpleNamespace(query=_slow_query)
+    store.source_filters = []
+    # ``rerank`` is unreachable on the timeout path but ``query``
+    # accesses ``self`` for ``_source_allowed``; bind the bound method
+    # back so the slow path stays representative.
+
+    with caplog.at_level(logging.WARNING, logger="docs.rag"):
+        with pytest.raises(RAGQueryTimeout):
+            RAGStore.query(store, "what is foo", n_results=2, timeout=0.1)
+
+    assert any(
+        "timeout" in rec.message.lower() and "rag retrieval" in rec.message.lower()
+        for rec in caplog.records
+    ), f"expected a structured timeout warning; got {[r.message for r in caplog.records]}"
+
+
+def test_ragstore_query_no_timeout_kwarg_runs_synchronously(monkeypatch):
+    """``timeout=None`` (or <=0) bypasses the executor entirely."""
+    from amx.docs.rag import RAGStore
+
+    calls = []
+
+    def _fast_query(**kw):
+        calls.append(kw)
+        return {
+            "documents": [["chunk text"]],
+            "metadatas": [[{"source": "/tmp/a", "source_root": "", "chunk_idx": 0}]],
+            "distances": [[0.1]],
+        }
+
+    store = object.__new__(RAGStore)
+    store.collection = SimpleNamespace(query=_fast_query)
+    store.source_filters = []
+
+    hits = RAGStore.query(store, "q", n_results=1, timeout=None)
+    assert len(hits) == 1
+    assert calls  # executed at least once
+
+
+def test_rag_agent_timeout_emits_diagnostic_and_returns_no_messages():
+    """When ``rag.query`` times out, the agent surfaces a diagnostic
+    and returns ``None`` from ``_build_messages`` so the orchestrator
+    proceeds without RAG context."""
+    from amx.agents.base import AgentContext
+    from amx.agents.rag_agent import RAGAgent
+    from amx.docs.rag import RAGQueryTimeout
+
+    fake_llm = MagicMock()
+    fake_llm.cfg = SimpleNamespace(
+        temperature=0.0,
+        max_tokens=512,
+        column_batch_size=10,
+        n_alternatives=3,
+        description_verbosity="brief",
+        logprob_high=0.9,
+        logprob_medium=0.7,
+        rag_query_timeout_sec=0.05,
+        prompt_detail_cfg=SimpleNamespace(rag_table_hits=2, rag_col_hits=0, rag_max_chunks=4),
+    )
+
+    fake_rag = MagicMock()
+    fake_rag.doc_count = 7  # non-zero so we exercise the live-query path
+
+    def _raise_timeout(*args, **kwargs):
+        raise RAGQueryTimeout("simulated")
+
+    fake_rag.query.side_effect = _raise_timeout
+
+    agent = RAGAgent(llm=fake_llm, rag_store=fake_rag)
+    ctx = AgentContext(
+        schema="public",
+        table="orders",
+        db_profile={"columns": [{"name": "id", "dtype": "int"}]},
+    )
+    out = agent.run(ctx)
+    assert out == []
+    diagnostics = agent.consume_diagnostics()
+    joined = " | ".join(diagnostics).lower()
+    assert "timed out" in joined or "timeout" in joined, (
+        f"expected a timeout diagnostic; got {diagnostics!r}"
+    )

--- a/tests/test_rerun_rag_snapshot.py
+++ b/tests/test_rerun_rag_snapshot.py
@@ -1,0 +1,123 @@
+"""PR D — re-Run snapshots the original run's RAG hits.
+
+The original run records the exact ``prompt_hits`` it fed the LLM
+into ``run_context_cache.payload["rag_hits"]``. When the re-Run
+worker rehydrates the snapshot, ``AgentContext.rag_hits`` carries
+those chunks and :class:`RAGAgent` skips the live ``RAGStore.query``
+calls. Pre-PR-D snapshots without ``rag_hits`` silently fall back to
+the live-query path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from amx.agents.base import AgentContext
+from amx.agents.rag_agent import RAGAgent
+from amx.agents.rerun_context import _serialize_rag_hit, hydrate_context
+
+
+def _llm_namespace():
+    return MagicMock(
+        cfg=SimpleNamespace(
+            temperature=0.0,
+            max_tokens=512,
+            column_batch_size=10,
+            n_alternatives=3,
+            description_verbosity="brief",
+            logprob_high=0.9,
+            logprob_medium=0.7,
+            rag_query_timeout_sec=5.0,
+            prompt_detail_cfg=SimpleNamespace(rag_table_hits=2, rag_col_hits=0, rag_max_chunks=4),
+        ),
+    )
+
+
+def test_serialize_rag_hit_keeps_text_and_metadata():
+    hit = {
+        "text": "alpha bravo",
+        "metadata": {
+            "source": "/docs/a.md",
+            "source_root": "/docs",
+            "source_type": "local",
+            "chunk_idx": 2,
+        },
+        "distance": 0.34,
+        "score": 1.5,
+    }
+    out = _serialize_rag_hit(hit)
+    assert out["text"] == "alpha bravo"
+    assert out["metadata"]["source"] == "/docs/a.md"
+    assert out["metadata"]["chunk_idx"] == 2
+    assert out["score"] == 1.5
+
+
+def test_hydrate_context_populates_rag_hits():
+    payload = {
+        "schema": "public",
+        "table": "orders",
+        "rag_hits": [
+            {"text": "x", "metadata": {"source": "/a", "chunk_idx": 0}, "score": 0.9},
+        ],
+    }
+    ctx = hydrate_context(payload)
+    assert len(ctx.rag_hits) == 1
+    assert ctx.rag_hits[0]["text"] == "x"
+
+
+def test_rag_agent_uses_snapshot_hits_and_skips_live_query():
+    """When ``ctx.rag_hits`` is populated, ``RAGAgent._build_messages``
+    consumes them directly and never calls ``self.rag.query``."""
+    fake_llm = _llm_namespace()
+    fake_rag = MagicMock()
+    fake_rag.doc_count = 0  # would normally short-circuit, but snapshot wins
+    fake_rag.query = MagicMock(side_effect=AssertionError("must not be called"))
+
+    snapshot_hits = [
+        {
+            "text": "frozen chunk",
+            "metadata": {"source": "/docs/freeze.md", "chunk_idx": 0},
+            "score": 1.2,
+            "distance": 0.2,
+        }
+    ]
+    ctx = AgentContext(
+        schema="public",
+        table="orders",
+        db_profile={"columns": [{"name": "id", "dtype": "int", "samples": []}]},
+        rag_hits=snapshot_hits,
+    )
+    agent = RAGAgent(llm=fake_llm, rag_store=fake_rag)
+    built = agent._build_messages(ctx)
+    assert built is not None, "agent should produce a prompt from snapshot hits"
+    messages, prompt_hits = built
+    assert prompt_hits == snapshot_hits
+    fake_rag.query.assert_not_called()
+
+
+def test_rag_agent_without_snapshot_falls_back_to_live_query():
+    """Pre-PR-D snapshots (or normal runs) have empty ``rag_hits``
+    and must go down the live-query path unchanged."""
+    fake_llm = _llm_namespace()
+    fake_rag = MagicMock()
+    fake_rag.doc_count = 5
+    fake_rag.query = MagicMock(
+        return_value=[
+            {
+                "text": "live chunk",
+                "metadata": {"source": "/docs/live.md", "chunk_idx": 0},
+                "score": 0.5,
+                "distance": 0.4,
+            }
+        ]
+    )
+    ctx = AgentContext(
+        schema="public",
+        table="orders",
+        db_profile={"columns": [{"name": "id", "dtype": "int", "samples": []}]},
+    )
+    agent = RAGAgent(llm=fake_llm, rag_store=fake_rag)
+    built = agent._build_messages(ctx)
+    assert built is not None
+    assert fake_rag.query.called

--- a/tests/web/test_doc_profile_health.py
+++ b/tests/web/test_doc_profile_health.py
@@ -1,0 +1,59 @@
+"""PR D — ``GET /api/profiles/docs/{name}/health``.
+
+Reports per-profile chunk count, last-ingested timestamp, last error,
+and the embedding metadata recorded on the Chroma collection.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def test_health_returns_404_for_unknown_profile(client, auth_headers):
+    resp = client.get("/api/profiles/docs/nope/health", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_health_combines_telemetry_and_chroma_metadata(client, auth_headers, cfg, monkeypatch):
+    cfg.doc_profiles["handbook"] = ["/abs/handbook"]
+    cfg.doc_profiles_last_ingested_at["handbook"] = 1715512345.6
+    cfg.doc_profiles_last_error["handbook"] = ""
+
+    fake_store = MagicMock()
+    fake_store.filtered_doc_count = MagicMock(return_value=37)
+    fake_store.collection = MagicMock()
+    fake_store.collection.metadata = {
+        "embedding_provider": "openai_compatible",
+        "embedding_model": "text-embedding-3-small",
+    }
+    monkeypatch.setattr("amx.docs.rag.RAGStore", lambda *a, **kw: fake_store)
+
+    resp = client.get("/api/profiles/docs/handbook/health", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "handbook"
+    assert body["chunk_count"] == 37
+    assert body["last_ingested_at"] == 1715512345.6
+    assert body["last_error"] is None
+    assert body["embedding_provider"] == "openai_compatible"
+    assert body["embedding_model"] == "text-embedding-3-small"
+    assert body["paths"] == ["/abs/handbook"]
+
+
+def test_health_handles_missing_chroma_gracefully(client, auth_headers, cfg, monkeypatch):
+    """When ``RAGStore`` fails to open (missing deps, no chroma_db,
+    etc.) the endpoint still returns 200 with zero chunks instead of
+    bubbling a 500 — the user can still see the config-side
+    telemetry."""
+    cfg.doc_profiles["handbook"] = ["/abs/handbook"]
+
+    def _boom(*a, **kw):
+        raise RuntimeError("chroma not installed")
+
+    monkeypatch.setattr("amx.docs.rag.RAGStore", _boom)
+
+    resp = client.get("/api/profiles/docs/handbook/health", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["chunk_count"] == 0
+    assert body["embedding_model"] is None

--- a/tests/web/test_docs_cancellation.py
+++ b/tests/web/test_docs_cancellation.py
@@ -1,0 +1,91 @@
+"""PR D — ingest cancellation endpoint + worker polling.
+
+``POST /api/docs/jobs/{job_id}/cancel`` sets the job's ``cancel``
+event. The ingest worker polls it between documents (never
+mid-Chroma write) and finalizes the summary with ``cancelled=True``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+
+def _wait_for_status(client, job_id: str, timeout: float = 5.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        body = client.get(
+            f"/api/runs/{job_id}",
+            headers={"Authorization": "Bearer test-studio-token-abc123"},
+        ).json()
+        if body["status"] in {"done", "cancelled", "failed"}:
+            return body
+        time.sleep(0.05)
+    raise AssertionError(f"Job {job_id} never terminated; last={body}")
+
+
+def test_cancel_endpoint_returns_404_for_unknown_job(client, auth_headers):
+    resp = client.post("/api/docs/jobs/does-not-exist/cancel", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_cancel_during_ingest_stops_worker_between_documents(
+    client, auth_headers, cfg, monkeypatch
+):
+    """Spawn an ingest worker that processes 5 documents; cancel after
+    the first one completes; expect the worker to bail before the
+    remaining 4 are ingested and to emit ``cancelled=True``."""
+    cfg.doc_profiles["x"] = ["/abs"]
+
+    docs = [f"doc{i}" for i in range(5)]
+    monkeypatch.setattr("amx.docs.scanner.scan_all_sources", lambda paths: docs)
+    monkeypatch.setattr("amx.docs.scanner.total_size_mb", lambda _docs: 1.0)
+
+    # Use a real lock so we can deterministically release one document
+    # at a time. ``ingest`` blocks until the test releases the gate.
+    first_started = threading.Event()
+    cancel_seen = threading.Event()
+    call_count = {"n": 0}
+
+    from amx.docs.rag import IngestSummary
+
+    def _fake_ingest(doc_list, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Signal the test thread to issue the cancel BEFORE we
+            # return from the first ingest. The second iteration of
+            # the worker loop will then observe ``job.cancel`` set and
+            # break before calling ingest again.
+            first_started.set()
+            cancel_seen.wait(timeout=3.0)
+        return IngestSummary(succeeded=[doc_list[0]], failed=[], chunk_count=3)
+
+    fake_store = MagicMock()
+    fake_store.ingest.side_effect = _fake_ingest
+    monkeypatch.setattr("amx.docs.rag.RAGStore", lambda *a, **kw: fake_store)
+
+    resp = client.post(
+        "/api/docs/ingest",
+        headers=auth_headers,
+        json={"profile": "x"},
+    )
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+
+    # Wait for the first ingest call to begin, then cancel BEFORE
+    # letting it return. Once the worker advances to the next loop
+    # iteration it observes ``job.cancel`` and bails without calling
+    # ingest a second time.
+    assert first_started.wait(timeout=3.0), "first ingest never started"
+    cancel = client.post(f"/api/docs/jobs/{job_id}/cancel", headers=auth_headers)
+    assert cancel.status_code == 200
+    assert cancel.json()["cancelled"] is True
+    cancel_seen.set()
+
+    body = _wait_for_status(client, job_id)
+    assert body["status"] == "cancelled"
+    assert body["summary"]["cancelled"] is True
+    # Only the first document was ingested before cancellation took
+    # effect; the worker did not chew through the remaining 4.
+    assert call_count["n"] == 1

--- a/tests/web/test_docs_ops.py
+++ b/tests/web/test_docs_ops.py
@@ -61,8 +61,16 @@ def test_ingest_streams_chunk_count(client, auth_headers, cfg, monkeypatch) -> N
     monkeypatch.setattr("amx.docs.scanner.scan_all_sources", lambda paths: ["doc1", "doc2"])
     monkeypatch.setattr("amx.docs.scanner.total_size_mb", lambda docs: 0.5)
 
+    # Per-document loop (PR D): the worker calls ``ingest`` once per
+    # document so it can poll ``job.cancel`` between docs. The
+    # ``IngestSummary`` shape is faked here so ``int(...)`` still
+    # answers the chunk count.
+    from amx.docs.rag import IngestSummary
+
     fake_store = MagicMock()
-    fake_store.ingest = MagicMock(return_value=42)
+    fake_store.ingest = MagicMock(
+        side_effect=lambda docs, **kw: IngestSummary(succeeded=[docs[0]], failed=[], chunk_count=21)
+    )
     monkeypatch.setattr("amx.docs.rag.RAGStore", lambda *a, **kw: fake_store)
 
     response = client.post(
@@ -73,9 +81,11 @@ def test_ingest_streams_chunk_count(client, auth_headers, cfg, monkeypatch) -> N
     assert response.status_code == 200
     job_id = response.json()["job_id"]
     body = _wait_for_status(client, job_id, "done")
+    # 21 chunks per doc × 2 docs = 42 total chunks across the batch.
     assert body["summary"]["chunks"] == 42
     assert body["summary"]["documents"] == 2
-    fake_store.ingest.assert_called_once_with(["doc1", "doc2"], refresh=False)
+    assert body["summary"]["cancelled"] is False
+    assert fake_store.ingest.call_count == 2
 
 
 def test_search_rejects_empty_query(client, auth_headers) -> None:

--- a/tests/web/test_docs_search_respects_filter.py
+++ b/tests/web/test_docs_search_respects_filter.py
@@ -1,0 +1,61 @@
+"""PR D — ``/api/docs/search`` applies the active profile's source filter.
+
+Before PR D the search endpoint instantiated ``RAGStore()`` with no
+``source_filters`` so results leaked chunks from every profile's
+documents. Now it passes ``cfg.effective_doc_paths()`` so the result
+set matches the user's active scope.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def test_search_passes_active_profile_paths_to_ragstore(client, auth_headers, cfg, monkeypatch):
+    cfg.doc_profiles["handbook"] = ["/abs/handbook"]
+    cfg.doc_profiles["other"] = ["/abs/other"]
+    cfg.active_doc_profile = "handbook"
+
+    captured: dict = {}
+
+    def _factory(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        store = MagicMock()
+        store.doc_count = 1
+        store.query = MagicMock(
+            return_value=[
+                {
+                    "text": "alpha",
+                    "metadata": {"source": "/abs/handbook/a.md"},
+                    "distance": 0.1,
+                }
+            ]
+        )
+        return store
+
+    monkeypatch.setattr("amx.docs.rag.RAGStore", _factory)
+
+    resp = client.get("/api/docs/search?q=foo", headers=auth_headers)
+    assert resp.status_code == 200
+    assert captured["kwargs"]["source_filters"] == ["/abs/handbook"]
+    body = resp.json()
+    assert body["count"] == 1
+
+
+def test_search_with_no_profile_uses_no_filter(client, auth_headers, monkeypatch):
+    captured: dict = {}
+
+    def _factory(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        store = MagicMock()
+        store.doc_count = 0
+        return store
+
+    monkeypatch.setattr("amx.docs.rag.RAGStore", _factory)
+
+    resp = client.get("/api/docs/search?q=foo", headers=auth_headers)
+    assert resp.status_code == 200
+    # With no active profile, ``effective_doc_paths()`` returns an
+    # empty list which becomes ``source_filters=None`` — the global
+    # collection scope.
+    assert captured["kwargs"]["source_filters"] is None


### PR DESCRIPTION
## Summary
Final PR of the RAG hardening series. Closes the remaining important findings:

- `RAGStore.query` honours a configurable timeout (`cfg.llm.rag_query_timeout_sec`, default 5s); on timeout raises `RAGQueryTimeout` and the `RAGAgent` falls back to "no docs used" with a structured diagnostic.
- `POST /api/docs/jobs/{id}/cancel` lets Studio cancel an in-flight ingest between documents; worker polls and exits cleanly with `cancelled=True` on the summary.
- `/doctor` (CLI + Studio) gains a `RAG store` check covering collection opens, embedding metadata, and persist-dir health (plus the `EmbeddingProviderMismatch` failure mode).
- `/run` accepts multi-profile doc scope via `cfg.run_doc_profiles` and CLI `--doc` (repeatable). `effective_run_doc_paths()` returns the union of named profiles' paths.
- `/rerun` snapshots the actual RAG chunks from the original run (via `run_context_cache.payload['rag_hits']`) so re-runs after a re-ingest are deterministic. Pre-PR-D snapshots without `rag_hits` fall back to a live query.
- `GET /api/profiles/docs/{name}/health` returns chunk count + last ingested + last error + embedding metadata.
- `/api/docs/search` now applies the active profile's source filter.

## Test plan
- [x] `pytest -q` — 1555 passed
- [x] `ruff check amx tests` — all checks passed
- [x] `ruff format --check amx tests` — clean
- [x] `cd frontend && npm run build` — clean
- [ ] Manual Studio smoke: cancel in-flight ingest; multi-profile `--doc` CLI invocation
- Spec: `docs/superpowers/specs/2026-05-12-rag-hardening-design.md` (PR D section)

## Notes on Studio UI
The Studio Run dialog multi-select and Settings health card were intentionally deferred to a follow-up frontend-only change — the backend endpoint, CLI flag, and config plumbing all ship in this PR, and the existing single-select UI keeps working because `run_doc_profiles` defaults to `[]`.