### PR TITLE
feat(code): Studio code surface fix (PR alpha of code-RAG hardening)

### DIFF
--- a/amx/web/routers/code_ops.py
+++ b/amx/web/routers/code_ops.py
@@ -63,6 +63,28 @@ def _resolve_path(body: _CodeScanRequest, cfg: AMXConfig) -> str:
     return str(cfg.code_profiles.get(profile, "") or "")
 
 
+@router.post("/jobs/{job_id}/cancel")
+def cancel_job(
+    job_id: str,
+    jobs: JobRegistry = Depends(get_jobs),
+) -> dict[str, Any]:
+    """Signal an in-flight code scan worker to stop.
+
+    The worker polls ``job.cancel`` between files (never mid-file —
+    that would orphan a partial Chroma upsert until the idempotent
+    delete lands in a follow-up PR). Returns 200 when the job exists
+    and the flag is set, 404 when the job id is unknown.
+    """
+    job = jobs.get(job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Job {job_id} not found.",
+        )
+    job.cancel.set()
+    return {"job_id": job_id, "cancelled": True, "status": job.status}
+
+
 @router.post("/scan")
 def submit_scan(
     body: _CodeScanRequest,
@@ -77,6 +99,13 @@ def submit_scan(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No path to scan. Pass path=, profile=, or activate a code profile.",
         )
+    # Resolve the profile name used for cache + catalog sync so the
+    # subsequent ``/api/code/analyze`` and ``/api/code/search`` calls
+    # can find the persisted report. Matches the CLI's fallback chain
+    # in ``commands/code.py`` so the two surfaces share a cache key.
+    profile_name = (
+        (body.profile or "").strip() or (cfg.active_code_profile or "").strip() or "default"
+    )
     job = jobs.new_job("code_scan")
     thread = threading.Thread(
         target=_scan_worker,
@@ -89,6 +118,7 @@ def submit_scan(
             body.db_profile,
             body.db_database,
             body.db_catalog,
+            profile_name,
         ),
         name=f"amx-code-scan-{job.id}",
         daemon=True,
@@ -101,16 +131,19 @@ def submit_scan(
 def search_code(
     q: str,
     n: int = 5,
-    profile: str | None = None,
+    profile: list[str] = Query(default_factory=list),
     cfg: AMXConfig = Depends(get_cfg),
 ) -> dict[str, Any]:
     """Synchronous embedding-only search over the ``amx_code`` Chroma
     index — the Studio counterpart to ``GET /api/docs/search``. No LLM
     call; the SPA renders results directly.
 
-    Pass ``profile`` to scope the hit list to one code profile's source
-    paths (the same gate the /ask ``search_code`` tool applies). Omit
-    to search across every indexed snippet.
+    ``profile`` is repeatable: ``?profile=foo&profile=bar`` searches
+    the union of those code profiles' source paths. When the parameter
+    is omitted, the search falls back to ``cfg.effective_code_paths()``
+    — i.e. the active code profile — so search hits stay scoped to
+    whatever the user has selected, matching how ``/ask`` resolves
+    code context. Pass an explicit list to override.
     """
     query = (q or "").strip()
     if not query:
@@ -126,28 +159,34 @@ def search_code(
             detail=f"Code RAG dependencies not installed: {exc}",
         ) from exc
 
-    profile_name = (profile or "").strip()
+    profile_names = [p.strip() for p in (profile or []) if p and p.strip()]
     source_filters: list[str] = []
-    if profile_name:
-        if profile_name not in cfg.code_profiles:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Unknown code profile {profile_name!r}.",
-            )
-        path = (cfg.code_profiles.get(profile_name) or "").strip()
-        if path:
-            source_filters = [path]
+    explicit_profiles = bool(profile_names)
+    if explicit_profiles:
+        for name in profile_names:
+            if name not in cfg.code_profiles:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Unknown code profile {name!r}.",
+                )
+            path = (cfg.code_profiles.get(name) or "").strip()
+            if path and path not in source_filters:
+                source_filters.append(path)
+    else:
+        # Default to the active code profile's paths — same scope rule
+        # as ``/api/docs/search`` uses via ``effective_doc_paths()``.
+        for path in cfg.effective_code_paths() or []:
+            cleaned = (path or "").strip()
+            if cleaned and cleaned not in source_filters:
+                source_filters.append(cleaned)
 
     if code_collection_count(source_filters=source_filters or None) == 0:
-        return {
-            "hits": [],
-            "count": 0,
-            "message": (
-                f"No indexed code for profile {profile_name!r} — run /code-scan first."
-                if profile_name
-                else "amx_code index is empty — run /code-scan first."
-            ),
-        }
+        if explicit_profiles:
+            label = ", ".join(profile_names)
+            message = f"No indexed code for profile {label!r} — run /code-scan first."
+        else:
+            message = "amx_code index is empty — run /code-scan first."
+        return {"hits": [], "count": 0, "message": message}
 
     hits = query_code_snippets(
         query,
@@ -384,6 +423,7 @@ def _scan_worker(
     db_profile: str | None = None,
     db_database: str | None = None,
     db_catalog: str | None = None,
+    profile_name: str = "default",
 ) -> None:
     with quiet_console():
         _scan_worker_body(
@@ -395,6 +435,7 @@ def _scan_worker(
             db_profile,
             db_database,
             db_catalog,
+            profile_name,
         )
 
 
@@ -407,6 +448,7 @@ def _scan_worker_body(
     db_profile: str | None = None,
     db_database: str | None = None,
     db_catalog: str | None = None,
+    profile_name: str = "default",
 ) -> None:
     job.status = "running"
     emit(job.queue, "activity.added", {"idx": 0, "label": "Collecting catalog assets"})
@@ -461,12 +503,101 @@ def _scan_worker_body(
         emit(job.queue, "activity.added", {"idx": 1, "label": f"Scanning {path}"})
         emit(job.queue, "activity.begin", {"idx": 1})
 
-        # 2. Run the analyzer.
-        report = analyze_codebase(
-            path,
-            table_names=table_names,
-            column_names=column_names or None,
-        )
+        # Per-file progress callback. ``analyze_codebase`` calls this
+        # with ``("__total__", total_files)`` once, then
+        # ``("__advance__", file_name)`` for each scanned file. Bridge
+        # those events to the SSE bus so the SPA renders per-file
+        # progress instead of a single "Scanning…" line — and use the
+        # same hook to poll ``job.cancel`` between files (never
+        # mid-file, to avoid orphaning a partial Chroma upsert).
+        progress_state: dict[str, int] = {"total": 0, "processed": 0}
+        cancelled = False
+
+        class _Cancelled(RuntimeError):
+            pass
+
+        def _scan_progress(action: str, value: object) -> None:
+            nonlocal cancelled
+            if action == "__total__":
+                progress_state["total"] = int(value or 0)
+                emit(
+                    job.queue,
+                    "code.scan.progress",
+                    {
+                        "file_path": "",
+                        "processed_count": 0,
+                        "total_count": progress_state["total"],
+                    },
+                )
+                return
+            if action == "__advance__":
+                # Poll cancellation BETWEEN files — raise out of the
+                # analyzer so the in-progress walk stops cleanly. The
+                # outer ``except _Cancelled`` finalizes a cancelled
+                # summary; any partial work is left for the operator
+                # to clear with ``/code-refresh`` (the same recovery
+                # path the docs ingest cancellation uses today).
+                if job.cancel.is_set():
+                    cancelled = True
+                    raise _Cancelled()
+                progress_state["processed"] += 1
+                emit(
+                    job.queue,
+                    "code.scan.progress",
+                    {
+                        "file_path": str(value or ""),
+                        "processed_count": progress_state["processed"],
+                        "total_count": progress_state["total"] or progress_state["processed"],
+                    },
+                )
+
+        # 2. Run the analyzer with semantic indexing so the ``amx_code``
+        # Chroma collection is populated — Studio /code-scan reached
+        # functional parity with the CLI here. Without this, /ask's
+        # ``search_code`` tool and /api/code/search return empty.
+        try:
+            report = analyze_codebase(
+                path,
+                table_names=table_names,
+                column_names=column_names or None,
+                index_semantic=True,
+                progress_callback=_scan_progress,
+            )
+        except _Cancelled:
+            # User cancelled mid-walk. Emit a cancelled summary and
+            # exit cleanly — no exception trail in the SSE stream.
+            scan_summary = {
+                "path": path,
+                "total_files": progress_state.get("total", 0),
+                "scanned_files": progress_state.get("processed", 0),
+                "catalog_assets": 0,
+                "external_assets": 0,
+                "catalog": [],
+                "external": [],
+                "cancelled": True,
+                "status": "cancelled",
+            }
+            emit(
+                job.queue,
+                "code.scan.summary",
+                {
+                    "scanned_files": scan_summary["scanned_files"],
+                    "catalog_assets": 0,
+                    "external_assets": 0,
+                    "cancelled": True,
+                    "status": "cancelled",
+                },
+            )
+            emit(
+                job.queue,
+                "activity.complete",
+                {"idx": 1, "detail": "scan cancelled"},
+            )
+            job.status = "cancelled"
+            job.summary = scan_summary
+            job.ended_at = time.time()
+            emit_terminal(job.queue, "job.cancelled", {"summary": scan_summary})
+            return
 
         # 3. Compact the report into something the SPA can render.
         # analyze_codebase emits per-asset CodeReference objects; we
@@ -516,6 +647,51 @@ def _scan_worker_body(
                 "external_assets": scan_summary["external_assets"],
             },
         )
+
+        # Persist the cached report so a follow-up ``/api/code/analyze``
+        # (and the CLI's ``/code-results``) finds it under the same
+        # slug the CLI writes. Without this step, Studio scans never
+        # populate the cache and downstream code-analyze 500s with
+        # "No cached code-scan".
+        # Cache manifests need a single schema label. ``schema_filter``
+        # wins when set; otherwise fall back to ``cfg.current_schema``
+        # — and finally to the literal "all" so a multi-schema scan
+        # still produces a stable, reload-able cache key.
+        schema_for_cache = (
+            (schema_filter or "").strip() or (cfg.current_schema or "").strip() or "all"
+        )
+        try:
+            from amx.codebase.cache import save_cached_report
+
+            save_cached_report(
+                profile_name=profile_name,
+                source_path=path,
+                schema=schema_for_cache,
+                tables=table_names,
+                column_names=column_names,
+                report=report,
+            )
+        except Exception as exc:
+            log.warning("Could not save code-scan cache: %s", exc)
+
+        # Sync the report into the search catalog so /search surfaces
+        # the same code-evidence rows the CLI's ``/code-scan`` writes.
+        try:
+            from amx.search.catalog import SearchCatalog
+
+            catalog_store = SearchCatalog.from_history_store()
+            if catalog_store is not None:
+                catalog_store.sync_code_report(
+                    db_profile=cfg.active_db_profile or "default",
+                    db_backend=cfg.db.backend,
+                    database_name=(cfg.db.database or cfg.db.catalog or cfg.db.project or ""),
+                    schema_name=schema_for_cache,
+                    source_path=path,
+                    report=report,
+                )
+        except Exception as exc:
+            log.warning("Could not sync code report into /search catalog: %s", exc)
+
         emit(
             job.queue,
             "activity.complete",

--- a/docs/superpowers/specs/2026-05-12-code-rag-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-12-code-rag-hardening-design.md
@@ -1,0 +1,224 @@
+# Code RAG Hardening — Design Spec
+
+**Status:** Approved (audit-driven)
+**Date:** 2026-05-12
+**Scope:** AMX CLI + AMX Studio code-RAG path, end-to-end
+
+## Motivation
+
+A read-only end-to-end audit of the code RAG pipeline (ingestion +
+retrieval, CLI + Studio) revealed that the code path repeats most of
+the docs-RAG defects that PRs #335-339 fixed, plus adds new
+code-specific issues.
+
+Headline user-visible symptoms:
+
+- **Studio "Scan" is non-functional end-to-end.** `analyze_codebase`
+  is called without `index_semantic=True`, so the Chroma collection
+  stays empty. `save_cached_report` is also skipped, so the analyze
+  endpoint dead-ends with "Run /code-scan first." A Studio user has
+  to drop into the CLI to make anything work.
+- **No `.gitignore` / `node_modules` / `.git` filter.** Scans walk the
+  entire tree, flooding the code index with third-party JS, vendored
+  artifacts, and packed git refs. Embedding cost and retrieval
+  relevance both suffer.
+- **Silent MiniLM override.** `cfg.embedding` is ignored — the docs
+  pre-PR-A bug, unfixed for code. The collection records nothing
+  about which embedding model wrote it.
+- **Orphan chunks on file shrink/delete.** Pure `upsert` with no
+  per-file pre-delete leaves stale chunks for renamed functions,
+  deleted files, and moved classes.
+- **No citations on code-derived suggestions.** `CodeAgent` never
+  populates `MetadataSuggestion.citations`. Users cannot trace a
+  suggestion back to `src/foo.py:120`.
+- **No re-Run snapshot for code hits.** `rerun_context.code_context`
+  is a hard-coded `[]` placeholder. Re-runs re-query live and can
+  produce different evidence than the original run.
+- **Most PR D capabilities missing for code**: no query timeout, no
+  doctor check, no health endpoint, no multi-profile `/run`, no
+  cancellation polling.
+
+## Approach
+
+Four sequenced PRs, each green-on-CI before the next starts. Same
+pattern as the docs-RAG hardening (PRs #335-339). Each PR is
+independently reviewable + revertable.
+
+### PR α — Studio code surface fix
+
+Bring Studio to the same functional level as the CLI. Highest
+user-visible impact; least invasive on the indexer.
+
+- `web/routers/code_ops.py` `_scan_worker_body` calls
+  `analyze_codebase(..., index_semantic=True)` and threads a progress
+  callback through the existing SSE infrastructure (matches PR A's
+  per-file events for docs).
+- `_scan_worker_body` calls `save_cached_report(...)` on success and
+  `sync_code_report(...)` to the search catalog — mirroring the CLI
+  exactly (`commands/code.py:272-279`).
+- `POST /api/code/jobs/{job_id}/cancel` endpoint sets `job.cancel`;
+  the worker polls between files.
+- `/api/code/search` accepts a list of profile names (or derives the
+  union from `cfg.code_profile_linked_dbs`) and passes
+  `source_filters=` to `query_code_snippets` so search respects
+  active scope.
+
+### PR β — Storage correctness
+
+Same template as docs-RAG PR B. Plumb the configured embedding
+provider into the code Chroma collection, record provenance, fix
+idempotency, and start ignoring directories nobody wants in the
+index.
+
+- `codebase/code_rag.py` `index_codebase_tree` accepts a `cfg`
+  argument and calls `make_embedding_function(cfg.embedding.kind,
+  model=..., api_key=..., base_url=...)`; passes the result as
+  `embedding_function=` to `get_or_create_collection`.
+- Collection metadata records
+  `{embedding_model, embedding_provider, hnsw:space}` on first
+  create. On reopen, mismatched provider/model raises
+  `CodeEmbeddingMismatch` (new exception) which propagates to the
+  run record's `code_unavailable_reason` and the CLI/Studio surface.
+- Grandfather: pre-PR-β collections with no recorded provider
+  inherit current config and write metadata silently on next access.
+- Per-file pre-delete: before `coll.upsert` for a file, `coll.get`
+  IDs scoped by `rel_path` and `coll.delete` any IDs that aren't in
+  the new chunk set. Closes the orphan-chunks bug for shrink, file
+  deletion, and function rename.
+- `.gitignore` parsing (via `pathspec`, already in
+  `amx/docs/scanner.py`), plus a hard-coded denylist for
+  `{node_modules, .git, .venv, venv, dist, build, target, vendor,
+  .next, .cache}`. The scanner walks the tree once and emits a
+  filtered file list; both `analyze_codebase` and
+  `index_codebase_tree` consume it instead of re-rglobbing.
+- `.ipynb` cell-aware: parse JSON, extract `cell.source` and
+  `cell.cell_type` (`code` / `markdown`) into per-cell chunks
+  metadata`{kind: "ipynb_code"|"ipynb_md", cell_idx: N}`.
+
+### PR γ — Citation chain
+
+Same template as docs-RAG PR C. Make every code-derived suggestion
+trace back to a file + line range.
+
+- Chunk metadata gains `start_line` / `end_line` (where available
+  from AST; fallback splitter sets them from token offsets).
+- `CodeAgent._parse_response` no longer drops the hits — the prompt
+  hits are remembered (`last_prompt_hits` mirroring `RAGAgent`) and
+  each emitted `MetadataSuggestion` carries citations populated
+  from retrieval metadata, NOT from LLM output.
+- Citation dataclass already exists (`Citation` from PR C). Code
+  citations reuse it; `source` is repo-relative `rel_path`,
+  `chunk_idx` is the `cid` numeric (0-based across the file's
+  chunks), `score` is rerank score, `snippet` is the first 200
+  chars of chunk text, plus a new optional `line_range:
+  tuple[int, int] | None` field (extends the dataclass; backwards
+  compatible because the field is optional with a `None` default).
+- `tool_agent._summarise_tool_call` extends the citation extraction
+  to `tool_call.name == "search_code"` (currently only
+  `search_docs`).
+- `AskChat.tsx` `CitationsList` renders code citations identical to
+  doc citations except the `line_range` appended after the path:
+  `src/foo.py:120-145 · score 0.84`.
+- CLI `_format_sources_cell` already supports the format generically
+  (`path:chunk_idx`); extends to `path:line_range` when present.
+- Drop the hardcoded `"SQL Spark dataframe usage"` semantic-query
+  bias (`code_agent.py:174`). Use a neutral
+  `f"{ctx.schema} {ctx.table}"` query string with optional per-column
+  expansion via a new `pd.code_col_hits` config knob (defaults to 0,
+  preserving today's behaviour).
+
+### PR δ — Stability + perf + UI
+
+Same template as docs-RAG PRs D + E combined. Closes the remaining
+audit items.
+
+- Query timeout: `query_code_snippets(... timeout=cfg.llm.rag_query_timeout_sec)`
+  reusing the same field PR D added (one timeout value covers both
+  doc and code paths — both run through Chroma).
+- Doctor `_check_code_rag`: opens the `amx_code` collection,
+  verifies provider metadata matches active config, sample query,
+  emits warn for empty collection, fail on exception.
+- `GET /api/profiles/code/{name}/health` returns
+  `{chunk_count, last_indexed_at, last_error, embedding_model,
+  embedding_provider, paths}`.
+- `AMXConfig.run_code_profiles: list[str]` (parallel to
+  `run_doc_profiles`). CLI `/run … --code <name>` repeatable; Studio
+  Run dialog gains a code-profile multi-select chip row mirroring
+  the doc one already shipped in PR E.
+- Re-Run RAG-style snapshot for code: `rerun_context.code_context`
+  is populated by `_cache_code_hits_for_rerun` after the agent
+  fan-out. On re-run, CodeAgent reads `ctx.code_hits` and skips the
+  live Chroma query when present (falls back when empty).
+- `CodeAgent._record_diagnostic` mirroring `RAGAgent`; orchestrator's
+  `table_processor` drains it so "no code context for X.Y" reaches
+  the user.
+- Batch Chroma upsert: `coll.upsert(ids=..., documents=..., metadatas=...)`
+  receives batched lists per file (and per source root) instead of
+  one chunk at a time.
+- `code_collection_count` server-side filter via Chroma `where={}`
+  instead of full-table Python filter.
+- Settings → Code tab in Studio gains a per-profile health line
+  identical to the docs version (chunks count, last indexed,
+  embedding model, optional last-error chip).
+- AskChat `ToolCallList` for `search_code` renders the same compact
+  hit table as docs (file:line, score).
+
+## Out of scope (deferred)
+
+- Tree-sitter / language-server based chunking — current AST-only
+  for Python is acceptable; broader language coverage is a
+  multi-PR effort better handled when retrieval quality data drives
+  the priority list.
+- Incremental git scans (`git diff --name-only HEAD`-driven
+  re-index) — separate perf PR. Today re-indexing a 200-file repo
+  re-embeds everything; with batched embeddings (PR δ) this is
+  cheaper but not free.
+- Cell-output suppression / executable-output normalization in
+  `.ipynb` — for now treat code cells as ordinary chunks and
+  markdown cells as documentation chunks.
+- Multi-language symbol extraction (Go, TypeScript, Java) — current
+  regex-based approach in `analyzer.py` is fine for evidence-finding
+  but not perfect for semantic search; tracker.
+
+## Per-PR risk
+
+- α: low-medium. Pure plumbing on Studio worker + endpoint, but the
+  scan worker hasn't been touched in a while; verify the cancel
+  polling doesn't strand orphan files.
+- β: medium-high. Touches the chunker, the collection metadata, and
+  the per-file pre-delete logic. Grandfather rule for existing
+  collections is critical; users with populated indexes must not
+  see them wiped on upgrade.
+- γ: medium. Adds a field to `Citation` (optional, backwards-compat),
+  but the chunk metadata format change in β must land first.
+- δ: medium. New thread executor for queries; multi-profile changes
+  the contract of code resolution; Studio surface gains a new card.
+
+## Test strategy
+
+Each PR ships with its own test file under `tests/` (flat layout
+matching docs-RAG convention):
+
+- α: `tests/web/test_code_scan_indexes.py`,
+  `tests/web/test_code_cancellation.py`,
+  `tests/web/test_code_search_respects_filter.py`
+- β: `tests/test_code_storage_correctness.py`,
+  `tests/test_code_gitignore_filter.py`,
+  `tests/test_code_ipynb_cells.py`
+- γ: `tests/test_code_citation_chain.py`,
+  `tests/test_search_code_citations.py`
+- δ: `tests/test_code_query_timeout.py`,
+  `tests/test_doctor_code_check.py`,
+  `tests/test_code_multi_profile.py`,
+  `tests/test_rerun_code_snapshot.py`,
+  `tests/web/test_code_profile_health.py`
+
+## Migration
+
+Pre-existing users have a populated `~/.amx/chroma_db/amx_code`
+collection. The grandfather rule in PR β handles this: absence of
+provider metadata → write current values, do NOT reindex. No data
+loss on upgrade.
+
+`run_code_profiles` defaults to `[]` (empty list) so the
+single-profile path is preserved until the user opts in.

--- a/tests/web/test_code_cancellation.py
+++ b/tests/web/test_code_cancellation.py
@@ -1,0 +1,89 @@
+"""PR alpha — code scan cancellation endpoint + worker polling.
+
+``POST /api/code/jobs/{job_id}/cancel`` sets the job's ``cancel``
+event. The scan worker polls it between files (never mid-file —
+that would orphan a partial Chroma upsert) and finalizes the
+summary with ``cancelled=True``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+
+def _wait_for_status(client, job_id: str, target: str, timeout: float = 5.0) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        body = client.get(
+            f"/api/runs/{job_id}",
+            headers={"Authorization": "Bearer test-studio-token-abc123"},
+        ).json()
+        last = body
+        if body["status"] == target:
+            return body
+        time.sleep(0.02)
+    raise AssertionError(f"Job {job_id} never reached {target}; last={last}")
+
+
+def test_cancel_endpoint_returns_404_for_unknown_job(client, auth_headers) -> None:
+    resp = client.post("/api/code/jobs/does-not-exist/cancel", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_cancel_endpoint_sets_flag_and_worker_exits(client, auth_headers, cfg, monkeypatch) -> None:
+    """Drive the analyzer's progress callback a few times, then cancel
+    BEFORE the next ``__advance__`` is delivered. The worker must
+    observe ``job.cancel`` and bail with status=cancelled."""
+    cfg.code_profiles["repo"] = "/abs/repo"
+    cfg.active_code_profile = "repo"
+
+    monkeypatch.setattr(
+        "amx.db.connector.DatabaseConnector",
+        lambda cfg: MagicMock(
+            list_schemas=MagicMock(return_value=["public"]),
+            list_tables=MagicMock(return_value=["users"]),
+        ),
+    )
+
+    first_advance = threading.Event()
+    cancel_seen = threading.Event()
+
+    def fake_analyze(path, **kw):
+        cb = kw.get("progress_callback")
+        if cb is not None:
+            cb("__total__", 5)
+            cb("__advance__", "a.py")
+            # Signal the test to fire the cancel and wait for it.
+            first_advance.set()
+            cancel_seen.wait(timeout=3.0)
+            # Next call should raise out of the analyzer because
+            # job.cancel is set — exactly the path the real analyzer
+            # would hit between files.
+            cb("__advance__", "b.py")
+        # Should never get here.
+        return MagicMock(
+            total_files=5,
+            scanned_files=5,
+            references={},
+            external_mentions={},
+        )
+
+    monkeypatch.setattr("amx.codebase.analyzer.analyze_codebase", fake_analyze)
+
+    resp = client.post("/api/code/scan", headers=auth_headers, json={})
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+
+    assert first_advance.wait(timeout=3.0), "scan never started"
+    cancel = client.post(f"/api/code/jobs/{job_id}/cancel", headers=auth_headers)
+    assert cancel.status_code == 200
+    assert cancel.json()["cancelled"] is True
+    cancel_seen.set()
+
+    body = _wait_for_status(client, job_id, "cancelled")
+    assert body["status"] == "cancelled"
+    assert (body.get("summary") or {}).get("cancelled") is True

--- a/tests/web/test_code_scan_indexes.py
+++ b/tests/web/test_code_scan_indexes.py
@@ -1,0 +1,221 @@
+"""PR alpha — Studio code scan reaches functional parity with the CLI.
+
+Three properties are pinned here:
+
+* ``index_semantic=True`` is passed to ``analyze_codebase`` so the
+  ``amx_code`` Chroma collection is populated (fix C1).
+* ``save_cached_report`` is called so a follow-up
+  ``POST /api/code/analyze`` finds the cached report under the same
+  slug the CLI writes (fix C2).
+* ``catalog_store.sync_code_report`` is called so the search catalog
+  has the code-evidence rows attached (fix I9).
+* Per-file SSE progress events are emitted so the SPA renders a
+  proper progress bar instead of one "Scanning…" line (fix I8).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+
+def _wait_for_status(client, job_id: str, target: str, timeout: float = 3.0) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = client.get(
+            f"/api/runs/{job_id}",
+            headers={"Authorization": "Bearer test-studio-token-abc123"},
+        )
+        body = resp.json()
+        if body["status"] == target:
+            return body
+        time.sleep(0.02)
+    raise AssertionError(f"Job {job_id} never reached status {target}; last={body}")
+
+
+def _patch_db(monkeypatch) -> None:
+    fake_db = MagicMock(
+        list_schemas=MagicMock(return_value=["public"]),
+        list_tables=MagicMock(return_value=["users"]),
+    )
+    monkeypatch.setattr("amx.db.connector.DatabaseConnector", lambda cfg: fake_db)
+
+
+def test_studio_scan_passes_index_semantic_true(client, auth_headers, cfg, monkeypatch) -> None:
+    """The Studio scan worker must call ``analyze_codebase`` with
+    ``index_semantic=True`` so the Chroma index gets populated. Without
+    this, ``/api/code/search`` always returns empty after a Studio scan.
+    """
+    cfg.code_profiles["repo"] = "/abs/repo"
+    cfg.active_code_profile = "repo"
+    _patch_db(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    def fake_analyze(path, **kw):
+        captured.update(kw)
+        return MagicMock(
+            total_files=2,
+            scanned_files=2,
+            references={"users": []},
+            external_mentions={},
+        )
+
+    monkeypatch.setattr("amx.codebase.analyzer.analyze_codebase", fake_analyze)
+
+    resp = client.post("/api/code/scan", headers=auth_headers, json={})
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+    _wait_for_status(client, job_id, "done")
+
+    assert captured.get("index_semantic") is True
+    # Per-file progress callback also wired in — the SPA depends on it.
+    assert callable(captured.get("progress_callback"))
+
+
+def test_studio_scan_persists_cached_report(client, auth_headers, cfg, monkeypatch) -> None:
+    """``save_cached_report`` must be invoked with the resolved code
+    profile name + source path so a follow-up ``/api/code/analyze``
+    finds the manifest the CLI wrote."""
+    cfg.code_profiles["repo"] = "/abs/repo"
+    cfg.active_code_profile = "repo"
+    _patch_db(monkeypatch)
+
+    fake_report = MagicMock(
+        total_files=1,
+        scanned_files=1,
+        references={},
+        external_mentions={},
+    )
+    monkeypatch.setattr(
+        "amx.codebase.analyzer.analyze_codebase",
+        lambda *a, **kw: fake_report,
+    )
+
+    save_calls: list[dict[str, Any]] = []
+
+    def _fake_save(**kwargs):
+        save_calls.append(kwargs)
+        from pathlib import Path
+
+        return Path("/tmp/dummy")
+
+    monkeypatch.setattr("amx.codebase.cache.save_cached_report", _fake_save)
+
+    resp = client.post(
+        "/api/code/scan",
+        headers=auth_headers,
+        json={"profile": "repo"},
+    )
+    assert resp.status_code == 200
+    _wait_for_status(client, resp.json()["job_id"], "done")
+
+    assert len(save_calls) == 1
+    call = save_calls[0]
+    assert call["profile_name"] == "repo"
+    assert call["source_path"] == "/abs/repo"
+    assert call["report"] is fake_report
+
+
+def test_studio_scan_syncs_search_catalog(client, auth_headers, cfg, monkeypatch) -> None:
+    """``SearchCatalog.sync_code_report`` must be called after the scan
+    so /search returns code-evidence rows."""
+    cfg.code_profiles["repo"] = "/abs/repo"
+    cfg.active_code_profile = "repo"
+    _patch_db(monkeypatch)
+
+    fake_report = MagicMock(
+        total_files=1,
+        scanned_files=1,
+        references={},
+        external_mentions={},
+    )
+    monkeypatch.setattr(
+        "amx.codebase.analyzer.analyze_codebase",
+        lambda *a, **kw: fake_report,
+    )
+    monkeypatch.setattr(
+        "amx.codebase.cache.save_cached_report",
+        lambda **kw: None,
+    )
+
+    sync_calls: list[dict[str, Any]] = []
+    fake_catalog = MagicMock()
+    fake_catalog.sync_code_report = MagicMock(
+        side_effect=lambda **kw: (sync_calls.append(kw), (0, 0))[1]
+    )
+    monkeypatch.setattr(
+        "amx.search.catalog.SearchCatalog.from_history_store",
+        classmethod(lambda cls: fake_catalog),
+    )
+
+    resp = client.post(
+        "/api/code/scan",
+        headers=auth_headers,
+        json={"profile": "repo"},
+    )
+    assert resp.status_code == 200
+    _wait_for_status(client, resp.json()["job_id"], "done")
+
+    assert len(sync_calls) == 1
+    call = sync_calls[0]
+    assert call["source_path"] == "/abs/repo"
+    assert call["report"] is fake_report
+
+
+def test_studio_scan_emits_per_file_progress(client, auth_headers, cfg, monkeypatch) -> None:
+    """The worker must invoke its per-file callback with each file
+    name so the SSE bus carries per-file progress events instead of a
+    single "Scanning…" line."""
+    cfg.code_profiles["repo"] = "/abs/repo"
+    cfg.active_code_profile = "repo"
+    _patch_db(monkeypatch)
+
+    callback_holder: dict[str, Any] = {}
+
+    def fake_analyze(path, **kw):
+        cb = kw.get("progress_callback")
+        callback_holder["cb"] = cb
+        # Simulate the analyzer driving the callback the same way the
+        # real one does: ``__total__`` once, then ``__advance__`` per file.
+        if cb is not None:
+            cb("__total__", 3)
+            cb("__advance__", "a.py")
+            cb("__advance__", "b.py")
+            cb("__advance__", "c.py")
+        return MagicMock(
+            total_files=3,
+            scanned_files=3,
+            references={},
+            external_mentions={},
+        )
+
+    monkeypatch.setattr("amx.codebase.analyzer.analyze_codebase", fake_analyze)
+    monkeypatch.setattr("amx.codebase.cache.save_cached_report", lambda **kw: None)
+
+    # Capture every SSE event the worker emits.
+    events: list[tuple[str, dict[str, Any]]] = []
+    real_emit = __import__("amx.web.progress_bus", fromlist=["emit"]).emit  # type: ignore[assignment]
+
+    def _spy_emit(queue, name, payload):
+        events.append((name, payload))
+        return real_emit(queue, name, payload)
+
+    monkeypatch.setattr("amx.web.routers.code_ops.emit", _spy_emit)
+
+    resp = client.post(
+        "/api/code/scan",
+        headers=auth_headers,
+        json={"profile": "repo"},
+    )
+    assert resp.status_code == 200
+    _wait_for_status(client, resp.json()["job_id"], "done")
+
+    progress_events = [p for n, p in events if n == "code.scan.progress"]
+    # One ``__total__`` event plus one per file.
+    assert len(progress_events) == 4
+    per_file = [p for p in progress_events if p["file_path"]]
+    assert [p["file_path"] for p in per_file] == ["a.py", "b.py", "c.py"]
+    assert per_file[-1]["processed_count"] == 3
+    assert per_file[-1]["total_count"] == 3

--- a/tests/web/test_code_search_respects_filter.py
+++ b/tests/web/test_code_search_respects_filter.py
@@ -1,0 +1,108 @@
+"""PR alpha — ``/api/code/search`` honours code-profile source filters.
+
+Before PR alpha the endpoint accepted a single optional ``profile=``
+and otherwise ran against the global Chroma collection — leaking
+hits from every indexed snippet regardless of the active scope.
+
+Now it:
+
+* accepts ``profile=`` repeatedly (``?profile=foo&profile=bar``) for
+  an explicit union override,
+* defaults to ``cfg.effective_code_paths()`` when the parameter is
+  omitted, matching how ``/api/docs/search`` scopes its results.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def test_default_uses_active_profile_paths(client, auth_headers, cfg, monkeypatch) -> None:
+    cfg.code_profiles["main"] = "/abs/main"
+    cfg.code_profiles["other"] = "/abs/other"
+    cfg.active_code_profile = "main"
+
+    captured: dict = {}
+
+    def _fake_count(persist_dir=None, source_filters=None):
+        captured["count_filters"] = list(source_filters or [])
+        return 7
+
+    def _fake_query(question, n_results=5, persist_dir=None, source_filters=None):
+        captured["query_filters"] = list(source_filters or [])
+        return [
+            {
+                "text": "hit",
+                "metadata": {"source": "/abs/main/a.py", "rel_path": "a.py"},
+                "distance": 0.1,
+            }
+        ]
+
+    monkeypatch.setattr("amx.codebase.code_rag.code_collection_count", _fake_count)
+    monkeypatch.setattr("amx.codebase.code_rag.query_code_snippets", _fake_query)
+
+    resp = client.get("/api/code/search?q=foo", headers=auth_headers)
+    assert resp.status_code == 200
+    assert captured["count_filters"] == ["/abs/main"]
+    assert captured["query_filters"] == ["/abs/main"]
+
+
+def test_explicit_profile_overrides_active(client, auth_headers, cfg, monkeypatch) -> None:
+    cfg.code_profiles["main"] = "/abs/main"
+    cfg.code_profiles["other"] = "/abs/other"
+    cfg.active_code_profile = "main"
+
+    captured: dict = {}
+
+    monkeypatch.setattr(
+        "amx.codebase.code_rag.code_collection_count",
+        lambda persist_dir=None, source_filters=None: (
+            captured.update(count_filters=list(source_filters or [])) or 3
+        ),
+    )
+    monkeypatch.setattr(
+        "amx.codebase.code_rag.query_code_snippets",
+        lambda question, n_results=5, persist_dir=None, source_filters=None: (
+            captured.update(query_filters=list(source_filters or [])) or []
+        ),
+    )
+
+    resp = client.get("/api/code/search?q=foo&profile=other", headers=auth_headers)
+    assert resp.status_code == 200
+    assert captured["query_filters"] == ["/abs/other"]
+
+
+def test_multi_profile_union(client, auth_headers, cfg, monkeypatch) -> None:
+    cfg.code_profiles["main"] = "/abs/main"
+    cfg.code_profiles["other"] = "/abs/other"
+    cfg.active_code_profile = "main"
+
+    captured: dict = {}
+
+    def _fake_count(persist_dir=None, source_filters=None):
+        captured["filters"] = list(source_filters or [])
+        return 0
+
+    monkeypatch.setattr("amx.codebase.code_rag.code_collection_count", _fake_count)
+    # ``query_code_snippets`` shouldn't be called when count is 0 —
+    # leave it as a sentinel that would explode if it were.
+    monkeypatch.setattr(
+        "amx.codebase.code_rag.query_code_snippets",
+        MagicMock(side_effect=AssertionError("should not be called")),
+    )
+
+    resp = client.get(
+        "/api/code/search?q=foo&profile=main&profile=other",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert sorted(captured["filters"]) == ["/abs/main", "/abs/other"]
+
+
+def test_unknown_profile_in_list_returns_404(client, auth_headers, cfg, monkeypatch) -> None:
+    cfg.code_profiles["main"] = "/abs/main"
+    resp = client.get(
+        "/api/code/search?q=foo&profile=main&profile=ghost",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
First PR of the code-RAG hardening series. Brings Studio code-scan/search to functional parity with the CLI.

- Studio `POST /api/code/scan` now actually builds the `amx_code` Chroma collection (`index_semantic=True`).
- Studio scan persists the cached report so `/api/code/analyze` works without dropping into the CLI.
- Studio scan syncs the search catalog (mirroring `commands/code.py:272-279`).
- Per-file SSE `code.scan.progress` events (`{file_path, processed_count, total_count}`) instead of a single "Scanning..." line.
- `POST /api/code/jobs/{id}/cancel` lets the SPA cancel an in-flight scan between files (never mid-file — partial Chroma upsert would orphan until PR beta's idempotent delete).
- `/api/code/search` accepts repeatable `profile=` and defaults to `cfg.effective_code_paths()`.

## Test plan
- [x] \`pytest -q\` (1572 passed)
- [x] \`ruff check amx tests\`
- [x] \`ruff format --check amx tests\`
- [x] New tests:
  - \`tests/web/test_code_scan_indexes.py\` (4 tests — index_semantic, cache persist, catalog sync, per-file SSE)
  - \`tests/web/test_code_cancellation.py\` (2 tests — 404 + worker exits between files)
  - \`tests/web/test_code_search_respects_filter.py\` (4 tests — default, override, multi-profile union, unknown 404)

Spec: \`docs/superpowers/specs/2026-05-12-code-rag-hardening-design.md\` (PR alpha section).