### PR TITLE
feat(code): storage correctness — embedding provider + idempotency + filters (PR beta)

### DIFF
--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -601,6 +601,27 @@ def _resolve_completion_mode(cfg: AMXConfig, llm: object, mode: str | None) -> b
     return use_batch
 
 
+def _record_code_unavailable_reason(
+    extra_metrics: dict[str, str],
+    exc: BaseException,
+) -> None:
+    """Record a one-line reason why the code RAG path could not be used.
+
+    Mirrors :func:`_record_rag_unavailable_reason` but writes
+    ``code_unavailable_reason`` on the run record so /history and
+    Studio can distinguish the two failure paths. ``CodeEmbeddingMismatch``
+    is tagged with an ``embedding_mismatch:`` prefix so downstream
+    tooling can render a remediation hint ("run /code-refresh")
+    instead of treating the run as a generic crash.
+    """
+    from amx.codebase.code_rag import CodeEmbeddingMismatch
+
+    if isinstance(exc, CodeEmbeddingMismatch):
+        extra_metrics["code_unavailable_reason"] = f"embedding_mismatch: {exc}"
+    else:
+        extra_metrics["code_unavailable_reason"] = f"{exc.__class__.__name__}: {exc}"
+
+
 def _record_rag_unavailable_reason(
     extra_metrics: dict[str, str],
     exc: BaseException,
@@ -1117,7 +1138,21 @@ def execute_analyze_run(
             provider=cfg.llm.provider,
             model=cfg.llm.model,
         ):
-            code_report = resolve_codebase_for_run(cfg, db, scope, code_profile, code_refresh)
+            try:
+                code_report = resolve_codebase_for_run(cfg, db, scope, code_profile, code_refresh)
+            except Exception as exc:  # noqa: BLE001 - downgrade to run diagnostic
+                from amx.codebase.code_rag import CodeEmbeddingMismatch
+
+                _record_code_unavailable_reason(extra_metrics, exc)
+                if isinstance(exc, CodeEmbeddingMismatch):
+                    error(f"Code RAG unavailable: {exc}. Run will proceed without code context.")
+                else:
+                    error(
+                        f"Code RAG unavailable: {exc.__class__.__name__}: {exc}. "
+                        "Run will proceed without code context."
+                    )
+                log.warning("Codebase resolve failed during analyze: %s", exc, exc_info=True)
+                code_report = None
         token_tracker.reset()
 
         # Per-schema orchestration loop (extracted in v0.9.4). Returns

--- a/amx/codebase/analyzer.py
+++ b/amx/codebase/analyzer.py
@@ -411,9 +411,13 @@ def analyze_codebase(
                 re.IGNORECASE,
             )
 
-        code_files = [
-            f for f in root.rglob("*") if f.is_file() and f.suffix.lower() in CODE_EXTENSIONS
-        ]
+        # Walk the tree via the shared helper so both the regex/AST
+        # analyzer and the semantic indexer agree on which files are
+        # in scope (skipping ``node_modules``, ``.git``, etc. and
+        # honouring ``.gitignore`` when ``pathspec`` is installed).
+        from amx.codebase.walker import walk_code_files
+
+        code_files = list(walk_code_files(root))
         report.total_files = len(code_files)
         if report.total_files == 0:
             exts = ", ".join(sorted(CODE_EXTENSIONS))
@@ -504,10 +508,15 @@ def analyze_codebase(
             ext_n,
         )
         if index_semantic and report.total_files:
-            try:
-                from amx.codebase.code_rag import index_codebase_tree
+            from amx.codebase.code_rag import CodeEmbeddingMismatch, index_codebase_tree
 
+            try:
                 index_codebase_tree(root, report=report, source_root=path)
+            except CodeEmbeddingMismatch:
+                # Propagate so the run-record helper can tag the
+                # failure with ``embedding_mismatch:`` instead of
+                # swallowing it as a generic warning.
+                raise
             except Exception as exc:
                 log.warning("Semantic code index failed: %s", exc)
         return report

--- a/amx/codebase/code_rag.py
+++ b/amx/codebase/code_rag.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import json
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from amx.utils.optional_deps import ensure as _ensure
+
+if TYPE_CHECKING:
+    from chromadb.api.types import EmbeddingFunction
 
 # Codebase RAG shares the ``rag`` bundle (chromadb + splitter +
 # tiktoken) with /docs and /search; whichever feature the user
@@ -17,11 +22,91 @@ import chromadb  # noqa: E402
 from langchain_text_splitters import RecursiveCharacterTextSplitter  # noqa: E402
 
 from amx.codebase.analyzer import CODE_EXTENSIONS, CodebaseReport  # noqa: E402
+from amx.codebase.walker import walk_code_files  # noqa: E402
 from amx.utils.logging import get_logger  # noqa: E402
 
 log = get_logger("codebase.code_rag")
 
 COLLECTION = "amx_code"
+
+# Schema version for the code RAG collection metadata. Bumped when the
+# metadata shape changes in a way old AMX cannot read. Mirrors the
+# value used by the docs RAG store so the two indexes evolve together.
+_AMX_CODE_SCHEMA_VERSION = 1
+
+
+class CodeEmbeddingMismatch(RuntimeError):
+    """Raised when the active embedding provider does not match the
+    one used to populate the existing ``amx_code`` collection.
+
+    The collection metadata records the provider/model used at first
+    create. If the user later switches embedding providers (via
+    ``/embeddings``) the existing vectors are in a different semantic
+    space, so retrieval would silently degrade. Raising here forces an
+    explicit reindex or revert decision.
+    """
+
+    def __init__(
+        self,
+        *,
+        recorded_provider: str,
+        recorded_model: str,
+        active_provider: str,
+        active_model: str,
+    ) -> None:
+        self.recorded_provider = recorded_provider
+        self.recorded_model = recorded_model
+        self.active_provider = active_provider
+        self.active_model = active_model
+        super().__init__(
+            f"Code RAG collection was indexed with provider={recorded_provider} "
+            f"model={recorded_model}. Current config says provider={active_provider} "
+            f"model={active_model}. "
+            "Run `/code-refresh` to rebuild the collection with the active provider, "
+            "or update the embedding profile to match the indexed model."
+        )
+
+
+def _resolve_active_embedding(
+    cfg: Any | None = None,
+) -> tuple[str, str, EmbeddingFunction | None]:
+    """Resolve ``(provider, model, embedding_function)`` from config.
+
+    Mirrors :func:`amx.docs.rag._resolve_active_embedding` so the code
+    path honours the same embedding provider as the docs path. Imports
+    are deferred to avoid a circular import (``amx.search.embeddings``
+    pulls Chroma which pulls this module on some platforms).
+    """
+    from amx.search.embeddings import make_embedding_function
+
+    if cfg is None:
+        try:
+            from amx.config import AMXConfig
+
+            cfg = AMXConfig.load()
+        except Exception:
+            cfg = None
+
+    embedding = getattr(cfg, "embedding", None) if cfg is not None else None
+    if embedding is None:
+        return ("minilm", "minilm-l6-v2", None)
+
+    kind = (getattr(embedding, "kind", "") or "minilm").lower().strip()
+    model = getattr(embedding, "model", "") or ""
+    api_key = getattr(embedding, "api_key", "") or ""
+    base_url = getattr(embedding, "base_url", "") or ""
+
+    if kind in {"", "minilm", "default", "minilm-l6-v2"}:
+        return ("minilm", "minilm-l6-v2", None)
+
+    if not model:
+        return ("minilm", "minilm-l6-v2", None)
+
+    try:
+        ef = make_embedding_function(kind, model=model, api_key=api_key, base_url=base_url)
+    except Exception:
+        return ("minilm", "minilm-l6-v2", None)
+    return (kind, model, ef)
 
 
 def _normalize_source_filter(source: str) -> str:
@@ -59,9 +144,126 @@ def _iter_python_chunks(rel_path: str, content: str) -> list[tuple[str, str]]:
     return chunks
 
 
+def _iter_ipynb_chunks(rel_path: str, content: str) -> list[tuple[str, str, str]]:
+    """Cell-aware ``.ipynb`` chunker.
+
+    Returns a list of ``(chunk_id_suffix, text, kind)`` tuples where
+    ``kind`` is one of ``"ipynb_code"`` / ``"ipynb_md"``. Cell outputs
+    are deliberately dropped — they're noisy, often huge (base64
+    images), and rarely useful for code retrieval.
+
+    On malformed JSON the caller falls back to the generic splitter
+    (returning ``None`` signals that to the loop without raising).
+    """
+    try:
+        nb = json.loads(content)
+    except json.JSONDecodeError:
+        log.warning("Failed to parse .ipynb at %s, falling back to text split", rel_path)
+        return []
+
+    out: list[tuple[str, str, str]] = []
+    cells = nb.get("cells") or []
+    for idx, cell in enumerate(cells):
+        cell_type = str(cell.get("cell_type") or "").lower()
+        if cell_type not in {"code", "markdown"}:
+            continue
+        source = cell.get("source") or ""
+        text = "".join(str(piece) for piece in source) if isinstance(source, list) else str(source)
+        if not text.strip():
+            continue
+        kind = "ipynb_code" if cell_type == "code" else "ipynb_md"
+        out.append((f"cell{idx}", text[:12000], kind))
+    return out
+
+
 def _split_fallback(text: str, max_chars: int = 4000) -> list[str]:
     sp = RecursiveCharacterTextSplitter(chunk_size=max_chars, chunk_overlap=200)
     return sp.split_text(text)
+
+
+def _manifest_path(persist_dir: str, source_root: str) -> Path:
+    """Resolve the sidecar manifest path for ``source_root``.
+
+    Stored under ``<persist_dir>/../code_cache/<slug>/index_manifest.json``
+    where the slug is a stable hash of the source root. Used to detect
+    files that disappeared between scans so their chunks can be
+    deleted (a pure ``upsert`` cannot infer deletion).
+    """
+    slug = hashlib.sha256(source_root.encode()).hexdigest()[:16]
+    base = Path(persist_dir).expanduser().resolve().parent / "code_cache" / slug
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "index_manifest.json"
+
+
+def _load_manifest(path: Path) -> list[str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    files = data.get("files") if isinstance(data, dict) else None
+    return [str(p) for p in files] if isinstance(files, list) else []
+
+
+def _save_manifest(path: Path, files: list[str]) -> None:
+    try:
+        path.write_text(
+            json.dumps({"files": sorted(set(files))}, indent=2),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        log.warning("Could not write code index manifest %s: %s", path, exc)
+
+
+def _open_collection(
+    client: chromadb.PersistentClient,
+    *,
+    embedding_provider: str,
+    embedding_model: str,
+    embedding_function: EmbeddingFunction | None,
+):
+    """Open / create the ``amx_code`` collection and reconcile metadata.
+
+    See :class:`amx.docs.rag.RAGStore.__init__` for the parallel
+    docs-path implementation. Raises :class:`CodeEmbeddingMismatch`
+    when the recorded provider/model disagree with the active config.
+    """
+    kwargs: dict[str, Any] = {
+        "name": COLLECTION,
+        "metadata": {
+            "hnsw:space": "cosine",
+            "embedding_provider": embedding_provider,
+            "embedding_model": embedding_model,
+            "amx_schema_version": _AMX_CODE_SCHEMA_VERSION,
+        },
+    }
+    if embedding_function is not None:
+        kwargs["embedding_function"] = embedding_function
+    coll = client.get_or_create_collection(**kwargs)
+
+    existing_meta = dict(coll.metadata or {})
+    recorded_provider = existing_meta.get("embedding_provider")
+    recorded_model = existing_meta.get("embedding_model")
+    if recorded_provider and recorded_model:
+        if recorded_provider != embedding_provider or recorded_model != embedding_model:
+            raise CodeEmbeddingMismatch(
+                recorded_provider=str(recorded_provider),
+                recorded_model=str(recorded_model),
+                active_provider=str(embedding_provider),
+                active_model=str(embedding_model),
+            )
+    else:
+        # Pre-PR-beta collection — backfill metadata silently. Strip
+        # ``hnsw:*`` keys before modify(): Chroma rejects construction-
+        # time parameters even when the value is unchanged.
+        merged = {k: v for k, v in existing_meta.items() if not str(k).startswith("hnsw:")}
+        merged["embedding_provider"] = embedding_provider
+        merged["embedding_model"] = embedding_model
+        merged["amx_schema_version"] = _AMX_CODE_SCHEMA_VERSION
+        try:
+            coll.modify(metadata=merged)
+        except Exception as exc:
+            log.warning("Could not backfill code RAG collection metadata: %s", exc)
+    return coll
 
 
 def index_codebase_tree(
@@ -70,20 +272,26 @@ def index_codebase_tree(
     report: CodebaseReport | None = None,
     persist_dir: str | None = None,
     source_root: str | None = None,
+    cfg: Any | None = None,
 ) -> int:
     """Chunk Python (AST) and other code files; upsert into ``amx_code`` collection."""
     persist = persist_dir or str(Path.home() / ".amx" / "chroma_db")
     Path(persist).mkdir(parents=True, exist_ok=True)
     client = chromadb.PersistentClient(path=persist)
-    coll = client.get_or_create_collection(
-        name=COLLECTION,
-        metadata={"hnsw:space": "cosine"},
+
+    provider, model, ef = _resolve_active_embedding(cfg)
+    coll = _open_collection(
+        client,
+        embedding_provider=provider,
+        embedding_model=model,
+        embedding_function=ef,
     )
 
-    code_files = [f for f in root.rglob("*") if f.is_file() and f.suffix.lower() in CODE_EXTENSIONS]
+    code_files = list(walk_code_files(root))
     total = 0
     root_s = str(root.resolve())
     source_root_s = _normalize_source_filter(source_root or root_s)
+    indexed_rels: list[str] = []
     for fpath in code_files:
         rel = str(fpath.relative_to(root))
         try:
@@ -92,26 +300,98 @@ def index_codebase_tree(
             continue
         suffix = fpath.suffix.lower()
         pieces: list[tuple[str, str]] = []
+        # ``per_chunk_kind`` lets the ipynb path stamp distinct chunk
+        # kinds per cell type without forcing a third tuple position
+        # on the AST / generic splits.
+        per_chunk_kind: dict[str, str] = {}
         if suffix == ".py":
             pieces = _iter_python_chunks(rel, text)
+        elif suffix == ".ipynb":
+            cell_chunks = _iter_ipynb_chunks(rel, text)
+            if cell_chunks:
+                for cid, chunk, kind in cell_chunks:
+                    pieces.append((cid, chunk))
+                    per_chunk_kind[cid] = kind
+            elif text.strip():
+                # Malformed notebook — fall back to the generic
+                # splitter so we still produce something rather than
+                # leaving the file unindexed.
+                for i, part in enumerate(_split_fallback(text)):
+                    pieces.append((f"part{i}", part))
         else:
             for i, part in enumerate(_split_fallback(text)):
                 pieces.append((f"part{i}", part))
 
+        # Pre-compute the chunk IDs the file will produce so we can
+        # find orphans from a previous larger version of the same file
+        # and delete them BEFORE upsert. Closes the
+        # function-rename / shrink / delete bug.
+        new_ids: list[str] = []
+        new_payload: list[tuple[str, str, dict[str, Any]]] = []
         for cid, chunk in pieces:
             if not chunk.strip():
                 continue
             h = hashlib.sha256(f"{root_s}:{rel}:{cid}".encode()).hexdigest()[:24]
             doc_id = f"code::{h}"
+            if suffix == ".py":
+                kind = "python_ast"
+            elif suffix == ".ipynb":
+                kind = per_chunk_kind.get(cid, "text_split")
+            else:
+                kind = "text_split"
             meta = {
                 "source": f"{root_s}/{rel}",
                 "source_root": source_root_s,
                 "rel_path": rel,
                 "chunk_id": cid,
-                "kind": "python_ast" if suffix == ".py" else "text_split",
+                "kind": kind,
             }
-            coll.upsert(ids=[doc_id], documents=[chunk], metadatas=[meta])
-            total += 1
+            new_ids.append(doc_id)
+            new_payload.append((doc_id, chunk, meta))
+
+        try:
+            existing = coll.get(where={"rel_path": rel}, include=[])
+            existing_ids = set(existing.get("ids") or [])
+        except Exception as exc:
+            log.warning("Could not enumerate existing code chunks for %s: %s", rel, exc)
+            existing_ids = set()
+        orphans = sorted(existing_ids - set(new_ids))
+        if orphans:
+            try:
+                coll.delete(ids=orphans)
+                log.info(
+                    "Deleted %d orphan code chunk(s) for %s before re-ingest",
+                    len(orphans),
+                    rel,
+                )
+            except Exception as exc:
+                log.warning("Could not delete orphan code chunks for %s: %s", rel, exc)
+
+        if new_payload:
+            ids = [p[0] for p in new_payload]
+            docs = [p[1] for p in new_payload]
+            metas = [p[2] for p in new_payload]
+            coll.upsert(ids=ids, documents=docs, metadatas=metas)
+            total += len(new_payload)
+            indexed_rels.append(rel)
+
+    # File-deletion detection via sidecar manifest. Compare the
+    # previous walk to this one; anything missing is gone from the
+    # tree and its chunks must be evicted.
+    manifest = _manifest_path(persist, source_root_s or root_s)
+    previous = set(_load_manifest(manifest))
+    current = set(indexed_rels)
+    removed_files = sorted(previous - current)
+    for dead_rel in removed_files:
+        try:
+            res = coll.get(where={"rel_path": dead_rel}, include=[])
+            dead_ids = list(res.get("ids") or [])
+            if dead_ids:
+                coll.delete(ids=dead_ids)
+                log.info("Deleted %d chunk(s) for removed file %s", len(dead_ids), dead_rel)
+        except Exception as exc:
+            log.warning("Could not evict chunks for removed file %s: %s", dead_rel, exc)
+    _save_manifest(manifest, indexed_rels)
 
     if report:
         log.info(
@@ -128,11 +408,26 @@ def query_code_snippets(
     n_results: int = 5,
     persist_dir: str | None = None,
     source_filters: list[str] | None = None,
+    *,
+    cfg: Any | None = None,
 ) -> list[dict]:
     persist = persist_dir or str(Path.home() / ".amx" / "chroma_db")
     client = chromadb.PersistentClient(path=persist)
     try:
-        coll = client.get_collection(COLLECTION)
+        # Honour cfg.embedding here too so a query running with a
+        # custom provider can hit the collection it indexed earlier.
+        provider, model, ef = _resolve_active_embedding(cfg)
+        coll = _open_collection(
+            client,
+            embedding_provider=provider,
+            embedding_model=model,
+            embedding_function=ef,
+        )
+    except CodeEmbeddingMismatch:
+        # Propagate the structured error so callers (agents, CLI,
+        # Studio) can surface a remediation hint rather than silently
+        # returning no hits.
+        raise
     except Exception:
         return []
     filters = [_normalize_source_filter(s) for s in (source_filters or []) if s]
@@ -218,3 +513,18 @@ def _source_allowed(metadata: dict | None, filters: list[str]) -> bool:
         if src and (src == flt or src.startswith(flt)):
             return True
     return False
+
+
+__all__ = [
+    "CodeEmbeddingMismatch",
+    "COLLECTION",
+    "code_collection_count",
+    "delete_code_collection",
+    "index_codebase_tree",
+    "query_code_snippets",
+]
+
+
+# Keep the extension list importable from here for any external
+# tooling that already depends on it.
+_ = CODE_EXTENSIONS

--- a/amx/codebase/walker.py
+++ b/amx/codebase/walker.py
@@ -1,0 +1,93 @@
+"""Shared filesystem walker for codebase scans.
+
+Both :func:`amx.codebase.analyzer.analyze_codebase` and
+:func:`amx.codebase.code_rag.index_codebase_tree` walk a repository
+root and pick code files. Historically each ran a naive
+``root.rglob("*")``, which dragged ``node_modules``, ``.git``, packed
+vendor directories, and build artefacts into the index. PR beta of
+the code-RAG hardening series consolidates the walk here so both
+sides apply the same two-layer filter:
+
+1. Hard-coded denylist of directory names that are never indexed.
+2. Optional ``.gitignore`` matcher (when ``pathspec`` is installed) —
+   reuses the helper from :mod:`amx.docs.scanner`.
+
+Either layer alone is enough to skip a path, mirroring how the docs
+scanner already behaves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from amx.codebase.analyzer import CODE_EXTENSIONS
+
+# Directory basenames that should never be traversed regardless of any
+# ``.gitignore`` content. Keeping this list small and unsurprising on
+# purpose: extending it is a behavioural change and needs a follow-up
+# PR / test, not a silent edit.
+_NEVER_INDEX_DIRS: frozenset[str] = frozenset(
+    {
+        "node_modules",
+        ".git",
+        ".venv",
+        "venv",
+        "dist",
+        "build",
+        "target",
+        "vendor",
+        ".next",
+        ".cache",
+        "__pycache__",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        "site-packages",
+        "egg-info",
+    }
+)
+
+
+def _load_gitignore_matcher(root: Path):
+    """Thin re-export of the docs-scanner helper.
+
+    Kept as a wrapper so a future move (e.g. to ``amx/utils/gitignore.py``)
+    only changes one import site. ``pathspec`` is optional; the helper
+    already degrades to ``None`` when it isn't installed.
+    """
+    from amx.docs.scanner import _load_gitignore_matcher as _impl
+
+    return _impl(root)
+
+
+def _is_under_denylist(rel_parts: tuple[str, ...]) -> bool:
+    """Return ``True`` when any path segment matches a denylisted dir."""
+    return any(part in _NEVER_INDEX_DIRS for part in rel_parts)
+
+
+def walk_code_files(root: Path) -> Iterator[Path]:
+    """Yield code files under ``root`` honouring the denylist + ``.gitignore``.
+
+    Yields absolute ``Path`` objects whose suffix is in
+    :data:`amx.codebase.analyzer.CODE_EXTENSIONS`. The traversal order
+    is sorted for deterministic test fixtures and reproducible chunk
+    ids.
+    """
+    matcher = _load_gitignore_matcher(root)
+    for f in sorted(root.rglob("*")):
+        if not f.is_file():
+            continue
+        if f.suffix.lower() not in CODE_EXTENSIONS:
+            continue
+        try:
+            rel_parts = f.relative_to(root).parts
+        except ValueError:
+            continue
+        if _is_under_denylist(rel_parts):
+            continue
+        if matcher is not None:
+            rel_posix = f.relative_to(root).as_posix()
+            if rel_posix and matcher.match_file(rel_posix):
+                continue
+        yield f

--- a/amx/services/analyze_scope.py
+++ b/amx/services/analyze_scope.py
@@ -443,5 +443,12 @@ def resolve_codebase_for_run(
                     warn(f"Could not save codebase cache: {exc}")
             merged_report = merge_codebase_reports(merged_report, report)
         except Exception as exc:
+            # Embedding-provider mismatch must propagate so the run
+            # record's ``code_unavailable_reason`` gets tagged with
+            # ``embedding_mismatch:`` (rather than buried as a warn).
+            from amx.codebase.code_rag import CodeEmbeddingMismatch
+
+            if isinstance(exc, CodeEmbeddingMismatch):
+                raise
             warn(f"Codebase analysis failed for {code_path}: {exc}")
     return merged_report

--- a/tests/test_code_gitignore_filter.py
+++ b/tests/test_code_gitignore_filter.py
@@ -1,0 +1,96 @@
+"""Filesystem filter checks for :func:`amx.codebase.walker.walk_code_files`.
+
+Pins three behaviours added in PR beta of the code-RAG hardening
+series:
+
+1. Directories under the hard-coded denylist (``node_modules``,
+   ``.git``, ``.venv``, ``dist``, ``build``, …) are always skipped.
+2. A ``.gitignore`` at the repo root excludes matching files when
+   ``pathspec`` is installed.
+3. With ``pathspec`` monkey-patched away the walker still applies the
+   denylist (graceful degrade).
+"""
+
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+
+from amx.codebase.walker import walk_code_files
+
+
+def _touch(path: Path, body: str = "x = 1\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def test_walker_skips_node_modules(tmp_path: Path) -> None:
+    _touch(tmp_path / "app.py", "def f():\n    return 1\n")
+    _touch(tmp_path / "node_modules" / "lib" / "junk.js")
+    _touch(tmp_path / ".git" / "hooks" / "post-commit.sh")
+    _touch(tmp_path / "__pycache__" / "stale.py")
+
+    rels = sorted(p.relative_to(tmp_path).as_posix() for p in walk_code_files(tmp_path))
+    assert "app.py" in rels
+    assert not any("node_modules" in r for r in rels)
+    assert not any(r.startswith(".git/") for r in rels)
+    assert not any("__pycache__" in r for r in rels)
+
+
+def test_walker_honours_gitignore(tmp_path: Path) -> None:
+    _touch(tmp_path / "keep.py", "def k():\n    return 1\n")
+    _touch(tmp_path / "secret.py", "def s():\n    return 2\n")
+    (tmp_path / ".gitignore").write_text("secret.py\n", encoding="utf-8")
+
+    pathspec = pytest_importorskip_inline("pathspec")
+    if pathspec is None:
+        return  # pathspec not installed in this environment
+
+    rels = sorted(p.relative_to(tmp_path).as_posix() for p in walk_code_files(tmp_path))
+    assert "keep.py" in rels
+    assert "secret.py" not in rels
+
+
+def test_walker_handles_missing_pathspec(tmp_path: Path, monkeypatch) -> None:
+    _touch(tmp_path / "keep.py", "def k():\n    return 1\n")
+    _touch(tmp_path / "node_modules" / "x.js")
+    (tmp_path / ".gitignore").write_text("keep.py\n", encoding="utf-8")
+
+    real_import = builtins.__import__
+
+    def _no_pathspec(name, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if name == "pathspec":
+            raise ImportError("pathspec unavailable in this test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_pathspec)
+
+    rels = sorted(p.relative_to(tmp_path).as_posix() for p in walk_code_files(tmp_path))
+    # Without pathspec the .gitignore rule is ignored — keep.py is
+    # still emitted — but the denylist still skips node_modules.
+    assert "keep.py" in rels
+    assert not any("node_modules" in r for r in rels)
+
+
+def test_walker_includes_normal_python(tmp_path: Path) -> None:
+    _touch(tmp_path / "src" / "module.py", "def f():\n    return 1\n")
+    _touch(tmp_path / "src" / "nested" / "thing.py")
+
+    rels = sorted(p.relative_to(tmp_path).as_posix() for p in walk_code_files(tmp_path))
+    assert "src/module.py" in rels
+    assert "src/nested/thing.py" in rels
+
+
+# ── tiny helper so the gitignore test no-ops on environments where
+#    pathspec genuinely isn't installed (CI matrix may exclude the
+#    optional dep). ``pytest.importorskip`` would skip the whole test,
+#    but we want to assert the denylist behaviour even when pathspec
+#    is missing — those checks live in the other tests.
+
+
+def pytest_importorskip_inline(name: str):  # noqa: D401 - tiny helper
+    """Return the imported module or ``None`` when not installed."""
+    try:
+        return __import__(name)
+    except Exception:
+        return None

--- a/tests/test_code_ipynb_cells.py
+++ b/tests/test_code_ipynb_cells.py
@@ -1,0 +1,139 @@
+"""Cell-aware ``.ipynb`` chunker for the code RAG (PR beta).
+
+Pins the behaviour of :func:`amx.codebase.code_rag._iter_ipynb_chunks`
+and its integration with :func:`index_codebase_tree`:
+
+* Code cells become ``ipynb_code`` chunks; markdown cells become
+  ``ipynb_md`` chunks.
+* Cell outputs are dropped on the floor.
+* Malformed JSON falls back to the generic splitter instead of
+  raising.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import chromadb
+
+from amx.codebase.code_rag import (
+    COLLECTION,
+    _iter_ipynb_chunks,
+    index_codebase_tree,
+)
+
+
+def _make_notebook(cells: list[dict]) -> str:
+    return json.dumps(
+        {
+            "cells": cells,
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+    )
+
+
+def test_ipynb_code_cells_become_chunks(tmp_path: Path) -> None:
+    nb = _make_notebook(
+        [
+            {
+                "cell_type": "code",
+                "source": ["import pandas as pd\n", "df = pd.DataFrame()\n"],
+                "outputs": [{"output_type": "stream", "text": "ignored"}],
+            },
+        ]
+    )
+    chunks = _iter_ipynb_chunks("nb.ipynb", nb)
+    assert len(chunks) == 1
+    cid, text, kind = chunks[0]
+    assert kind == "ipynb_code"
+    assert "pandas" in text
+    assert "ignored" not in text
+    assert cid == "cell0"
+
+
+def test_ipynb_markdown_cells_become_chunks(tmp_path: Path) -> None:
+    nb = _make_notebook(
+        [
+            {"cell_type": "markdown", "source": "# Heading\n\nSome prose."},
+            {"cell_type": "code", "source": "x = 1\n"},
+        ]
+    )
+    chunks = _iter_ipynb_chunks("nb.ipynb", nb)
+    assert len(chunks) == 2
+    kinds = {c[2] for c in chunks}
+    assert kinds == {"ipynb_md", "ipynb_code"}
+
+
+def test_ipynb_outputs_are_dropped(tmp_path: Path) -> None:
+    nb = _make_notebook(
+        [
+            {
+                "cell_type": "code",
+                "source": "print('hello')\n",
+                "outputs": [
+                    {"output_type": "stream", "name": "stdout", "text": "OUTPUT_LEAK"},
+                    {
+                        "output_type": "display_data",
+                        "data": {"image/png": "BASE64_LEAK_PAYLOAD"},
+                    },
+                ],
+            }
+        ]
+    )
+    chunks = _iter_ipynb_chunks("nb.ipynb", nb)
+    blob = "\n".join(c[1] for c in chunks)
+    assert "OUTPUT_LEAK" not in blob
+    assert "BASE64_LEAK_PAYLOAD" not in blob
+
+
+def test_ipynb_empty_cells_are_skipped() -> None:
+    nb = _make_notebook(
+        [
+            {"cell_type": "code", "source": "   \n\t\n"},
+            {"cell_type": "markdown", "source": ""},
+            {"cell_type": "code", "source": "real = 1\n"},
+        ]
+    )
+    chunks = _iter_ipynb_chunks("nb.ipynb", nb)
+    assert len(chunks) == 1
+    assert chunks[0][2] == "ipynb_code"
+
+
+def test_malformed_ipynb_falls_back_gracefully(tmp_path: Path) -> None:
+    chunks = _iter_ipynb_chunks("broken.ipynb", "{ this is not json")
+    # Returning the empty list signals "use the generic splitter".
+    assert chunks == []
+
+
+def test_index_codebase_tree_indexes_ipynb_cells(tmp_path: Path) -> None:
+    persist = tmp_path / "chroma"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    nb_path = repo / "demo.ipynb"
+    nb_path.write_text(
+        _make_notebook(
+            [
+                {"cell_type": "markdown", "source": "# Demo\n"},
+                {
+                    "cell_type": "code",
+                    "source": "import pandas\n",
+                    "outputs": [{"output_type": "stream", "text": "drop"}],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    n = index_codebase_tree(repo, persist_dir=str(persist), source_root=str(repo))
+    assert n >= 2
+
+    client = chromadb.PersistentClient(path=str(persist))
+    coll = client.get_collection(COLLECTION)
+    rows = coll.get(where={"rel_path": "demo.ipynb"}, include=["metadatas", "documents"])
+    kinds = {(m or {}).get("kind") for m in (rows.get("metadatas") or [])}
+    assert kinds == {"ipynb_md", "ipynb_code"}
+    docs = rows.get("documents") or []
+    assert all("drop" not in d for d in docs)

--- a/tests/test_code_storage_correctness.py
+++ b/tests/test_code_storage_correctness.py
@@ -1,0 +1,253 @@
+"""Storage correctness for the code RAG (PR beta).
+
+Mirrors :mod:`tests.test_rag_storage_correctness` for the code path:
+
+1. The ``amx_code`` collection records ``embedding_provider`` /
+   ``embedding_model`` on first create so a later reopen can detect a
+   provider switch.
+2. Reopening with a different provider raises
+   :class:`CodeEmbeddingMismatch`; a pre-PR-beta collection without
+   those metadata keys is grandfathered in and gets the metadata
+   back-filled silently.
+3. Re-indexing a file deletes orphan chunks (shrink / function rename /
+   file removal) before upserting the new ones.
+4. ``analyze_flow`` tags the mismatch with an ``embedding_mismatch:``
+   prefix on ``code_unavailable_reason``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import chromadb
+import pytest
+
+from amx.codebase import code_rag
+from amx.codebase.code_rag import (
+    COLLECTION,
+    CodeEmbeddingMismatch,
+    index_codebase_tree,
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_embedding_resolver(monkeypatch):
+    """Bypass the real :func:`make_embedding_function` so tests can
+    pretend to use ``openai_compatible``/``sentence_transformers``
+    without hitting the network or requiring the optional deps.
+
+    The mismatch check operates on the recorded ``embedding_provider`` /
+    ``embedding_model`` metadata strings; the actual ``ef`` object is
+    irrelevant to it. Returning ``None`` means Chroma falls back to its
+    bundled default which is fine for the test's purposes (we never
+    enqueue real vectors to compare).
+    """
+    current: dict[str, tuple[str, str]] = {"value": ("minilm", "minilm-l6-v2")}
+
+    def _fake_resolve(cfg=None):
+        emb = getattr(cfg, "embedding", None)
+        if emb is not None:
+            return (
+                getattr(emb, "kind", "minilm"),
+                getattr(emb, "model", "minilm-l6-v2"),
+                None,
+            )
+        return (*current["value"], None)
+
+    monkeypatch.setattr(code_rag, "_resolve_active_embedding", _fake_resolve)
+    yield current
+
+
+def _seed_collection(
+    persist: Path,
+    *,
+    provider: str = "minilm",
+    model: str = "minilm-l6-v2",
+) -> None:
+    """Force-create the collection with explicit provider metadata.
+
+    Uses a tiny throwaway repo so :func:`index_codebase_tree` does the
+    create-path work (and stamps metadata) for us; keeps the test
+    aligned with the production helper rather than poking Chroma
+    directly.
+    """
+    repo = persist.parent / f"seed_{provider}"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "x.py").write_text("def x():\n    return 1\n", encoding="utf-8")
+
+    class _FakeEmbedding:
+        def __init__(self, k: str, m: str) -> None:
+            self.kind = k
+            self.model = m
+            self.api_key = ""
+            self.base_url = ""
+
+    class _FakeCfg:
+        def __init__(self, k: str, m: str) -> None:
+            self.embedding = _FakeEmbedding(k, m)
+
+    index_codebase_tree(
+        repo,
+        persist_dir=str(persist),
+        source_root=str(repo),
+        cfg=_FakeCfg(provider, model),
+    )
+
+
+# ── metadata recorded on first create ────────────────────────────────
+
+
+def test_collection_records_embedding_metadata_on_create(tmp_path: Path) -> None:
+    persist = tmp_path / "chroma"
+    _seed_collection(persist, provider="minilm", model="minilm-l6-v2")
+    client = chromadb.PersistentClient(path=str(persist))
+    coll = client.get_collection(COLLECTION)
+    meta = dict(coll.metadata or {})
+    assert meta.get("embedding_provider") == "minilm"
+    assert meta.get("embedding_model") == "minilm-l6-v2"
+    assert meta.get("amx_schema_version") == 1
+
+
+# ── mismatch raises ──────────────────────────────────────────────────
+
+
+def test_mismatch_raises_code_embedding_mismatch(tmp_path: Path) -> None:
+    persist = tmp_path / "chroma"
+    _seed_collection(persist, provider="openai_compatible", model="text-embedding-3-small")
+    # Reopen with provider B; expect the structured mismatch error.
+    with pytest.raises(CodeEmbeddingMismatch) as excinfo:
+        _seed_collection(persist, provider="minilm", model="minilm-l6-v2")
+    msg = str(excinfo.value)
+    assert "openai_compatible" in msg
+    assert "text-embedding-3-small" in msg
+    assert "minilm" in msg
+    assert "/code-refresh" in msg
+
+
+# ── grandfather rule for pre-PR-beta collections ─────────────────────
+
+
+def test_pre_existing_collection_without_metadata_is_grandfathered(
+    tmp_path: Path,
+) -> None:
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    # Simulate a pre-PR-beta collection: only the ``hnsw:space`` key.
+    client = chromadb.PersistentClient(path=str(persist))
+    client.get_or_create_collection(name=COLLECTION, metadata={"hnsw:space": "cosine"})
+
+    _seed_collection(persist, provider="minilm", model="minilm-l6-v2")
+
+    coll = client.get_collection(COLLECTION)
+    backfilled = dict(coll.metadata or {})
+    assert backfilled.get("embedding_provider") == "minilm"
+    assert backfilled.get("embedding_model") == "minilm-l6-v2"
+
+
+# ── idempotency ──────────────────────────────────────────────────────
+
+
+def _ids_for_rel(persist: Path, rel: str) -> list[str]:
+    client = chromadb.PersistentClient(path=str(persist))
+    coll = client.get_collection(COLLECTION)
+    return list(coll.get(where={"rel_path": rel}, include=[]).get("ids") or [])
+
+
+def test_idempotent_ingest_deletes_orphan_chunks_on_shrink(tmp_path: Path) -> None:
+    persist = tmp_path / "chroma"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    src = repo / "lots.py"
+    # Three functions → three AST chunks. The chunker drops segments
+    # shorter than 40 chars, so each body is padded with a long
+    # docstring that lives inside the function (counts toward the
+    # source segment, unlike a trailing comment which AST excludes).
+    pad = "x" * 200
+    src.write_text(
+        "\n\n".join([f'def fn_{i}(x):\n    """{pad}"""\n    return x + {i}\n' for i in range(3)]),
+        encoding="utf-8",
+    )
+    index_codebase_tree(repo, persist_dir=str(persist), source_root=str(repo))
+    initial = _ids_for_rel(persist, "lots.py")
+    assert len(initial) == 3
+
+    # Shrink to a single function — expect only one chunk to remain.
+    src.write_text(
+        f'def only_one(x):\n    """{pad}"""\n    return x\n',
+        encoding="utf-8",
+    )
+    index_codebase_tree(repo, persist_dir=str(persist), source_root=str(repo))
+    final = _ids_for_rel(persist, "lots.py")
+    assert len(final) == 1
+
+
+def test_idempotent_ingest_deletes_orphans_on_file_removal(tmp_path: Path) -> None:
+    persist = tmp_path / "chroma"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    keep = repo / "keep.py"
+    drop = repo / "drop.py"
+    pad = "p" * 200
+    keep.write_text(f'def keep_me():\n    """{pad}"""\n    return 1\n', encoding="utf-8")
+    drop.write_text(f'def drop_me():\n    """{pad}"""\n    return 2\n', encoding="utf-8")
+    index_codebase_tree(repo, persist_dir=str(persist), source_root=str(repo))
+    assert _ids_for_rel(persist, "drop.py")
+
+    drop.unlink()
+    index_codebase_tree(repo, persist_dir=str(persist), source_root=str(repo))
+    assert _ids_for_rel(persist, "drop.py") == []
+    assert _ids_for_rel(persist, "keep.py")
+
+
+def test_idempotent_ingest_handles_function_rename(tmp_path: Path) -> None:
+    persist = tmp_path / "chroma"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    src = repo / "rename.py"
+    pad = "r" * 200
+    src.write_text(
+        f'def original_name(x):\n    """{pad}"""\n    return x + 1\n',
+        encoding="utf-8",
+    )
+    index_codebase_tree(repo, persist_dir=str(persist), source_root=str(repo))
+    before = sorted(_ids_for_rel(persist, "rename.py"))
+    assert before  # at least one chunk exists
+
+    # Rename the function — chunk id suffix changes (function name +
+    # lineno), so the doc_id hash changes too. The old id must be
+    # deleted by the per-file pre-delete step.
+    src.write_text(
+        f'def renamed_name(x):\n    """{pad}"""\n    return x + 1\n',
+        encoding="utf-8",
+    )
+    index_codebase_tree(repo, persist_dir=str(persist), source_root=str(repo))
+    after = sorted(_ids_for_rel(persist, "rename.py"))
+    assert after
+    assert set(after).isdisjoint(set(before))
+
+
+# ── caller surfaces mismatch as a run-record reason ──────────────────
+
+
+def test_record_code_unavailable_reason_tags_mismatch() -> None:
+    from amx.cli_support.commands.analyze_flow import _record_code_unavailable_reason
+
+    exc = CodeEmbeddingMismatch(
+        recorded_provider="openai_compatible",
+        recorded_model="text-embedding-3-small",
+        active_provider="minilm",
+        active_model="minilm-l6-v2",
+    )
+    sink: dict[str, str] = {}
+    _record_code_unavailable_reason(sink, exc)
+    assert sink["code_unavailable_reason"].startswith("embedding_mismatch:")
+    assert "openai_compatible" in sink["code_unavailable_reason"]
+
+
+def test_record_code_unavailable_reason_tags_generic_failure() -> None:
+    from amx.cli_support.commands.analyze_flow import _record_code_unavailable_reason
+
+    sink: dict[str, str] = {}
+    _record_code_unavailable_reason(sink, RuntimeError("boom"))
+    assert sink["code_unavailable_reason"].startswith("RuntimeError:")
+    assert "boom" in sink["code_unavailable_reason"]


### PR DESCRIPTION
## Summary
Second PR of the code-RAG hardening series. Brings code Chroma storage to the same correctness level as the docs path:

- `index_codebase_tree` plumbs `cfg.embedding` through to Chroma so the user's chosen embedding provider is honoured for code (was silently defaulting to bundled MiniLM regardless).
- Collection metadata records `embedding_model` / `embedding_provider` on first create; mismatched reopen raises `CodeEmbeddingMismatch` which surfaces via run record + console. Pre-PR-beta collections grandfathered (metadata backfilled silently, no forced reindex).
- Per-file pre-delete before upsert plus a sidecar `index_manifest.json`: shrinking, renaming, or deleting files no longer leaves orphan chunks in the collection.
- New shared walker (`amx/codebase/walker.py`) skips `node_modules`, `.git`, `.venv`, `dist`, `build`, etc. and honours `.gitignore` via the existing `pathspec` helper.
- `.ipynb` files are parsed cell-aware: code cells become `ipynb_code` chunks, markdown cells become `ipynb_md` chunks, outputs dropped.

## Test plan
- [x] `pytest -q` (1590 passed)
- [x] `ruff check amx tests`
- [x] `ruff format --check amx tests`
- Spec: docs/superpowers/specs/2026-05-12-code-rag-hardening-design.md (PR beta section)