### PR TITLE
fix: code-analyze resilience for missing tables + SQLite locks + sqlglot noise

### DIFF
--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from sqlalchemy import inspect, text
 from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.exc import NoSuchTableError
 
 from amx.config import DBConfig
 from amx.core.errors import actionable_error_message
@@ -704,13 +705,23 @@ class DatabaseConnector:
         schema = self._normalize_id(schema)
         table = self._normalize_id(table)
         insp = inspect(self.engine)
+        try:
+            raw_cols = insp.get_columns(table, schema=schema)
+        except NoSuchTableError:
+            # Code analysis routinely surfaces table names (e.g. SAP-style
+            # ``sap_s6p.vbrk``) that exist in the referenced codebase but
+            # not in the database AMX is connected to. Returning an empty
+            # column list lets the analyze worker degrade gracefully
+            # instead of crashing the whole code agent run.
+            log.debug("list_column_profiles: %s.%s not present in live DB", schema, table)
+            return []
         return [
             ColumnProfile(
                 name=str(c["name"]),
                 dtype=str(c["type"]),
                 nullable=bool(c.get("nullable", True)),
             )
-            for c in insp.get_columns(table, schema=schema)
+            for c in raw_cols
         ]
 
     def resolve_asset_kind(self, schema: str, name: str) -> AssetKind:

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -1963,10 +1963,20 @@ class SQLiteHistoryStore:
         return out
 
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path, timeout=10)
+        # ``timeout=30`` and the matching ``PRAGMA busy_timeout`` both
+        # bump the lock-wait budget so concurrent Studio + CLI writers
+        # don't surface ``database is locked`` warnings under realistic
+        # contention (Studio worker writing run rows while the chat
+        # session is mid-LLM call, plus catalog scans landing alongside).
+        # WAL keeps readers non-blocking; the timeout only matters for
+        # writer-vs-writer overlap. The PRAGMA is the authoritative
+        # knob — sqlite3's ``timeout=`` arg is occasionally ignored
+        # depending on the platform's libsqlite version.
+        conn = sqlite3.connect(self.db_path, timeout=30)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA busy_timeout=30000")
         return conn
 
     def log_event(

--- a/amx/utils/logging.py
+++ b/amx/utils/logging.py
@@ -281,6 +281,15 @@ def mute_root_logger_for_studio() -> None:
         lib_logger.setLevel(logging.CRITICAL)
         lib_logger.propagate = False
 
+    # sqlglot logs ``... contains unsupported syntax. Falling back to
+    # parsing as a 'Command'`` at WARNING level whenever it can't parse
+    # a vendor-specific statement (PostgreSQL ``SET search_path``, SAP
+    # HANA pragmas, etc.). Code analysis is best-effort — the fallback
+    # path already returns sensibly — so these warnings are pure noise
+    # for the user. Lift to ERROR so genuine parser bugs still surface.
+    sqlglot_logger = logging.getLogger("sqlglot")
+    sqlglot_logger.setLevel(logging.ERROR)
+
 
 def log_event(event_type: str, /, **fields: Any) -> None:
     """Write a structured event line to the rotating JSON log.

--- a/tests/test_list_column_profiles_missing_table.py
+++ b/tests/test_list_column_profiles_missing_table.py
@@ -1,0 +1,55 @@
+"""Regression: ``list_column_profiles`` must not crash the code-analyze
+worker when a table named in the codebase isn't present in the live DB.
+
+Symptom (reproducer in the original report): a user connected a
+PostgreSQL profile, linked an SAP codebase via GitHub, and clicked
+Search. The code agent surfaced ``sap_s6p.vbrk`` (an SAP-specific
+table name from the source files) and the analyze worker called
+``connector.list_column_profiles("sap_s6p", "vbrk")``. PostgreSQL
+introspection raised ``sqlalchemy.exc.NoSuchTableError`` and the
+worker died, taking down the analyze job.
+
+After the fix the call returns an empty list and the worker continues
+processing the remaining suggestions.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.exc import NoSuchTableError
+
+
+def test_list_column_profiles_returns_empty_when_table_missing():
+    from amx.db.connector import DatabaseConnector
+
+    conn = DatabaseConnector.__new__(DatabaseConnector)
+    conn._engine = MagicMock()  # property getter reads from here
+    conn._normalize_id = lambda v: v  # type: ignore[method-assign]
+
+    fake_inspector = MagicMock()
+    fake_inspector.get_columns.side_effect = NoSuchTableError("sap_s6p.vbrk")
+
+    with patch("amx.db.connector.inspect", return_value=fake_inspector):
+        out = DatabaseConnector.list_column_profiles(conn, "sap_s6p", "vbrk")
+    assert out == []
+
+
+def test_list_column_profiles_returns_columns_when_table_present():
+    from amx.db.connector import DatabaseConnector
+
+    conn = DatabaseConnector.__new__(DatabaseConnector)
+    conn._engine = MagicMock()
+    conn._normalize_id = lambda v: v  # type: ignore[method-assign]
+
+    fake_inspector = MagicMock()
+    fake_inspector.get_columns.return_value = [
+        {"name": "id", "type": "INTEGER", "nullable": False},
+        {"name": "label", "type": "TEXT", "nullable": True},
+    ]
+
+    with patch("amx.db.connector.inspect", return_value=fake_inspector):
+        out = DatabaseConnector.list_column_profiles(conn, "public", "users")
+    assert [c.name for c in out] == ["id", "label"]
+    assert out[0].nullable is False
+    assert out[1].nullable is True


### PR DESCRIPTION
Three bugs surfaced in the same flow (link a GitHub code repo → click Search):

1. **Code analyze worker crashed** with \`sqlalchemy.exc.NoSuchTableError: sap_s6p.vbrk\` because the SAP codebase mentioned table names not present in the live PostgreSQL DB. \`list_column_profiles\` now returns \`[]\` on \`NoSuchTableError\` so the worker keeps processing.

2. **\`database is locked\`** warning from \`/api/ask\` under concurrent Studio + CLI writes. Bumped SQLite connect timeout 10s → 30s plus an explicit \`PRAGMA busy_timeout=30000\` (some platforms ignore the connect-arg). WAL was already on; this only affects writer-vs-writer contention.

3. **\`'X' contains unsupported syntax. Falling back to parsing as a 'Command'\`** noise from sqlglot whenever it hit a vendor-specific statement (PostgreSQL \`SET search_path\`, SAP HANA pragmas). The parser fallback already returns sensibly — these were pure terminal spam. Lifted the \`sqlglot\` logger to ERROR.

## Test plan
- [x] \`pytest tests/test_list_column_profiles_missing_table.py -v\` — 2 new tests pin the NoSuchTable behaviour
- [x] \`pytest -q\` — 1713 passed
- [x] \`ruff check amx tests\` clean