### PR TITLE
fix(studio): triple-layer defense against Ctrl+C terminal freeze

### DIFF
--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -140,6 +140,58 @@ PrintDbHint = Callable[[], None]
 _NS_STATE: dict[str, str] = {"namespace": ""}
 
 
+def _rebuild_prompt_input() -> None:
+    """Force prompt_toolkit to drop its cached ``Vt100Input``.
+
+    Background: ``PromptSession`` constructs an ``Input`` once at
+    startup and reuses it for every ``prompt()`` call (the instance
+    caches ``_fileno``, a ``PosixStdinReader``, and a ``Vt100Parser``).
+    When an external subprocess such as ``/studio`` runs between
+    iterations and leaves stdin in a weird state, the next call to
+    ``Vt100Input.raw_mode().__enter__`` hits ``termios.tcgetattr`` —
+    which on error **silently no-ops** — and the terminal stays in
+    cooked mode. ICANON then buffers arrow-key escapes and the user
+    sees ``^[[C`` echo until the CLI is restarted.
+
+    The fix is to invalidate the AppSession's cached input so the
+    next ``prompt()`` rebuilds it via ``create_input()``, which
+    snapshots a fresh fileno from ``sys.stdin`` and constructs new
+    reader/parser objects. We also do a defensive ``tcflush`` to
+    drain any stale bytes the subprocess may have left in the
+    kernel-side input queue.
+
+    Cheap (one syscall + one attribute set); safe to call every
+    iteration of the prompt loop.
+    """
+    # Flush kernel-side stale input bytes. Platform/tty guarded so
+    # it's a no-op on Windows / piped input / detached tty.
+    try:
+        import os as _os
+        import sys as _sys
+        import termios as _termios
+
+        fd = _sys.stdin.fileno()
+        if _os.isatty(fd):
+            _termios.tcflush(fd, _termios.TCIFLUSH)
+    except (ImportError, AttributeError, ValueError, OSError):
+        pass
+    except Exception:  # pragma: no cover - termios.error on some platforms
+        pass
+
+    # Drop the AppSession's cached Vt100Input. ``_input`` is the
+    # documented (via source) cache slot; setting it to ``None``
+    # triggers a fresh ``create_input()`` on next access.
+    try:
+        from prompt_toolkit.application.current import get_app_session
+
+        app_session = get_app_session()
+        # Lazy property — setting to None invalidates the cache so the
+        # next read recreates a Vt100Input from sys.stdin.
+        app_session._input = None  # type: ignore[assignment]
+    except Exception:  # pragma: no cover - prompt_toolkit internals shift
+        pass
+
+
 def _canonical_namespace(namespace: str) -> str:
     return "metadata" if namespace == "manual" else namespace
 
@@ -1309,6 +1361,18 @@ def run_interactive_session(
                     "cli.cfg_reload_failed",
                     error=str(exc),
                 )
+
+            # Recover from any external subprocess (notably ``/studio``)
+            # that may have left stdin in a weird state. prompt_toolkit
+            # caches a single ``Vt100Input`` instance per AppSession,
+            # whose ``raw_mode.__enter__`` silently no-ops on
+            # ``termios.error`` — leaving the terminal in cooked mode
+            # and ICANON-buffering arrow-key escapes as literal
+            # ``^[[C``. Forcing the AppSession to rebuild its input
+            # gives the next ``session.prompt()`` a fresh fd snapshot,
+            # PosixStdinReader, and Vt100Parser. One TCIFLUSH + one
+            # object replacement; harmless when nothing was wrong.
+            _rebuild_prompt_input()
 
             if raw == "__amx_exit__":
                 console.print()

--- a/amx/web/launcher.py
+++ b/amx/web/launcher.py
@@ -1,26 +1,30 @@
 """Boot AMX Studio from the ``/studio`` slash command.
 
-The launcher:
+Architecture (triple-layer defense after PRs #353/#354/#355 each
+fixed a layer but left a sibling open):
 
-1. Picks a port (preferred 47821, otherwise an ephemeral one).
-2. Generates a one-shot URL-safe Bearer token.
-3. Spawns a **subprocess** running :mod:`amx.web._studio_subprocess`
-   which boots uvicorn in a conventional foreground configuration.
-4. Polls ``127.0.0.1:<port>`` until the child binds (or the startup
-   timeout elapses), then opens the user's default browser.
-5. Blocks the parent on ``proc.wait()``; Ctrl-C in the terminal
-   reaches the child via the shared process group and uvicorn's own
-   SIGINT handler shuts it down cleanly. The parent then escalates
-   to SIGTERM / SIGKILL only if the child overstays its grace
-   period.
+1. Pick a port (preferred 47821, otherwise an ephemeral one).
+2. Generate a one-shot URL-safe Bearer token.
+3. Spawn a **subprocess** running :mod:`amx.web._studio_subprocess`
+   under ``start_new_session=True`` so the child gets its own
+   session, its own process group, and **no controlling tty**. The
+   parent's foreground process group keeps Ctrl-C, the child does
+   not see it directly; we forward via ``os.killpg`` instead.
+4. Redirect the child's stdout and stderr to
+   ``~/.amx/logs/studio-<port>.log`` so uvicorn logs and shutdown
+   tracebacks land in a file the user can ``tail -f`` instead of
+   on the parent's terminal — where they would corrupt
+   ``prompt_toolkit``'s rendered state.
+5. Poll ``127.0.0.1:<port>`` until the child binds, then open the
+   browser.
+6. Block the parent on ``proc.wait()``; on Ctrl-C, ``os.killpg``
+   the child group with SIGINT and escalate to SIGTERM/SIGKILL on
+   timeout. Wrap escalation against a second Ctrl-C so we never
+   leak an orphan.
 
-The subprocess model replaces an earlier in-process daemon-thread
-implementation that left stdin in a flushed-but-non-canonical state
-on macOS — arrow keys echoed as literal ``^[[C`` after Ctrl-C and
-the user had to restart the CLI. termios-level restoration (PRs
-#353/#354) did not fully recover. Process isolation does, because
-uvicorn's asyncio loop, signal handlers, and file-descriptor edits
-all live in a separate Python interpreter.
+The third layer — :func:`amx.cli_support.session._rebuild_prompt_input`
+called by the prompt loop — handles the remaining failure mode
+where ``Vt100Input`` has cached a stale ``_fileno`` / parser state.
 
 Returns ``True`` once the launch attempt completes (server may or
 may not have responded — the URL is still printed) and ``False``
@@ -31,6 +35,7 @@ renders an actionable error in that case.
 from __future__ import annotations
 
 import logging
+import os
 import signal
 import socket
 import subprocess
@@ -39,6 +44,7 @@ import time
 import webbrowser
 from contextlib import suppress
 from pathlib import Path as _Path
+from typing import IO
 
 from amx.config import AMXConfig
 
@@ -49,14 +55,20 @@ log = logging.getLogger("amx.web.launcher")
 #: rule. Falls back to an ephemeral port when busy.
 PREFERRED_PORT = 47821
 
-#: How long to wait for uvicorn to flip ``server.started`` to True
-#: before opening the browser. Tarpits past this (rare on localhost)
-#: still launch the browser, the user just sees a load spinner.
+#: How long to wait for uvicorn to bind the listening socket before
+#: opening the browser. Tarpits past this (rare on localhost) still
+#: launch the browser; the user just sees a load spinner.
 STARTUP_TIMEOUT_SEC = 5.0
 
-#: Grace period for uvicorn to drain on shutdown. After this we move
-#: on so Ctrl-C feels responsive even if a hung connection lingers.
+#: Grace period for uvicorn to drain on shutdown. After this we
+#: escalate to SIGTERM so Ctrl-C feels responsive even when a hung
+#: connection lingers.
 SHUTDOWN_TIMEOUT_SEC = 3.0
+
+#: SIGTERM-to-SIGKILL grace period — uvicorn ignored SIGINT/SIGTERM,
+#: we force-kill the group after this.
+TERMINATE_TIMEOUT_SEC = 2.0
+KILL_TIMEOUT_SEC = 1.0
 
 
 def _pick_port(preferred: int) -> int:
@@ -77,6 +89,27 @@ def _pick_port(preferred: int) -> int:
         sock.close()
 
 
+def _studio_log_path(cfg: AMXConfig, port: int) -> _Path:
+    """Resolve ``~/.amx/logs/studio-<port>.log`` (creating the dir)."""
+    base = getattr(cfg, "CONFIG_DIR", None) or str(_Path.home() / ".amx")
+    log_dir = _Path(base) / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir / f"studio-{port}.log"
+
+
+def _signal_child_group(proc: subprocess.Popen, sig: int) -> None:
+    """Send ``sig`` to the child's process group.
+
+    The child was spawned with ``start_new_session=True``, so it is
+    its own session leader and ``proc.pid`` equals the pgid. Using
+    ``killpg`` covers any uvicorn worker subprocesses that may have
+    been forked by ``--reload`` etc., even though we don't enable
+    those today — costs nothing to be correct.
+    """
+    with suppress(ProcessLookupError, OSError):
+        os.killpg(proc.pid, sig)
+
+
 def launch_studio(
     cfg: AMXConfig,
     *,
@@ -86,20 +119,11 @@ def launch_studio(
 ) -> bool:
     """Start AMX Studio for one ``/studio`` invocation.
 
-    Studio runs as a CHILD PROCESS — see
-    :mod:`amx.web._studio_subprocess`. The parent CLI then has zero
-    risk of inheriting uvicorn's asyncio loop, signal handler edits,
-    or stdin file-descriptor state; Ctrl-C reaches the child via the
-    shared process group and the child exits cleanly via its own
-    SIGINT handler. After the child exits, the parent's terminal is
-    in exactly the state it was in before ``/studio`` and the next
-    ``prompt_toolkit`` session resumes normally.
-
-    Earlier in-process daemon-thread implementation left stdin in a
-    flushed-but-non-canonical state on macOS — arrow keys echoed as
-    literal ``^[[C`` after Ctrl-C and the user had to restart the
-    CLI. termios restoration (PRs #353/#354) didn't fully recover.
-    Process isolation does.
+    See module docstring for the architecture. The parent never sees
+    uvicorn's stdout, never shares a process group with the child,
+    and never relies on terminal Ctrl-C reaching the child — every
+    aspect of the failing-CLI-after-Ctrl-C symptom is closed at the
+    source.
 
     Parameters
     ----------
@@ -116,20 +140,31 @@ def launch_studio(
     block
         When ``True`` (the default), block until the child exits.
         Pass ``False`` in tests so the function returns once the
-        child has been spawned (the caller controls shutdown).
+        child has been spawned (the caller controls shutdown and is
+        responsible for closing the log file).
     """
     chosen_port = port if port is not None else _pick_port(PREFERRED_PORT)
 
     # Generate the bearer token in the PARENT so we can immediately
-    # surface the URL to the user without round-tripping through the
-    # child's app.state.token. The child accepts the token via CLI
-    # arg and seeds it onto the FastAPI app at startup.
+    # surface the URL without round-tripping through the child's
+    # ``app.state.token``. The child accepts the token via CLI arg
+    # and seeds it onto the FastAPI app at startup.
     from amx.web.auth import generate_token
 
     token = generate_token()
     url = f"http://127.0.0.1:{chosen_port}/?t={token}"
 
     config_path = getattr(cfg, "_config_path", "") or str(_Path(cfg.CONFIG_DIR) / "config.yml")
+
+    log_path = _studio_log_path(cfg, chosen_port)
+    # Line-buffered append so ``tail -f`` shows uvicorn output as it
+    # happens, and a second ``/studio`` invocation on the same port
+    # appends rather than truncating somebody else's debugging.
+    # Lifetime spans the whole ``proc.wait()`` window — closed in the
+    # ``finally`` below, so a ``with`` block doesn't fit.
+    log_fd: IO[str] = open(log_path, "a", buffering=1, encoding="utf-8")  # noqa: SIM115
+    log_fd.write(f"\n--- studio launch {time.strftime('%Y-%m-%d %H:%M:%S')} pid=parent ---\n")
+    log_fd.flush()
 
     cmd = [
         sys.executable,
@@ -142,7 +177,17 @@ def launch_studio(
         "--config-path",
         config_path,
     ]
-    proc = subprocess.Popen(cmd)
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=log_fd,
+        stderr=subprocess.STDOUT,
+        # setsid() in the child: new session + new process group +
+        # no controlling tty. Terminal-generated SIGINT no longer
+        # reaches the child; we forward explicitly via killpg.
+        start_new_session=True,
+        close_fds=True,
+    )
 
     started = _wait_for_http(chosen_port, STARTUP_TIMEOUT_SEC)
     if not started:
@@ -153,7 +198,9 @@ def launch_studio(
         )
 
     print(  # user-facing — keep print, not log
-        f"AMX Studio running → {url}\nPress Ctrl-C in this terminal to stop AMX Studio."
+        f"AMX Studio running → {url}\n"
+        f"AMX Studio logs    → {log_path}\n"
+        "Press Ctrl-C in this terminal to stop AMX Studio."
     )
     if open_browser:
         try:
@@ -162,46 +209,67 @@ def launch_studio(
             log.debug("Could not auto-open browser: %s", exc)
 
     if not block:
+        # Caller (tests) owns the lifecycle; leave the log file open
+        # for them to inspect or close.
         return True
 
     try:
-        proc.wait()
-    except KeyboardInterrupt:
-        # The terminal Ctrl-C reaches the whole foreground process
-        # group, so the child has typically already received SIGINT
-        # and is shutting down. Send another SIGINT for good measure
-        # and then wait briefly for graceful exit before escalating
-        # to SIGTERM / SIGKILL.
-        with suppress(ProcessLookupError, OSError):
-            proc.send_signal(signal.SIGINT)
         try:
-            proc.wait(timeout=SHUTDOWN_TIMEOUT_SEC)
-        except subprocess.TimeoutExpired:  # pragma: no cover - graceful path
-            log.warning(
-                "AMX Studio child did not exit within %.1fs; sending SIGTERM.",
-                SHUTDOWN_TIMEOUT_SEC,
-            )
-            proc.terminate()
-            try:
-                proc.wait(timeout=2.0)
-            except subprocess.TimeoutExpired:
-                log.warning("AMX Studio child still alive; sending SIGKILL.")
-                proc.kill()
-                with suppress(subprocess.TimeoutExpired):
-                    proc.wait(timeout=1.0)
+            proc.wait()
+        except KeyboardInterrupt:
+            # Child is in its own session — no implicit SIGINT
+            # delivery, so forward explicitly. Wrap escalation
+            # against a second Ctrl-C so we don't leave an orphan
+            # if the user mashes the key twice.
+            _shutdown_child(proc)
+    finally:
+        with suppress(Exception):
+            log_fd.close()
     print("AMX Studio stopped.")
     return True
+
+
+def _shutdown_child(proc: subprocess.Popen) -> None:
+    """Send SIGINT to the child group; escalate to SIGTERM then SIGKILL.
+
+    Each escalation is wrapped against a second ``KeyboardInterrupt``
+    so a user mashing Ctrl-C never leaves an orphan child process.
+    """
+    _signal_child_group(proc, signal.SIGINT)
+    try:
+        proc.wait(timeout=SHUTDOWN_TIMEOUT_SEC)
+        return
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "AMX Studio child did not exit within %.1fs; sending SIGTERM.",
+            SHUTDOWN_TIMEOUT_SEC,
+        )
+    except KeyboardInterrupt:  # pragma: no cover - mash-Ctrl-C path
+        pass
+
+    _signal_child_group(proc, signal.SIGTERM)
+    try:
+        proc.wait(timeout=TERMINATE_TIMEOUT_SEC)
+        return
+    except subprocess.TimeoutExpired:
+        log.warning("AMX Studio child still alive after SIGTERM; sending SIGKILL.")
+    except KeyboardInterrupt:  # pragma: no cover
+        pass
+
+    _signal_child_group(proc, signal.SIGKILL)
+    with suppress(subprocess.TimeoutExpired, KeyboardInterrupt):
+        proc.wait(timeout=KILL_TIMEOUT_SEC)
 
 
 def _wait_for_http(port: int, timeout: float) -> bool:
     """Poll a TCP connect on ``127.0.0.1:port`` until it succeeds or
     the deadline elapses.
 
-    Used to confirm the Studio child has bound its listening socket
-    before the parent prints the URL and opens the browser. Replaces
-    the old daemon-thread ``server.started`` probe — with the child
-    in a separate process the parent no longer has direct access to
-    uvicorn's internal state, so we fall back to the network signal.
+    Confirms the Studio child has bound its listening socket before
+    the parent prints the URL and opens the browser. The parent no
+    longer has direct access to uvicorn's ``server.started`` flag
+    (it lives in the child interpreter); the network signal is the
+    next best thing.
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:

--- a/tests/test_prompt_input_rebuild.py
+++ b/tests/test_prompt_input_rebuild.py
@@ -1,0 +1,128 @@
+"""prompt_toolkit caches a single ``Vt100Input`` per AppSession; when
+``/studio`` (or any other subprocess) leaves stdin in a state that
+makes ``tcgetattr`` fail, ``raw_mode.__enter__`` silently no-ops and
+the terminal stays cooked — arrow keys then echo as literal
+``^[[C`` until the CLI restarts.
+
+The fix is :func:`amx.cli_support.session._rebuild_prompt_input`
+called once per prompt iteration after dispatch. It drops the cached
+``_input`` so the next ``prompt()`` rebuilds via ``create_input()``,
+and defensively ``tcflush``-es stale bytes from the kernel input
+queue. These tests pin both behaviours.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def test_rebuild_clears_app_session_cached_input():
+    from amx.cli_support.session import _rebuild_prompt_input
+
+    fake_session = MagicMock()
+    fake_session._input = object()  # pretend a Vt100Input is cached
+
+    with patch(
+        "prompt_toolkit.application.current.get_app_session",
+        return_value=fake_session,
+    ):
+        _rebuild_prompt_input()
+
+    assert fake_session._input is None
+
+
+def test_rebuild_calls_tcflush_when_stdin_is_a_tty():
+    """Drain any stale bytes the subprocess may have left buffered
+    by the kernel so the next prompt doesn't replay them as input."""
+    from amx.cli_support import session as session_mod
+
+    fake_session = MagicMock()
+    fake_session._input = object()
+
+    with patch.object(session_mod, "_rebuild_prompt_input.__wrapped__", create=True):
+        # the actual helper is module-level — patch its termios call
+        pass
+
+    with (
+        patch("sys.stdin") as fake_stdin,
+        patch("os.isatty", return_value=True),
+        patch("termios.tcflush") as fake_tcflush,
+        patch(
+            "prompt_toolkit.application.current.get_app_session",
+            return_value=fake_session,
+        ),
+    ):
+        fake_stdin.fileno.return_value = 0
+        session_mod._rebuild_prompt_input()
+
+    import termios
+
+    fake_tcflush.assert_called_once_with(0, termios.TCIFLUSH)
+
+
+def test_rebuild_no_ops_when_stdin_not_a_tty():
+    """In tests / piped input / detached tty the tcflush call must
+    silently no-op — no exception bubbles up."""
+    from amx.cli_support import session as session_mod
+
+    fake_session = MagicMock()
+    fake_session._input = object()
+
+    with (
+        patch("sys.stdin") as fake_stdin,
+        patch("os.isatty", return_value=False),
+        patch("termios.tcflush") as fake_tcflush,
+        patch(
+            "prompt_toolkit.application.current.get_app_session",
+            return_value=fake_session,
+        ),
+    ):
+        fake_stdin.fileno.return_value = 7
+        session_mod._rebuild_prompt_input()
+
+    fake_tcflush.assert_not_called()
+    # Still invalidates the cached input even when the tty branch is
+    # skipped — the input layer needs rebuilding regardless of the
+    # kernel buffer drain.
+    assert fake_session._input is None
+
+
+def test_rebuild_swallows_termios_error():
+    """A failed tcflush (e.g. transient OSError) must NOT break the
+    prompt loop. Worst case we lose one chance to recover this
+    iteration; the next prompt round will try again."""
+    from amx.cli_support import session as session_mod
+
+    fake_session = MagicMock()
+    fake_session._input = object()
+
+    with (
+        patch("sys.stdin") as fake_stdin,
+        patch("os.isatty", return_value=True),
+        patch("termios.tcflush", side_effect=OSError("transient")),
+        patch(
+            "prompt_toolkit.application.current.get_app_session",
+            return_value=fake_session,
+        ),
+    ):
+        fake_stdin.fileno.return_value = 0
+        # Must not raise
+        session_mod._rebuild_prompt_input()
+
+
+def test_rebuild_swallows_app_session_unavailable():
+    """If prompt_toolkit internals shift and ``get_app_session`` is
+    gone or raises, we still don't take down the prompt loop."""
+    from amx.cli_support import session as session_mod
+
+    with (
+        patch(
+            "prompt_toolkit.application.current.get_app_session",
+            side_effect=RuntimeError("no current session"),
+        ),
+        patch("sys.stdin") as fake_stdin,
+        patch("os.isatty", return_value=False),
+    ):
+        fake_stdin.fileno.return_value = 0
+        # Must not raise
+        session_mod._rebuild_prompt_input()

--- a/tests/web/test_launcher_subprocess.py
+++ b/tests/web/test_launcher_subprocess.py
@@ -1,14 +1,27 @@
-"""Regression: ``/studio`` must run uvicorn in a child PROCESS, not
-a daemon thread. The thread-based implementation left stdin in a
-flushed-but-non-canonical state after Ctrl-C on macOS — arrow keys
-echoed as literal ``^[[C`` and the user had to restart the CLI.
-Process isolation fixes the symptom categorically because uvicorn's
-asyncio loop, signal handlers, and stdin file-descriptor edits live
-in a separate Python interpreter.
+"""Regression: ``/studio`` must run uvicorn in a child PROCESS that
+is fully isolated from the parent CLI's terminal state.
+
+Three layers verified here (one each per defect that earlier PRs
+exposed and failed to fully fix):
+
+1. ``start_new_session=True`` so the child has its own session and
+   process group, and the parent's foreground Ctrl-C does not reach
+   the child implicitly — we forward explicitly via ``os.killpg``.
+2. ``stdin=DEVNULL`` + ``stdout=<log_fd>`` + ``stderr=STDOUT`` so the
+   child cannot write to the parent's tty regardless of what
+   uvicorn or anyio raises on shutdown.
+3. The Ctrl-C path forwards ``SIGINT`` via ``os.killpg`` (covers any
+   uvicorn workers that may exist in the future) and escalates to
+   ``SIGTERM`` then ``SIGKILL`` on timeout.
+
+Without these, the user-visible symptom is arrow keys echoing
+literal ``^[[C`` after ``/studio`` + Ctrl-C until the CLI restarts.
 """
 
 from __future__ import annotations
 
+import signal
+import subprocess
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -19,19 +32,18 @@ def test_launch_studio_spawns_subprocess_with_python_module(tmp_path, monkeypatc
 
     cfg = AMXConfig()
     object.__setattr__(cfg, "_config_path", str(tmp_path / "config.yml"))
+    object.__setattr__(cfg, "CONFIG_DIR", str(tmp_path))
 
     fake_proc = MagicMock()
     fake_proc.wait.return_value = 0
-    with patch.object(launcher, "subprocess") as fake_sub:
-        fake_sub.Popen.return_value = fake_proc
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc) as fake_popen:
         with (
             patch.object(launcher, "_wait_for_http", return_value=True),
             patch.object(launcher, "webbrowser"),
         ):
             ok = launcher.launch_studio(cfg, port=47821, open_browser=False)
     assert ok is True
-    args, _ = fake_sub.Popen.call_args
-    cmd = args[0]
+    cmd = fake_popen.call_args.args[0]
     assert cmd[0] == sys.executable
     assert cmd[1:4] == ["-m", "amx.web._studio_subprocess", "--port"]
     assert "47821" in cmd
@@ -39,34 +51,119 @@ def test_launch_studio_spawns_subprocess_with_python_module(tmp_path, monkeypatc
     assert "--config-path" in cmd
 
 
-def test_launch_studio_sigint_triggers_child_shutdown(tmp_path, monkeypatch):
-    """Ctrl-C in the parent must send SIGINT to the child and wait
-    for it to exit. Without this, the parent CLI's prompt loop would
-    block forever on proc.wait() when the user wants out of /studio."""
+def test_popen_kwargs_isolate_child_from_parent_terminal(tmp_path):
+    """Triple-layer isolation: separate session, DEVNULL stdin, log
+    file stdout, stderr merged to stdout. Without this combination the
+    child's tracebacks corrupt the parent's prompt_toolkit rendering."""
     from amx.config import AMXConfig
     from amx.web import launcher
 
     cfg = AMXConfig()
     object.__setattr__(cfg, "_config_path", str(tmp_path / "config.yml"))
+    object.__setattr__(cfg, "CONFIG_DIR", str(tmp_path))
 
     fake_proc = MagicMock()
-    fake_proc.wait.side_effect = [KeyboardInterrupt, 0]
-    with patch.object(launcher, "subprocess") as fake_sub:
-        fake_sub.Popen.return_value = fake_proc
-        fake_sub.TimeoutExpired = TimeoutError  # so .wait(timeout=...) compares fine
+    fake_proc.wait.return_value = 0
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc) as fake_popen:
         with (
             patch.object(launcher, "_wait_for_http", return_value=True),
             patch.object(launcher, "webbrowser"),
         ):
-            launcher.launch_studio(cfg, port=47822, open_browser=False)
-    # First wait() raised KI, then we send SIGINT and wait again.
-    assert fake_proc.send_signal.called
-    sent_sig = fake_proc.send_signal.call_args[0][0]
-    import signal as _signal
+            launcher.launch_studio(cfg, port=47823, open_browser=False)
+    kwargs = fake_popen.call_args.kwargs
+    assert kwargs["start_new_session"] is True
+    assert kwargs["stdin"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.STDOUT
+    assert kwargs["close_fds"] is True
+    # stdout must be a writable file handle, not the parent's stdout.
+    out = kwargs["stdout"]
+    assert hasattr(out, "write")
+    assert out is not sys.stdout
 
-    assert sent_sig == _signal.SIGINT
-    # wait() called at least twice (initial + post-SIGINT)
-    assert fake_proc.wait.call_count >= 2
+
+def test_log_file_is_created_under_config_dir(tmp_path):
+    from amx.config import AMXConfig
+    from amx.web import launcher
+
+    cfg = AMXConfig()
+    object.__setattr__(cfg, "_config_path", str(tmp_path / "config.yml"))
+    object.__setattr__(cfg, "CONFIG_DIR", str(tmp_path))
+
+    fake_proc = MagicMock()
+    fake_proc.wait.return_value = 0
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc):
+        with (
+            patch.object(launcher, "_wait_for_http", return_value=True),
+            patch.object(launcher, "webbrowser"),
+        ):
+            launcher.launch_studio(cfg, port=47824, open_browser=False)
+    expected = tmp_path / "logs" / "studio-47824.log"
+    assert expected.exists()
+    contents = expected.read_text()
+    assert "studio launch" in contents
+
+
+def test_sigint_uses_killpg_not_proc_send_signal(tmp_path):
+    """Because the child is a session leader (``start_new_session=True``),
+    ``proc.pid`` is also the pgid. We use ``os.killpg`` so any worker
+    processes the child may spawn (uvicorn ``--reload`` etc.) are
+    signalled too — and so the parent doesn't accidentally rely on
+    the now-broken shared-pgrp implicit Ctrl-C delivery."""
+    from amx.config import AMXConfig
+    from amx.web import launcher
+
+    cfg = AMXConfig()
+    object.__setattr__(cfg, "_config_path", str(tmp_path / "config.yml"))
+    object.__setattr__(cfg, "CONFIG_DIR", str(tmp_path))
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 12345
+    fake_proc.wait.side_effect = [KeyboardInterrupt, 0]
+
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc):
+        with (
+            patch.object(launcher, "_wait_for_http", return_value=True),
+            patch.object(launcher, "webbrowser"),
+            patch.object(launcher.os, "killpg") as fake_killpg,
+        ):
+            launcher.launch_studio(cfg, port=47825, open_browser=False)
+    assert fake_killpg.called
+    pid, sig = fake_killpg.call_args.args
+    assert pid == 12345
+    assert sig == signal.SIGINT
+
+
+def test_sigterm_escalation_on_shutdown_timeout(tmp_path):
+    """When the child ignores SIGINT we escalate to SIGTERM, then
+    SIGKILL — each within its grace period — so a hung uvicorn never
+    leaves the parent blocked indefinitely after Ctrl-C."""
+    from amx.config import AMXConfig
+    from amx.web import launcher
+
+    cfg = AMXConfig()
+    object.__setattr__(cfg, "_config_path", str(tmp_path / "config.yml"))
+    object.__setattr__(cfg, "CONFIG_DIR", str(tmp_path))
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 9999
+    # Initial wait → KI; post-SIGINT wait → TimeoutExpired (we then
+    # send SIGTERM); post-SIGTERM wait → succeeds.
+    fake_proc.wait.side_effect = [
+        KeyboardInterrupt,
+        subprocess.TimeoutExpired(cmd="x", timeout=3.0),
+        0,
+    ]
+
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc):
+        with (
+            patch.object(launcher, "_wait_for_http", return_value=True),
+            patch.object(launcher, "webbrowser"),
+            patch.object(launcher.os, "killpg") as fake_killpg,
+        ):
+            launcher.launch_studio(cfg, port=47826, open_browser=False)
+    sent = [call.args[1] for call in fake_killpg.call_args_list]
+    assert signal.SIGINT in sent
+    assert signal.SIGTERM in sent
 
 
 def test_subprocess_entry_module_is_importable():


### PR DESCRIPTION
## Symptom

After \`/studio\` + Ctrl-C, the CLI prompt was frozen — arrow keys echoed as literal \`^[[C\` and the user had to restart the CLI. PRs #353, #354, #355 each closed one piece but the freeze persisted because three concurrent defects each opened the same failure mode through a different path.

## Root cause (cross-checked via three parallel Explore audits)

1. **Process-group sharing.** \`subprocess.Popen(cmd)\` inherited the parent's foreground process group. Ctrl-C went to both processes simultaneously; the child's mid-shutdown traceback flooded the parent's terminal.
2. **Inherited stdout/stderr.** Default fd inheritance let uvicorn shutdown logs, CancelledError tracebacks, and SGR/CSI escape codes write directly to the parent's tty.
3. **prompt_toolkit input caching.** \`PromptSession\` constructs ONE \`Vt100Input\` instance for its lifetime. Its \`raw_mode.__enter__\` silently no-ops on \`termios.error\` — terminal stays cooked, ICANON buffers escapes as literal \`^[[C\`.

## Fix (three concurrent changes in one PR)

| Layer | Change | File |
|---|---|---|
| 1 | \`subprocess.Popen(..., start_new_session=True, close_fds=True)\` + \`os.killpg\` for SIGINT/SIGTERM/SIGKILL escalation | \`amx/web/launcher.py\` |
| 2 | \`stdin=DEVNULL\`, \`stdout=<log_fd>\`, \`stderr=STDOUT\` redirected to \`~/.amx/logs/studio-<port>.log\` | \`amx/web/launcher.py\` |
| 3 | New \`_rebuild_prompt_input()\` drops the cached \`Vt100Input\` + \`tcflush\` defensive drain — called once per prompt iteration | \`amx/cli_support/session.py\` |

Plus cleanup of dead \`_snapshot_stdin_tty\` / \`_restore_stdin_tty\` / \`_stdin_fd\` helpers from PRs #353/#354 — the new architecture makes them unnecessary and keeping them would mislead future maintainers about which path is load-bearing.

## Tests

- \`tests/web/test_launcher_subprocess.py\` extended: pins \`start_new_session=True\`, \`stdin=DEVNULL\`, log-file stdout, \`os.killpg\` mechanism, and SIGTERM escalation on shutdown timeout.
- \`tests/test_prompt_input_rebuild.py\` (new, 5 tests): pins that the rebuild helper clears the cached input, calls \`tcflush\` only on a real tty, and swallows every error path so the prompt loop is never killed by a transient OS error.

## Manual verification (the failing repro)

1. \`pip install -e .\` from this branch
2. \`amx\` → \`/studio\`
3. Delete a doc profile in Studio
4. Back at the terminal, press Ctrl-C
5. **Expected:** "AMX Studio stopped." appears clean; next prompt accepts input; **arrow keys move the cursor**; up-arrow recalls history; tab-complete works
6. Open \`~/.amx/logs/studio-<port>.log\` to confirm uvicorn shutdown lines went there, not to the terminal

## Test plan
- [x] \`pytest tests/test_prompt_input_rebuild.py tests/web/test_launcher_subprocess.py -v\` — 11/11 passed
- [x] \`pytest -q\` — 1737 passed
- [x] \`ruff check amx tests\` clean
- [x] \`ruff format --check amx tests\` clean

## Plan document

\`/Users/omeryasirkucuk/.claude/plans/calm-snacking-graham.md\` (the user-approved plan that drove this PR)