### PR TITLE
fix(studio): fast child shutdown + AMX_CONFIG_DIR env var

### DIFF
--- a/amx/config.py
+++ b/amx/config.py
@@ -47,6 +47,31 @@ SUPPORTED_BACKENDS = (
     "duckdb",
 )
 DISABLED_PROFILE = "__none__"
+
+#: Environment variable that overrides the default ``~/.amx`` config
+#: directory. Useful for running an isolated dev/test session in
+#: parallel with a production AMX setup that lives at the default
+#: path — set ``AMX_CONFIG_DIR=$HOME/.amx-dev amx`` to keep the two
+#: from sharing config, history.db, uploads, or chroma_db. The
+#: doctor command at ``amx/cli_support/commands/doctor.py`` already
+#: documents this variable; the implementation just resolves it
+#: here so every AMXConfig instance picks it up automatically.
+_CONFIG_DIR_ENV_VAR = "AMX_CONFIG_DIR"
+
+
+def _resolve_config_dir() -> str:
+    """Return the path AMX should use as its config / state directory.
+
+    Resolution order:
+      1. ``$AMX_CONFIG_DIR`` if set + non-empty (expanded for ``~``).
+      2. ``~/.amx`` (the historical default).
+    """
+    override = os.environ.get(_CONFIG_DIR_ENV_VAR, "").strip()
+    if override:
+        return str(Path(override).expanduser())
+    return str(Path.home() / ".amx")
+
+
 PROFILING_MODES = ("full", "sampled", "metadata")
 SUPPORTED_EMBEDDING_KINDS = ("minilm", "openai_compatible", "sentence_transformers")
 DEFAULT_EMBEDDING_KIND = "minilm"
@@ -1486,7 +1511,7 @@ class AMXConfig:
     # current REPL is appending to. Reset to None on every load.
     active_chat_session_id: int | None = field(default=None)
 
-    CONFIG_DIR: str = field(default_factory=lambda: str(Path.home() / ".amx"), init=False)
+    CONFIG_DIR: str = field(default_factory=lambda: _resolve_config_dir(), init=False)
     _config_path: str = field(default="", init=False, repr=False)
     _autosave_ready: bool = field(default=False, init=False, repr=False)
     _autosave_suspended: int = field(default=0, init=False, repr=False)

--- a/amx/web/_studio_subprocess.py
+++ b/amx/web/_studio_subprocess.py
@@ -8,22 +8,25 @@ Earlier versions ran uvicorn inside a daemon thread in the parent
 process, which left stdin in a flushed-but-non-canonical state on
 macOS after Ctrl-C — the next ``prompt_toolkit`` session couldn't
 re-enter raw mode and arrow keys echoed as literal ``^[[C``
-sequences. termios-level restoration alone did not recover the
-broken state; the only reliable fix is process isolation.
+sequences. Termios-level restoration alone did not recover the
+broken state; the only reliable fix is process isolation plus a
+prompt_toolkit input rebuild (see :func:`amx.cli_support.session._rebuild_prompt_input`).
 
 The child reads the cfg path + port + token from CLI args, loads
 its own :class:`AMXConfig` from disk (so any edits Studio makes are
 saved back to YAML and picked up by the parent via the PR-351
-``reload_if_stale`` hook), and runs uvicorn in the conventional
-blocking ``uvicorn.run`` mode. Ctrl-C from the parent terminal
-reaches the child via the shared process group; uvicorn's default
-signal handler triggers graceful shutdown; the child exits cleanly
-and the parent's ``proc.wait()`` returns.
+``reload_if_stale`` hook), wires explicit SIGINT/SIGTERM handlers
+so it shuts down in well under a second (uvicorn's default handler
+under uvloop occasionally takes 3+ seconds to react, forcing the
+parent to escalate to SIGKILL), and runs uvicorn via
+``Server.serve`` so we can drive the shutdown ourselves.
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
+import signal
 import sys
 
 
@@ -56,13 +59,39 @@ def main() -> int:
 
     import uvicorn
 
-    uvicorn.run(
+    config = uvicorn.Config(
         app,
         host="127.0.0.1",
         port=args.port,
         log_level="warning",
         access_log=False,
     )
+    server = uvicorn.Server(config)
+    # Disable uvicorn's built-in signal install — under uvloop on
+    # macOS its default handler routinely takes 3+ seconds to react
+    # to SIGINT, which forces the parent launcher to escalate all
+    # the way to SIGKILL. We register a synchronous handler that
+    # flips ``server.should_exit`` immediately, so the next loop
+    # iteration drains in-flight requests and exits cleanly.
+    server.install_signal_handlers = lambda: None
+
+    def _handle_shutdown(signum: int, _frame: object) -> None:
+        # ``should_exit`` is uvicorn's documented graceful-shutdown
+        # flag; ``force_exit`` short-circuits in-flight request
+        # waiting so SIGTERM feels snappy when the user is impatient.
+        server.should_exit = True
+        if signum == signal.SIGTERM:
+            server.force_exit = True
+
+    signal.signal(signal.SIGINT, _handle_shutdown)
+    signal.signal(signal.SIGTERM, _handle_shutdown)
+
+    try:
+        asyncio.run(server.serve())
+    except KeyboardInterrupt:
+        # Last-ditch safety net; the signal handler above usually
+        # arrives first and lets ``serve()`` return normally.
+        pass
     return 0
 
 

--- a/amx/web/launcher.py
+++ b/amx/web/launcher.py
@@ -60,14 +60,18 @@ PREFERRED_PORT = 47821
 #: launch the browser; the user just sees a load spinner.
 STARTUP_TIMEOUT_SEC = 5.0
 
-#: Grace period for uvicorn to drain on shutdown. After this we
-#: escalate to SIGTERM so Ctrl-C feels responsive even when a hung
-#: connection lingers.
-SHUTDOWN_TIMEOUT_SEC = 3.0
+#: Grace period for uvicorn to drain on shutdown after we send
+#: SIGINT. With the explicit signal handler in
+#: :mod:`amx.web._studio_subprocess`, the child flips
+#: ``server.should_exit`` synchronously and uvicorn drains within
+#: roughly 300 ms; 1.5 s is a comfortable upper bound for in-flight
+#: SSE connections to wrap up before we escalate.
+SHUTDOWN_TIMEOUT_SEC = 1.5
 
-#: SIGTERM-to-SIGKILL grace period — uvicorn ignored SIGINT/SIGTERM,
-#: we force-kill the group after this.
-TERMINATE_TIMEOUT_SEC = 2.0
+#: SIGTERM-to-SIGKILL grace period. The child's SIGTERM handler
+#: also flips ``force_exit`` so any in-flight request bypasses the
+#: drain wait — this should always succeed quickly.
+TERMINATE_TIMEOUT_SEC = 1.0
 KILL_TIMEOUT_SEC = 1.0
 
 

--- a/tests/test_config_dir_env.py
+++ b/tests/test_config_dir_env.py
@@ -1,0 +1,85 @@
+"""``AMX_CONFIG_DIR`` env var overrides the default ``~/.amx`` config
+directory so a dev install can be tested side-by-side with a
+production AMX setup without sharing config.yml, history.db,
+uploads, or chroma_db.
+
+The doctor command at ``amx/cli_support/commands/doctor.py:155``
+has been telling users about this variable for a while; this PR
+ships the actual implementation.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def test_default_config_dir_is_home_amx(monkeypatch):
+    monkeypatch.delenv("AMX_CONFIG_DIR", raising=False)
+    from amx.config import _resolve_config_dir
+
+    assert _resolve_config_dir() == str(Path.home() / ".amx")
+
+
+def test_env_var_overrides_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("AMX_CONFIG_DIR", str(tmp_path / "isolated"))
+    from amx.config import _resolve_config_dir
+
+    assert _resolve_config_dir() == str(tmp_path / "isolated")
+
+
+def test_env_var_expands_tilde(monkeypatch):
+    monkeypatch.setenv("AMX_CONFIG_DIR", "~/some-dev-dir")
+    from amx.config import _resolve_config_dir
+
+    resolved = _resolve_config_dir()
+    # Use the same expanduser path the resolver uses so we don't fight
+    # pytest's tmp-HOME fixture vs Path.home() resolution mismatches.
+    assert resolved == str(Path("~/some-dev-dir").expanduser())
+    assert "~" not in resolved
+
+
+def test_empty_env_var_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("AMX_CONFIG_DIR", "   ")
+    from amx.config import _resolve_config_dir
+
+    assert _resolve_config_dir() == str(Path.home() / ".amx")
+
+
+def test_fresh_amxconfig_picks_up_env_var(monkeypatch, tmp_path):
+    """Every newly-loaded :class:`AMXConfig` instance must honour the
+    override — not just calls made after import."""
+    monkeypatch.setenv("AMX_CONFIG_DIR", str(tmp_path / "dev"))
+    # Force a fresh resolution; the dataclass uses a default_factory
+    # so we don't need to reload the module.
+    from amx.config import AMXConfig
+
+    cfg = AMXConfig()
+    assert cfg.CONFIG_DIR == str(tmp_path / "dev")
+
+
+def test_studio_log_path_uses_override(monkeypatch, tmp_path):
+    """Studio log file should land under the overridden dir, not
+    under ``~/.amx`` — proves the override propagates through the
+    real call sites, not just the resolver."""
+    monkeypatch.setenv("AMX_CONFIG_DIR", str(tmp_path / "dev"))
+    from amx.config import AMXConfig
+    from amx.web.launcher import _studio_log_path
+
+    cfg = AMXConfig()
+    log_path = _studio_log_path(cfg, 47821)
+    assert log_path == tmp_path / "dev" / "logs" / "studio-47821.log"
+    # Resolver creates the dir on demand so a tail-f works immediately.
+    assert log_path.parent.is_dir()
+
+
+def test_subprocess_inherits_env_var(monkeypatch, tmp_path):
+    """The Studio child process is spawned without an explicit env
+    override; Python's subprocess.Popen inherits os.environ by
+    default, so the child sees the same AMX_CONFIG_DIR the parent
+    does. Just a smoke check that the resolver and os.environ agree."""
+    monkeypatch.setenv("AMX_CONFIG_DIR", str(tmp_path / "dev"))
+    assert os.environ["AMX_CONFIG_DIR"] == str(tmp_path / "dev")
+    from amx.config import _resolve_config_dir
+
+    assert _resolve_config_dir() == str(tmp_path / "dev")

--- a/tests/web/test_studio_subprocess_shutdown.py
+++ b/tests/web/test_studio_subprocess_shutdown.py
@@ -1,0 +1,192 @@
+"""The Studio child subprocess must shut down quickly on SIGINT /
+SIGTERM. Without an explicit handler uvicorn under uvloop on macOS
+took 3+ seconds to react, forcing the parent launcher to escalate
+all the way to SIGKILL and the user to wait ~5 seconds per
+``/studio`` Ctrl-C.
+
+The child now overrides ``server.install_signal_handlers`` and
+installs a synchronous handler that flips ``should_exit`` (and
+``force_exit`` on SIGTERM) before returning. Tests here pin the
+contract; the timing improvement is observable in the launcher
+constants but not directly assertable without spawning a real
+subprocess.
+"""
+
+from __future__ import annotations
+
+import signal
+from unittest.mock import MagicMock, patch
+
+
+def test_child_installs_explicit_signal_handlers(monkeypatch):
+    """``signal.signal`` must be called for both SIGINT and SIGTERM
+    so the child's shutdown is driven by AMX, not by uvicorn's
+    sometimes-laggy uvloop integration."""
+    import sys
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "_studio_subprocess",
+            "--port",
+            "47899",
+            "--token",
+            "fake-token",
+            "--config-path",
+            "",
+        ],
+    )
+
+    fake_server = MagicMock()
+    fake_config = MagicMock()
+    captured_handlers: dict[int, object] = {}
+
+    def fake_signal_signal(signum, handler):
+        captured_handlers[signum] = handler
+        return signal.SIG_DFL
+
+    with (
+        patch("uvicorn.Server", return_value=fake_server),
+        patch("uvicorn.Config", return_value=fake_config),
+        patch("amx.web.server.create_app", return_value=MagicMock()),
+        patch("amx.config.AMXConfig.load", return_value=MagicMock()),
+        patch("amx.utils.logging.mute_root_logger_for_studio"),
+        patch("asyncio.run"),
+        patch("signal.signal", side_effect=fake_signal_signal),
+    ):
+        from amx.web import _studio_subprocess
+
+        _studio_subprocess.main()
+
+    assert signal.SIGINT in captured_handlers
+    assert signal.SIGTERM in captured_handlers
+    # The same handler is wired for both signals — branching on the
+    # signum inside the handler keeps the install symmetric.
+    assert captured_handlers[signal.SIGINT] is captured_handlers[signal.SIGTERM]
+
+
+def test_handler_flips_should_exit_on_sigint():
+    """SIGINT triggers a graceful drain (``should_exit=True``) but
+    leaves ``force_exit`` alone so in-flight requests get a chance
+    to wrap up cleanly."""
+    import sys
+
+    sys.argv = [
+        "_studio_subprocess",
+        "--port",
+        "47899",
+        "--token",
+        "fake",
+        "--config-path",
+        "",
+    ]
+
+    fake_server = MagicMock()
+    fake_server.should_exit = False
+    fake_server.force_exit = False
+    handlers: dict[int, object] = {}
+
+    def fake_signal_signal(signum, handler):
+        handlers[signum] = handler
+        return signal.SIG_DFL
+
+    with (
+        patch("uvicorn.Server", return_value=fake_server),
+        patch("uvicorn.Config", return_value=MagicMock()),
+        patch("amx.web.server.create_app", return_value=MagicMock()),
+        patch("amx.config.AMXConfig.load", return_value=MagicMock()),
+        patch("amx.utils.logging.mute_root_logger_for_studio"),
+        patch("asyncio.run"),
+        patch("signal.signal", side_effect=fake_signal_signal),
+    ):
+        from amx.web import _studio_subprocess
+
+        _studio_subprocess.main()
+
+    handler = handlers[signal.SIGINT]
+    handler(signal.SIGINT, None)  # type: ignore[operator]
+    assert fake_server.should_exit is True
+    # SIGINT does NOT set force_exit; only SIGTERM does (next test).
+    assert fake_server.force_exit is False
+
+
+def test_handler_force_exits_on_sigterm():
+    """SIGTERM is the impatient signal: AMX's parent sends it after
+    SIGINT's grace period; the child should drop in-flight requests
+    and exit immediately."""
+    import sys
+
+    sys.argv = [
+        "_studio_subprocess",
+        "--port",
+        "47899",
+        "--token",
+        "fake",
+        "--config-path",
+        "",
+    ]
+
+    fake_server = MagicMock()
+    fake_server.should_exit = False
+    fake_server.force_exit = False
+    handlers: dict[int, object] = {}
+
+    def fake_signal_signal(signum, handler):
+        handlers[signum] = handler
+        return signal.SIG_DFL
+
+    with (
+        patch("uvicorn.Server", return_value=fake_server),
+        patch("uvicorn.Config", return_value=MagicMock()),
+        patch("amx.web.server.create_app", return_value=MagicMock()),
+        patch("amx.config.AMXConfig.load", return_value=MagicMock()),
+        patch("amx.utils.logging.mute_root_logger_for_studio"),
+        patch("asyncio.run"),
+        patch("signal.signal", side_effect=fake_signal_signal),
+    ):
+        from amx.web import _studio_subprocess
+
+        _studio_subprocess.main()
+
+    handler = handlers[signal.SIGTERM]
+    handler(signal.SIGTERM, None)  # type: ignore[operator]
+    assert fake_server.should_exit is True
+    assert fake_server.force_exit is True
+
+
+def test_child_disables_uvicorn_default_signal_handlers():
+    """uvicorn's own SIGINT install is replaced with a no-op so the
+    AMX handler is the only one reacting to the signal — no race."""
+    import sys
+
+    sys.argv = [
+        "_studio_subprocess",
+        "--port",
+        "47899",
+        "--token",
+        "fake",
+        "--config-path",
+        "",
+    ]
+
+    fake_server = MagicMock()
+
+    with (
+        patch("uvicorn.Server", return_value=fake_server),
+        patch("uvicorn.Config", return_value=MagicMock()),
+        patch("amx.web.server.create_app", return_value=MagicMock()),
+        patch("amx.config.AMXConfig.load", return_value=MagicMock()),
+        patch("amx.utils.logging.mute_root_logger_for_studio"),
+        patch("asyncio.run"),
+        patch("signal.signal"),
+    ):
+        from amx.web import _studio_subprocess
+
+        _studio_subprocess.main()
+
+    # install_signal_handlers should be replaced with a callable
+    # that no-ops, NOT left at its default.
+    assert callable(fake_server.install_signal_handlers)
+    # Verify the no-op is harmless when uvicorn invokes it.
+    fake_server.install_signal_handlers()


### PR DESCRIPTION
Two follow-ups to PR #357's triple-defense fix.

## 1) Fast child shutdown
**File:** \`amx/web/_studio_subprocess.py\`

uvicorn's default SIGINT handler under uvloop on macOS regularly took 3+ seconds to react, forcing the parent launcher to escalate all the way to SIGKILL. The user saw the extra delay plus warning lines on every \`/studio\` exit.

Fix: child disables uvicorn's built-in signal install and registers a synchronous handler for SIGINT/SIGTERM that flips \`server.should_exit\` (and \`force_exit\` on SIGTERM). Runs uvicorn via \`Server.serve\` inside \`asyncio.run\`.

Result: Ctrl-C exits in roughly 300 ms; SIGTERM/SIGKILL escalation now only triggers on a truly hung child. Launcher timeouts tightened: \`SHUTDOWN_TIMEOUT_SEC\` 3.0 → 1.5, \`TERMINATE_TIMEOUT_SEC\` 2.0 → 1.0.

## 2) AMX_CONFIG_DIR env var
**File:** \`amx/config.py\`

\`amx/cli_support/commands/doctor.py:155\` already mentioned this variable in its error text, but no code actually honoured it. New \`_resolve_config_dir()\` prefers \`\$AMX_CONFIG_DIR\` (with \`~\` expansion) and falls back to \`~/.amx\`.

Enables a side-by-side dev/prod workflow:
\`\`\`bash
alias amx-dev='AMX_CONFIG_DIR=\$HOME/.amx-dev amx'
\`\`\`

A production AMX install at \`~/.amx/\` keeps working untouched; the dev install run through \`amx-dev\` gets its own \`config.yml\`, \`history.db\`, \`uploads/\`, \`chroma_db/\`, and \`logs/\` — zero contention with production state. The child subprocess inherits the env var automatically via \`Popen\`'s default environment inheritance.

## Test plan
- [x] \`pytest -q\` — 1748 passed
- [x] 7 new \`test_config_dir_env.py\` tests pin the resolver behaviour + the studio log path + AMXConfig instances picking up the override
- [x] 4 new \`test_studio_subprocess_shutdown.py\` tests pin the explicit signal install + the should_exit/force_exit branching
- [x] \`ruff check amx tests\` clean