### PR TITLE
fix(studio): silent Ctrl+C path + loop-aware fast shutdown

### DIFF
--- a/amx/web/_studio_subprocess.py
+++ b/amx/web/_studio_subprocess.py
@@ -70,29 +70,49 @@ def main() -> int:
     # Disable uvicorn's built-in signal install — under uvloop on
     # macOS its default handler routinely takes 3+ seconds to react
     # to SIGINT, which forces the parent launcher to escalate all
-    # the way to SIGKILL. We register a synchronous handler that
-    # flips ``server.should_exit`` immediately, so the next loop
-    # iteration drains in-flight requests and exits cleanly.
+    # the way to SIGKILL. We install our own loop-aware handler
+    # below so the shutdown flag flips inside the running loop,
+    # NOT from a Python signal handler that competes with uvloop.
     server.install_signal_handlers = lambda: None
 
-    def _handle_shutdown(signum: int, _frame: object) -> None:
-        # ``should_exit`` is uvicorn's documented graceful-shutdown
-        # flag; ``force_exit`` short-circuits in-flight request
-        # waiting so SIGTERM feels snappy when the user is impatient.
+    asyncio.run(_serve_with_fast_shutdown(server))
+    return 0
+
+
+async def _serve_with_fast_shutdown(server: uvicorn.Server) -> None:  # noqa: F821
+    """Run uvicorn with loop-aware signal handlers.
+
+    Python's synchronous :func:`signal.signal` handler can race with
+    uvloop's event loop — the flip to ``server.should_exit`` is
+    deferred until the loop next checks bytecode, which under
+    in-flight ASGI middleware can take several seconds. Asyncio's
+    ``loop.add_signal_handler`` instead schedules the callback
+    inside the loop itself, so the flag flips on the next event
+    tick. Same outcome, much faster (~100ms vs 3s+ in practice).
+
+    SIGTERM also flips ``force_exit`` so anyio cancel-scopes in the
+    middleware stack release immediately instead of waiting for
+    pending tasks to drain.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _trigger_shutdown(signum: int) -> None:
         server.should_exit = True
         if signum == signal.SIGTERM:
             server.force_exit = True
 
-    signal.signal(signal.SIGINT, _handle_shutdown)
-    signal.signal(signal.SIGTERM, _handle_shutdown)
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _trigger_shutdown, sig)
+        except NotImplementedError:  # pragma: no cover - Windows
+            # asyncio on Windows doesn't support add_signal_handler;
+            # fall back to the synchronous variant for those platforms.
+            signal.signal(sig, lambda s, _f, _sig=sig: _trigger_shutdown(_sig))
 
     try:
-        asyncio.run(server.serve())
-    except KeyboardInterrupt:
-        # Last-ditch safety net; the signal handler above usually
-        # arrives first and lets ``serve()`` return normally.
+        await server.serve()
+    except KeyboardInterrupt:  # pragma: no cover - safety net
         pass
-    return 0
 
 
 if __name__ == "__main__":

--- a/amx/web/launcher.py
+++ b/amx/web/launcher.py
@@ -202,10 +202,14 @@ def launch_studio(
         )
 
     print(  # user-facing — keep print, not log
-        f"AMX Studio running → {url}\n"
-        f"AMX Studio logs    → {log_path}\n"
-        "Press Ctrl-C in this terminal to stop AMX Studio."
+        f"AMX Studio running → {url}\nPress Ctrl-C in this terminal to stop AMX Studio."
     )
+    # Log path also goes to the rotating file logger so a user who
+    # needs to debug can find it via ``amx doctor`` or by tailing
+    # the logs directory directly. Not printed to the interactive
+    # terminal because it adds visual noise for the 99% of users
+    # who never need it.
+    log.debug("AMX Studio logs at %s", log_path)
     if open_browser:
         try:
             webbrowser.open_new_tab(url)
@@ -238,13 +242,21 @@ def _shutdown_child(proc: subprocess.Popen) -> None:
 
     Each escalation is wrapped against a second ``KeyboardInterrupt``
     so a user mashing Ctrl-C never leaves an orphan child process.
+
+    Escalation events go to ``log.debug``, not stdout — with the
+    child-side fast-shutdown handler in
+    :mod:`amx.web._studio_subprocess` they should never fire in
+    normal use. The (rare) cases where they do still write to the
+    AMX log file so a curious user can investigate via
+    ``~/.amx*/logs/`` without forcing visible noise on every
+    Ctrl-C.
     """
     _signal_child_group(proc, signal.SIGINT)
     try:
         proc.wait(timeout=SHUTDOWN_TIMEOUT_SEC)
         return
     except subprocess.TimeoutExpired:
-        log.warning(
+        log.debug(
             "AMX Studio child did not exit within %.1fs; sending SIGTERM.",
             SHUTDOWN_TIMEOUT_SEC,
         )
@@ -256,7 +268,7 @@ def _shutdown_child(proc: subprocess.Popen) -> None:
         proc.wait(timeout=TERMINATE_TIMEOUT_SEC)
         return
     except subprocess.TimeoutExpired:
-        log.warning("AMX Studio child still alive after SIGTERM; sending SIGKILL.")
+        log.debug("AMX Studio child still alive after SIGTERM; sending SIGKILL.")
     except KeyboardInterrupt:  # pragma: no cover
         pass
 

--- a/tests/web/test_studio_subprocess_shutdown.py
+++ b/tests/web/test_studio_subprocess_shutdown.py
@@ -4,171 +4,43 @@ took 3+ seconds to react, forcing the parent launcher to escalate
 all the way to SIGKILL and the user to wait ~5 seconds per
 ``/studio`` Ctrl-C.
 
-The child now overrides ``server.install_signal_handlers`` and
-installs a synchronous handler that flips ``should_exit`` (and
-``force_exit`` on SIGTERM) before returning. Tests here pin the
-contract; the timing improvement is observable in the launcher
-constants but not directly assertable without spawning a real
-subprocess.
+The child overrides ``server.install_signal_handlers`` and uses
+``loop.add_signal_handler`` (the asyncio-aware variant) so the
+flag flips inside the running loop on the next tick — Python's
+synchronous :func:`signal.signal` handler races with uvloop and is
+why the earlier fast-shutdown attempt didn't actually feel fast.
 """
 
 from __future__ import annotations
 
+import asyncio
 import signal
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
-def test_child_installs_explicit_signal_handlers(monkeypatch):
-    """``signal.signal`` must be called for both SIGINT and SIGTERM
-    so the child's shutdown is driven by AMX, not by uvicorn's
-    sometimes-laggy uvloop integration."""
-    import sys
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "_studio_subprocess",
-            "--port",
-            "47899",
-            "--token",
-            "fake-token",
-            "--config-path",
-            "",
-        ],
-    )
-
-    fake_server = MagicMock()
-    fake_config = MagicMock()
-    captured_handlers: dict[int, object] = {}
-
-    def fake_signal_signal(signum, handler):
-        captured_handlers[signum] = handler
-        return signal.SIG_DFL
-
-    with (
-        patch("uvicorn.Server", return_value=fake_server),
-        patch("uvicorn.Config", return_value=fake_config),
-        patch("amx.web.server.create_app", return_value=MagicMock()),
-        patch("amx.config.AMXConfig.load", return_value=MagicMock()),
-        patch("amx.utils.logging.mute_root_logger_for_studio"),
-        patch("asyncio.run"),
-        patch("signal.signal", side_effect=fake_signal_signal),
-    ):
-        from amx.web import _studio_subprocess
-
-        _studio_subprocess.main()
-
-    assert signal.SIGINT in captured_handlers
-    assert signal.SIGTERM in captured_handlers
-    # The same handler is wired for both signals — branching on the
-    # signum inside the handler keeps the install symmetric.
-    assert captured_handlers[signal.SIGINT] is captured_handlers[signal.SIGTERM]
-
-
-def test_handler_flips_should_exit_on_sigint():
-    """SIGINT triggers a graceful drain (``should_exit=True``) but
-    leaves ``force_exit`` alone so in-flight requests get a chance
-    to wrap up cleanly."""
-    import sys
-
-    sys.argv = [
+def _studio_argv() -> list[str]:
+    return [
         "_studio_subprocess",
         "--port",
         "47899",
         "--token",
-        "fake",
+        "fake-token",
         "--config-path",
         "",
     ]
 
-    fake_server = MagicMock()
-    fake_server.should_exit = False
-    fake_server.force_exit = False
-    handlers: dict[int, object] = {}
 
-    def fake_signal_signal(signum, handler):
-        handlers[signum] = handler
-        return signal.SIG_DFL
-
-    with (
-        patch("uvicorn.Server", return_value=fake_server),
-        patch("uvicorn.Config", return_value=MagicMock()),
-        patch("amx.web.server.create_app", return_value=MagicMock()),
-        patch("amx.config.AMXConfig.load", return_value=MagicMock()),
-        patch("amx.utils.logging.mute_root_logger_for_studio"),
-        patch("asyncio.run"),
-        patch("signal.signal", side_effect=fake_signal_signal),
-    ):
-        from amx.web import _studio_subprocess
-
-        _studio_subprocess.main()
-
-    handler = handlers[signal.SIGINT]
-    handler(signal.SIGINT, None)  # type: ignore[operator]
-    assert fake_server.should_exit is True
-    # SIGINT does NOT set force_exit; only SIGTERM does (next test).
-    assert fake_server.force_exit is False
+def _run(coro):
+    """Tiny wrapper so the tests don't need pytest-asyncio."""
+    return asyncio.run(coro)
 
 
-def test_handler_force_exits_on_sigterm():
-    """SIGTERM is the impatient signal: AMX's parent sends it after
-    SIGINT's grace period; the child should drop in-flight requests
-    and exit immediately."""
-    import sys
-
-    sys.argv = [
-        "_studio_subprocess",
-        "--port",
-        "47899",
-        "--token",
-        "fake",
-        "--config-path",
-        "",
-    ]
-
-    fake_server = MagicMock()
-    fake_server.should_exit = False
-    fake_server.force_exit = False
-    handlers: dict[int, object] = {}
-
-    def fake_signal_signal(signum, handler):
-        handlers[signum] = handler
-        return signal.SIG_DFL
-
-    with (
-        patch("uvicorn.Server", return_value=fake_server),
-        patch("uvicorn.Config", return_value=MagicMock()),
-        patch("amx.web.server.create_app", return_value=MagicMock()),
-        patch("amx.config.AMXConfig.load", return_value=MagicMock()),
-        patch("amx.utils.logging.mute_root_logger_for_studio"),
-        patch("asyncio.run"),
-        patch("signal.signal", side_effect=fake_signal_signal),
-    ):
-        from amx.web import _studio_subprocess
-
-        _studio_subprocess.main()
-
-    handler = handlers[signal.SIGTERM]
-    handler(signal.SIGTERM, None)  # type: ignore[operator]
-    assert fake_server.should_exit is True
-    assert fake_server.force_exit is True
-
-
-def test_child_disables_uvicorn_default_signal_handlers():
+def test_child_disables_uvicorn_default_signal_handlers(monkeypatch):
     """uvicorn's own SIGINT install is replaced with a no-op so the
     AMX handler is the only one reacting to the signal — no race."""
     import sys
 
-    sys.argv = [
-        "_studio_subprocess",
-        "--port",
-        "47899",
-        "--token",
-        "fake",
-        "--config-path",
-        "",
-    ]
+    monkeypatch.setattr(sys, "argv", _studio_argv())
 
     fake_server = MagicMock()
 
@@ -179,14 +51,111 @@ def test_child_disables_uvicorn_default_signal_handlers():
         patch("amx.config.AMXConfig.load", return_value=MagicMock()),
         patch("amx.utils.logging.mute_root_logger_for_studio"),
         patch("asyncio.run"),
-        patch("signal.signal"),
     ):
         from amx.web import _studio_subprocess
 
         _studio_subprocess.main()
 
-    # install_signal_handlers should be replaced with a callable
-    # that no-ops, NOT left at its default.
+    # install_signal_handlers replaced with a callable that no-ops.
     assert callable(fake_server.install_signal_handlers)
-    # Verify the no-op is harmless when uvicorn invokes it.
-    fake_server.install_signal_handlers()
+    fake_server.install_signal_handlers()  # must not raise
+
+
+def test_loop_signal_handlers_registered_for_sigint_and_sigterm():
+    """Both signals must be wired to the loop, not to Python's
+    synchronous handler — the loop variant is what makes the
+    shutdown fast under uvloop."""
+    from amx.web._studio_subprocess import _serve_with_fast_shutdown
+
+    fake_server = MagicMock()
+    fake_server.serve = AsyncMock(return_value=None)
+    fake_loop = MagicMock()
+    captured: dict[int, object] = {}
+
+    def fake_add_signal_handler(sig, callback, *args):
+        captured[sig] = (callback, args)
+
+    fake_loop.add_signal_handler = fake_add_signal_handler
+
+    with patch("asyncio.get_running_loop", return_value=fake_loop):
+        _run(_serve_with_fast_shutdown(fake_server))
+
+    assert signal.SIGINT in captured
+    assert signal.SIGTERM in captured
+
+
+def test_sigint_callback_flips_should_exit_only():
+    """SIGINT triggers a graceful drain; force_exit stays False so
+    in-flight requests get a chance to finish."""
+    from amx.web._studio_subprocess import _serve_with_fast_shutdown
+
+    fake_server = MagicMock()
+    fake_server.serve = AsyncMock(return_value=None)
+    fake_server.should_exit = False
+    fake_server.force_exit = False
+    captured: dict[int, object] = {}
+
+    def fake_add(sig, cb, *args):
+        captured[sig] = (cb, args)
+
+    fake_loop = MagicMock()
+    fake_loop.add_signal_handler = fake_add
+    with patch("asyncio.get_running_loop", return_value=fake_loop):
+        _run(_serve_with_fast_shutdown(fake_server))
+
+    cb, args = captured[signal.SIGINT]
+    cb(*args)
+    assert fake_server.should_exit is True
+    assert fake_server.force_exit is False
+
+
+def test_sigterm_callback_also_sets_force_exit():
+    """SIGTERM is the impatient signal: parent sends it after
+    SIGINT's grace period; the child drops in-flight work."""
+    from amx.web._studio_subprocess import _serve_with_fast_shutdown
+
+    fake_server = MagicMock()
+    fake_server.serve = AsyncMock(return_value=None)
+    fake_server.should_exit = False
+    fake_server.force_exit = False
+    captured: dict[int, object] = {}
+
+    def fake_add(sig, cb, *args):
+        captured[sig] = (cb, args)
+
+    fake_loop = MagicMock()
+    fake_loop.add_signal_handler = fake_add
+    with patch("asyncio.get_running_loop", return_value=fake_loop):
+        _run(_serve_with_fast_shutdown(fake_server))
+
+    cb, args = captured[signal.SIGTERM]
+    cb(*args)
+    assert fake_server.should_exit is True
+    assert fake_server.force_exit is True
+
+
+def test_windows_falls_back_to_synchronous_signal():
+    """asyncio on Windows raises NotImplementedError from
+    add_signal_handler. We must fall back to signal.signal so the
+    child still has a working shutdown path."""
+    from amx.web._studio_subprocess import _serve_with_fast_shutdown
+
+    fake_server = MagicMock()
+    fake_server.serve = AsyncMock(return_value=None)
+    fake_loop = MagicMock()
+    fake_loop.add_signal_handler.side_effect = NotImplementedError
+
+    captured: dict[int, object] = {}
+
+    def fake_signal(sig, handler):
+        captured[sig] = handler
+        return signal.SIG_DFL
+
+    with (
+        patch("asyncio.get_running_loop", return_value=fake_loop),
+        patch("signal.signal", side_effect=fake_signal),
+    ):
+        _run(_serve_with_fast_shutdown(fake_server))
+
+    assert signal.SIGINT in captured
+    assert signal.SIGTERM in captured


### PR DESCRIPTION
Two follow-ups to PR #358 reported during real usage.

## 1) Banner noise removed
The launch banner used to print:
\`\`\`
AMX Studio running -> http://127.0.0.1:53584/?t=...
AMX Studio logs    -> /Users/.../.amx-dev/logs/studio-53584.log
Press Ctrl-C in this terminal to stop AMX Studio.
\`\`\`

The log-path line was useful for debugging Studio when something broke, but the 99% of users who never need it saw it on every \`/studio\` invocation. Moved to \`log.debug\` so it still lands in the AMX log file for diagnostics; not printed to the terminal.

## 2) Real fast shutdown (loop-aware signal handler)
PR #358 installed a synchronous \`signal.signal\` handler — but under uvloop on macOS that handler is deferred until the loop's next bytecode checkpoint. With ASGI middleware in flight (SSE connections, anyio task groups), the flip to \`should_exit\` was reliably 3+ seconds late, blowing past the 1.5 s grace and forcing SIGTERM/SIGKILL escalation on every Ctrl+C.

Fix: switched to \`loop.add_signal_handler\` (the asyncio-aware variant) which schedules the callback inside the running loop, so the flag flips on the next event tick (~100 ms in practice). Falls back to \`signal.signal\` on Windows where \`add_signal_handler\` raises \`NotImplementedError\`.

The escalation warning lines (\`sending SIGTERM\`, \`sending SIGKILL\`) are also demoted to \`log.debug\` so even in the rare case where a hung middleware does need force-kill, the user's terminal stays clean. Diagnostic info still lands in the AMX log file.

## Test plan
- [x] \`pytest -q\` — 1749 passed
- [x] 5 tests in \`test_studio_subprocess_shutdown.py\` rewritten to pin the loop.add_signal_handler contract + Windows fallback
- [x] \`ruff check amx tests\` clean

## Manual verification (the failing repro)
- \`amx-dev\`
- \`/studio\` → banner shows just URL + Press Ctrl+C line
- Ctrl+C
- "AMX Studio stopped." appears immediately, no SIGTERM/SIGKILL warnings
- Arrow keys work