### PR TITLE
fix(config): rolling backup + /restore-config recovery command

### DIFF
--- a/amx/cli_support/commands/restore_config.py
+++ b/amx/cli_support/commands/restore_config.py
@@ -1,0 +1,104 @@
+"""``/restore-config`` slash command.
+
+Recovery tool for the rare case where a save() corrupts
+``~/.amx/config.yml`` (or its ``AMX_CONFIG_DIR`` override). Lists the
+rotated backups, asks the user to pick one, and restores it. The
+pre-restore state itself becomes the new ``.bak.1`` so the operation
+is always reversible.
+
+Backed by the rotation helpers shipped alongside the same PR:
+:func:`amx.config.list_config_backups` and
+:func:`amx.config.restore_config_from_backup`.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+from amx.config import (
+    AMXConfig,
+    list_config_backups,
+    restore_config_from_backup,
+)
+from amx.utils.console import ask_choice, console, error, info, success, warn
+
+
+def cmd_restore_config(cfg: AMXConfig, rest: list[str]) -> None:
+    """Show available config backups and restore the user's pick.
+
+    Usage forms:
+      ``/restore-config``                 → interactive picker
+      ``/restore-config --list``          → just list, no restore
+      ``/restore-config --from <path>``   → restore an explicit backup file
+                                            (also accepts ``.bak.N``)
+    """
+    config_path = Path(cfg._config_path) if getattr(cfg, "_config_path", "") else None
+
+    if rest and rest[0] in ("--list", "-l"):
+        _print_backup_table(config_path)
+        return
+
+    if len(rest) >= 2 and rest[0] in ("--from", "-f"):
+        target = Path(rest[1]).expanduser()
+        if not target.is_file():
+            error(f"Backup file not found: {target}")
+            return
+        _perform_restore(target, config_path)
+        return
+
+    backups = list_config_backups(config_path)
+    if not backups:
+        warn(
+            "No rotated config backups found. "
+            "Backups are created on every save() — start a fresh AMX "
+            "session and they'll begin accumulating."
+        )
+        return
+
+    _print_backup_table(config_path)
+    console.print()
+    choices = [_format_backup_choice(b) for b in backups]
+    picked = ask_choice("Restore which backup?", choices)
+    idx = choices.index(picked)
+    _perform_restore(backups[idx], config_path)
+
+
+def _print_backup_table(config_path: Path | None) -> None:
+    backups = list_config_backups(config_path)
+    if not backups:
+        info(
+            "No backups yet. The first save() after this PR will create "
+            "config.yml.bak.1; up to five generations are kept."
+        )
+        return
+    info(f"Available backups ({len(backups)} of max 5):")
+    for backup in backups:
+        ts = _format_backup_choice(backup)
+        console.print(f"  {ts}")
+
+
+def _format_backup_choice(backup: Path) -> str:
+    try:
+        stat = backup.stat()
+        mtime = datetime.datetime.fromtimestamp(stat.st_mtime)
+        size_kb = stat.st_size / 1024
+        return f"{backup.name} ({mtime:%Y-%m-%d %H:%M:%S}, {size_kb:.1f} KB)"
+    except OSError:
+        return backup.name
+
+
+def _perform_restore(backup: Path, config_path: Path | None) -> None:
+    try:
+        restored = restore_config_from_backup(backup, config_path)
+    except FileNotFoundError as exc:
+        error(str(exc))
+        return
+    except Exception as exc:
+        error(f"Restore failed: {exc}")
+        return
+    success(
+        f"Restored {backup.name} -> {restored.name}. "
+        "The pre-restore state was rotated to .bak.1 so the restore is "
+        "reversible. Restart the CLI for the new config to take effect."
+    )

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -1062,6 +1062,11 @@ def _handle_session_builtin(
         path = cfg.save()
         success(f"Saved configuration to {path}")
         return True
+    if head == "restore-config":
+        from amx.cli_support.commands.restore_config import cmd_restore_config
+
+        cmd_restore_config(cfg, parts[1:])
+        return True
     if head == "usage":
         # Top-level: /usage summarises LLM cost from local history without
         # requiring the user to enter any namespace first. No network call.

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -82,6 +82,19 @@ _ROOT_BUILTINS: tuple[SlashCommand, ...] = (
         ),
         cross_namespace=True,
     ),
+    SlashCommand(
+        "/restore-config",
+        "",
+        "Restore config.yml from a rotated backup",
+        long_desc=(
+            "Recovery tool when a recent save corrupted config.yml. Lists "
+            "available `config.yml.bak.1..N` backups with timestamps; pick "
+            "one and AMX rotates the current live file into a backup slot "
+            "before restoring. Always reversible: the pre-restore state "
+            "becomes the new .bak.1."
+        ),
+        cross_namespace=True,
+    ),
 )
 
 _ROOT_ENTRYPOINTS: tuple[SlashCommand, ...] = (

--- a/amx/config.py
+++ b/amx/config.py
@@ -72,6 +72,115 @@ def _resolve_config_dir() -> str:
     return str(Path.home() / ".amx")
 
 
+#: How many rotated config.yml backups to keep next to the live file.
+#: Stored as ``config.yml.bak.1`` (newest) through ``config.yml.bak.N``
+#: (oldest). Five generations matches the convention of editors with
+#: built-in quick-undo and is enough headroom for a user to notice and
+#: recover within a session even if multiple bad saves stack up before
+#: they spot the regression.
+BACKUP_ROTATION_KEEP = 5
+
+
+def _rotate_config_backups(target: Path, keep: int = BACKUP_ROTATION_KEEP) -> None:
+    """Rotate ``<target>.bak.1..N`` immediately before overwriting target.
+
+    Sequence (called BEFORE the atomic write):
+      * Drop the oldest backup (``.bak.N``).
+      * Promote ``.bak.N-1`` → ``.bak.N``, ``.bak.N-2`` → ``.bak.N-1`` ...
+      * Copy the current ``target`` (the about-to-be-overwritten file)
+        to ``.bak.1``.
+
+    Best-effort throughout: a failure here must NOT block the save.
+    The live save is still atomic on its own, so the worst case from a
+    rotation failure is missing a single backup generation, not a
+    corrupted file.
+    """
+    if not target.exists():
+        return  # first-ever save: nothing to back up yet
+    try:
+        # Drop the oldest first to make room.
+        oldest = target.with_suffix(target.suffix + f".bak.{keep}")
+        if oldest.exists():
+            with suppress(OSError):
+                oldest.unlink()
+        # Promote each generation by one slot.
+        for i in range(keep - 1, 0, -1):
+            src = target.with_suffix(target.suffix + f".bak.{i}")
+            dst = target.with_suffix(target.suffix + f".bak.{i + 1}")
+            if src.exists():
+                with suppress(OSError):
+                    src.replace(dst)
+        # Copy live → .bak.1 (copy, not rename, so the atomic save
+        # below still has a target to overwrite).
+        import shutil as _shutil
+
+        dst = target.with_suffix(target.suffix + ".bak.1")
+        with suppress(OSError):
+            _shutil.copy2(target, dst)
+            # Backup inherits the same owner-only permissions as the
+            # source — credentials shouldn't be world-readable.
+            with suppress(OSError):
+                os.chmod(dst, 0o600)
+    except Exception:
+        # Rotation is purely opportunistic; never propagate a failure
+        # that would block the user's save.
+        return
+
+
+def list_config_backups(config_path: Path | None = None) -> list[Path]:
+    """Return the on-disk rotated backups, newest first.
+
+    Used by ``amx restore-config`` to show the user which generations
+    are available. Defaults to ``~/.amx/config.yml.bak.*`` (or the
+    ``AMX_CONFIG_DIR`` override).
+    """
+    if config_path is None:
+        config_path = Path(_resolve_config_dir()) / "config.yml"
+    parent = config_path.parent
+    if not parent.is_dir():
+        return []
+    out: list[tuple[int, Path]] = []
+    for child in parent.iterdir():
+        name = child.name
+        prefix = config_path.name + ".bak."
+        if not name.startswith(prefix):
+            continue
+        try:
+            idx = int(name[len(prefix) :])
+        except ValueError:
+            continue
+        out.append((idx, child))
+    out.sort(key=lambda pair: pair[0])
+    return [path for _, path in out]
+
+
+def restore_config_from_backup(
+    backup: Path,
+    config_path: Path | None = None,
+) -> Path:
+    """Atomically copy ``backup`` over the live config.
+
+    The current live file is rotated into ``.bak.1`` first (via the
+    standard rotation helper) so a restore is itself undoable. Returns
+    the path of the restored live file.
+    """
+    if config_path is None:
+        config_path = Path(_resolve_config_dir()) / "config.yml"
+    if not backup.is_file():
+        raise FileNotFoundError(f"backup not found: {backup}")
+    # Snapshot the backup's contents BEFORE rotation: rotating the live
+    # file would shift .bak.N → .bak.N+1 and could move the user's
+    # chosen backup out from under us (e.g. picking .bak.5 with the
+    # chain already full).
+    payload = backup.read_bytes()
+    _rotate_config_backups(config_path)
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_bytes(payload)
+    with suppress(OSError):
+        os.chmod(config_path, 0o600)
+    return config_path
+
+
 PROFILING_MODES = ("full", "sampled", "metadata")
 SUPPORTED_EMBEDDING_KINDS = ("minilm", "openai_compatible", "sentence_transformers")
 DEFAULT_EMBEDDING_KIND = "minilm"
@@ -2084,6 +2193,17 @@ class AMXConfig:
                 store=get_default_store(),
             )
             payload = yaml.dump(data, default_flow_style=False, sort_keys=False)
+            # Rotating backup BEFORE the atomic write: if the new
+            # YAML turns out to be corrupted or wipes profile dicts
+            # via some future bug, the user can restore from one of
+            # the previous N saves. Five generations is the same
+            # ballpark Vim, JetBrains, and macOS Finder use for
+            # quick undo. Best-effort: a backup failure must never
+            # block the save itself (the new write is still atomic
+            # and the user's in-memory state is the source of truth
+            # at this instant).
+            with suppress(Exception):
+                _rotate_config_backups(p, keep=BACKUP_ROTATION_KEEP)
             # Atomic write to reduce config corruption/state loss on interruptions.
             with tempfile.NamedTemporaryFile(
                 mode="w",

--- a/tests/test_config_rolling_backup.py
+++ b/tests/test_config_rolling_backup.py
@@ -1,0 +1,142 @@
+"""Every :meth:`AMXConfig.save` rotates the previous on-disk YAML
+into a backup slot (``config.yml.bak.1`` … ``.bak.N``) so that if a
+future bug ever again silently truncates the live file, the user
+has up to five generations of pre-incident data on disk for
+recovery via ``/restore-config``.
+
+These tests pin the rotation contract end-to-end and verify the
+restore helper actually puts the backup contents back as the live
+file (with the pre-restore state preserved as the new ``.bak.1``).
+"""
+
+from __future__ import annotations
+
+
+def test_first_save_creates_no_backup_if_no_prior_file(tmp_path):
+    """A fresh install: the very first save() has nothing to back up
+    because there's no existing file on disk."""
+    from amx.config import AMXConfig
+
+    cfg_path = tmp_path / "config.yml"
+    cfg = AMXConfig()
+    cfg.save(str(cfg_path))
+    assert cfg_path.exists()
+    assert not (tmp_path / "config.yml.bak.1").exists()
+
+
+def test_save_rotates_prior_file_into_bak1(tmp_path):
+    """Second save: the previous on-disk content becomes .bak.1."""
+    from amx.config import AMXConfig
+
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text("active_db_profile: pre-save\n")
+
+    cfg = AMXConfig.load(str(cfg_path))
+    cfg.save(str(cfg_path))
+
+    bak1 = tmp_path / "config.yml.bak.1"
+    assert bak1.exists()
+    assert "pre-save" in bak1.read_text()
+
+
+def test_save_keeps_at_most_5_generations(tmp_path):
+    """A sixth save rolls .bak.5 off the end."""
+    from amx.config import AMXConfig
+
+    cfg_path = tmp_path / "config.yml"
+    # Seed with a base file so the first save() will rotate it.
+    cfg_path.write_text("generation: 0\n")
+
+    for i in range(1, 7):
+        # Each save writes new content and rotates the prior file.
+        cfg = AMXConfig.load(str(cfg_path))
+        cfg_path.write_text(f"generation: {i}\n")
+        cfg.save(str(cfg_path))
+
+    # We should have .bak.1 through .bak.5; .bak.6 must not exist.
+    for i in range(1, 6):
+        assert (tmp_path / f"config.yml.bak.{i}").exists(), f"missing bak.{i}"
+    assert not (tmp_path / "config.yml.bak.6").exists()
+
+
+def test_list_config_backups_returns_newest_first(tmp_path):
+    """``.bak.1`` is the newest backup; list_config_backups returns
+    backups in numeric order so callers can show them most-recent-first."""
+    from amx.config import list_config_backups
+
+    cfg_path = tmp_path / "config.yml"
+    for i in range(1, 4):
+        (tmp_path / f"config.yml.bak.{i}").write_text(f"gen {i}\n")
+
+    backups = list_config_backups(cfg_path)
+    names = [b.name for b in backups]
+    assert names == [
+        "config.yml.bak.1",
+        "config.yml.bak.2",
+        "config.yml.bak.3",
+    ]
+
+
+def test_restore_from_backup_swaps_in_place(tmp_path):
+    """Restore replaces the live config with the backup contents AND
+    rotates the pre-restore state into the new .bak.1 so the user
+    can undo the restore itself."""
+    from amx.config import restore_config_from_backup
+
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text("active_db_profile: live-broken\ndb_profiles: {}\n")
+    backup = tmp_path / "config.yml.bak.2"
+    backup.write_text("active_db_profile: known-good\ndb_profiles: {}\n")
+
+    restore_config_from_backup(backup, cfg_path)
+
+    live = cfg_path.read_text()
+    assert "known-good" in live, "restore didn't take effect"
+
+    new_bak1 = tmp_path / "config.yml.bak.1"
+    assert new_bak1.exists(), "pre-restore state not rotated to bak.1"
+    assert "live-broken" in new_bak1.read_text()
+
+
+def test_restore_raises_for_missing_backup(tmp_path):
+    """Restoring from a non-existent backup raises FileNotFoundError —
+    the CLI handler surfaces this as an error() instead of crashing."""
+    from amx.config import restore_config_from_backup
+
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text("live\n")
+    missing = tmp_path / "does-not-exist.bak.42"
+
+    try:
+        restore_config_from_backup(missing, cfg_path)
+    except FileNotFoundError:
+        return
+    raise AssertionError("expected FileNotFoundError")
+
+
+def test_rotation_is_best_effort_and_does_not_block_save(tmp_path, monkeypatch):
+    """If the rotation step somehow fails (e.g. permission error),
+    the save() must still succeed. The user's data on disk is more
+    important than a perfect backup chain."""
+    from amx import config as cfg_mod
+
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text("active_db_profile: prior\ndb_profiles: {}\n")
+
+    cfg = cfg_mod.AMXConfig.load(str(cfg_path))
+
+    # Force rotation to raise — save() should still complete because
+    # the helper wraps every step in suppress().
+    def boom(*_a, **_kw):
+        raise OSError("simulated rotation failure")
+
+    monkeypatch.setattr(cfg_mod, "_rotate_config_backups", boom)
+    try:
+        cfg.save(str(cfg_path))
+    except OSError:
+        raise AssertionError(
+            "rotation failure leaked through save() — would block user's "
+            "ability to persist config when backups are misbehaving"
+        )
+    # Live file is still written; that's the contract.
+    assert cfg_path.exists()


### PR DESCRIPTION
## Summary
- `save()` now rotates the live `config.yml` into `config.yml.bak.1..5` before the atomic write, keeping five generations on disk so a future autosave bug can't silently obliterate the user's profile dicts again.
- New `list_config_backups()` / `restore_config_from_backup()` helpers plus a `/restore-config` slash command — interactive picker by default, also `--list` and `--from <path>`. The pre-restore live file is rotated to `.bak.1` so the restore itself is undoable.
- Rotation is best-effort: any failure (permission errors, ENOSPC, racy fs) is suppressed so the live save still completes. The user's in-memory state is the source of truth at write time.

Follow-up to #360. Together they form the data-integrity safety net: #360 stops the bug class, this PR makes the next slip recoverable without leaving the CLI.

## Test plan
- [x] `pytest tests/test_config_rolling_backup.py tests/test_config_reload_no_autosave_race.py -v` — 11/11 green
- [x] `pytest -q` — 1760 passed
- [x] `ruff check amx tests` + `ruff format --check` — clean
- [x] New regression tests pin: no backup on first save, rotation into `.bak.1`, at-most-5-generation cap, restore in-place with pre-state rotated to `.bak.1`, missing-backup error, rotation failure does not block save