### PR TITLE
fix(config): refuse to save when in-memory state is inconsistent

### DIFF
--- a/amx/config.py
+++ b/amx/config.py
@@ -81,6 +81,37 @@ def _resolve_config_dir() -> str:
 BACKUP_ROTATION_KEEP = 5
 
 
+def _detect_silent_truncation(cfg) -> list[str]:
+    """Return integrity problems that should block a save.
+
+    The PR #351 autosave race produced configs where ``active_*_profile``
+    pointed at a name but the matching ``*_profiles`` dict was empty —
+    the on-disk evidence of in-memory state being silently truncated
+    before write. Any save in that shape would propagate the loss to
+    every rotated backup over time. We catch the pattern at the
+    serialization boundary and refuse to write.
+
+    The placeholder ``"default"`` is ignored because the loader injects
+    it on fresh installs where no real profile choice has ever been
+    recorded — flagging it would block the very first legitimate save.
+    """
+    problems: list[str] = []
+    pairs = (
+        ("active_db_profile", "db_profiles"),
+        ("active_llm_profile", "llm_profiles"),
+        ("active_doc_profile", "doc_profiles"),
+        ("active_code_profile", "code_profiles"),
+    )
+    for active_attr, dict_attr in pairs:
+        active = getattr(cfg, active_attr, "") or ""
+        bucket = getattr(cfg, dict_attr, {}) or {}
+        if active and active != "default" and active not in bucket:
+            problems.append(
+                f"{active_attr}={active!r} but {dict_attr} has no such entry"
+            )
+    return problems
+
+
 def _rotate_config_backups(target: Path, keep: int = BACKUP_ROTATION_KEEP) -> None:
     """Rotate ``<target>.bak.1..N`` immediately before overwriting target.
 
@@ -2112,6 +2143,28 @@ class AMXConfig:
                 self.db_profiles[self.active_db_profile] = self.db
             if self.active_llm_profile:
                 self.llm_profiles[self.active_llm_profile] = replace(self.llm)
+
+            # Shadow integrity check: ``db_profiles`` and ``llm_profiles``
+            # have just been auto-repaired above (the historical save
+            # contract). Anything still inconsistent at this point —
+            # ``active_doc_profile`` / ``active_code_profile`` pointing
+            # at an absent dict entry — matches the PR #351 autosave
+            # race signature with no built-in recovery. Refuse the
+            # write so the truncation doesn't propagate into the
+            # rotated backups.
+            problems = _detect_silent_truncation(self)
+            if problems:
+                import logging as _logging
+
+                _logging.getLogger("amx.config").error(
+                    "AMX config save refused — in-memory state is "
+                    "internally inconsistent:\n  - %s\nDisk file %s left "
+                    "untouched. Run /restore-config to recover from the "
+                    "most recent backup if needed.",
+                    "\n  - ".join(problems),
+                    p,
+                )
+                return p
 
             doc_paths_yaml = self._doc_paths_for_yaml()
             code_paths_yaml = self._code_paths_for_yaml()

--- a/amx/config.py
+++ b/amx/config.py
@@ -106,9 +106,7 @@ def _detect_silent_truncation(cfg) -> list[str]:
         active = getattr(cfg, active_attr, "") or ""
         bucket = getattr(cfg, dict_attr, {}) or {}
         if active and active != "default" and active not in bucket:
-            problems.append(
-                f"{active_attr}={active!r} but {dict_attr} has no such entry"
-            )
+            problems.append(f"{active_attr}={active!r} but {dict_attr} has no such entry")
     return problems
 
 

--- a/tests/test_config_rolling_backup.py
+++ b/tests/test_config_rolling_backup.py
@@ -29,7 +29,12 @@ def test_save_rotates_prior_file_into_bak1(tmp_path):
     from amx.config import AMXConfig
 
     cfg_path = tmp_path / "config.yml"
-    cfg_path.write_text("active_db_profile: pre-save\n")
+    cfg_path.write_text(
+        "active_db_profile: pre-save\n"
+        "db_profiles:\n"
+        "  pre-save:\n"
+        "    backend: postgresql\n"
+    )
 
     cfg = AMXConfig.load(str(cfg_path))
     cfg.save(str(cfg_path))
@@ -121,7 +126,7 @@ def test_rotation_is_best_effort_and_does_not_block_save(tmp_path, monkeypatch):
     from amx import config as cfg_mod
 
     cfg_path = tmp_path / "config.yml"
-    cfg_path.write_text("active_db_profile: prior\ndb_profiles: {}\n")
+    cfg_path.write_text("active_db_profile: ''\ndb_profiles: {}\n")
 
     cfg = cfg_mod.AMXConfig.load(str(cfg_path))
 

--- a/tests/test_config_rolling_backup.py
+++ b/tests/test_config_rolling_backup.py
@@ -30,10 +30,7 @@ def test_save_rotates_prior_file_into_bak1(tmp_path):
 
     cfg_path = tmp_path / "config.yml"
     cfg_path.write_text(
-        "active_db_profile: pre-save\n"
-        "db_profiles:\n"
-        "  pre-save:\n"
-        "    backend: postgresql\n"
+        "active_db_profile: pre-save\ndb_profiles:\n  pre-save:\n    backend: postgresql\n"
     )
 
     cfg = AMXConfig.load(str(cfg_path))

--- a/tests/test_config_save_integrity_gate.py
+++ b/tests/test_config_save_integrity_gate.py
@@ -32,8 +32,7 @@ def test_save_refused_when_active_doc_profile_missing_from_dict(tmp_path, caplog
 
     cfg_path = tmp_path / "config.yml"
     pristine = (
-        "active_doc_profile: ghost-docs\n"
-        "doc_profiles:\n  ghost-docs:\n    - /tmp/something\n"
+        "active_doc_profile: ghost-docs\ndoc_profiles:\n  ghost-docs:\n    - /tmp/something\n"
     )
     cfg_path.write_text(pristine)
 
@@ -45,8 +44,7 @@ def test_save_refused_when_active_doc_profile_missing_from_dict(tmp_path, caplog
         "live config was overwritten — gate didn't fire and broken state is now on disk"
     )
     assert any(
-        "refused" in r.message.lower() or "integrity" in r.message.lower()
-        for r in caplog.records
+        "refused" in r.message.lower() or "integrity" in r.message.lower() for r in caplog.records
     ), "expected a loud error log explaining the refusal"
 
 

--- a/tests/test_config_save_integrity_gate.py
+++ b/tests/test_config_save_integrity_gate.py
@@ -1,0 +1,130 @@
+"""Pre-save integrity gate: refuse to overwrite the on-disk config
+when in-memory state has the autosave-race truncation signature.
+
+After PR #360 (race fix) and PR #361 (rotating backup + restore), the
+remaining recovery hole is: a future regression that re-introduces an
+inconsistent state would have its bad payload copied through every
+rotated backup over subsequent saves, gradually overwriting the
+clean history. The gate stops that propagation at the source.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def _make_cfg():
+    from amx.config import AMXConfig
+
+    return AMXConfig()
+
+
+def test_save_refused_when_active_doc_profile_missing_from_dict(tmp_path, caplog):
+    """``doc_profiles`` has no in-save auto-repair (unlike db/llm where
+    ``save()`` re-inserts ``self.db`` / ``self.llm`` on the fly), so a
+    state with ``active_doc_profile="ghost"`` and ``doc_profiles={}`` is
+    the PR #351 truncation signature with nothing to fall back on. The
+    gate must refuse rather than write a YAML that ratchets the loss
+    into every rotated backup."""
+    cfg = _make_cfg()
+    cfg.active_doc_profile = "ghost-docs"
+    cfg.doc_profiles.clear()
+
+    cfg_path = tmp_path / "config.yml"
+    pristine = (
+        "active_doc_profile: ghost-docs\n"
+        "doc_profiles:\n  ghost-docs:\n    - /tmp/something\n"
+    )
+    cfg_path.write_text(pristine)
+
+    with caplog.at_level(logging.ERROR, logger="amx.config"):
+        result = cfg.save(str(cfg_path))
+
+    assert result == cfg_path
+    assert cfg_path.read_text() == pristine, (
+        "live config was overwritten — gate didn't fire and broken state is now on disk"
+    )
+    assert any(
+        "refused" in r.message.lower() or "integrity" in r.message.lower()
+        for r in caplog.records
+    ), "expected a loud error log explaining the refusal"
+
+
+def test_save_refused_when_active_code_profile_missing_from_dict(tmp_path):
+    cfg = _make_cfg()
+    cfg.active_code_profile = "ghost-code"
+    cfg.code_profiles.clear()
+
+    cfg_path = tmp_path / "config.yml"
+    pristine = "active_code_profile: ghost-code\ncode_profiles:\n  ghost-code: {}\n"
+    cfg_path.write_text(pristine)
+    cfg.save(str(cfg_path))
+    assert cfg_path.read_text() == pristine
+
+
+def test_save_repairs_db_and_llm_inconsistency_then_writes(tmp_path):
+    """For ``active_db_profile`` / ``active_llm_profile`` the save()
+    contract has historically auto-inserted the in-memory dataclass
+    into the dict before serialization. The gate must not break that
+    repair path — it should only fire when no fallback exists."""
+    cfg = _make_cfg()
+    cfg.active_db_profile = "pg-prod"
+    cfg.db_profiles.clear()  # would trip the raw integrity check
+
+    cfg_path = tmp_path / "config.yml"
+    cfg.save(str(cfg_path))
+
+    assert cfg_path.exists()
+    reloaded_text = cfg_path.read_text()
+    assert "pg-prod" in reloaded_text
+    assert "active_db_profile: pg-prod" in reloaded_text
+
+
+def test_save_succeeds_when_active_matches_dict(tmp_path):
+    """Counter-test: legitimate save with consistent state must still write."""
+    from amx.config import LLMConfig
+
+    cfg = _make_cfg()
+    cfg.active_llm_profile = "real"
+    cfg.llm_profiles["real"] = LLMConfig(provider="openai", model="gpt-4")
+
+    cfg_path = tmp_path / "config.yml"
+    cfg.save(str(cfg_path))
+
+    body = cfg_path.read_text()
+    assert "real" in body
+    assert "active_llm_profile: real" in body
+
+
+def test_save_succeeds_for_fresh_install_default_placeholder(tmp_path):
+    """The loader injects ``active_db_profile: "default"`` on fresh
+    installs with no profile dict. That state is legitimate (the user
+    hasn't picked anything yet) and must not trigger the gate."""
+    cfg = _make_cfg()
+    cfg.active_db_profile = "default"
+    cfg.db_profiles.clear()
+
+    cfg_path = tmp_path / "config.yml"
+    cfg.save(str(cfg_path))
+    assert cfg_path.exists()
+    assert "active_db_profile: default" in cfg_path.read_text()
+
+
+def test_detect_silent_truncation_lists_all_broken_pairs():
+    from amx.config import _detect_silent_truncation
+
+    cfg = _make_cfg()
+    cfg.active_db_profile = "x"
+    cfg.active_llm_profile = "y"
+    cfg.active_doc_profile = "z"
+    cfg.active_code_profile = "w"
+    cfg.db_profiles.clear()
+    cfg.llm_profiles.clear()
+    cfg.doc_profiles.clear()
+    cfg.code_profiles.clear()
+
+    problems = _detect_silent_truncation(cfg)
+    assert len(problems) == 4
+    joined = " ".join(problems)
+    for ghost in ("x", "y", "z", "w"):
+        assert f"'{ghost}'" in joined


### PR DESCRIPTION
## Summary
- New ``_detect_silent_truncation()`` helper plus a gate in ``AMXConfig.save()`` that refuses to write when any ``active_doc_profile`` / ``active_code_profile`` points to a name missing from its dict — the PR #351 autosave-race signature with no built-in repair.
- Gate runs AFTER the historical ``db_profiles[active]=self.db`` / ``llm_profiles[active]=self.llm`` auto-repair lines, so legitimate save() callers that set an active name without pre-populating the dict still work for db/llm (unchanged contract).
- On refusal: error logged, the live file is left untouched, the user is pointed at ``/restore-config`` for recovery from the rotated backups shipped in #361.

Completes the three-PR data-integrity series (#360 stop, #361 recover, #362 prevent).

## Test plan
- [x] ``pytest tests/test_config_save_integrity_gate.py -v`` — 5 new regression tests
- [x] ``pytest tests/test_config_reload_no_autosave_race.py tests/test_config_rolling_backup.py tests/test_doctor_and_schema.py`` — 39/39 green (existing tests still pass under the new gate)
- [x] ``pytest -q`` — 1766 passed
- [x] ``ruff check amx tests`` — clean