### PR TITLE
fix(config): remove_db_profile / remove_llm_profile resurrection via mid-removal autosave

### DIFF
--- a/amx/config.py
+++ b/amx/config.py
@@ -2462,32 +2462,47 @@ class AMXConfig:
         """
         if name not in self.db_profiles:
             raise KeyError(f"Unknown DB profile: {name}")
-        del self.db_profiles[name]
-        # Drop the deleted DB from every doc/code link list so /ask scope
-        # resolution doesn't reference a phantom profile.
-        for prof, dbs in list(self.doc_profile_linked_dbs.items()):
-            self.doc_profile_linked_dbs[prof] = [d for d in dbs if d != name]
-        for prof, dbs in list(self.code_profile_linked_dbs.items()):
-            self.code_profile_linked_dbs[prof] = [d for d in dbs if d != name]
-        # 0.11.0: also evict from the multi-pick scope to prevent ghost
-        # selections after a profile is removed.
-        if name in self.active_db_profiles:
-            self.active_db_profiles = [n for n in self.active_db_profiles if n != name]
-        if self.active_db_profile == name:
-            # Promote the next available profile when there is one;
-            # otherwise clear the active pointer + reset cfg.db to an
-            # empty DBConfig so callers reading those fields don't see
-            # stale data from the just-deleted profile.
-            if self.db_profiles:
-                self.active_db_profile = next(iter(self.db_profiles.keys()))
-                self.db = self.db_profiles[self.active_db_profile]
-                if not self.active_db_profiles:
-                    self.active_db_profiles = [self.active_db_profile]
-            else:
-                self.active_db_profile = ""
-                self.db = DBConfig()
+        # Wrap the whole mutation set in a transaction. Two of the
+        # writes below (``active_db_profiles = ...`` and the late
+        # ``self.db = DBConfig()`` / ``self.active_db_profile = ...``
+        # assignments) each trip ``__setattr__`` -> autosave on their
+        # own. If autosave fires while ``active_db_profile`` still
+        # names the just-deleted entry, ``save()``'s "mirror active
+        # profile data into ``db_profiles[active]``" contract
+        # resurrects the row we just popped — the user sees
+        # ``/remove-db-profile dbr`` claim success but ``dbr`` is back
+        # on the next prompt. Defer every save to the outermost exit
+        # so the on-disk state never observes the mid-removal,
+        # inconsistent shape.
+        with self.transaction():
+            del self.db_profiles[name]
+            # Drop the deleted DB from every doc/code link list so /ask scope
+            # resolution doesn't reference a phantom profile.
+            for prof, dbs in list(self.doc_profile_linked_dbs.items()):
+                self.doc_profile_linked_dbs[prof] = [d for d in dbs if d != name]
+            for prof, dbs in list(self.code_profile_linked_dbs.items()):
+                self.code_profile_linked_dbs[prof] = [d for d in dbs if d != name]
+            # Clear the active pointer FIRST (when it names the
+            # removed profile) so the trailing scope/list assignments
+            # cannot trigger the resurrection path described above.
+            if self.active_db_profile == name:
+                if self.db_profiles:
+                    self.active_db_profile = next(iter(self.db_profiles.keys()))
+                    self.db = self.db_profiles[self.active_db_profile]
+                else:
+                    self.active_db_profile = ""
+                    self.db = DBConfig()
+            # 0.11.0: also evict from the multi-pick scope to prevent
+            # ghost selections after a profile is removed.
+            if name in self.active_db_profiles:
+                self.active_db_profiles = [n for n in self.active_db_profiles if n != name]
+            if (
+                self.active_db_profile
+                and not self.active_db_profiles
+            ):
+                self.active_db_profiles = [self.active_db_profile]
+            elif not self.active_db_profile:
                 self.active_db_profiles = []
-        self._autosave()
 
     def apply_active_llm_profile(self) -> None:
         name = self.active_llm_profile or "default"
@@ -2533,21 +2548,28 @@ class AMXConfig:
         """
         if name not in self.llm_profiles:
             raise KeyError(f"Unknown LLM profile: {name}")
-        del self.llm_profiles[name]
-        if self.active_llm_profile == name:
-            if self.llm_profiles:
-                self.active_llm_profile = next(iter(self.llm_profiles.keys()))
-                self.llm = replace(self.llm_profiles[self.active_llm_profile])
-            else:
-                # No remaining profiles → clear active pointer and reset
-                # cfg.llm to an empty LLMConfig. The /ask surfaces that
-                # state via the configure-llm 412 (Studio) and the
-                # `/search` discussion-requires-LLM message (CLI).
-                self.active_llm_profile = ""
-                self.llm = LLMConfig()
-        if self.rag_llm_profile == name:
-            self.rag_llm_profile = ""
-        self._autosave()
+        # Same transaction pattern as remove_db_profile. The active-pointer
+        # update and the cfg.llm refresh below must land together: if
+        # ``active_llm_profile = next_name`` is allowed to autosave on its
+        # own, ``save()``'s mirror clause copies the still-stale ``cfg.llm``
+        # onto ``llm_profiles[next_name]`` and overwrites the promoted
+        # profile's data (the same shape as the bug ``set_active_llm_profile``
+        # already calls out).
+        with self.transaction():
+            del self.llm_profiles[name]
+            if self.active_llm_profile == name:
+                if self.llm_profiles:
+                    self.active_llm_profile = next(iter(self.llm_profiles.keys()))
+                    self.llm = replace(self.llm_profiles[self.active_llm_profile])
+                else:
+                    # No remaining profiles → clear active pointer and reset
+                    # cfg.llm to an empty LLMConfig. The /ask surfaces that
+                    # state via the configure-llm 412 (Studio) and the
+                    # `/search` discussion-requires-LLM message (CLI).
+                    self.active_llm_profile = ""
+                    self.llm = LLMConfig()
+            if self.rag_llm_profile == name:
+                self.rag_llm_profile = ""
 
     def effective_rag_llm(self) -> LLMConfig:
         """Return the LLMConfig the RAG agent should use right now.

--- a/tests/test_remove_last_profile.py
+++ b/tests/test_remove_last_profile.py
@@ -113,6 +113,41 @@ def test_llm_available_returns_false_after_last_delete(cfg_one_db_one_llm) -> No
     assert hasattr(SessionMemoryMixin, "_llm_available")
 
 
+def test_remove_last_db_profile_through_loaded_config_persists(tmp_path) -> None:
+    """Regression: deleting the last DB profile through a write-through
+    ``AMXConfig.load()`` instance must actually drop the entry — both in
+    memory and in the YAML. The pre-fix shape was: mid-removal,
+    ``active_db_profiles = [...]`` reassignment tripped ``__setattr__`` ->
+    autosave, and ``save()``'s "mirror active profile data into
+    ``db_profiles[active]``" contract resurrected the just-popped row
+    because ``active_db_profile`` was still pointing at it. The CLI then
+    reported success while the profile silently came back."""
+    import yaml
+
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text(
+        "schema_version: 1\n"
+        "db_profiles:\n"
+        "  dbr:\n"
+        "    backend: databricks\n"
+        "    host: dbc-example.cloud.databricks.com\n"
+        "active_db_profile: dbr\n"
+        "active_db_profiles: [dbr]\n"
+    )
+    cfg = AMXConfig.load(str(cfg_path))
+    assert "dbr" in cfg.db_profiles
+
+    cfg.remove_db_profile("dbr")
+
+    assert cfg.db_profiles == {}
+    assert cfg.active_db_profile == ""
+    assert cfg.active_db_profiles == []
+
+    on_disk = yaml.safe_load(cfg_path.read_text()) or {}
+    assert on_disk.get("db_profiles") in ({}, None)
+    assert (on_disk.get("active_db_profile") or "") == ""
+
+
 def test_remove_unknown_profile_still_raises() -> None:
     """Trying to remove a name that doesn't exist still raises
     KeyError — no silent failure that masks typos."""


### PR DESCRIPTION
## Summary
- ``/remove-db-profile dbr`` reported success but the profile silently came back on the next prompt — both in memory and on disk.
- Root cause: ``remove_db_profile`` reassigns ``self.active_db_profiles = [...]`` mid-flight, which trips ``__setattr__`` -> autosave while ``db_profiles`` has already been popped but ``active_db_profile`` still names the deleted entry. ``save()``'s mirror clause (``self.db_profiles[self.active_db_profile] = self.db``) resurrects the just-popped row, ``_detect_silent_truncation`` sees a consistent state, and the YAML gets written with the deleted profile back in place.
- Fix: wrap both ``remove_db_profile`` and ``remove_llm_profile`` in ``cfg.transaction()`` so every mutation lands together and only the final, consistent state hits ``save()``. DB variant also reorders the cleanup so the active pointer clears before the scope list is touched — robust even outside the transaction.

## Test plan
- [x] ``pytest tests/test_remove_last_profile.py`` — 8/8 pass, includes new regression test that drives the bug through a real ``AMXConfig.load()`` instance (write-through enabled, as in prod).
- [x] ``pytest -k 'config or profile or remove'`` — 398/398 pass.
- [x] Manual repro: with the user's actual config, ``cfg.remove_db_profile('dbr')`` now leaves ``db_profiles == {}`` and ``active_db_profile == ''`` (verified pre/post fix).