### PR TITLE
fix(studio): bootstrap history-store singleton in subprocess

### DIFF
--- a/amx/web/_studio_subprocess.py
+++ b/amx/web/_studio_subprocess.py
@@ -53,6 +53,26 @@ def main() -> int:
 
     cfg = AMXConfig.load(args.config_path) if args.config_path else AMXConfig.load()
 
+    # Bootstrap the history-store singleton the same way the CLI entry
+    # point does. Without this, every /api/ask call lands on the
+    # ``Search catalog isn't initialised yet — run /search sync first.``
+    # branch even when the SQLite file is fully populated, because
+    # ``SearchCatalog.from_history_store()`` consults the global
+    # singleton that ``init_history_store`` is responsible for setting.
+    # The studio subprocess is its own Python process (PR-X spawns it
+    # via ``_studio_subprocess.main``), so the parent CLI's init does
+    # not carry over.
+    from amx.storage.factory import init_history_store
+
+    try:
+        init_history_store(cfg)
+    except Exception:
+        # Best-effort: a failure here still lets the SPA come up so the
+        # user can fix profile / DB issues from Settings. The /ask
+        # route surfaces a fresh diagnostic if the catalog is still
+        # unreachable when a question is asked.
+        pass
+
     from amx.web.server import create_app
 
     app = create_app(cfg, token=args.token)

--- a/tests/web/test_studio_subprocess_shutdown.py
+++ b/tests/web/test_studio_subprocess_shutdown.py
@@ -35,6 +35,43 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+def test_child_bootstraps_history_store_singleton(monkeypatch):
+    """Regression: the child subprocess must call ``init_history_store``
+    on its own ``AMXConfig`` before handing the app to uvicorn. Earlier
+    versions relied on the parent CLI's init carrying over, but Studio
+    spawns the subprocess via ``_studio_subprocess.main`` in a fresh
+    Python process — so ``history_store()`` returned ``None`` for every
+    request and ``/api/ask`` rendered the spurious "Search catalog
+    isn't initialised yet — run /search sync first." error even when
+    the SQLite file was fully populated."""
+    import sys
+
+    monkeypatch.setattr(sys, "argv", _studio_argv())
+
+    init_calls: list[object] = []
+
+    def fake_init(cfg):
+        init_calls.append(cfg)
+        return MagicMock()
+
+    fake_cfg = MagicMock(name="cfg")
+
+    with (
+        patch("uvicorn.Server", return_value=MagicMock()),
+        patch("uvicorn.Config", return_value=MagicMock()),
+        patch("amx.web.server.create_app", return_value=MagicMock()),
+        patch("amx.config.AMXConfig.load", return_value=fake_cfg),
+        patch("amx.utils.logging.mute_root_logger_for_studio"),
+        patch("amx.storage.factory.init_history_store", side_effect=fake_init),
+        patch("asyncio.run"),
+    ):
+        from amx.web import _studio_subprocess
+
+        _studio_subprocess.main()
+
+    assert init_calls == [fake_cfg]
+
+
 def test_child_disables_uvicorn_default_signal_handlers(monkeypatch):
     """uvicorn's own SIGINT install is replaced with a no-op so the
     AMX handler is the only one reacting to the signal — no race."""


### PR DESCRIPTION
## Summary
- Fresh installs hit ``Search catalog isn't initialised yet — run /search sync first.`` on every ``/api/ask`` call, even when their config listed two active DB profiles and the SQLite history DB existed and was fully populated.
- Root cause: ``_studio_subprocess.main`` spawns the SPA server in its own Python process, so the parent CLI's ``init_history_store(cfg)`` call doesn't carry over — and the child never ran one. ``SearchCatalog.from_history_store()`` consults the module-level singleton that ``init_history_store`` is responsible for setting, so it kept returning ``None`` and the ``/ask`` route's "catalog is None" branch lit up as a hard error.
- Fix: child invokes ``init_history_store(cfg)`` after loading its own ``AMXConfig`` and before handing the app to uvicorn. Best-effort guarded so a bootstrap failure still lets the SPA come up.

## Test plan
- [x] ``pytest tests/web/test_studio_subprocess_shutdown.py`` — 6/6, including a new regression test that pins ``init_history_store`` is called with the child's loaded cfg.
- [ ] Fresh install repro: launch Studio, navigate to /ask, send a question — the spurious "Search catalog isn't initialised yet" banner is gone.

## Follow-up open question
The error is gone, but the catalog may legitimately have zero rows for the active profile on a brand-new install. The agent will now answer with whatever empty-state retrieval produces. Open question for a follow-up PR: should ``/api/ask`` auto-trigger a ``sync_catalog`` for the active DB profile when entity count is zero, streaming progress through the SSE channel? That replaces the implicit "agent says nothing useful" with an explicit "indexing your warehouse" first-run flow.