### PR TITLE
fix(codebase): IndexError on /code-scan with empty asset list

### DIFF
--- a/amx/codebase/analyzer.py
+++ b/amx/codebase/analyzer.py
@@ -401,15 +401,28 @@ def analyze_codebase(
                 break
         assets_list = ordered[:MAX_REGEX_ASSETS]
         assets: set[str] = set(assets_list)
-        if not assets_list:
-            pattern = re.compile(r"$^")
-        else:
-            pattern = re.compile(
+        if assets_list:
+            pattern: re.Pattern[str] | None = re.compile(
                 r"\b("
                 + "|".join(re.escape(a) for a in sorted(assets_list, key=len, reverse=True))
                 + r")\b",
                 re.IGNORECASE,
             )
+        else:
+            # No table / column names to look for — the caller fed an
+            # empty asset set (fresh install with no synced catalog yet,
+            # or a code profile pointing at a repo that doesn't reference
+            # the linked DB at all). Skip the per-line asset regex
+            # entirely; the Spark/SQL literal scanners below still
+            # operate. The previous fix used a placeholder ``r"$^"``
+            # pattern which actually matches once on every empty line
+            # under default mode (``$`` and ``^`` are both zero-width
+            # and overlap at position 0 in an empty string). Then
+            # ``match.group(1)`` raised ``IndexError: no such group``
+            # because the pattern carries no capture group — surfacing
+            # as the "Last index failed" banner on /code-scan for any
+            # repo with blank lines.
+            pattern = None
 
         # Walk the tree via the shared helper so both the regex/AST
         # analyzer and the semantic indexer agree on which files are
@@ -444,20 +457,21 @@ def analyze_codebase(
             rel = str(fpath.relative_to(root))
 
             for i, line in enumerate(lines):
-                for match in pattern.finditer(line):
-                    asset = match.group(1).lower()
-                    start = max(0, i - context_lines)
-                    end = min(len(lines), i + context_lines + 1)
-                    ctx = "\n".join(lines[start:end])
+                if pattern is not None:
+                    for match in pattern.finditer(line):
+                        asset = match.group(1).lower()
+                        start = max(0, i - context_lines)
+                        end = min(len(lines), i + context_lines + 1)
+                        ctx = "\n".join(lines[start:end])
 
-                    ref = CodeReference(
-                        file=rel,
-                        line_no=i + 1,
-                        line_text=line.strip(),
-                        matched_asset=asset,
-                        context=ctx,
-                    )
-                    report.references.setdefault(asset, []).append(ref)
+                        ref = CodeReference(
+                            file=rel,
+                            line_no=i + 1,
+                            line_text=line.strip(),
+                            matched_asset=asset,
+                            context=ctx,
+                        )
+                        report.references.setdefault(asset, []).append(ref)
 
                 _scan_spark_sql_literals_in_line(
                     line,

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -306,6 +306,36 @@ class DocumentScannerTests(unittest.TestCase):
         self.assertEqual(paths, {"team-a/spec.md", "team-b/spec.md"})
 
 
+class CodebaseEmptyAssetsTests(unittest.TestCase):
+    def test_scan_with_empty_assets_handles_blank_lines(self) -> None:
+        """Regression: ``analyze_codebase`` used to compile ``r"$^"`` as
+        a "never match" placeholder when the caller passed no table /
+        column names. That pattern actually matches once on every blank
+        line under default mode (``$`` and ``^`` are both zero-width
+        and overlap at position 0 in an empty string), and the loop
+        body then called ``match.group(1)`` on a pattern with no
+        capture group — raising ``IndexError: no such group`` and
+        flipping the /code-scan job to ``failed``. The Studio surfaced
+        it as "Last index failed: IndexError: no such group" on any
+        code profile that hadn't seen a DB sync yet.
+
+        Now the empty-asset branch sets ``pattern = None`` and the
+        per-line loop skips it, so a fresh code profile with no
+        synced tables scans cleanly."""
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Path(tmp) / "job.sql"
+            # A blank line is the trigger — without one the bug stays
+            # latent. Real-world SQL files have lots of them.
+            f.write_text("SELECT 1;\n\n-- nothing else\n", encoding="utf-8")
+
+            report = analyze_codebase(tmp, [])  # empty asset list
+
+        self.assertEqual(report.scanned_files, 1)
+        # No matches because there are no assets to match, but the
+        # scan itself completed without crashing.
+        self.assertEqual(report.references, {})
+
+
 class CodebaseCleanupTests(unittest.TestCase):
     def test_remote_codebase_clone_is_removed_after_scan(self) -> None:
         cloned: list[str] = []


### PR DESCRIPTION
## Summary
A code profile bound to a DB profile that had not yet been synced into the search catalog (brand-new install: user defined both profiles but hadn't run /search sync) surfaced ``Last index failed: IndexError: no such group`` on the Studio Settings → Code card after every ingest attempt.

**Root cause:** ``analyze_codebase`` builds a per-line asset regex from caller-supplied table / column lists. When that list was empty, the function compiled the placeholder ``r"$^"`` as a "never match" pattern. Default-mode regex says both ``$`` and ``^`` are zero-width and they overlap at position 0 of an empty string — so ``$^`` actually matches **once** on every blank line in the repo (verified: ``re.compile(r"$^").finditer("")`` yields a single Match). The loop body then called ``match.group(1)`` on a pattern that carried no capture group → ``IndexError: no such group``. Real-world SQL / Python files have lots of blank lines, so the bug fired for almost every empty-asset scan.

**Fix:** empty-asset branch now sets ``pattern = None`` and the per-line loop gates on it. The Spark / SQL literal scanners that run alongside still operate, so the rest of the scan stays useful even when the catalog hasn't been synced.

## Test plan
- [x] ``pytest tests/test_regressions.py::CodebaseEmptyAssetsTests`` — new regression: ``analyze_codebase(tmp, [])`` against a file containing a blank line completes without raising.
- [x] ``-k 'codebase or analyzer or code_scan or regressions'`` — 245/245.
- [ ] Studio: re-trigger ``Ingest`` on the failing code profile — the "Last index failed: IndexError: no such group" banner is gone; the card shows the new chunk count.