### PR TITLE
fix(rag): drop weakly-matching doc chunks before they reach the LLM

### DIFF
--- a/amx/agents/rag_agent.py
+++ b/amx/agents/rag_agent.py
@@ -241,8 +241,18 @@ class RAGAgent(BaseAgent):
         from amx.docs.rag import RAGQueryTimeout
 
         timeout = self._rag_query_timeout()
+        # Carry the prompt-detail floor through to the store so a doc
+        # profile that's only weakly related to the table (e.g. the
+        # user uploaded a resume PDF instead of warehouse docs)
+        # doesn't bleed into the LLM prompt as if it were evidence.
+        min_similarity = float(getattr(self._prompt_detail, "rag_min_similarity", 0.0) or 0.0)
         try:
-            hits = self.rag.query(question, n_results=n_results, timeout=timeout)
+            hits = self.rag.query(
+                question,
+                n_results=n_results,
+                timeout=timeout,
+                min_similarity=min_similarity,
+            )
             return (hits, False)
         except RAGQueryTimeout:
             return ([], True)

--- a/amx/config.py
+++ b/amx/config.py
@@ -515,6 +515,19 @@ class PromptDetail:
     rag_table_hits: int = 5  # Doc chunks fetched for the table-level query
     rag_col_hits: int = 1  # Doc chunks fetched per column query
     rag_max_chunks: int = 8  # Hard cap on total chunks injected into the RAG prompt
+    # Minimum cosine similarity a chunk must carry before it can feed
+    # into a column-description prompt. Chroma's default cosine
+    # distance is ``1 - cosine_similarity`` in the range [0, 2], so
+    # ``min_similarity = 0.40`` drops every chunk with distance > 0.60.
+    # Calibrated against the bug a user reported: a resume PDF whose
+    # chunks returned distances 0.66–1.02 against a ``zip_code``
+    # column (cosine_sim ≈ 0.34 down to -0.02 — basically orthogonal)
+    # was still being treated as authoritative evidence and the LLM
+    # synthesised absurd "address alias / exclusion" descriptions from
+    # it. With the filter, those chunks are dropped before they reach
+    # the prompt and the agent falls back to db_profile-only synthesis.
+    # Set to ``0.0`` to disable the filter (legacy behaviour).
+    rag_min_similarity: float = 0.40
     # PR γ: per-column code-RAG fan-out, parallel to ``rag_col_hits``.
     # ``0`` preserves the pre-PR-γ behaviour (one neutral
     # ``"<schema> <table>"`` semantic query only). Higher values let the

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -430,6 +430,7 @@ class RAGStore:
         n_results: int = 5,
         *,
         timeout: float | None = None,
+        min_similarity: float = 0.0,
     ) -> list[dict]:
         raw_n = max(int(n_results), min(int(n_results) * 4, 40))
 
@@ -468,16 +469,35 @@ class RAGStore:
         else:
             results = _do_query()
 
+        # Drop chunks below the caller's relevance floor before anything
+        # else looks at them. Chroma uses cosine *distance* (1 -
+        # cosine_similarity) on minilm-l6-v2 collections — so a higher
+        # distance is a worse match. The threshold compares against the
+        # equivalent ``1 - min_similarity`` ceiling. ``min_similarity=0``
+        # disables the filter (legacy behaviour). A real-world case the
+        # filter catches: a resume PDF chunked alongside a database
+        # generated distances 0.66–1.02 against a ``zip_code`` column
+        # (cosine_sim ≈ 0.34 down to -0.02 — basically orthogonal); the
+        # LLM consumed them and synthesised absurd descriptions.
+        threshold = float(min_similarity or 0.0)
+        max_distance = (1.0 - threshold) if threshold > 0.0 else None
         hits: list[dict] = []
         for i in range(len(results["documents"][0])):
             meta = results["metadatas"][0][i]
             if not self._source_allowed(meta):
                 continue
+            raw_distance = results["distances"][0][i] if results.get("distances") else None
+            if (
+                max_distance is not None
+                and raw_distance is not None
+                and float(raw_distance) > max_distance
+            ):
+                continue
             hits.append(
                 {
                     "text": results["documents"][0][i],
                     "metadata": meta,
-                    "distance": results["distances"][0][i] if results.get("distances") else None,
+                    "distance": raw_distance,
                 }
             )
         return self.rerank(question, hits)[:n_results]

--- a/tests/test_rag_storage_correctness.py
+++ b/tests/test_rag_storage_correctness.py
@@ -168,6 +168,56 @@ def test_record_rag_unavailable_reason_tags_mismatch(monkeypatch) -> None:
     assert "openai_compatible" in sink["rag_unavailable_reason"]
 
 
+def test_query_drops_chunks_above_distance_ceiling(monkeypatch, tmp_path: Path) -> None:
+    """Regression: a doc profile whose chunks return high cosine
+    distances (cosine_sim < ``rag_min_similarity``) used to flow into
+    the LLM prompt as if they were authoritative. A real-world case
+    was a CV uploaded as the doc profile — every column-level query
+    returned the resume with distance 0.66–1.02 and the agent
+    synthesised absurd "address alias / exclusion" descriptions from
+    it. ``min_similarity`` filters those out before they ever reach
+    the rerank step or the prompt.
+
+    Test plan:
+      * Stub Chroma's raw ``collection.query`` so we control the
+        distances directly (no embedding model needed).
+      * Confirm a strong match (distance 0.30) survives.
+      * Confirm a weak match (distance 0.85) is dropped when
+        ``min_similarity=0.40`` is passed.
+      * Confirm ``min_similarity=0.0`` (legacy default) keeps the
+        weak chunk in the result so existing callers don't change
+        behaviour silently.
+    """
+    store = _make_store(tmp_path / "chroma")
+
+    def _fake_query(query_texts: list[str], n_results: int) -> dict:
+        return {
+            "documents": [["RELEVANT chunk about zip codes.", "RESUME irrelevant block."]],
+            "metadatas": [
+                [{"source": "/abs/zips.md", "source_root": "/abs"}],
+            ][:0]
+            + [
+                [
+                    {"source": "/abs/zips.md", "source_root": "/abs"},
+                    {"source": "/abs/resume.pdf", "source_root": "/abs"},
+                ]
+            ],
+            "distances": [[0.30, 0.85]],
+        }
+
+    monkeypatch.setattr(store.collection, "query", _fake_query)
+    # Legacy default keeps every hit.
+    hits_default = store.query("zip code column", n_results=5)
+    assert len(hits_default) == 2
+    sources_default = [h["metadata"].get("source") for h in hits_default]
+    assert "/abs/resume.pdf" in sources_default
+
+    # Threshold drops the noise chunk.
+    hits_filtered = store.query("zip code column", n_results=5, min_similarity=0.40)
+    assert len(hits_filtered) == 1
+    assert hits_filtered[0]["metadata"].get("source") == "/abs/zips.md"
+
+
 def test_format_rag_unavailable_reason_tags_mismatch() -> None:
     """The library-side helper used by ``infer_table_metadata`` mirrors
     the analyze-flow tagging so the two paths never drift."""


### PR DESCRIPTION
## Summary
A user uploaded their CV as a doc profile to test the RAG path, then ran ``/run``. Every column suggestion's WHY field cited the resume as authoritative evidence and the LLM synthesised absurdities — ``zip_code`` got "Numeric geographic code within the valid US ZIP code range that participates in identifying locations associated with known address data quality problems" with sources pointing at the resume PDF at distances 0.66–1.02.

**Root cause:** Chroma cosine distance 0.66–1.02 means cosine similarity 0.34 down to **-0.02** — basically orthogonal vectors. There was no relevance floor on the retrieval path: every chunk Chroma returned was reranked (by keyword/explanatory heuristics) but never filtered, so the prompt always got *something* to cite. For a fresh install where the only doc profile happens to be unrelated to the warehouse, that *something* is whatever PDF the user uploaded.

**Fix:**
- New ``PromptDetail.rag_min_similarity`` knob (default ``0.40``, legacy ``0.0`` disables the filter).
- ``RAGStore.query(..., min_similarity=…)`` honours it — chunks with cosine similarity below the floor are dropped before rerank, before reaching the prompt, before the LLM sees them. Maps to Chroma's distance ceiling as ``1 - min_similarity``.
- ``RAGAgent._query_with_timeout`` threads the prompt-detail knob through every per-table and per-column query.
- When every retrieved chunk gets dropped, the existing "no docs available" branch (``_build_messages`` returns ``None``) takes over and the run falls back to db_profile-only synthesis — no more phantom resume citations.

## Test plan
- [x] ``pytest tests/test_rag_storage_correctness.py`` — 8/8 incl. new ``test_query_drops_chunks_above_distance_ceiling`` regression that pins:
  - Legacy ``min_similarity=0.0`` keeps both strong + weak chunks.
  - ``min_similarity=0.40`` drops the weak chunk (distance 0.85, similarity 0.15) while preserving the strong one (distance 0.30, similarity 0.70).
- [x] ``-k 'rag or doc or rerank or rag_agent or prompt_detail'`` — 177/177.
- [ ] Re-run ``/run`` with the resume PDF still attached: confirm columns no longer cite the resume — the WHY field now reads from db_profile only (or the live DB profile when the link map applies).

## Knob
Drop ``rag_min_similarity`` to ``0.0`` to restore the old behaviour. Set it higher (e.g. ``0.55``) to be even stricter — useful when the doc profile is large and the user wants only confident matches.