### PR TITLE
fix(ask): surface a useful diagnostic instead of bare "(empty response)"

### DIFF
--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -905,6 +905,7 @@ def _run_tool_loop(
     loop_start = _time.monotonic()
     final_answer = ""
     finish_reason: str | None = None
+    last_thinking_content: str = ""
     iterations = 0
     tools_schema = ToolBox.schemas()
 
@@ -961,6 +962,15 @@ def _run_tool_loop(
         for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
             aggregated_usage[key] += int((result.usage or {}).get(key, 0) or 0)
         finish_reason = result.finish_reason or finish_reason
+
+        # Some thinking-channel models (gpt-oss family on Ollama, etc.)
+        # emit their visible answer into ``reasoning_content`` and leave
+        # ``content`` empty when the prompt is short or the harmony
+        # ``final`` channel never fires. Capture the last seen reasoning
+        # so the empty-content branch below can surface it instead of a
+        # bare "(empty response)".
+        if getattr(result, "thinking_content", "") or "":
+            last_thinking_content = str(result.thinking_content)
 
         if not result.tool_calls:
             final_answer = (result.content or "").strip()
@@ -1032,10 +1042,49 @@ def _run_tool_loop(
             aggregated_usage[key] += int((result.usage or {}).get(key, 0) or 0)
         final_answer = (result.content or "").strip()
         finish_reason = result.finish_reason or finish_reason
+        if getattr(result, "thinking_content", "") or "":
+            last_thinking_content = str(result.thinking_content)
 
     total_latency_ms = int((_time.monotonic() - loop_start) * 1000)
+    # When the model produced no visible content, surface *why* instead
+    # of a bare "(empty response)". Three observed shapes:
+    #   1. Reasoning-channel models (gpt-oss on Ollama, Kimi K2.x
+    #      thinking, …) emit their entire answer into the thinking
+    #      channel — show the last thinking block (truncated) so the
+    #      user has something to react to and points at the model as
+    #      the root cause.
+    #   2. finish_reason == "length" means the budget was exhausted
+    #      mid-generation — say so explicitly with the configured
+    #      max_tokens in the message.
+    #   3. Otherwise: just "(empty response)" with a hint to try a
+    #      different model.
+    if not final_answer:
+        if last_thinking_content.strip():
+            thinking_preview = last_thinking_content.strip()
+            if len(thinking_preview) > 1200:
+                thinking_preview = thinking_preview[:1200].rstrip() + "…"
+            final_answer = (
+                "_The model returned reasoning text but no visible answer "
+                "— likely a thinking-channel model whose final channel "
+                "never fired. Showing the reasoning summary below; try a "
+                "different model for a clean answer._\n\n"
+                f"{thinking_preview}"
+            )
+        elif finish_reason == "length":
+            final_answer = (
+                "_The model hit its output-token budget before producing "
+                "a visible answer. Raise ``max_tokens`` under Settings → "
+                "LLM (or set ``AMX_LLM_MIN_MAX_TOKENS``) and retry._"
+            )
+        else:
+            final_answer = (
+                "_Empty response from the model. The provider returned no "
+                "tool calls and no content — try rephrasing the question "
+                "or switching to a different model._"
+            )
+
     return ToolAgentResult(
-        answer=final_answer or "(empty response)",
+        answer=final_answer,
         tool_calls=tool_call_log,
         iterations=iterations,
         usage=aggregated_usage,

--- a/tests/web/test_tool_agent_callbacks.py
+++ b/tests/web/test_tool_agent_callbacks.py
@@ -179,3 +179,94 @@ def test_on_tool_call_fires_for_each_returned_tool(monkeypatch) -> None:
     assert captured[0]["name"] == "list_schemas"
     assert captured[0]["arguments"] == "{}"
     assert "result-payload" in captured[0]["result_preview"]
+
+
+def test_empty_content_with_thinking_surfaces_reasoning_summary(monkeypatch) -> None:
+    """Regression: gpt-oss 20b on Ollama replied to the user's ``test``
+    prompt with empty ``content`` but populated ``thinking_content``
+    (the model's final channel never fired). The tool_agent used to
+    render this as a bare "(empty response)" bubble that left the user
+    with no idea what went wrong. The fix surfaces the reasoning
+    summary inline with a "(model returned only reasoning)" hint so
+    the user can react — switch model, rephrase, etc."""
+    import amx.search.tool_agent as ta
+
+    _patch_toolbox(monkeypatch)
+    fake_llm = MagicMock()
+    fake_llm.chat.return_value = SimpleNamespace(
+        content="",
+        tool_calls=[],
+        finish_reason="stop",
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        thinking_content="I was asked to test. I'll consider this a smoke check.",
+    )
+
+    result = ta.run_tool_agent(
+        cfg=_build_cfg(),
+        catalog=MagicMock(),
+        llm=fake_llm,
+        question="test",
+        answer_language="english",
+        session_memory=None,
+    )
+    # The bare "(empty response)" sentinel is gone.
+    assert result.answer != "(empty response)"
+    # The hint is present, the reasoning is included.
+    assert "reasoning" in result.answer.lower()
+    assert "I was asked to test" in result.answer
+
+
+def test_empty_content_finish_length_surfaces_budget_hint(monkeypatch) -> None:
+    """When the model exhausts its output budget before producing any
+    visible content (``finish_reason=length`` with empty content), the
+    user-facing answer must point at the max_tokens knob — not just
+    say "(empty response)" and leave them puzzled."""
+    import amx.search.tool_agent as ta
+
+    _patch_toolbox(monkeypatch)
+    fake_llm = MagicMock()
+    fake_llm.chat.return_value = SimpleNamespace(
+        content="",
+        tool_calls=[],
+        finish_reason="length",
+        usage={"prompt_tokens": 1, "completion_tokens": 4096, "total_tokens": 4097},
+        thinking_content="",
+    )
+
+    result = ta.run_tool_agent(
+        cfg=_build_cfg(),
+        catalog=MagicMock(),
+        llm=fake_llm,
+        question="test",
+        answer_language="english",
+        session_memory=None,
+    )
+    assert result.answer != "(empty response)"
+    assert "max_tokens" in result.answer.lower()
+
+
+def test_empty_content_no_thinking_uses_neutral_hint(monkeypatch) -> None:
+    """No thinking, no length signal — surface a neutral "try another
+    model" hint instead of the bare sentinel."""
+    import amx.search.tool_agent as ta
+
+    _patch_toolbox(monkeypatch)
+    fake_llm = MagicMock()
+    fake_llm.chat.return_value = SimpleNamespace(
+        content="",
+        tool_calls=[],
+        finish_reason="stop",
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        thinking_content="",
+    )
+
+    result = ta.run_tool_agent(
+        cfg=_build_cfg(),
+        catalog=MagicMock(),
+        llm=fake_llm,
+        question="test",
+        answer_language="english",
+        session_memory=None,
+    )
+    assert result.answer != "(empty response)"
+    assert "rephras" in result.answer.lower() or "different model" in result.answer.lower()


### PR DESCRIPTION
## Summary
A user running ``gpt-oss 20b`` via local Ollama in Studio /ask asked ``test`` and got a bubble with literally just ``(empty response)`` — zero information about what went wrong or how to fix it.

**Root cause:** gpt-oss-family models route their visible answer through a ``final`` channel separate from their ``analysis`` channel. Ollama maps analysis → ``reasoning_content`` / ``thinking_content`` and only the ``final`` channel text reaches ``message.content``. For short prompts like ``test``, the model often emits only analysis and ``content`` stays empty. The tool_agent's "no tool calls → break" path then sets ``final_answer = ""`` and the response renderer prints the bare sentinel.

**Fix:** the tool_agent tracks the most recent ``thinking_content`` across iterations (both the iteration loop and the budget-cap closing call) and replaces the sentinel with one of three context-aware messages:
1. **Reasoning-only**: surface the reasoning block (truncated to 1.2 KB) with a hint that the user is hitting a thinking-channel model whose final channel never fired. They see what the model thought + a pointer at the model.
2. **Budget exhausted** (``finish_reason=length`` + empty content): point at ``max_tokens`` / ``AMX_LLM_MIN_MAX_TOKENS``.
3. **Otherwise**: neutral "try rephrasing or a different model" hint.

## Test plan
- [x] ``pytest tests/web/test_tool_agent_callbacks.py`` — 7/7 incl. three new regressions pinning each diagnostic branch.
- [x] ``-k 'tool_agent or ask or llm'`` — 190/190.
- [ ] On a local Ollama install with ``gpt-oss 20b``, re-ask ``test`` in Studio /ask — the bubble now shows the reasoning summary + the hint, not a bare ``(empty response)``.