### PR TITLE
feat(scheduler): phase 0 — parallel-run preflight + advisory lock helper

### DIFF
--- a/amx/runtime/__init__.py
+++ b/amx/runtime/__init__.py
@@ -1,0 +1,7 @@
+"""Shared runtime utilities for AMX run workers.
+
+This package holds primitives consumed by both the Studio FastAPI workers
+and the upcoming scheduler engine — currently just the file-backed
+advisory lock used to serialise concurrent run workers on a per-table
+basis.
+"""

--- a/amx/runtime/advisory_lock.py
+++ b/amx/runtime/advisory_lock.py
@@ -1,0 +1,115 @@
+"""Process-tree-wide advisory lock keyed by (db_profile, schema, table).
+
+Backed by a SQLite file inside ``$AMX_CONFIG_DIR``. The lock table holds
+one row per active holder; ``acquire()`` does an INSERT inside a
+short-lived connection and lets the PRIMARY KEY on the 3-tuple block
+contenders, polling until either it gets in or the supplied timeout
+elapses.
+
+Why SQLite and not ``threading.Lock``:
+
+1. The same primitive must keep working if a second AMX process somehow
+   targets the same config dir. The AMX single-instance config lock
+   should normally prevent that, but defence-in-depth is cheap here.
+2. The row holds the holder's PID + thread id + acquisition timestamp,
+   which lets a future sweep reclaim a lock left behind by a crashed
+   worker. The sweep is out of scope for the initial helper; the schema
+   already supports it.
+
+The lock is **per (db_profile, schema, table)**: two run workers writing
+metadata for *different* tables run fully in parallel; two workers
+targeting the *same* table serialise on that table only.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sqlite3
+import threading
+import time
+from collections.abc import Iterator
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS advisory_locks (
+    db_profile TEXT NOT NULL,
+    schema_name TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    holder_pid INTEGER NOT NULL,
+    holder_thread INTEGER NOT NULL,
+    acquired_at REAL NOT NULL,
+    PRIMARY KEY (db_profile, schema_name, table_name)
+);
+"""
+
+
+class AdvisoryLockStore:
+    """File-backed advisory lock keyed by ``(db_profile, schema, table)``."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._init()
+
+    def _init(self) -> None:
+        with sqlite3.connect(self._path, timeout=30) as conn:
+            # WAL keeps readers non-blocking; the timeout matters only
+            # when two would-be holders contend on the PRIMARY KEY.
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=30000")
+            conn.executescript(_SCHEMA)
+
+    @contextlib.contextmanager
+    def acquire(
+        self,
+        key: tuple[str, str, str],
+        *,
+        timeout_sec: float = 60.0,
+        poll_sec: float = 0.02,
+    ) -> Iterator[None]:
+        """Block until *key* is held by the current thread, then yield.
+
+        Raises ``TimeoutError`` if *timeout_sec* elapses before the
+        lock can be inserted. On exit the lock is released
+        unconditionally (the caller's exception, if any, propagates).
+        """
+        db_profile, schema_name, table_name = key
+        pid = os.getpid()
+        thread = threading.get_ident()
+        deadline = time.monotonic() + timeout_sec
+
+        while True:
+            try:
+                with sqlite3.connect(self._path, timeout=5) as conn:
+                    conn.execute(
+                        "INSERT INTO advisory_locks "
+                        "(db_profile, schema_name, table_name, "
+                        "holder_pid, holder_thread, acquired_at) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        (
+                            db_profile,
+                            schema_name,
+                            table_name,
+                            pid,
+                            thread,
+                            time.time(),
+                        ),
+                    )
+                break
+            except sqlite3.IntegrityError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"advisory lock {key!r} not acquired within {timeout_sec}s"
+                    ) from None
+                time.sleep(poll_sec)
+
+        try:
+            yield
+        finally:
+            with sqlite3.connect(self._path, timeout=5) as conn:
+                conn.execute(
+                    "DELETE FROM advisory_locks "
+                    "WHERE db_profile=? AND schema_name=? "
+                    "AND table_name=? AND holder_pid=? "
+                    "AND holder_thread=?",
+                    (db_profile, schema_name, table_name, pid, thread),
+                )

--- a/docs/internal/parallel-run-audit.md
+++ b/docs/internal/parallel-run-audit.md
@@ -1,0 +1,114 @@
+# Parallel-run safety audit (Phase 0)
+
+**Goal:** Establish that AMX can host two simultaneous run workers in the
+same install without data corruption or deadlock — the prerequisite for
+allowing concurrent scheduled runs.
+
+**Scope:** SQLite history store (always-on, source of truth for the
+local install) and the Chroma RAG store. The remote SQLAlchemy half of
+the dual-write façade is intentionally out of scope here: it is
+best-effort with an outbox, so any contention surfaces as queued
+retries rather than data loss.
+
+---
+
+## SQLite history store
+
+The local history store already enables a concurrency-friendly
+configuration on every connection
+(`amx/storage/sqlite_store.py:1977-1979`):
+
+```python
+conn.execute("PRAGMA journal_mode=WAL")
+conn.execute("PRAGMA synchronous=NORMAL")
+conn.execute("PRAGMA busy_timeout=30000")
+```
+
+WAL allows non-blocking readers and one writer; `busy_timeout=30000`
+gives a contending writer 30 seconds to retry before raising
+`database is locked`. The hot path scheduled-run workers will exercise
+is `create_run` → many `increment_run_processed` → `finish_run`.
+
+The smoke test
+`tests/runtime/test_sqlite_concurrent_writes.py::test_two_workers_can_create_and_finish_runs_concurrently`
+fires that exact path from two threads against the same database file
+and asserts no exceptions are raised on either thread. It passes
+reliably on the developer's machine. The intermediate
+`increment_run_processed` writes are bounded `UPDATE` statements
+holding the `self._lock` (process-wide threading lock) only for the
+duration of the statement; no transaction is held across a slow
+operation.
+
+**Conclusion (SQLite):** Safe out of the box for the scope this feature
+ships.
+
+---
+
+## Chroma RAG store
+
+The smoke test `tests/runtime/test_chroma_concurrent_writes.py` covers
+two access patterns:
+
+1. **Distinct collections, two threads.** Both threads' writes land;
+   no exceptions; the final counts on each collection are exact.
+2. **Same collection, two threads.** Both threads' writes land; no
+   exceptions; the final count is the sum of both batches.
+
+Both cases pass on a stock `chromadb` install. The internal locking
+inside Chroma's persistent client appears to serialise on the
+collection without raising, which is exactly the behaviour we need.
+
+The test is `pytest.importorskip`-guarded so a stripped CI install
+without `chromadb` skips it rather than failing.
+
+**Conclusion (Chroma):** Safe out of the box for the scope this feature
+ships.
+
+---
+
+## Advisory lock — defence in depth
+
+Even though both stores tolerate concurrent writes, the scheduler engine
+will still wrap per-table work in a SQLite-backed advisory lock keyed by
+`(db_profile, schema_name, table_name)`. Reasons:
+
+* Two runs targeting *the same table* almost certainly shouldn't race
+  on metadata writes (LLM-generated descriptions of the same column
+  could collide and the last-write-wins outcome would be confusing).
+  Serialising per-table costs nothing when distinct tables are in
+  flight, because the lock is keyed at table granularity.
+* The lock row carries `holder_pid`, `holder_thread`, `acquired_at`,
+  so a future crash-recovery sweep can reclaim stale rows from a
+  worker that died mid-acquisition. (Sweep not implemented in this
+  phase; the schema supports it.)
+* The lock is a single small helper
+  (`amx/runtime/advisory_lock.py`), independently tested, and easily
+  removed if it ever proves unnecessary.
+
+The lock is verified by three behaviour tests:
+
+* `test_lock_serialises_two_holders` — same key, two threads; second
+  thread cannot enter the critical section before the first exits.
+* `test_lock_distinct_keys_run_in_parallel` — two threads with
+  different keys enter within ~150 ms of each other; no incidental
+  serialisation.
+* `test_lock_timeout_raises` — `acquire(..., timeout_sec=0.2)`
+  raises `TimeoutError` when the lock is held elsewhere.
+
+---
+
+## Open items (deliberately deferred)
+
+* **Advisory-lock sweep for crashed holders.** Schema is ready; the
+  Phase 2 scheduler engine can call a sweep at tick start. Not in
+  this PR.
+* **Two AMX *processes* sharing one config dir.** The AMX single-
+  instance config lock should prevent this; the audit assumed it does
+  and did not stress that path. If a future incident shows otherwise,
+  the advisory lock's PID column gives us cross-process serialisation
+  for free, but the test coverage would need to grow.
+* **High-end contention behaviour.** The smoke tests run two workers.
+  Tens of concurrent workers writing the same hot column has not been
+  measured. Scheduled runs in this design fire one schedule at a time
+  via `claim_due_schedule` (Phase 1), so the realistic concurrent
+  count stays small. We can revisit if usage demands it.

--- a/tests/runtime/test_advisory_lock.py
+++ b/tests/runtime/test_advisory_lock.py
@@ -1,0 +1,107 @@
+"""Tests for the per-(db_profile, schema, table) advisory lock helper.
+
+These cover the three properties scheduler workers rely on:
+
+* same-key contention serialises holders (no interleaving),
+* distinct-key holders run in parallel (no incidental serialisation),
+* acquire() honours its timeout and surfaces TimeoutError.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from amx.runtime.advisory_lock import AdvisoryLockStore
+
+
+def test_lock_serialises_two_holders(tmp_path: Path) -> None:
+    store = AdvisoryLockStore(str(tmp_path / "locks.sqlite3"))
+    order: list[str] = []
+    key = ("prod_sf", "public", "users")
+
+    def hold(name: str, hold_sec: float) -> None:
+        with store.acquire(key, timeout_sec=5.0):
+            order.append(f"{name}-enter")
+            time.sleep(hold_sec)
+            order.append(f"{name}-exit")
+
+    t1 = threading.Thread(target=hold, args=("A", 0.2))
+    t2 = threading.Thread(target=hold, args=("B", 0.05))
+    t1.start()
+    # Give A a head start so the test is deterministic about who wins
+    # the lock; B should still be forced to wait for A's exit.
+    time.sleep(0.02)
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert order == ["A-enter", "A-exit", "B-enter", "B-exit"], (
+        f"expected B to wait for A's exit; got: {order}"
+    )
+
+
+def test_lock_distinct_keys_run_in_parallel(tmp_path: Path) -> None:
+    store = AdvisoryLockStore(str(tmp_path / "locks.sqlite3"))
+    starts: list[float] = []
+    starts_lock = threading.Lock()
+
+    def hold(key: tuple[str, str, str]) -> None:
+        with store.acquire(key, timeout_sec=5.0):
+            with starts_lock:
+                starts.append(time.monotonic())
+            time.sleep(0.2)
+
+    t1 = threading.Thread(target=hold, args=(("prod_sf", "public", "a"),))
+    t2 = threading.Thread(target=hold, args=(("prod_sf", "public", "b"),))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # Distinct keys must not serialise; both starts within 150ms is
+    # generous slack for thread scheduling on a busy CI runner.
+    assert len(starts) == 2
+    assert abs(starts[0] - starts[1]) < 0.15, (
+        f"distinct keys should run in parallel; gap was {abs(starts[0] - starts[1]):.3f}s"
+    )
+
+
+def test_lock_timeout_raises(tmp_path: Path) -> None:
+    store = AdvisoryLockStore(str(tmp_path / "locks.sqlite3"))
+    key = ("prod_sf", "public", "users")
+    holder_release = threading.Event()
+    holder_acquired = threading.Event()
+
+    def hold_long() -> None:
+        with store.acquire(key, timeout_sec=5.0):
+            holder_acquired.set()
+            # Hold long enough for the contender's timeout to elapse.
+            holder_release.wait(timeout=2.0)
+
+    t = threading.Thread(target=hold_long)
+    t.start()
+    assert holder_acquired.wait(timeout=2.0), "holder failed to acquire its lock"
+
+    with pytest.raises(TimeoutError):
+        with store.acquire(key, timeout_sec=0.2):
+            pass
+
+    holder_release.set()
+    t.join()
+
+
+def test_release_lets_subsequent_acquire_succeed(tmp_path: Path) -> None:
+    """After a holder exits, a fresh acquire on the same key must succeed."""
+    store = AdvisoryLockStore(str(tmp_path / "locks.sqlite3"))
+    key = ("prod_sf", "public", "users")
+
+    with store.acquire(key, timeout_sec=2.0):
+        pass
+
+    # Second acquisition should not be blocked by the released row.
+    with store.acquire(key, timeout_sec=2.0):
+        pass

--- a/tests/runtime/test_chroma_concurrent_writes.py
+++ b/tests/runtime/test_chroma_concurrent_writes.py
@@ -1,0 +1,75 @@
+"""Smoke test: concurrent Chroma writes from two threads in one process.
+
+Two angles:
+
+* Distinct collections — should be fully parallel.
+* Same collection — Chroma's own per-collection lock may serialise, but
+  the goal is "no corruption, both writes land".
+
+If ``chromadb`` is not importable in the current environment the test is
+skipped so we don't fail under stripped CI installs.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+chromadb = pytest.importorskip("chromadb")
+
+
+def test_two_threads_write_distinct_collections(tmp_path: Path) -> None:
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    errors: list[BaseException] = []
+    err_lock = threading.Lock()
+
+    def worker(name: str) -> None:
+        try:
+            col = client.get_or_create_collection(name)
+            col.add(
+                ids=[f"{name}-{i}" for i in range(20)],
+                documents=[f"doc {i}" for i in range(20)],
+            )
+        except BaseException as exc:  # noqa: BLE001
+            with err_lock:
+                errors.append(exc)
+
+    t1 = threading.Thread(target=worker, args=("col_a",))
+    t2 = threading.Thread(target=worker, args=("col_b",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert errors == [], f"distinct-collection writes failed: {errors!r}"
+    assert client.get_collection("col_a").count() == 20
+    assert client.get_collection("col_b").count() == 20
+
+
+def test_two_threads_write_same_collection_no_corruption(tmp_path: Path) -> None:
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    col = client.get_or_create_collection("shared")
+    errors: list[BaseException] = []
+    err_lock = threading.Lock()
+
+    def worker(offset: int) -> None:
+        try:
+            col.add(
+                ids=[f"x-{offset}-{i}" for i in range(20)],
+                documents=[f"d {offset}-{i}" for i in range(20)],
+            )
+        except BaseException as exc:  # noqa: BLE001
+            with err_lock:
+                errors.append(exc)
+
+    t1 = threading.Thread(target=worker, args=(0,))
+    t2 = threading.Thread(target=worker, args=(1000,))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert errors == [], f"same-collection writes failed: {errors!r}"
+    assert col.count() == 40

--- a/tests/runtime/test_sqlite_concurrent_writes.py
+++ b/tests/runtime/test_sqlite_concurrent_writes.py
@@ -1,0 +1,60 @@
+"""Smoke test: SQLiteHistoryStore tolerates two concurrent run workers.
+
+We don't try to exercise every write method; the goal is to verify the
+hot path scheduled-run workers will hit (create_run + many
+increment_run_processed + finish_run) does not deadlock or surface
+``database is locked`` under the WAL+busy_timeout settings already in
+place. If this ever regresses, that's a real signal — the scheduler
+engine assumes parallel runs are honest.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def test_two_workers_can_create_and_finish_runs_concurrently(
+    tmp_path: Path,
+) -> None:
+    store = SQLiteHistoryStore(tmp_path / "history.sqlite3")
+    store.init()
+    errors: list[BaseException] = []
+    error_lock = threading.Lock()
+
+    def worker(scope: dict, profile: str) -> None:
+        try:
+            run_id = store.create_run(
+                command="run",
+                mode="metadata",
+                db_backend="snowflake",
+                db_profile=profile,
+                llm_provider="anthropic",
+                llm_model="claude-sonnet",
+                scope=scope,
+            )
+            for _ in range(20):
+                store.increment_run_processed(run_id, by=1)
+                time.sleep(0.005)
+            store.finish_run(
+                run_id,
+                status="completed",
+                metrics={},
+                tokens={},
+                results={},
+            )
+        except BaseException as exc:  # noqa: BLE001 - any failure is fatal here
+            with error_lock:
+                errors.append(exc)
+
+    t1 = threading.Thread(target=worker, args=({"public": ["t1", "t2"]}, "prod_sf"))
+    t2 = threading.Thread(target=worker, args=({"staging": ["t3", "t4"]}, "stg_sf"))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert errors == [], f"concurrent writes failed: {errors!r}"


### PR DESCRIPTION
## Summary
- Two-thread smoke tests for the SQLite history store and the Chroma RAG store; both stores tolerate concurrent writes on the patterns scheduled runs will exercise.
- New `amx.runtime.advisory_lock.AdvisoryLockStore`: file-backed per-`(db_profile, schema, table)` lock with serialise / parallel / timeout coverage. The future scheduler engine will use this to serialise two parallel runs that touch the same table while disjoint runs stay fully parallel.
- Internal audit doc summarising findings.

This is the foundation for the upcoming scheduled-runs feature: the engine assumes parallel runs are honest, and this PR is the proof.

## Test plan
- [x] `pytest tests/runtime/ -v` — 7 / 7 pass
- [x] `ruff check amx/runtime tests/runtime` clean
- [x] `ruff format --check amx/runtime tests/runtime` clean
- [x] `mypy amx/runtime` clean
- [x] No `paid` in changed paths