### PR TITLE
feat(scheduler): phase 1a — scheduled_runs table + local CRUD

### DIFF
--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -559,6 +559,51 @@ class SQLiteHistoryStore:
                 )
                 """
             )
+            # ── scheduled_runs: one-shot scheduled metadata runs ──
+            #
+            # Created and managed via the `amx schedule` command group
+            # (Phase 3) and the Studio Schedules page (Phase 5). The
+            # tick engine (Phase 2) reads pending rows whose
+            # ``fire_at_utc`` has elapsed and transitions them through
+            # the state machine documented in
+            # docs/superpowers/specs/2026-05-13-scheduled-runs-design.md.
+            #
+            # ``fire_at_utc`` is always canonical UTC; ``fire_at_tz``
+            # is the IANA tz id the user picked for display and DST
+            # handling. ``scope_json`` stores a high-level reference
+            # (schema/table names) and is resolved against the live DB
+            # at fire time -- new tables under a scheduled schema are
+            # picked up automatically; missing entities surface as a
+            # clean failure with last_error populated.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS scheduled_runs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    fire_at_utc REAL NOT NULL,
+                    fire_at_tz TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    db_profile TEXT NOT NULL,
+                    scope_json TEXT NOT NULL,
+                    llm_profile TEXT NOT NULL,
+                    review_strategy TEXT NOT NULL,
+                    extra_args_json TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    fired_at REAL,
+                    triggered_run_id INTEGER,
+                    last_error TEXT
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_scheduled_runs_status_fireat "
+                "ON scheduled_runs(status, fire_at_utc)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_scheduled_runs_db_profile "
+                "ON scheduled_runs(db_profile)"
+            )
 
     def _ensure_run_columns(self, conn: Any) -> None:
         """Idempotently add the v0.5.2 reporting columns to analysis_runs.
@@ -607,6 +652,14 @@ class SQLiteHistoryStore:
             ("hostname", "TEXT"),
             ("client_version", "TEXT"),
             ("shared_uuid", "TEXT"),
+            # Scheduled-runs feature (Phase 1a). ``triggered_by_schedule_id``
+            # links a run back to the scheduled_runs row that fired it;
+            # ``last_heartbeat_at`` is bumped by the orchestrator while a
+            # run is in flight and consumed by the stale-run recovery
+            # path (Phase 2). Both are NULL for runs not driven by the
+            # scheduler and for runs created before this migration.
+            ("triggered_by_schedule_id", "INTEGER"),
+            ("last_heartbeat_at", "REAL"),
         ):
             if col_name in existing_cols:
                 continue
@@ -2302,6 +2355,301 @@ class SQLiteHistoryStore:
                     d["details_json"] = json.loads(raw)
             out.append(d)
         return out
+
+    # ── scheduled_runs CRUD ─────────────────────────────────────────────
+    #
+    # The state machine governs which transitions are legal. See the
+    # design spec for the full diagram; the dict below is its
+    # source-of-truth implementation. Terminal states (failed,
+    # completed, cancelled) intentionally have empty sets -- once a
+    # schedule is terminal it stays terminal; the user "re-arms" by
+    # cloning into a fresh schedule.
+    _SCHEDULE_TRANSITIONS: dict[str, set[str]] = {
+        "pending": {"paused", "running", "missed", "cancelled"},
+        "paused": {"pending", "cancelled"},
+        "running": {"completed", "failed"},
+        "missed": {"running", "cancelled", "pending"},
+        "failed": set(),
+        "completed": set(),
+        "cancelled": set(),
+    }
+
+    _SCHEDULE_UPDATABLE_FIELDS: frozenset[str] = frozenset(
+        {
+            "name",
+            "fire_at_utc",
+            "fire_at_tz",
+            "db_profile",
+            "scope_json",
+            "llm_profile",
+            "review_strategy",
+            "extra_args_json",
+        }
+    )
+
+    def create_scheduled_run(
+        self,
+        *,
+        name: str,
+        fire_at_utc: float,
+        fire_at_tz: str,
+        db_profile: str,
+        scope_json: str,
+        llm_profile: str,
+        review_strategy: str,
+        extra_args_json: str | None = None,
+    ) -> int:
+        """Insert a new scheduled_runs row in status='pending'."""
+        now = time.time()
+        with self._lock, self._connect() as conn:
+            cur = conn.execute(
+                """
+                INSERT INTO scheduled_runs (
+                    name, fire_at_utc, fire_at_tz, status,
+                    db_profile, scope_json, llm_profile, review_strategy,
+                    extra_args_json, created_at, updated_at
+                ) VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    name,
+                    fire_at_utc,
+                    fire_at_tz,
+                    db_profile,
+                    scope_json,
+                    llm_profile,
+                    review_strategy,
+                    extra_args_json,
+                    now,
+                    now,
+                ),
+            )
+            return int(cur.lastrowid or 0)
+
+    def get_scheduled_run(self, schedule_id: int) -> dict[str, Any] | None:
+        """Return the full row as a dict, or None if missing."""
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute("SELECT * FROM scheduled_runs WHERE id=?", (schedule_id,)).fetchone()
+        return dict(row) if row else None
+
+    def list_scheduled_runs(
+        self,
+        *,
+        statuses: list[str] | None = None,
+        db_profile: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """List rows sorted by fire_at_utc ASC with optional filters."""
+        clauses: list[str] = []
+        params: list[Any] = []
+        if statuses:
+            placeholders = ",".join("?" for _ in statuses)
+            clauses.append(f"status IN ({placeholders})")
+            params.extend(statuses)
+        if db_profile is not None:
+            clauses.append("db_profile = ?")
+            params.append(db_profile)
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        params.append(int(limit))
+        sql = "SELECT * FROM scheduled_runs" + where + " ORDER BY fire_at_utc ASC LIMIT ?"
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
+
+    def list_due_pending_schedules(
+        self,
+        *,
+        now_utc: float,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Return rows that are pending and whose fire time has elapsed.
+
+        Read-only: does not transition status. Used by the bootstrap
+        tick path to surface "missed while AMX was closed" entries.
+        """
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT * FROM scheduled_runs
+                WHERE status = 'pending'
+                  AND fire_at_utc <= ?
+                ORDER BY fire_at_utc ASC
+                LIMIT ?
+                """,
+                (now_utc, int(limit)),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def update_scheduled_run(
+        self,
+        schedule_id: int,
+        *,
+        patch: dict[str, Any],
+    ) -> None:
+        """Apply a whitelisted patch to a scheduled_runs row.
+
+        Only the fields in ``_SCHEDULE_UPDATABLE_FIELDS`` can be
+        modified through this path -- status changes go through
+        :meth:`set_scheduled_run_status`, and id/created_at/fired_at/
+        triggered_run_id/last_error are owned by the engine.
+        """
+        if not patch:
+            return
+        unknown = (
+            set(patch)
+            - self._SCHEDULE_UPDATABLE_FIELDS
+            - {
+                "status",
+                "id",
+                "created_at",
+                "updated_at",
+                "fired_at",
+                "triggered_run_id",
+                "last_error",
+            }
+        )
+        if unknown:
+            raise ValueError(f"unknown patch field(s): {sorted(unknown)}")
+        forbidden = set(patch) - self._SCHEDULE_UPDATABLE_FIELDS
+        if forbidden:
+            raise ValueError(
+                f"forbidden patch field(s) for update_scheduled_run: "
+                f"{sorted(forbidden)} -- use a dedicated method"
+            )
+        cols = sorted(patch)
+        set_clause = ", ".join(f"{c} = ?" for c in cols)
+        params: list[Any] = [patch[c] for c in cols]
+        params.append(time.time())
+        params.append(schedule_id)
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                f"UPDATE scheduled_runs SET {set_clause}, updated_at = ? WHERE id = ?",
+                params,
+            )
+
+    def set_scheduled_run_status(
+        self,
+        schedule_id: int,
+        status: str,
+        *,
+        last_error: str | None = None,
+        fired_at: float | None = None,
+        triggered_run_id: int | None = None,
+    ) -> None:
+        """Transition a schedule to *status*, enforcing the state machine."""
+        if status not in self._SCHEDULE_TRANSITIONS:
+            raise ValueError(f"unknown status: {status!r}")
+        now = time.time()
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                "SELECT status FROM scheduled_runs WHERE id = ?",
+                (schedule_id,),
+            ).fetchone()
+            if row is None:
+                raise ValueError(f"no scheduled_runs row with id={schedule_id}")
+            current = str(row[0])
+            allowed = self._SCHEDULE_TRANSITIONS.get(current, set())
+            if status not in allowed and status != current:
+                raise ValueError(f"illegal transition: {current!r} -> {status!r}")
+            sets = ["status = ?", "updated_at = ?"]
+            params: list[Any] = [status, now]
+            if last_error is not None:
+                sets.append("last_error = ?")
+                params.append(last_error)
+            if fired_at is not None:
+                sets.append("fired_at = ?")
+                params.append(fired_at)
+            if triggered_run_id is not None:
+                sets.append("triggered_run_id = ?")
+                params.append(triggered_run_id)
+            params.append(schedule_id)
+            conn.execute(
+                f"UPDATE scheduled_runs SET {', '.join(sets)} WHERE id = ?",
+                params,
+            )
+
+    def delete_scheduled_run(self, schedule_id: int) -> None:
+        """Hard-delete a scheduled_runs row; write an audit event.
+
+        Idempotent: deleting a non-existent id is a no-op (no error,
+        no audit row).
+        """
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                "SELECT name FROM scheduled_runs WHERE id = ?",
+                (schedule_id,),
+            ).fetchone()
+            if row is None:
+                return
+            name = str(row[0])
+            conn.execute("DELETE FROM scheduled_runs WHERE id = ?", (schedule_id,))
+            conn.execute(
+                """
+                INSERT INTO app_events (
+                    created_at, event_type, status, command, details_json
+                ) VALUES (?, 'schedule.deleted', 'ok', 'schedule.rm', ?)
+                """,
+                (
+                    time.time(),
+                    json.dumps({"schedule_id": schedule_id, "name": name}),
+                ),
+            )
+
+    def claim_due_schedule(self, *, now_utc: float) -> int | None:
+        """Atomically transition the oldest due pending schedule to running.
+
+        Returns the claimed schedule id, or None if none are due. Safe
+        under concurrent calls from multiple threads -- the
+        ``WHERE status='pending'`` predicate on the UPDATE turns a lost
+        race into a return of None for the loser.
+        """
+        now = time.time()
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT id FROM scheduled_runs
+                WHERE status = 'pending' AND fire_at_utc <= ?
+                ORDER BY fire_at_utc ASC
+                LIMIT 1
+                """,
+                (now_utc,),
+            ).fetchone()
+            if row is None:
+                return None
+            sid = int(row[0])
+            cur = conn.execute(
+                """
+                UPDATE scheduled_runs
+                SET status = 'running', fired_at = ?, updated_at = ?
+                WHERE id = ? AND status = 'pending'
+                """,
+                (now, now, sid),
+            )
+            if cur.rowcount == 1:
+                return sid
+            return None
+
+    def update_run_heartbeat(
+        self,
+        run_id: int,
+        *,
+        now_utc: float | None = None,
+    ) -> None:
+        """Bump ``last_heartbeat_at`` for an in-flight analysis_runs row.
+
+        Used by the orchestrator while a run is in flight; consumed by
+        the stale-run recovery path (Phase 2) to detect interrupted
+        runs after an unclean shutdown. No-ops for unknown run_ids so
+        the caller can be defensive without checking first.
+        """
+        ts = now_utc if now_utc is not None else time.time()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                "UPDATE analysis_runs SET last_heartbeat_at = ? WHERE id = ?",
+                (ts, run_id),
+            )
 
 
 # The singleton is typed as ``Any`` so v0.12.0+ shared-history mode

--- a/tests/storage/test_scheduled_runs_sqlite.py
+++ b/tests/storage/test_scheduled_runs_sqlite.py
@@ -1,0 +1,365 @@
+"""Local-SQLite storage tests for the ``scheduled_runs`` table.
+
+Phase 1a covers the local source-of-truth side only. The shared
+SQLAlchemy mirror and the dual-write façade are added in Phase 1b.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def _make(
+    store: SQLiteHistoryStore,
+    *,
+    name: str = "sched",
+    fire_at_utc: float | None = None,
+    fire_at_tz: str = "Europe/Istanbul",
+    db_profile: str = "prod_sf",
+    scope: dict | None = None,
+    llm_profile: str = "claude",
+    review_strategy: str = "auto",
+) -> int:
+    return store.create_scheduled_run(
+        name=name,
+        fire_at_utc=fire_at_utc if fire_at_utc is not None else time.time() + 3600,
+        fire_at_tz=fire_at_tz,
+        db_profile=db_profile,
+        scope_json=json.dumps(scope or {"mode": "schemas", "schemas": ["public"]}),
+        llm_profile=llm_profile,
+        review_strategy=review_strategy,
+    )
+
+
+# ── Schema ───────────────────────────────────────────────────────────
+
+
+def test_schema_contains_scheduled_runs_table(store: SQLiteHistoryStore) -> None:
+    with sqlite3.connect(store.db_path) as conn:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    names = {row[0] for row in rows}
+    assert "scheduled_runs" in names
+
+
+def test_scheduled_runs_has_expected_columns(store: SQLiteHistoryStore) -> None:
+    with sqlite3.connect(store.db_path) as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(scheduled_runs)").fetchall()}
+    expected = {
+        "id",
+        "name",
+        "fire_at_utc",
+        "fire_at_tz",
+        "status",
+        "db_profile",
+        "scope_json",
+        "llm_profile",
+        "review_strategy",
+        "extra_args_json",
+        "created_at",
+        "updated_at",
+        "fired_at",
+        "triggered_run_id",
+        "last_error",
+    }
+    missing = expected - cols
+    assert not missing, f"missing columns: {missing}"
+
+
+def test_analysis_runs_has_scheduler_columns(store: SQLiteHistoryStore) -> None:
+    with sqlite3.connect(store.db_path) as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(analysis_runs)").fetchall()}
+    assert "triggered_by_schedule_id" in cols
+    assert "last_heartbeat_at" in cols
+
+
+# ── Create + read ────────────────────────────────────────────────────
+
+
+def test_create_then_get_round_trip(store: SQLiteHistoryStore) -> None:
+    sid = store.create_scheduled_run(
+        name="quarterly refresh",
+        fire_at_utc=1_700_000_000.0,
+        fire_at_tz="Europe/Istanbul",
+        db_profile="prod_sf",
+        scope_json='{"mode":"schemas","schemas":["public"]}',
+        llm_profile="claude",
+        review_strategy="auto",
+    )
+    assert isinstance(sid, int) and sid > 0
+    row = store.get_scheduled_run(sid)
+    assert row is not None
+    assert row["name"] == "quarterly refresh"
+    assert row["status"] == "pending"
+    assert row["fire_at_utc"] == pytest.approx(1_700_000_000.0)
+    assert row["fire_at_tz"] == "Europe/Istanbul"
+    assert row["db_profile"] == "prod_sf"
+    assert row["created_at"] > 0
+    assert row["updated_at"] > 0
+    assert row["fired_at"] is None
+    assert row["triggered_run_id"] is None
+    assert row["last_error"] is None
+
+
+def test_get_nonexistent_returns_none(store: SQLiteHistoryStore) -> None:
+    assert store.get_scheduled_run(99999) is None
+
+
+# ── List + filters ──────────────────────────────────────────────────
+
+
+def test_list_filters_by_status(store: SQLiteHistoryStore) -> None:
+    pending = _make(store, name="p")
+    paused = _make(store, name="x")
+    store.set_scheduled_run_status(paused, "paused")
+
+    pendings = store.list_scheduled_runs(statuses=["pending"])
+    assert {r["id"] for r in pendings} == {pending}
+
+    pauseds = store.list_scheduled_runs(statuses=["paused"])
+    assert {r["id"] for r in pauseds} == {paused}
+
+
+def test_list_filters_by_db_profile(store: SQLiteHistoryStore) -> None:
+    a = _make(store, db_profile="prod_sf")
+    _make(store, db_profile="staging")
+    rows = store.list_scheduled_runs(db_profile="prod_sf")
+    assert {r["id"] for r in rows} == {a}
+
+
+def test_list_default_sorts_by_fire_at_utc_ascending(
+    store: SQLiteHistoryStore,
+) -> None:
+    later = _make(store, name="later", fire_at_utc=2_000_000_000.0)
+    earlier = _make(store, name="earlier", fire_at_utc=1_000_000_000.0)
+    ids = [r["id"] for r in store.list_scheduled_runs()]
+    assert ids == [earlier, later]
+
+
+def test_list_honours_limit(store: SQLiteHistoryStore) -> None:
+    for i in range(5):
+        _make(store, name=f"s{i}", fire_at_utc=1_000_000_000.0 + i)
+    rows = store.list_scheduled_runs(limit=2)
+    assert len(rows) == 2
+
+
+def test_list_due_pending_returns_only_due_pending(
+    store: SQLiteHistoryStore,
+) -> None:
+    now = time.time()
+    due_pending = _make(store, name="due", fire_at_utc=now - 60)
+    _make(store, name="future", fire_at_utc=now + 60)  # future, pending
+    paused_due = _make(store, name="paused-due", fire_at_utc=now - 30)
+    store.set_scheduled_run_status(paused_due, "paused")
+
+    rows = store.list_due_pending_schedules(now_utc=now)
+    assert {r["id"] for r in rows} == {due_pending}
+
+
+# ── update_scheduled_run ────────────────────────────────────────────
+
+
+def test_update_changes_allowed_fields(store: SQLiteHistoryStore) -> None:
+    sid = _make(store, name="old")
+    store.update_scheduled_run(sid, patch={"name": "new", "fire_at_tz": "UTC"})
+    row = store.get_scheduled_run(sid)
+    assert row["name"] == "new"
+    assert row["fire_at_tz"] == "UTC"
+    assert row["updated_at"] >= row["created_at"]
+
+
+def test_update_rejects_forbidden_field(store: SQLiteHistoryStore) -> None:
+    sid = _make(store)
+    with pytest.raises(ValueError, match="forbidden"):
+        store.update_scheduled_run(sid, patch={"status": "running"})
+
+
+def test_update_rejects_unknown_field(store: SQLiteHistoryStore) -> None:
+    sid = _make(store)
+    with pytest.raises(ValueError, match="unknown"):
+        store.update_scheduled_run(sid, patch={"nonsense": 1})
+
+
+# ── set_scheduled_run_status ────────────────────────────────────────
+
+
+def test_status_transition_pending_to_paused(
+    store: SQLiteHistoryStore,
+) -> None:
+    sid = _make(store)
+    store.set_scheduled_run_status(sid, "paused")
+    assert store.get_scheduled_run(sid)["status"] == "paused"
+
+
+def test_status_transition_pending_to_running(
+    store: SQLiteHistoryStore,
+) -> None:
+    sid = _make(store)
+    store.set_scheduled_run_status(sid, "running")
+    assert store.get_scheduled_run(sid)["status"] == "running"
+
+
+def test_status_transition_running_to_completed_records_run_link(
+    store: SQLiteHistoryStore,
+) -> None:
+    sid = _make(store)
+    store.set_scheduled_run_status(sid, "running")
+    store.set_scheduled_run_status(sid, "completed", triggered_run_id=42)
+    row = store.get_scheduled_run(sid)
+    assert row["status"] == "completed"
+    assert row["triggered_run_id"] == 42
+
+
+def test_status_transition_running_to_failed_records_error(
+    store: SQLiteHistoryStore,
+) -> None:
+    sid = _make(store)
+    store.set_scheduled_run_status(sid, "running")
+    store.set_scheduled_run_status(
+        sid, "failed", last_error="scope resolution: schema 'public' missing"
+    )
+    row = store.get_scheduled_run(sid)
+    assert row["status"] == "failed"
+    assert "public" in row["last_error"]
+
+
+def test_illegal_transition_raises(store: SQLiteHistoryStore) -> None:
+    sid = _make(store)
+    store.set_scheduled_run_status(sid, "running")
+    store.set_scheduled_run_status(sid, "completed")
+    with pytest.raises(ValueError, match="illegal transition"):
+        store.set_scheduled_run_status(sid, "running")
+
+
+def test_transition_to_unknown_status_raises(
+    store: SQLiteHistoryStore,
+) -> None:
+    sid = _make(store)
+    with pytest.raises(ValueError, match="unknown status"):
+        store.set_scheduled_run_status(sid, "frobnicated")
+
+
+# ── delete_scheduled_run ────────────────────────────────────────────
+
+
+def test_delete_removes_row_and_writes_audit_event(
+    store: SQLiteHistoryStore,
+) -> None:
+    sid = _make(store, name="goodbye")
+    store.delete_scheduled_run(sid)
+    assert store.get_scheduled_run(sid) is None
+
+    with sqlite3.connect(store.db_path) as conn:
+        rows = conn.execute(
+            "SELECT event_type, details_json FROM app_events WHERE event_type = 'schedule.deleted'"
+        ).fetchall()
+    assert len(rows) == 1
+    payload = json.loads(rows[0][1])
+    assert payload["schedule_id"] == sid
+    assert payload["name"] == "goodbye"
+
+
+def test_delete_unknown_id_is_a_noop(store: SQLiteHistoryStore) -> None:
+    # No exception; nothing in audit.
+    store.delete_scheduled_run(99999)
+
+
+# ── claim_due_schedule ──────────────────────────────────────────────
+
+
+def test_claim_returns_oldest_pending_due(store: SQLiteHistoryStore) -> None:
+    now = time.time()
+    older = _make(store, name="older", fire_at_utc=now - 60)
+    newer = _make(store, name="newer", fire_at_utc=now - 1)
+    claimed = store.claim_due_schedule(now_utc=now)
+    assert claimed == older
+    assert store.get_scheduled_run(older)["status"] == "running"
+    assert store.get_scheduled_run(newer)["status"] == "pending"
+
+
+def test_claim_returns_none_when_nothing_due(
+    store: SQLiteHistoryStore,
+) -> None:
+    now = time.time()
+    _make(store, name="future", fire_at_utc=now + 3600)
+    assert store.claim_due_schedule(now_utc=now) is None
+
+
+def test_claim_skips_paused_schedules(store: SQLiteHistoryStore) -> None:
+    now = time.time()
+    sid = _make(store, name="x", fire_at_utc=now - 60)
+    store.set_scheduled_run_status(sid, "paused")
+    assert store.claim_due_schedule(now_utc=now) is None
+
+
+def test_two_concurrent_claims_dont_double_fire(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Race-safety: two threads racing claim on one due row → exactly one wins."""
+    now = time.time()
+    sid = _make(store, name="contested", fire_at_utc=now - 1)
+
+    results: list[int | None] = []
+    rlock = threading.Lock()
+
+    def claim() -> None:
+        r = store.claim_due_schedule(now_utc=now)
+        with rlock:
+            results.append(r)
+
+    t1 = threading.Thread(target=claim)
+    t2 = threading.Thread(target=claim)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    won = [r for r in results if r is not None]
+    lost = [r for r in results if r is None]
+    assert won == [sid]
+    assert lost == [None]
+
+
+# ── update_run_heartbeat ────────────────────────────────────────────
+
+
+def test_update_run_heartbeat_writes_column(
+    store: SQLiteHistoryStore,
+) -> None:
+    run_id = store.create_run(
+        command="run",
+        mode="metadata",
+        db_backend="snowflake",
+        db_profile="prod_sf",
+        llm_provider="anthropic",
+        llm_model="claude-sonnet",
+        scope={"public": ["t"]},
+    )
+    before = time.time()
+    store.update_run_heartbeat(run_id)
+    with sqlite3.connect(store.db_path) as conn:
+        (hb,) = conn.execute(
+            "SELECT last_heartbeat_at FROM analysis_runs WHERE id=?", (run_id,)
+        ).fetchone()
+    assert hb is not None
+    assert hb >= before - 1.0
+
+
+def test_update_run_heartbeat_unknown_id_is_a_noop(
+    store: SQLiteHistoryStore,
+) -> None:
+    store.update_run_heartbeat(99999)  # must not raise


### PR DESCRIPTION
## Summary
- New `scheduled_runs` table on the local SQLite history store with indexes on `(status, fire_at_utc)` and `(db_profile)`.
- New `analysis_runs.triggered_by_schedule_id` + `analysis_runs.last_heartbeat_at` columns (idempotent ALTERs).
- Eight new methods on `SQLiteHistoryStore` covering CRUD, listing, state-machine-validated status transitions, atomic claim, and per-run heartbeat. State machine enforces the transitions documented in the design spec.

No tick engine, no CLI surface in this PR. Shared-store mirror + dual-write façade land in phase 1b.

## Test plan
- [x] `pytest tests/storage/test_scheduled_runs_sqlite.py -v` — 27 / 27 pass
- [x] `pytest tests -q -k "storage or sqlite or dual_write or history"` — 170 / 170 pass (no regressions)
- [x] `ruff check amx/storage tests/storage` clean
- [x] `mypy amx/storage/sqlite_store.py` introduces no new errors (the two pre-existing `lastrowid` warnings are unchanged)
- [x] No \`paid\` hits in changed paths

## Base
This PR targets \`feat/scheduler-phase-0\` rather than \`main\` so the stack stays explicit. Rebase onto \`main\` once \#377 merges.