### PR TITLE
feat(scheduler): phase 2 — stateless tick engine

### DIFF
--- a/amx/scheduler/__init__.py
+++ b/amx/scheduler/__init__.py
@@ -1,0 +1,17 @@
+"""Scheduler engine for one-shot scheduled metadata runs.
+
+The single public entry point is :func:`amx.scheduler.tick.tick` — a
+stateless function that performs one pass over the local history
+store: it fires due schedules, surfaces missed ones for review, and
+recovers stale running runs. Three call sites:
+
+* CLI bootstrap (every ``amx ...`` invocation, ``source='bootstrap'``)
+* Studio process startup (lifespan hook, ``source='bootstrap'``)
+* Cron / launchd / systemd timer (``source='daemon'``)
+* Manual ``run-now`` from CLI or Studio (``source='manual'``)
+
+The bootstrap source surfaces but does not auto-fire; the daemon and
+manual sources auto-fire. This split is the explicit user-warning
+contract — when AMX is closed, missed schedules wait for the user's
+next session.
+"""

--- a/amx/scheduler/tick.py
+++ b/amx/scheduler/tick.py
@@ -1,0 +1,241 @@
+"""Stateless tick: one pass over the schedule store.
+
+The tick performs three things per call:
+
+1. Surface stale running runs so the UI can mark them recovered. The
+   spawn-worker integration that updates ``analysis_runs.status`` for
+   crashed runs is intentionally out of scope here — the heartbeat
+   wiring lands together with the orchestrator update in a follow-up
+   PR. For now the report's ``stale_recovered`` list is always empty
+   so the call sites have the shape they need.
+2. Find pending schedules whose ``fire_at_utc`` has elapsed. The
+   *source* controls what happens next:
+
+   * ``"bootstrap"`` — surface them in ``missed_for_review``. Do
+     **not** fire. The CLI banner / Studio dashboard banner show the
+     user this list; the user decides per-item what to do via
+     ``amx schedule review`` or the Schedules page.
+   * ``"daemon"`` — fire each in turn via the injected
+     ``spawn_worker`` callable. Used by the launchd/systemd cron
+     entry once the daemon ships in phase 4.
+   * ``"manual"`` — fire exactly the schedule named by
+     ``target_id``, transitioning it from ``pending`` (or ``missed``)
+     to ``running`` first.
+
+3. Return a :class:`TickReport` summarising what happened. Callers
+   render it (CLI banner, Studio bootstrap-report endpoint) — the
+   tick itself is purely transactional.
+
+``spawn_worker`` is injectable so tests can supply a recorder and so
+the production wiring (Studio's run worker) can land in a follow-up
+without rewriting this module. The default — used in production once
+phase 2b lands — will delegate to ``amx.runtime.worker.run_orchestrator``.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+Source = Literal["bootstrap", "daemon", "manual"]
+
+
+class _ScheduleStore(Protocol):
+    """The subset of ``SQLiteHistoryStore`` (or any IHistoryStore
+    implementation) that the tick relies on.
+
+    Defined as a structural Protocol so tests can pass a minimal fake
+    without dragging in the full storage stack.
+    """
+
+    def list_due_pending_schedules(
+        self, *, now_utc: float, limit: int = 200
+    ) -> list[dict[str, Any]]: ...
+
+    def claim_due_schedule(self, *, now_utc: float) -> int | None: ...
+
+    def get_scheduled_run(self, schedule_id: int) -> dict[str, Any] | None: ...
+
+    def set_scheduled_run_status(
+        self,
+        schedule_id: int,
+        status: str,
+        *,
+        last_error: str | None = ...,
+        fired_at: float | None = ...,
+        triggered_run_id: int | None = ...,
+    ) -> None: ...
+
+
+SpawnWorker = Callable[[dict[str, Any]], int]
+"""Callable that spawns a run worker from a schedule's payload.
+
+Receives the full ``scheduled_runs`` row as a dict; returns the
+``analysis_runs.id`` of the new run. The worker itself runs in
+its own thread / process and updates the schedule status when
+it completes.
+"""
+
+
+@dataclass
+class TickReport:
+    """Summary of a single tick. All lists may be empty."""
+
+    fired: list[int] = field(default_factory=list)
+    """Schedule ids that were transitioned to ``running`` and handed
+    to ``spawn_worker``. Populated only for daemon / manual sources."""
+
+    failed_resolution: list[tuple[int, str]] = field(default_factory=list)
+    """Schedules that could not be fired because resolution failed
+    (e.g., missing schema). Pairs of ``(schedule_id, error_message)``."""
+
+    missed_for_review: list[int] = field(default_factory=list)
+    """Schedules whose fire time has elapsed but which were NOT fired
+    because ``source='bootstrap'``. The UI surfaces these to the user."""
+
+    stale_recovered: list[int] = field(default_factory=list)
+    """analysis_runs ids that were recovered as ``failed`` because
+    their last heartbeat is older than the threshold. Always empty
+    until the heartbeat wiring lands; the field is here so the
+    report shape is stable across phases."""
+
+
+def tick(
+    *,
+    store: _ScheduleStore,
+    source: Source,
+    target_id: int | None = None,
+    spawn_worker: SpawnWorker | None = None,
+    now_utc: float | None = None,
+    max_per_tick: int = 50,
+) -> TickReport:
+    """Perform one scheduling pass against *store*.
+
+    The tick never raises for per-schedule failures: a resolution
+    error on one schedule is recorded in ``failed_resolution`` and
+    the loop continues. Only programmer errors (wrong source value,
+    manual without ``target_id``) surface as exceptions.
+    """
+    if source not in ("bootstrap", "daemon", "manual"):
+        raise ValueError(f"unknown tick source: {source!r}")
+
+    now = now_utc if now_utc is not None else time.time()
+    report = TickReport()
+
+    if source == "bootstrap":
+        # Surface missed schedules. Do NOT fire — bootstrap respects
+        # the user-warning contract: when AMX is closed, missed
+        # schedules wait for the user's next interactive review.
+        due = store.list_due_pending_schedules(now_utc=now)
+        report.missed_for_review = [int(row["id"]) for row in due]
+        return report
+
+    if source == "manual":
+        if target_id is None:
+            raise ValueError("tick(source='manual') requires target_id")
+        if spawn_worker is None:
+            raise ValueError("tick(source='manual') requires a spawn_worker callable")
+        _fire_one(
+            store=store,
+            schedule_id=target_id,
+            now=now,
+            spawn_worker=spawn_worker,
+            report=report,
+            force=True,
+        )
+        return report
+
+    # source == "daemon"
+    if spawn_worker is None:
+        raise ValueError("tick(source='daemon') requires a spawn_worker callable")
+
+    for _ in range(max_per_tick):
+        sid = store.claim_due_schedule(now_utc=now)
+        if sid is None:
+            break
+        _fire_one(
+            store=store,
+            schedule_id=sid,
+            now=now,
+            spawn_worker=spawn_worker,
+            report=report,
+            force=False,
+        )
+    return report
+
+
+def _fire_one(
+    *,
+    store: _ScheduleStore,
+    schedule_id: int,
+    now: float,
+    spawn_worker: SpawnWorker,
+    report: TickReport,
+    force: bool,
+) -> None:
+    """Move a single schedule from its current state to ``running`` (if
+    not already moved by a prior claim) and hand it to ``spawn_worker``.
+
+    For ``source='daemon'`` the caller has already transitioned the
+    row to ``running`` via ``claim_due_schedule`` -- we just fetch the
+    payload. For ``source='manual'`` (``force=True``) we drive the
+    transition here so user-initiated re-runs work regardless of the
+    schedule's prior state.
+    """
+    payload = store.get_scheduled_run(schedule_id)
+    if payload is None:
+        report.failed_resolution.append((schedule_id, f"schedule id={schedule_id} not found"))
+        return
+
+    if force and payload["status"] != "running":
+        # Manual fire: transition via the state-machine path. If the
+        # state machine rejects (e.g., schedule is already in a
+        # terminal state), surface the error and stop.
+        try:
+            store.set_scheduled_run_status(schedule_id, "running", fired_at=now)
+        except ValueError as exc:
+            report.failed_resolution.append((schedule_id, str(exc)))
+            return
+        payload = store.get_scheduled_run(schedule_id) or payload
+
+    try:
+        run_id = spawn_worker(payload)
+    except Exception as exc:  # noqa: BLE001 - worker failures must not crash the tick
+        # Mark schedule as failed so the user sees it; ``last_error``
+        # carries the worker's complaint verbatim.
+        try:
+            store.set_scheduled_run_status(
+                schedule_id,
+                "failed",
+                last_error=f"spawn_worker failed: {exc}",
+            )
+        except ValueError:
+            # Already in a terminal state; nothing useful to do but
+            # record it in the report so the caller can log.
+            pass
+        report.failed_resolution.append((schedule_id, str(exc)))
+        return
+
+    # Worker has been spawned; record the linkage so the UI can deep-
+    # link from the schedule row to the live run. The schedule
+    # itself stays in ``running`` until the worker updates its
+    # status on completion -- not the tick's job.
+    try:
+        # Re-read status first to avoid touching anything that's
+        # already terminal (worker could in principle have finished
+        # before this UPDATE lands, in which case ``running`` ->
+        # ``running`` is a no-op and the state machine accepts it).
+        current = store.get_scheduled_run(schedule_id)
+        if current is not None and current["status"] == "running":
+            # Use an in-place no-op transition to attach the run id;
+            # the store's set_scheduled_run_status preserves status
+            # when source==target.
+            store.set_scheduled_run_status(schedule_id, "running", triggered_run_id=run_id)
+    except ValueError:
+        # Worker finished extremely fast; the schedule is already
+        # terminal. The worker's own status update has the linkage.
+        pass
+
+    report.fired.append(schedule_id)

--- a/tests/scheduler/test_tick.py
+++ b/tests/scheduler/test_tick.py
@@ -1,0 +1,279 @@
+"""Tests for the stateless ``tick`` engine.
+
+These exercise the source-gated behaviour (bootstrap surfaces, daemon
+fires, manual targets a specific id) against a real
+:class:`SQLiteHistoryStore` populated via the phase-1a CRUD helpers.
+The worker is mocked: tests record what ``spawn_worker`` saw and
+assert on the report.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amx.scheduler.tick import TickReport, tick
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def _create_schedule(
+    store: SQLiteHistoryStore,
+    *,
+    fire_at_utc: float,
+    name: str = "s",
+    db_profile: str = "prod_sf",
+) -> int:
+    return store.create_scheduled_run(
+        name=name,
+        fire_at_utc=fire_at_utc,
+        fire_at_tz="UTC",
+        db_profile=db_profile,
+        scope_json=json.dumps({"mode": "schemas", "schemas": ["public"]}),
+        llm_profile="claude",
+        review_strategy="auto",
+    )
+
+
+def _recording_spawn(records: list[dict[str, Any]], next_id: int = 1):
+    """Build a spawn_worker callable that records its arg and returns a fresh id."""
+    counter = {"n": next_id}
+
+    def spawn(payload: dict[str, Any]) -> int:
+        records.append(payload)
+        rid = counter["n"]
+        counter["n"] += 1
+        return rid
+
+    return spawn
+
+
+# ── Source gating ───────────────────────────────────────────────────
+
+
+def test_bootstrap_surfaces_missed_without_firing(
+    store: SQLiteHistoryStore,
+) -> None:
+    now = time.time()
+    overdue = _create_schedule(store, fire_at_utc=now - 60, name="overdue")
+    _create_schedule(store, fire_at_utc=now + 60, name="future")
+
+    spawned: list[dict[str, Any]] = []
+    report = tick(
+        store=store,
+        source="bootstrap",
+        spawn_worker=_recording_spawn(spawned),
+        now_utc=now,
+    )
+
+    assert report.missed_for_review == [overdue]
+    assert report.fired == []
+    assert spawned == []
+    # The overdue schedule must stay pending — bootstrap never transitions.
+    assert store.get_scheduled_run(overdue)["status"] == "pending"
+
+
+def test_daemon_fires_due_schedules(store: SQLiteHistoryStore) -> None:
+    now = time.time()
+    s1 = _create_schedule(store, fire_at_utc=now - 120, name="oldest")
+    s2 = _create_schedule(store, fire_at_utc=now - 60, name="newer")
+    _create_schedule(store, fire_at_utc=now + 60, name="future")
+
+    spawned: list[dict[str, Any]] = []
+    report = tick(
+        store=store,
+        source="daemon",
+        spawn_worker=_recording_spawn(spawned, next_id=100),
+        now_utc=now,
+    )
+
+    # Both due rows fired; future stays pending.
+    assert sorted(report.fired) == sorted([s1, s2])
+    assert report.missed_for_review == []
+    assert {p["id"] for p in spawned} == {s1, s2}
+    for sid in (s1, s2):
+        row = store.get_scheduled_run(sid)
+        assert row["status"] == "running"
+        assert row["fired_at"] is not None
+        assert row["triggered_run_id"] in (100, 101)
+
+
+def test_daemon_with_nothing_due_returns_empty_report(
+    store: SQLiteHistoryStore,
+) -> None:
+    now = time.time()
+    _create_schedule(store, fire_at_utc=now + 3600, name="future")
+    report = tick(
+        store=store,
+        source="daemon",
+        spawn_worker=_recording_spawn([]),
+        now_utc=now,
+    )
+    assert report.fired == []
+    assert report.missed_for_review == []
+
+
+def test_manual_fires_target_id(store: SQLiteHistoryStore) -> None:
+    now = time.time()
+    sid = _create_schedule(store, fire_at_utc=now + 3600, name="future")
+    spawned: list[dict[str, Any]] = []
+    report = tick(
+        store=store,
+        source="manual",
+        target_id=sid,
+        spawn_worker=_recording_spawn(spawned, next_id=42),
+        now_utc=now,
+    )
+    assert report.fired == [sid]
+    row = store.get_scheduled_run(sid)
+    assert row["status"] == "running"
+    assert row["triggered_run_id"] == 42
+    assert spawned == [pytest.approx(spawned[0], abs=0)] or spawned[0]["id"] == sid
+
+
+def test_manual_without_target_id_raises(
+    store: SQLiteHistoryStore,
+) -> None:
+    with pytest.raises(ValueError, match="requires target_id"):
+        tick(store=store, source="manual", spawn_worker=lambda _: 1)
+
+
+def test_manual_without_spawn_worker_raises(
+    store: SQLiteHistoryStore,
+) -> None:
+    sid = _create_schedule(store, fire_at_utc=time.time() + 60)
+    with pytest.raises(ValueError, match="spawn_worker"):
+        tick(store=store, source="manual", target_id=sid)
+
+
+def test_daemon_without_spawn_worker_raises(
+    store: SQLiteHistoryStore,
+) -> None:
+    with pytest.raises(ValueError, match="spawn_worker"):
+        tick(store=store, source="daemon")
+
+
+def test_unknown_source_raises(store: SQLiteHistoryStore) -> None:
+    with pytest.raises(ValueError, match="unknown tick source"):
+        tick(store=store, source="frobnicate")  # type: ignore[arg-type]
+
+
+# ── Worker failure handling ─────────────────────────────────────────
+
+
+def test_worker_failure_marks_schedule_failed_and_records_error(
+    store: SQLiteHistoryStore,
+) -> None:
+    now = time.time()
+    sid = _create_schedule(store, fire_at_utc=now - 60, name="boom")
+
+    def boom(_payload: dict[str, Any]) -> int:
+        raise RuntimeError("simulated worker crash")
+
+    report = tick(
+        store=store,
+        source="daemon",
+        spawn_worker=boom,
+        now_utc=now,
+    )
+
+    assert report.fired == []
+    assert len(report.failed_resolution) == 1
+    rid, msg = report.failed_resolution[0]
+    assert rid == sid
+    assert "simulated worker crash" in msg
+
+    row = store.get_scheduled_run(sid)
+    assert row["status"] == "failed"
+    assert "simulated worker crash" in row["last_error"]
+
+
+def test_manual_on_terminal_schedule_surfaces_state_machine_error(
+    store: SQLiteHistoryStore,
+) -> None:
+    now = time.time()
+    sid = _create_schedule(store, fire_at_utc=now - 60, name="done")
+    # Manually drive the row to a terminal state.
+    store.set_scheduled_run_status(sid, "running")
+    store.set_scheduled_run_status(sid, "completed", triggered_run_id=1)
+
+    spawned: list[dict[str, Any]] = []
+    report = tick(
+        store=store,
+        source="manual",
+        target_id=sid,
+        spawn_worker=_recording_spawn(spawned),
+        now_utc=now,
+    )
+
+    assert report.fired == []
+    assert len(report.failed_resolution) == 1
+    assert "illegal transition" in report.failed_resolution[0][1]
+    assert spawned == []
+
+
+# ── Concurrency ─────────────────────────────────────────────────────
+
+
+def test_two_concurrent_daemon_ticks_dont_double_fire(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Two ticks racing on the same single due schedule -- one fires, one is empty."""
+    now = time.time()
+    sid = _create_schedule(store, fire_at_utc=now - 60, name="contested")
+
+    reports: list[TickReport] = []
+    rlock = threading.Lock()
+
+    def run() -> None:
+        spawned: list[dict[str, Any]] = []
+        r = tick(
+            store=store,
+            source="daemon",
+            spawn_worker=_recording_spawn(spawned, next_id=999),
+            now_utc=now,
+        )
+        with rlock:
+            reports.append(r)
+
+    t1 = threading.Thread(target=run)
+    t2 = threading.Thread(target=run)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    fired_lists = [r.fired for r in reports]
+    fired_lists.sort(key=lambda lst: len(lst))
+    assert fired_lists == [[], [sid]], (
+        f"expected one tick to fire {sid} and the other to fire nothing; got {fired_lists}"
+    )
+
+
+# ── Report shape ────────────────────────────────────────────────────
+
+
+def test_stale_recovered_field_exists_and_is_empty_until_wired(
+    store: SQLiteHistoryStore,
+) -> None:
+    """The TickReport.stale_recovered list is part of the contract even
+    before the heartbeat-based recovery wires in (deferred to a
+    follow-up PR). Asserting on shape protects callers."""
+    report = tick(
+        store=store,
+        source="bootstrap",
+        spawn_worker=lambda _: 1,
+        now_utc=time.time(),
+    )
+    assert report.stale_recovered == []


### PR DESCRIPTION
## Summary
- New \`amx.scheduler\` package with a stateless one-pass \`tick(source, ...)\` over the local schedule store.
- Source-gated behaviour:
  - \`bootstrap\` surfaces missed schedules but does NOT auto-fire (user-warning contract).
  - \`daemon\` loops \`claim_due_schedule\` and fires each via injected \`spawn_worker\`.
  - \`manual\` targets one schedule, validating through the state machine.
- \`TickReport\` carries \`fired\` / \`failed_resolution\` / \`missed_for_review\` / \`stale_recovered\`. Shape stable across phases.
- Worker exceptions are caught and reflected as \`status='failed'\` + \`last_error\` on the schedule; the tick loop never crashes.

Deliberately out of scope here (deferred to phase 2b): orchestrator heartbeat emission and Studio's \`_run_worker\` extraction to \`amx.runtime.worker\`. The production \`spawn_worker\` callable lands with that work; this PR keeps it injectable so tests cover the engine fully.

## Test plan
- [x] \`pytest tests/scheduler/ -v\` — 12 / 12 pass
- [x] \`ruff check amx/scheduler tests/scheduler\` clean
- [x] \`mypy amx/scheduler\` clean
- [x] No \`paid\` hits in changed paths

## Base
Stacked on \`feat/scheduler-phase-1a\` (PR \#378). Rebase onto \`main\` once \#377 + \#378 merge.