### PR TITLE
feat(scheduler): phase 2b — stale recovery + runtime worker scaffold

### DIFF
--- a/amx/runtime/worker.py
+++ b/amx/runtime/worker.py
@@ -1,0 +1,263 @@
+"""Production worker entry for scheduled runs.
+
+The scheduler engine (``amx.scheduler.tick``) accepts an injectable
+``spawn_worker`` callable. This module provides the default
+implementation that integrates with the local history store.
+
+The full Orchestrator integration -- building the LLM client,
+resolving the live DB profile, looping every table in the resolved
+scope, persisting alternatives -- is a separate large concern that
+benefits from per-table heartbeat plumbing inside the orchestrator
+itself. For the initial cut shipped here, ``spawn_scheduled_worker``
+performs the steps the rest of the pipeline depends on:
+
+* Create an ``analysis_runs`` row with ``command='schedule'`` and
+  attach the originating ``scheduled_runs`` id via
+  ``set_run_schedule_link``. Status starts as ``running``;
+  ``last_heartbeat_at`` is set to the current time so the
+  stale-recovery sweep does not immediately reclaim it.
+* Hand control to the (pluggable) per-run executor and update the
+  history row + schedule status on completion.
+* On exception, mark both rows as failed with the error message so
+  the user sees a clean failure in ``amx schedule list`` / Studio.
+
+The pluggable executor (``run_orchestrator_impl``) defaults to a
+small no-op stub that simply marks the run as complete -- enough for
+the CLI ``schedule run-now`` command, the daemon-cron path, and end-
+to-end tests to confirm the full state-machine flow. Wiring the real
+Orchestrator (with full LLM + DB resolution) is a follow-up that
+benefits from an awake reviewer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable
+from typing import Any, Protocol
+
+log = logging.getLogger("amx.runtime.worker")
+
+
+class _HistoryStore(Protocol):
+    """The subset of the history store used by the worker."""
+
+    def create_run(self, **kwargs: Any) -> int: ...
+
+    def set_run_schedule_link(self, run_id: int, schedule_id: int) -> None: ...
+
+    def update_run_heartbeat(self, run_id: int, *, now_utc: float | None = ...) -> None: ...
+
+    def finish_run(self, run_id: int, **kwargs: Any) -> None: ...
+
+    def set_scheduled_run_status(
+        self,
+        schedule_id: int,
+        status: str,
+        *,
+        last_error: str | None = ...,
+        fired_at: float | None = ...,
+        triggered_run_id: int | None = ...,
+    ) -> None: ...
+
+
+# Pluggable per-run executor. Default is the small no-op stub below;
+# callers can swap in a real Orchestrator runner in a follow-up PR.
+RunExecutor = Callable[[int, dict[str, Any]], None]
+"""Signature: (analysis_runs_id, schedule_payload) -> None.
+
+Raises any exception to indicate failure; the worker translates this
+into ``status='failed'`` on both rows.
+"""
+
+
+def default_run_executor(run_id: int, payload: dict[str, Any]) -> None:
+    """No-op executor used until the real Orchestrator integration lands.
+
+    Performs no real metadata-discovery work -- it exists so the
+    scheduler's state-machine flow can be exercised end-to-end. A
+    follow-up PR replaces this with the genuine Orchestrator drive
+    (build LLM, resolve DB, loop tables, persist alternatives).
+
+    A clear log line names the deferral so anyone tracing a run sees
+    why this row finishes immediately.
+    """
+    log.warning(
+        "amx.runtime.worker.default_run_executor: scheduled run %s "
+        "marked complete WITHOUT running metadata discovery -- the "
+        "full Orchestrator integration lands in a follow-up PR. "
+        "Schedule payload: %s",
+        run_id,
+        json.dumps(
+            {
+                k: payload.get(k)
+                for k in (
+                    "id",
+                    "name",
+                    "db_profile",
+                    "llm_profile",
+                    "review_strategy",
+                )
+            }
+        ),
+    )
+
+
+def spawn_scheduled_worker(
+    payload: dict[str, Any],
+    *,
+    store: _HistoryStore,
+    run_executor: RunExecutor | None = None,
+    background: bool = True,
+) -> int:
+    """Create an ``analysis_runs`` row for the given schedule and run it.
+
+    Returns the new ``analysis_runs.id`` immediately. When
+    ``background=True`` (the production default for the daemon path)
+    the executor runs in its own daemon thread so the tick loop is
+    not blocked. ``background=False`` runs synchronously -- useful
+    for the CLI ``schedule run-now`` flow where the user wants their
+    invocation to block until the run finishes.
+
+    *payload* is the full ``scheduled_runs`` row as returned by
+    :meth:`SQLiteHistoryStore.get_scheduled_run`.
+    """
+    executor = run_executor or default_run_executor
+    scope = _parse_scope(payload.get("scope_json"))
+
+    run_id = store.create_run(
+        command="schedule",
+        mode="metadata",
+        db_backend="(scheduled)",  # resolved by the real executor
+        db_profile=str(payload.get("db_profile") or ""),
+        llm_provider="(scheduled)",
+        llm_model="(scheduled)",
+        scope=scope,
+        review_strategy=str(payload.get("review_strategy") or "auto"),
+        llm_profile=str(payload.get("llm_profile") or ""),
+    )
+    schedule_id = int(payload["id"])
+    store.set_run_schedule_link(run_id, schedule_id)
+    # First heartbeat: keeps the stale-recovery sweep from immediately
+    # reclaiming the row before the executor's first internal beat.
+    store.update_run_heartbeat(run_id)
+    # If the caller (tick's daemon path) has already transitioned the
+    # schedule to ``running`` via claim_due_schedule, this is a no-op
+    # (running -> running is accepted by the state machine). When the
+    # worker is invoked standalone (CLI ``schedule run-now`` or tests),
+    # we drive the transition here so the lifecycle is well-defined
+    # regardless of entry point.
+    try:
+        store.set_scheduled_run_status(schedule_id, "running", fired_at=time.time())
+    except ValueError:
+        # Already in a terminal state -- nothing we can do; the
+        # completion handler below will hit the same wall and skip.
+        pass
+
+    def _drive() -> None:
+        try:
+            executor(run_id, payload)
+        except BaseException as exc:  # noqa: BLE001 - propagate to history
+            log.exception("scheduled worker failed for schedule_id=%s", schedule_id)
+            _mark_failed(store, run_id=run_id, schedule_id=schedule_id, error=str(exc))
+            return
+        _mark_completed(store, run_id=run_id, schedule_id=schedule_id)
+
+    if background:
+        threading.Thread(
+            target=_drive,
+            name=f"amx-scheduled-run-{run_id}",
+            daemon=True,
+        ).start()
+    else:
+        _drive()
+    return run_id
+
+
+def _parse_scope(scope_json: str | None) -> dict[str, list[str]]:
+    """Turn the stored ``scope_json`` into the {schema: [table, ...]}
+    shape ``create_run`` expects.
+
+    The stored payload uses ``{"mode":"schemas|tables|all", ...}``;
+    until the live resolver lands the worker passes through what it
+    can extract and lets the (future) executor resolve the rest.
+    """
+    if not scope_json:
+        return {}
+    try:
+        obj = json.loads(scope_json)
+    except (TypeError, ValueError):
+        return {}
+    mode = obj.get("mode")
+    if mode == "schemas":
+        return {s: [] for s in obj.get("schemas", []) if isinstance(s, str)}
+    if mode == "tables":
+        out: dict[str, list[str]] = {}
+        for item in obj.get("tables", []) or []:
+            if not isinstance(item, dict):
+                continue
+            schema = str(item.get("schema") or "")
+            table = str(item.get("table") or "")
+            if not schema or not table:
+                continue
+            out.setdefault(schema, []).append(table)
+        return out
+    return {}
+
+
+def _mark_completed(store: _HistoryStore, *, run_id: int, schedule_id: int) -> None:
+    """Finalise analysis_runs + schedule rows on success."""
+    now = time.time()
+    try:
+        store.finish_run(
+            run_id,
+            status="completed",
+            metrics={},
+            tokens={},
+            results={},
+        )
+    except BaseException:  # noqa: BLE001
+        log.exception("finish_run failed for run_id=%s", run_id)
+    try:
+        store.set_scheduled_run_status(
+            schedule_id,
+            "completed",
+            triggered_run_id=run_id,
+            fired_at=now,
+        )
+    except ValueError:
+        # Already terminal -- the tick's manual path may have raced us.
+        pass
+
+
+def _mark_failed(
+    store: _HistoryStore,
+    *,
+    run_id: int,
+    schedule_id: int,
+    error: str,
+) -> None:
+    """Finalise analysis_runs + schedule rows on failure."""
+    truncated = error[:1000]
+    try:
+        store.finish_run(
+            run_id,
+            status="failed",
+            metrics={},
+            tokens={},
+            results={},
+            error_text=truncated,
+        )
+    except BaseException:  # noqa: BLE001
+        log.exception("finish_run failed for run_id=%s", run_id)
+    try:
+        store.set_scheduled_run_status(
+            schedule_id,
+            "failed",
+            last_error=truncated,
+            triggered_run_id=run_id,
+        )
+    except ValueError:
+        pass

--- a/amx/scheduler/tick.py
+++ b/amx/scheduler/tick.py
@@ -68,6 +68,13 @@ class _ScheduleStore(Protocol):
         triggered_run_id: int | None = ...,
     ) -> None: ...
 
+    def recover_stale_runs(
+        self,
+        *,
+        threshold_sec: float = ...,
+        now_utc: float | None = ...,
+    ) -> list[int]: ...
+
 
 SpawnWorker = Callable[[dict[str, Any]], int]
 """Callable that spawns a run worker from a schedule's payload.
@@ -110,6 +117,8 @@ def tick(
     spawn_worker: SpawnWorker | None = None,
     now_utc: float | None = None,
     max_per_tick: int = 50,
+    stale_threshold_sec: float = 300.0,
+    recover_stale: bool = True,
 ) -> TickReport:
     """Perform one scheduling pass against *store*.
 
@@ -117,12 +126,26 @@ def tick(
     error on one schedule is recorded in ``failed_resolution`` and
     the loop continues. Only programmer errors (wrong source value,
     manual without ``target_id``) surface as exceptions.
+
+    Every tick begins with a stale-run sweep: ``analysis_runs`` rows
+    whose ``last_heartbeat_at`` is older than ``stale_threshold_sec``
+    (or NULL) and whose status is still ``running`` are marked
+    ``failed``. Set ``recover_stale=False`` in tests that want to
+    isolate scheduling behaviour from interruption recovery.
     """
     if source not in ("bootstrap", "daemon", "manual"):
         raise ValueError(f"unknown tick source: {source!r}")
 
     now = now_utc if now_utc is not None else time.time()
     report = TickReport()
+
+    if recover_stale and hasattr(store, "recover_stale_runs"):
+        try:
+            report.stale_recovered = store.recover_stale_runs(
+                threshold_sec=stale_threshold_sec, now_utc=now
+            )
+        except Exception:  # noqa: BLE001 - never let stale sweep crash the tick
+            report.stale_recovered = []
 
     if source == "bootstrap":
         # Surface missed schedules. Do NOT fire — bootstrap respects

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -2631,6 +2631,76 @@ class SQLiteHistoryStore:
                 return sid
             return None
 
+    def set_run_schedule_link(self, run_id: int, schedule_id: int) -> None:
+        """Attach a scheduled_runs id to an existing analysis_runs row.
+
+        Idempotent: writing the same link twice has no effect, and a
+        missing run_id is a no-op (callers can be defensive without a
+        preflight check).
+        """
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                "UPDATE analysis_runs SET triggered_by_schedule_id = ? WHERE id = ?",
+                (schedule_id, run_id),
+            )
+
+    def recover_stale_runs(
+        self,
+        *,
+        threshold_sec: float = 300.0,
+        now_utc: float | None = None,
+    ) -> list[int]:
+        """Mark stale running rows as failed and return their ids.
+
+        A run is "stale" when ``status='running'`` and ``ended_at IS NULL``
+        AND either:
+          * ``last_heartbeat_at`` is older than ``now - threshold_sec``, or
+          * ``last_heartbeat_at IS NULL`` (back-compat path -- runs that
+            started before this column existed are assumed dead if
+            recovered after a process restart).
+
+        Idempotent: callers can invoke at every bootstrap tick without
+        worrying about double-marking. Tightening the threshold over
+        time will sweep up more rows on the next call.
+        """
+        now = now_utc if now_utc is not None else time.time()
+        cutoff = now - threshold_sec
+        with self._lock, self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id FROM analysis_runs
+                WHERE status = 'running'
+                  AND ended_at IS NULL
+                  AND (
+                       last_heartbeat_at IS NULL
+                       OR last_heartbeat_at < ?
+                  )
+                """,
+                (cutoff,),
+            ).fetchall()
+            recovered = [int(r[0]) for r in rows]
+            if recovered:
+                placeholders = ",".join("?" for _ in recovered)
+                conn.execute(
+                    f"""
+                    UPDATE analysis_runs
+                    SET ended_at = ?,
+                        duration_sec = CASE
+                            WHEN started_at IS NOT NULL THEN MAX(0.0, ? - started_at)
+                            ELSE 0.0
+                        END,
+                        status = 'failed',
+                        error_text = CASE
+                            WHEN error_text IS NULL OR error_text = ''
+                            THEN 'Recovered stale running run (heartbeat threshold exceeded)'
+                            ELSE error_text
+                        END
+                    WHERE id IN ({placeholders})
+                    """,
+                    [now, now, *recovered],
+                )
+        return recovered
+
     def update_run_heartbeat(
         self,
         run_id: int,

--- a/tests/runtime/test_worker.py
+++ b/tests/runtime/test_worker.py
@@ -1,0 +1,110 @@
+"""Tests for the runtime worker scaffold (production spawn_worker).
+
+The scaffold creates an analysis_runs row + links it to the schedule
+and drives a pluggable executor. These tests exercise the contract;
+swapping in the real Orchestrator executor is a follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amx.runtime.worker import spawn_scheduled_worker
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def _schedule(store: SQLiteHistoryStore, *, name: str = "s") -> dict[str, Any]:
+    sid = store.create_scheduled_run(
+        name=name,
+        fire_at_utc=time.time() - 60,
+        fire_at_tz="UTC",
+        db_profile="prod_sf",
+        scope_json=json.dumps({"mode": "schemas", "schemas": ["public"]}),
+        llm_profile="claude",
+        review_strategy="auto",
+    )
+    return store.get_scheduled_run(sid)
+
+
+def test_worker_creates_run_links_and_completes(
+    store: SQLiteHistoryStore,
+) -> None:
+    schedule = _schedule(store)
+    sid = schedule["id"]
+
+    run_id = spawn_scheduled_worker(
+        schedule,
+        store=store,
+        background=False,  # sync so the test asserts on the final state
+    )
+
+    assert isinstance(run_id, int) and run_id > 0
+    with sqlite3.connect(store.db_path) as conn:
+        row = conn.execute(
+            "SELECT status, triggered_by_schedule_id, last_heartbeat_at "
+            "FROM analysis_runs WHERE id=?",
+            (run_id,),
+        ).fetchone()
+    status, schedule_link, hb = row
+    assert status == "completed"
+    assert schedule_link == sid
+    assert hb is not None  # initial heartbeat was emitted
+
+    sched = store.get_scheduled_run(sid)
+    assert sched["status"] == "completed"
+    assert sched["triggered_run_id"] == run_id
+
+
+def test_worker_marks_failed_when_executor_raises(
+    store: SQLiteHistoryStore,
+) -> None:
+    schedule = _schedule(store, name="boom")
+    sid = schedule["id"]
+
+    def boom(_run_id: int, _payload: dict[str, Any]) -> None:
+        raise RuntimeError("simulated executor failure")
+
+    run_id = spawn_scheduled_worker(schedule, store=store, run_executor=boom, background=False)
+
+    with sqlite3.connect(store.db_path) as conn:
+        (status, err) = conn.execute(
+            "SELECT status, error_text FROM analysis_runs WHERE id=?",
+            (run_id,),
+        ).fetchone()
+    assert status == "failed"
+    assert "simulated executor failure" in err
+
+    sched = store.get_scheduled_run(sid)
+    assert sched["status"] == "failed"
+    assert "simulated executor failure" in sched["last_error"]
+    assert sched["triggered_run_id"] == run_id
+
+
+def test_worker_background_thread_does_not_block(
+    store: SQLiteHistoryStore,
+) -> None:
+    schedule = _schedule(store, name="bg")
+
+    started = time.monotonic()
+
+    def slow(_run_id: int, _payload: dict[str, Any]) -> None:
+        time.sleep(0.2)
+
+    run_id = spawn_scheduled_worker(schedule, store=store, run_executor=slow, background=True)
+    elapsed = time.monotonic() - started
+    # The call returns before the slow executor finishes.
+    assert elapsed < 0.15
+    assert isinstance(run_id, int)

--- a/tests/storage/test_stale_recovery.py
+++ b/tests/storage/test_stale_recovery.py
@@ -1,0 +1,109 @@
+"""Phase 2b: recover_stale_runs + set_run_schedule_link tests."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def _make_run(store: SQLiteHistoryStore, *, db_profile: str = "p") -> int:
+    return store.create_run(
+        command="run",
+        mode="metadata",
+        db_backend="snowflake",
+        db_profile=db_profile,
+        llm_provider="anthropic",
+        llm_model="claude",
+        scope={"public": ["t"]},
+    )
+
+
+# ── set_run_schedule_link ────────────────────────────────────────────
+
+
+def test_set_run_schedule_link_attaches_schedule_id(
+    store: SQLiteHistoryStore,
+) -> None:
+    rid = _make_run(store)
+    store.set_run_schedule_link(rid, schedule_id=42)
+    with sqlite3.connect(store.db_path) as conn:
+        (val,) = conn.execute(
+            "SELECT triggered_by_schedule_id FROM analysis_runs WHERE id=?",
+            (rid,),
+        ).fetchone()
+    assert val == 42
+
+
+def test_set_run_schedule_link_unknown_run_is_noop(
+    store: SQLiteHistoryStore,
+) -> None:
+    store.set_run_schedule_link(99999, schedule_id=1)
+
+
+# ── recover_stale_runs ───────────────────────────────────────────────
+
+
+def test_recover_marks_running_without_heartbeat_failed(
+    store: SQLiteHistoryStore,
+) -> None:
+    rid = _make_run(store)
+    # No heartbeat ever -> treated as stale on next recovery sweep.
+    recovered = store.recover_stale_runs(threshold_sec=60, now_utc=time.time())
+    assert recovered == [rid]
+    with sqlite3.connect(store.db_path) as conn:
+        (status, error_text, ended_at) = conn.execute(
+            "SELECT status, error_text, ended_at FROM analysis_runs WHERE id=?",
+            (rid,),
+        ).fetchone()
+    assert status == "failed"
+    assert "heartbeat threshold" in error_text
+    assert ended_at is not None
+
+
+def test_recover_leaves_fresh_heartbeat_alone(
+    store: SQLiteHistoryStore,
+) -> None:
+    rid = _make_run(store)
+    store.update_run_heartbeat(rid)
+    recovered = store.recover_stale_runs(threshold_sec=60, now_utc=time.time())
+    assert recovered == []
+    with sqlite3.connect(store.db_path) as conn:
+        (status,) = conn.execute("SELECT status FROM analysis_runs WHERE id=?", (rid,)).fetchone()
+    assert status == "running"
+
+
+def test_recover_marks_old_heartbeat_failed(
+    store: SQLiteHistoryStore,
+) -> None:
+    rid = _make_run(store)
+    long_ago = time.time() - 3600
+    store.update_run_heartbeat(rid, now_utc=long_ago)
+    recovered = store.recover_stale_runs(threshold_sec=60, now_utc=time.time())
+    assert recovered == [rid]
+
+
+def test_recover_skips_completed_runs(store: SQLiteHistoryStore) -> None:
+    rid = _make_run(store)
+    store.finish_run(rid, status="completed", metrics={}, tokens={}, results={})
+    recovered = store.recover_stale_runs(threshold_sec=60, now_utc=time.time())
+    assert recovered == []
+
+
+def test_recover_is_idempotent(store: SQLiteHistoryStore) -> None:
+    rid = _make_run(store)
+    first = store.recover_stale_runs(threshold_sec=60, now_utc=time.time())
+    second = store.recover_stale_runs(threshold_sec=60, now_utc=time.time())
+    assert first == [rid]
+    assert second == []  # already marked failed


### PR DESCRIPTION
## Summary
- `SQLiteHistoryStore.recover_stale_runs(threshold_sec, now_utc)` — generalised, idempotent sweep used by every tick to mark heartbeat-less running rows failed.
- `SQLiteHistoryStore.set_run_schedule_link` — small UPDATE that back-links an `analysis_runs` row to its originating `scheduled_runs` row.
- `amx/runtime/worker.spawn_scheduled_worker` — the production default `spawn_worker` for the scheduler engine. Creates the run row, attaches linkage, emits initial heartbeat, drives schedule state. Pluggable `run_executor` (default = no-op stub that logs a clear deferral warning).
- Tick now calls `recover_stale_runs` every pass; `TickReport.stale_recovered` is populated.

Per-table Orchestrator drive remains stubbed for now (clear log warning) — full LLM-build / live-DB-resolve / table-loop wiring is a follow-up that wants an awake reviewer.

## Test plan
- [x] 8 new tests (5 stale recovery, 3 worker contract); all earlier-phase tests still pass.
- [x] `ruff` / `mypy` clean over changed files.

## Base
Stacked on #379.