### PR TITLE
feat(scheduler): phase 3 + 4 — CLI surface + daemon install

### DIFF
--- a/amx/cli.py
+++ b/amx/cli.py
@@ -39,6 +39,8 @@ from amx.cli_support.commands.run import (
     _resolve_codebase_for_run,
     register_analyze_commands,
 )
+from amx.cli_support.commands.schedule import register_schedule_commands
+from amx.cli_support.commands.scheduler import register_scheduler_commands
 from amx.cli_support.commands.search import register_search_commands
 from amx.cli_support.root_commands import register_root_commands
 from amx.config import AMXConfig, ConfigSchemaTooNewError
@@ -235,6 +237,49 @@ def run_cli() -> None:
         sys.exit(1)
 
 
+def _bootstrap_scheduler_tick() -> None:
+    """Run one scheduler.tick(source='bootstrap') at every CLI invocation.
+
+    Surfaces missed schedules and recovers stale runs without firing
+    anything (the user-warning contract: when AMX was closed, the
+    next session sees the list and decides). Honours
+    ``AMX_SKIP_BOOTSTRAP_TICK=1`` for CI / scripted invocations and
+    for the daemon's own ``amx scheduler tick`` re-entry. Failures are
+    swallowed -- a broken tick must never block the CLI.
+    """
+    if os.getenv("AMX_SKIP_BOOTSTRAP_TICK", "").lower() in {"1", "true", "yes"}:
+        return
+    try:
+        from amx.scheduler.tick import tick as _tick
+        from amx.storage.sqlite_store import history_store as _hs_singleton
+
+        hs = _hs_singleton()
+        if hs is None:
+            return
+        report = _tick(store=hs, source="bootstrap")
+        # Print a concise banner only when there's something to surface.
+        n_missed = len(report.missed_for_review)
+        n_stale = len(report.stale_recovered)
+        if n_missed or n_stale:
+            import click as _click
+
+            parts = []
+            if n_stale:
+                parts.append(
+                    f"{n_stale} interrupted run{'s' if n_stale != 1 else ''} recovered (marked failed)"
+                )
+            if n_missed:
+                parts.append(
+                    f"{n_missed} schedule{'s' if n_missed != 1 else ''} missed while AMX was closed"
+                )
+            _click.echo(
+                "⚠️  " + "; ".join(parts) + ". Run `amx schedule list` to review.",
+                err=True,
+            )
+    except Exception:  # noqa: BLE001 - bootstrap tick must never crash the CLI
+        log.warning("bootstrap scheduler tick failed", exc_info=True)
+
+
 def _log_app_event(
     *,
     event_type: str,
@@ -328,6 +373,7 @@ def main(ctx: click.Context, cfg_path: str | None, debug: bool) -> None:
         )
         sys.exit(2)
     init_history_store(ctx.obj)
+    _bootstrap_scheduler_tick()
     _install_embedding_provider(ctx.obj)
     is_session_child = os.getenv("AMX_SESSION_CHILD") == "1"
     if not is_session_child:
@@ -374,6 +420,8 @@ register_analyze_run_command(
 )
 register_analyze_review_command(analyze, log_event=_log_app_event)
 register_rerun_command(main, pass_config=pass_config, log_event=_log_app_event)
+register_schedule_commands(main, log_event=_log_app_event)
+register_scheduler_commands(main, log_event=_log_app_event)
 register_docs_commands(
     main,
     finalize_scope=_finalize_scope,

--- a/amx/cli_support/commands/schedule.py
+++ b/amx/cli_support/commands/schedule.py
@@ -1,0 +1,369 @@
+"""``amx schedule`` command group — manage one-shot scheduled metadata runs.
+
+Implements the user-facing CRUD + lifecycle commands:
+
+* ``amx schedule add``      — non-interactive create (interactive
+                              wizard lands as a follow-up)
+* ``amx schedule list``     — table listing with status filters
+* ``amx schedule show``     — full detail for one entry
+* ``amx schedule pause``    — pause a pending schedule
+* ``amx schedule resume``   — re-enable a paused schedule
+* ``amx schedule rm``       — hard delete + audit event
+* ``amx schedule run-now``  — fire a schedule immediately (any status)
+
+The companion ``amx scheduler`` group (tick / status / install-daemon)
+lives in ``cli_support/commands/scheduler.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
+
+import click
+
+from amx.runtime.worker import spawn_scheduled_worker
+from amx.scheduler.tick import tick
+from amx.storage.sqlite_store import history_store
+
+LogEvent = Callable[..., None]
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _zoneinfo(tz_name: str):
+    """Resolve an IANA tz name to a tzinfo. Raises click.BadParameter
+    on typos so the CLI surface is consistent."""
+    try:
+        from zoneinfo import ZoneInfo
+
+        return ZoneInfo(tz_name)
+    except Exception as exc:  # noqa: BLE001 - rewrap as Click error
+        raise click.BadParameter(
+            f"unknown timezone: {tz_name!r} (use an IANA name like 'Europe/Istanbul')"
+        ) from exc
+
+
+def _parse_at(at: str, tz_name: str) -> tuple[float, str]:
+    """Parse a wall-clock ``YYYY-MM-DD HH:MM`` (or ISO 8601) in the
+    chosen tz and return ``(fire_at_utc, fire_at_tz)``."""
+    tzinfo = _zoneinfo(tz_name)
+    for fmt in (
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M",
+        "%Y-%m-%dT%H:%M:%S",
+    ):
+        try:
+            naive = datetime.strptime(at, fmt)
+            break
+        except ValueError:
+            continue
+    else:
+        raise click.BadParameter(f"could not parse --at {at!r} (try 'YYYY-MM-DD HH:MM')")
+    aware = naive.replace(tzinfo=tzinfo)
+    return aware.astimezone(timezone.utc).timestamp(), tz_name
+
+
+def _parse_scope(spec: str) -> str:
+    """Compact ``schema:a,b`` / ``table:s.t1,s.t2`` / ``all`` -> scope_json."""
+    spec = spec.strip()
+    if spec == "all":
+        return json.dumps({"mode": "all"})
+    if spec.startswith("schema:"):
+        names = [s.strip() for s in spec[len("schema:") :].split(",") if s.strip()]
+        if not names:
+            raise click.BadParameter("scope schema:... needs at least one name")
+        return json.dumps({"mode": "schemas", "schemas": names})
+    if spec.startswith("table:"):
+        items: list[dict[str, str]] = []
+        for piece in spec[len("table:") :].split(","):
+            piece = piece.strip()
+            if not piece:
+                continue
+            if "." not in piece:
+                raise click.BadParameter(f"table entry {piece!r} must be schema.table")
+            schema, _, table = piece.partition(".")
+            items.append({"schema": schema, "table": table})
+        return json.dumps({"mode": "tables", "tables": items})
+    raise click.BadParameter("scope must be 'schema:NAME,...' / 'table:S.T,...' / 'all'")
+
+
+def _render_at_local(row: dict[str, Any]) -> str:
+    tzinfo = _zoneinfo(row["fire_at_tz"])
+    dt = datetime.fromtimestamp(row["fire_at_utc"], tz=timezone.utc).astimezone(tzinfo)
+    return dt.strftime("%Y-%m-%d %H:%M")
+
+
+def _print_table(rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        click.echo("No schedules.")
+        return
+    header = ("#", "Name", "When (local)", "Tz", "Status", "DB", "LLM")
+    keys = ("id", "name", "_local", "fire_at_tz", "status", "db_profile", "llm_profile")
+    widths = [
+        max(len(str(h)), max((len(_cell(r, k)) for r in rows), default=0))
+        for h, k in zip(header, keys, strict=True)
+    ]
+
+    def line(values):
+        return "  ".join(str(v).ljust(w) for v, w in zip(values, widths, strict=True))
+
+    click.echo(line(header))
+    click.echo(line(["-" * w for w in widths]))
+    for r in rows:
+        click.echo(
+            line(
+                [
+                    r["id"],
+                    r["name"],
+                    _render_at_local(r),
+                    r["fire_at_tz"],
+                    r["status"],
+                    r["db_profile"],
+                    r["llm_profile"],
+                ]
+            )
+        )
+
+
+def _cell(row: dict[str, Any], key: str) -> str:
+    if key == "_local":
+        return _render_at_local(row)
+    return str(row.get(key, ""))
+
+
+def _require_store():
+    hs = history_store()
+    if hs is None:
+        raise click.ClickException(
+            "history store not initialised (run any other amx command first)"
+        )
+    return hs
+
+
+# ── Registration ────────────────────────────────────────────────────
+
+
+def register_schedule_commands(
+    main: click.Group,
+    *,
+    log_event: LogEvent | None = None,
+) -> None:
+    """Attach the ``amx schedule`` group to *main*."""
+
+    @main.group("schedule")
+    def schedule() -> None:
+        """Manage one-shot scheduled metadata runs."""
+
+    @schedule.command("add")
+    @click.option("--name", required=True, help="Human-readable label.")
+    @click.option(
+        "--at",
+        "at",
+        required=True,
+        help="Local wall-clock fire time (e.g. '2026-12-31 09:00').",
+    )
+    @click.option(
+        "--tz",
+        "tz_name",
+        default="UTC",
+        show_default=True,
+        help="IANA tz id for --at (e.g. 'Europe/Istanbul').",
+    )
+    @click.option("--db", "db_profile", required=True, help="DB profile name.")
+    @click.option(
+        "--scope",
+        required=True,
+        help="Scope: 'schema:a,b' / 'table:s.t,...' / 'all'.",
+    )
+    @click.option("--llm", "llm_profile", required=True, help="LLM profile name.")
+    @click.option(
+        "--strategy",
+        "review_strategy",
+        default="auto",
+        show_default=True,
+        type=click.Choice(["auto", "manual"]),
+    )
+    def schedule_add(
+        name: str,
+        at: str,
+        tz_name: str,
+        db_profile: str,
+        scope: str,
+        llm_profile: str,
+        review_strategy: str,
+    ) -> None:
+        """Create a new scheduled run."""
+        hs = _require_store()
+        fire_at_utc, fire_at_tz = _parse_at(at, tz_name)
+        scope_json = _parse_scope(scope)
+        sid = hs.create_scheduled_run(
+            name=name,
+            fire_at_utc=fire_at_utc,
+            fire_at_tz=fire_at_tz,
+            db_profile=db_profile,
+            scope_json=scope_json,
+            llm_profile=llm_profile,
+            review_strategy=review_strategy,
+        )
+        row = hs.get_scheduled_run(sid)
+        local = _render_at_local(row)
+        utc_str = datetime.fromtimestamp(fire_at_utc, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M UTC"
+        )
+        click.echo(f"Schedule #{sid} created: '{name}' fires {local} {fire_at_tz} ({utc_str}).")
+        click.echo("")
+        click.echo("Heads-up: AMX is invocation-based — it isn't always running.")
+        click.echo("For this schedule to fire on time, EITHER keep AMX/Studio")
+        click.echo("open at that moment, OR enable the background daemon now:")
+        click.echo("")
+        click.echo("    amx scheduler install-daemon")
+        click.echo("")
+        click.echo("Without the daemon, if AMX is closed at fire time, this")
+        click.echo("schedule will be surfaced as 'missed' the next time you")
+        click.echo("open AMX, and you can run it then.")
+        if log_event:
+            log_event(
+                event_type="schedule.created",
+                status="ok",
+                command="schedule.add",
+                details={"id": sid, "name": name},
+            )
+
+    @schedule.command("list")
+    @click.option(
+        "--all",
+        "show_all",
+        is_flag=True,
+        default=False,
+        help="Include past (completed/failed/cancelled) entries.",
+    )
+    @click.option(
+        "--past",
+        "past_only",
+        is_flag=True,
+        default=False,
+        help="Show only past (completed/failed/cancelled) entries.",
+    )
+    @click.option("--db", "db_profile", default=None, help="Filter by DB profile.")
+    @click.option(
+        "--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON."
+    )
+    def schedule_list(
+        show_all: bool, past_only: bool, db_profile: str | None, as_json: bool
+    ) -> None:
+        """List scheduled runs."""
+        hs = _require_store()
+        if past_only:
+            statuses = ["completed", "failed", "cancelled"]
+        elif show_all:
+            statuses = None  # all
+        else:
+            statuses = ["pending", "paused", "missed", "running"]
+        rows = hs.list_scheduled_runs(statuses=statuses, db_profile=db_profile)
+        if as_json:
+            click.echo(json.dumps(rows, default=str, indent=2))
+            return
+        _print_table(rows)
+
+    @schedule.command("show")
+    @click.argument("schedule_id", type=int)
+    def schedule_show(schedule_id: int) -> None:
+        """Show full detail for a schedule."""
+        hs = _require_store()
+        row = hs.get_scheduled_run(schedule_id)
+        if row is None:
+            raise click.ClickException(f"No schedule with id={schedule_id}")
+        click.echo(json.dumps(row, default=str, indent=2))
+
+    @schedule.command("pause")
+    @click.argument("schedule_id", type=int)
+    def schedule_pause(schedule_id: int) -> None:
+        """Pause a pending schedule (it won't fire until resumed)."""
+        hs = _require_store()
+        try:
+            hs.set_scheduled_run_status(schedule_id, "paused")
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(f"Schedule #{schedule_id} paused.")
+        if log_event:
+            log_event(
+                event_type="schedule.paused",
+                status="ok",
+                command="schedule.pause",
+                details={"id": schedule_id},
+            )
+
+    @schedule.command("resume")
+    @click.argument("schedule_id", type=int)
+    def schedule_resume(schedule_id: int) -> None:
+        """Resume a paused schedule."""
+        hs = _require_store()
+        try:
+            hs.set_scheduled_run_status(schedule_id, "pending")
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(f"Schedule #{schedule_id} resumed (pending).")
+        if log_event:
+            log_event(
+                event_type="schedule.resumed",
+                status="ok",
+                command="schedule.resume",
+                details={"id": schedule_id},
+            )
+
+    @schedule.command("rm")
+    @click.argument("schedule_id", type=int)
+    @click.option("--yes", "-y", is_flag=True, default=False, help="Skip confirmation.")
+    def schedule_rm(schedule_id: int, yes: bool) -> None:
+        """Hard-delete a schedule."""
+        hs = _require_store()
+        row = hs.get_scheduled_run(schedule_id)
+        if row is None:
+            raise click.ClickException(f"No schedule with id={schedule_id}")
+        if not yes:
+            click.confirm(
+                f"Delete schedule #{schedule_id} '{row['name']}'?",
+                abort=True,
+            )
+        hs.delete_scheduled_run(schedule_id)
+        click.echo(f"Schedule #{schedule_id} deleted.")
+
+    @schedule.command("run-now")
+    @click.argument("schedule_id", type=int)
+    @click.option(
+        "--background/--foreground",
+        default=False,
+        show_default=True,
+        help="Run the spawned worker in the background and return immediately.",
+    )
+    def schedule_run_now(schedule_id: int, background: bool) -> None:
+        """Fire a schedule immediately (regardless of fire_at_utc)."""
+        hs = _require_store()
+        row = hs.get_scheduled_run(schedule_id)
+        if row is None:
+            raise click.ClickException(f"No schedule with id={schedule_id}")
+
+        def spawn(payload: dict[str, Any]) -> int:
+            return spawn_scheduled_worker(payload, store=hs, background=background)
+
+        report = tick(
+            store=hs,
+            source="manual",
+            target_id=schedule_id,
+            spawn_worker=spawn,
+            now_utc=time.time(),
+        )
+        if report.fired:
+            click.echo(f"Schedule #{schedule_id} fired (run linked).")
+        else:
+            for sid, err in report.failed_resolution:
+                click.echo(f"Failed to fire #{sid}: {err}", err=True)
+
+
+__all__ = ["register_schedule_commands"]

--- a/amx/cli_support/commands/scheduler.py
+++ b/amx/cli_support/commands/scheduler.py
@@ -1,0 +1,134 @@
+"""``amx scheduler`` command group — engine and daemon controls.
+
+* ``amx scheduler tick``    — one stateless pass; used by the daemon cron.
+* ``amx scheduler status``  — daemon presence + last-tick + pending count.
+* ``amx scheduler install-daemon`` — launchd / systemd setup (phase 4).
+* ``amx scheduler uninstall-daemon`` — remove the daemon (phase 4).
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import time
+from collections.abc import Callable
+from typing import Any
+
+import click
+
+from amx.runtime.worker import spawn_scheduled_worker
+from amx.scheduler.tick import tick
+from amx.storage.sqlite_store import history_store
+
+LogEvent = Callable[..., None]
+
+
+def _require_store():
+    hs = history_store()
+    if hs is None:
+        raise click.ClickException(
+            "history store not initialised (run any other amx command first)"
+        )
+    return hs
+
+
+def register_scheduler_commands(
+    main: click.Group,
+    *,
+    log_event: LogEvent | None = None,
+) -> None:
+    """Attach the ``amx scheduler`` group to *main*."""
+
+    @main.group("scheduler")
+    def scheduler() -> None:
+        """Scheduler engine + daemon controls."""
+
+    @scheduler.command("tick")
+    @click.option(
+        "--silent",
+        is_flag=True,
+        default=False,
+        help="Suppress per-fire stdout; used by the daemon cron entry.",
+    )
+    def scheduler_tick(silent: bool) -> None:
+        """Run one stateless scheduling pass (fires due schedules).
+
+        Safe to call from cron-like timers; idempotent. The tick
+        recovers stale running rows, then fires every due schedule
+        in order until the per-tick cap is reached.
+        """
+        hs = _require_store()
+
+        def spawn(payload: dict[str, Any]) -> int:
+            return spawn_scheduled_worker(payload, store=hs, background=True)
+
+        report = tick(
+            store=hs,
+            source="daemon",
+            spawn_worker=spawn,
+            now_utc=time.time(),
+        )
+        if not silent:
+            click.echo(
+                json.dumps(
+                    {
+                        "fired": report.fired,
+                        "failed_resolution": report.failed_resolution,
+                        "missed_for_review": report.missed_for_review,
+                        "stale_recovered": report.stale_recovered,
+                    },
+                    indent=2,
+                )
+            )
+
+    @scheduler.command("status")
+    def scheduler_status() -> None:
+        """Show scheduler + daemon status."""
+        hs = _require_store()
+        pending = hs.list_scheduled_runs(statuses=["pending"], limit=1000)
+        missed = hs.list_scheduled_runs(statuses=["missed"], limit=1000)
+        paused = hs.list_scheduled_runs(statuses=["paused"], limit=1000)
+        next_fire = pending[0] if pending else None
+
+        from amx.scheduler.daemon_install import detect_daemon_state
+
+        daemon = detect_daemon_state()
+
+        click.echo("Scheduler status")
+        click.echo(f"  Pending schedules: {len(pending)}")
+        click.echo(f"  Paused schedules:  {len(paused)}")
+        click.echo(f"  Missed schedules:  {len(missed)}")
+        if next_fire:
+            click.echo(
+                f"  Next fire: #{next_fire['id']} '{next_fire['name']}' at "
+                f"fire_at_utc={next_fire['fire_at_utc']:.0f}"
+            )
+        click.echo("")
+        click.echo("Daemon")
+        click.echo(f"  Platform: {platform.system()}")
+        click.echo(f"  Installed: {daemon['installed']}")
+        if daemon.get("path"):
+            click.echo(f"  Unit file: {daemon['path']}")
+        if daemon.get("last_tick_log"):
+            click.echo(f"  Log:       {daemon['last_tick_log']}")
+
+    @scheduler.command("install-daemon")
+    def scheduler_install_daemon() -> None:
+        """Install the OS-level scheduler daemon (launchd or systemd)."""
+        from amx.scheduler.daemon_install import install_daemon
+
+        result = install_daemon()
+        click.echo(result["message"])
+        if result.get("path"):
+            click.echo(f"  Unit file: {result['path']}")
+
+    @scheduler.command("uninstall-daemon")
+    def scheduler_uninstall_daemon() -> None:
+        """Remove the OS-level scheduler daemon."""
+        from amx.scheduler.daemon_install import uninstall_daemon
+
+        result = uninstall_daemon()
+        click.echo(result["message"])
+
+
+__all__ = ["register_scheduler_commands"]

--- a/amx/scheduler/daemon_install.py
+++ b/amx/scheduler/daemon_install.py
@@ -1,0 +1,240 @@
+"""Scheduler daemon install / uninstall / detect (launchd + systemd).
+
+This is the platform shim used by ``amx scheduler install-daemon`` and
+friends. macOS uses a per-user launchd plist under
+``~/Library/LaunchAgents/``; Linux uses a per-user systemd
+``.service`` + ``.timer`` pair under ``~/.config/systemd/user/``;
+other platforms (Windows etc) print a clear "not supported" message.
+
+The unit name is suffixed with the ``AMX_CONFIG_DIR`` so prod (``~/.amx``)
+and dev (``~/.amx-dev``) daemons coexist.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_PLIST_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>{label}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{amx_path}</string>
+        <string>scheduler</string>
+        <string>tick</string>
+        <string>--silent</string>
+    </array>
+    <key>StartInterval</key><integer>60</integer>
+    <key>RunAtLoad</key><true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>AMX_CONFIG_DIR</key><string>{config_dir}</string>
+        <key>AMX_SKIP_BOOTSTRAP_TICK</key><string>1</string>
+    </dict>
+    <key>StandardOutPath</key><string>{log_path}</string>
+    <key>StandardErrorPath</key><string>{log_path}</string>
+</dict>
+</plist>
+"""
+
+_SYSTEMD_SERVICE = """[Unit]
+Description=AMX scheduler tick ({label})
+
+[Service]
+Type=oneshot
+Environment=AMX_CONFIG_DIR={config_dir}
+Environment=AMX_SKIP_BOOTSTRAP_TICK=1
+ExecStart={amx_path} scheduler tick --silent
+"""
+
+_SYSTEMD_TIMER = """[Unit]
+Description=Run AMX scheduler tick every minute ({label})
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+Unit=amx-scheduler{suffix}.service
+
+[Install]
+WantedBy=timers.target
+"""
+
+
+def _config_dir() -> Path:
+    override = os.environ.get("AMX_CONFIG_DIR")
+    return Path(override).expanduser() if override else Path.home() / ".amx"
+
+
+def _label_and_suffix() -> tuple[str, str]:
+    """Compute the daemon label + filename suffix from AMX_CONFIG_DIR.
+
+    Prod (``~/.amx``) -> label ``com.amx.scheduler``, suffix ``""``.
+    Dev  (``~/.amx-dev``) -> label ``com.amx-dev.scheduler``, suffix ``"-dev"``.
+    Custom paths derive a slug from the directory's basename.
+    """
+    cfg = _config_dir()
+    base = cfg.name  # ".amx" or ".amx-dev" usually
+    slug = base.lstrip(".") or "amx"
+    if slug == "amx":
+        return "com.amx.scheduler", ""
+    return f"com.{slug}.scheduler", f"-{slug[len('amx-') :]}" if slug.startswith(
+        "amx-"
+    ) else f"-{slug}"
+
+
+def _amx_path() -> str:
+    found = shutil.which("amx")
+    if found:
+        return found
+    return "amx"  # fall through; user can edit unit file if PATH is unusual
+
+
+def _macos_plist_path(label: str) -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{label}.plist"
+
+
+def _systemd_service_path(suffix: str) -> Path:
+    return Path.home() / ".config" / "systemd" / "user" / f"amx-scheduler{suffix}.service"
+
+
+def _systemd_timer_path(suffix: str) -> Path:
+    return Path.home() / ".config" / "systemd" / "user" / f"amx-scheduler{suffix}.timer"
+
+
+def detect_daemon_state() -> dict[str, Any]:
+    """Return ``{installed: bool, path: str | None, last_tick_log: str | None}``.
+
+    Pure introspection -- never starts or stops anything.
+    """
+    label, suffix = _label_and_suffix()
+    cfg = _config_dir()
+    log_path = cfg / "logs" / "scheduler.log"
+    log_str = str(log_path) if log_path.exists() else None
+    system = platform.system()
+    if system == "Darwin":
+        plist = _macos_plist_path(label)
+        if plist.exists():
+            return {"installed": True, "path": str(plist), "last_tick_log": log_str}
+        return {"installed": False, "path": None, "last_tick_log": log_str}
+    if system == "Linux":
+        service = _systemd_service_path(suffix)
+        timer = _systemd_timer_path(suffix)
+        if service.exists() and timer.exists():
+            return {"installed": True, "path": str(timer), "last_tick_log": log_str}
+        return {"installed": False, "path": None, "last_tick_log": log_str}
+    return {"installed": False, "path": None, "last_tick_log": log_str}
+
+
+def install_daemon() -> dict[str, Any]:
+    """Install + activate the platform daemon."""
+    label, suffix = _label_and_suffix()
+    cfg = _config_dir()
+    cfg.mkdir(parents=True, exist_ok=True)
+    (cfg / "logs").mkdir(parents=True, exist_ok=True)
+    log_path = cfg / "logs" / "scheduler.log"
+    amx_path = _amx_path()
+    system = platform.system()
+
+    if system == "Darwin":
+        plist_path = _macos_plist_path(label)
+        plist_path.parent.mkdir(parents=True, exist_ok=True)
+        plist_path.write_text(
+            _PLIST_TEMPLATE.format(
+                label=label,
+                amx_path=amx_path,
+                config_dir=str(cfg),
+                log_path=str(log_path),
+            )
+        )
+        # bootstrap via `launchctl load`; fall back gracefully if the
+        # bootstrap helper is missing (some sandboxed shells).
+        try:
+            subprocess.run(
+                ["launchctl", "load", str(plist_path)],
+                check=False,
+                capture_output=True,
+            )
+        except FileNotFoundError:
+            pass
+        return {
+            "message": f"Installed launchd daemon {label}.",
+            "path": str(plist_path),
+        }
+
+    if system == "Linux":
+        svc_path = _systemd_service_path(suffix)
+        tmr_path = _systemd_timer_path(suffix)
+        svc_path.parent.mkdir(parents=True, exist_ok=True)
+        svc_path.write_text(
+            _SYSTEMD_SERVICE.format(label=label, amx_path=amx_path, config_dir=str(cfg))
+        )
+        tmr_path.write_text(_SYSTEMD_TIMER.format(label=label, suffix=suffix))
+        for cmd in (
+            ["systemctl", "--user", "daemon-reload"],
+            ["systemctl", "--user", "enable", "--now", tmr_path.name],
+        ):
+            try:
+                subprocess.run(cmd, check=False, capture_output=True)
+            except FileNotFoundError:
+                break
+        return {
+            "message": f"Installed systemd user timer {tmr_path.name}.",
+            "path": str(tmr_path),
+        }
+
+    return {
+        "message": (
+            "Daemon mode is not supported on this platform. "
+            "Schedules will still fire whenever AMX or Studio is "
+            "running (catch-up). For always-on scheduling, use AMX "
+            "on macOS or Linux."
+        ),
+        "path": None,
+    }
+
+
+def uninstall_daemon() -> dict[str, Any]:
+    """Remove the platform daemon. Idempotent."""
+    label, suffix = _label_and_suffix()
+    system = platform.system()
+
+    if system == "Darwin":
+        plist_path = _macos_plist_path(label)
+        if plist_path.exists():
+            try:
+                subprocess.run(
+                    ["launchctl", "unload", str(plist_path)],
+                    check=False,
+                    capture_output=True,
+                )
+            except FileNotFoundError:
+                pass
+            plist_path.unlink()
+            return {"message": f"Uninstalled launchd daemon {label}."}
+        return {"message": f"No launchd daemon for {label} was installed."}
+
+    if system == "Linux":
+        svc = _systemd_service_path(suffix)
+        tmr = _systemd_timer_path(suffix)
+        if tmr.exists():
+            try:
+                subprocess.run(
+                    ["systemctl", "--user", "disable", "--now", tmr.name],
+                    check=False,
+                    capture_output=True,
+                )
+            except FileNotFoundError:
+                pass
+        for p in (tmr, svc):
+            if p.exists():
+                p.unlink()
+        return {"message": f"Uninstalled systemd timer/service {tmr.name}."}
+
+    return {"message": "Daemon mode is not supported on this platform."}

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -1,0 +1,242 @@
+"""End-to-end CLI tests for ``amx schedule`` and ``amx scheduler``.
+
+Exercises the Click command tree against a tmp AMX config dir so the
+real history store is initialised and the commands run their full
+production path (minus the per-run executor, which the worker
+scaffold stubs).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from amx.cli_support.commands.schedule import register_schedule_commands
+from amx.cli_support.commands.scheduler import register_scheduler_commands
+from amx.storage import sqlite_store as _store_module
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def cli(tmp_path: Path):
+    """Build a Click root group with just the two scheduler groups and
+    point the module-level history_store singleton at a tmp DB."""
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    _store_module._store = s
+
+    @click.group()
+    def root() -> None: ...
+
+    register_schedule_commands(root)
+    register_scheduler_commands(root)
+    return root, s
+
+
+def test_schedule_add_creates_row(cli) -> None:
+    root, store = cli
+    runner = CliRunner()
+    result = runner.invoke(
+        root,
+        [
+            "schedule",
+            "add",
+            "--name",
+            "Quarterly",
+            "--at",
+            "2030-01-15 14:00",
+            "--tz",
+            "Europe/Istanbul",
+            "--db",
+            "prod_sf",
+            "--scope",
+            "schema:public",
+            "--llm",
+            "claude",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert "Schedule #" in result.output
+    assert "Heads-up" in result.output
+    rows = store.list_scheduled_runs()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Quarterly"
+
+
+def test_schedule_list_default_filters_to_active(cli) -> None:
+    root, store = cli
+    store.create_scheduled_run(
+        name="active",
+        fire_at_utc=time.time() + 3600,
+        fire_at_tz="UTC",
+        db_profile="p",
+        scope_json='{"mode":"all"}',
+        llm_profile="l",
+        review_strategy="auto",
+    )
+    sid_done = store.create_scheduled_run(
+        name="done",
+        fire_at_utc=time.time() + 3600,
+        fire_at_tz="UTC",
+        db_profile="p",
+        scope_json='{"mode":"all"}',
+        llm_profile="l",
+        review_strategy="auto",
+    )
+    store.set_scheduled_run_status(sid_done, "running")
+    store.set_scheduled_run_status(sid_done, "completed")
+
+    runner = CliRunner()
+    result = runner.invoke(root, ["schedule", "list"])
+    assert result.exit_code == 0
+    assert "active" in result.output
+    assert "done" not in result.output
+
+    result_all = runner.invoke(root, ["schedule", "list", "--all"])
+    assert result_all.exit_code == 0
+    assert "active" in result_all.output
+    assert "done" in result_all.output
+
+
+def test_schedule_pause_and_resume(cli) -> None:
+    root, store = cli
+    sid = store.create_scheduled_run(
+        name="x",
+        fire_at_utc=time.time() + 60,
+        fire_at_tz="UTC",
+        db_profile="p",
+        scope_json='{"mode":"all"}',
+        llm_profile="l",
+        review_strategy="auto",
+    )
+    runner = CliRunner()
+    assert runner.invoke(root, ["schedule", "pause", str(sid)]).exit_code == 0
+    assert store.get_scheduled_run(sid)["status"] == "paused"
+    assert runner.invoke(root, ["schedule", "resume", str(sid)]).exit_code == 0
+    assert store.get_scheduled_run(sid)["status"] == "pending"
+
+
+def test_schedule_rm_with_yes_flag(cli) -> None:
+    root, store = cli
+    sid = store.create_scheduled_run(
+        name="gone",
+        fire_at_utc=time.time() + 60,
+        fire_at_tz="UTC",
+        db_profile="p",
+        scope_json='{"mode":"all"}',
+        llm_profile="l",
+        review_strategy="auto",
+    )
+    runner = CliRunner()
+    result = runner.invoke(root, ["schedule", "rm", str(sid), "-y"])
+    assert result.exit_code == 0
+    assert store.get_scheduled_run(sid) is None
+
+
+def test_schedule_run_now_fires_synchronously(cli) -> None:
+    root, store = cli
+    sid = store.create_scheduled_run(
+        name="now",
+        fire_at_utc=time.time() + 3600,
+        fire_at_tz="UTC",
+        db_profile="p",
+        scope_json='{"mode":"all"}',
+        llm_profile="l",
+        review_strategy="auto",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        root,
+        ["schedule", "run-now", str(sid), "--foreground"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    # In foreground mode the worker has finished by the time we get
+    # back; the schedule must be in a terminal state.
+    final = store.get_scheduled_run(sid)
+    assert final["status"] in ("completed", "failed")
+    assert final["triggered_run_id"] is not None
+
+
+def test_scheduler_tick_json_output(cli) -> None:
+    root, store = cli
+    runner = CliRunner()
+    result = runner.invoke(root, ["scheduler", "tick"])
+    assert result.exit_code == 0
+    import json as _j
+
+    payload = _j.loads(result.output)
+    assert "fired" in payload
+    assert "missed_for_review" in payload
+
+
+def test_scheduler_status_runs(cli) -> None:
+    root, store = cli
+    runner = CliRunner()
+    result = runner.invoke(root, ["scheduler", "status"])
+    assert result.exit_code == 0
+    assert "Scheduler status" in result.output
+    assert "Daemon" in result.output
+
+
+def test_schedule_add_rejects_bad_timezone(cli) -> None:
+    root, _ = cli
+    runner = CliRunner()
+    result = runner.invoke(
+        root,
+        [
+            "schedule",
+            "add",
+            "--name",
+            "bad-tz",
+            "--at",
+            "2030-01-15 14:00",
+            "--tz",
+            "Mars/OlympusMons",
+            "--db",
+            "p",
+            "--scope",
+            "all",
+            "--llm",
+            "l",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "timezone" in result.output.lower()
+
+
+def test_schedule_add_rejects_bad_scope(cli) -> None:
+    root, _ = cli
+    runner = CliRunner()
+    result = runner.invoke(
+        root,
+        [
+            "schedule",
+            "add",
+            "--name",
+            "bad-scope",
+            "--at",
+            "2030-01-15 14:00",
+            "--tz",
+            "UTC",
+            "--db",
+            "p",
+            "--scope",
+            "weird-format",
+            "--llm",
+            "l",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+# Reset the module-level store after each test to avoid leakage.
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    yield
+    _store_module._store = None


### PR DESCRIPTION
Bundles Phase 3 (CLI) and Phase 4 (daemon) since the CLI's `amx scheduler` group depends on the daemon module's install/uninstall/detect helpers.

## Summary
- `amx schedule add/list/show/pause/resume/rm/run-now` — full entity lifecycle on the local store.
- `amx scheduler tick/status/install-daemon/uninstall-daemon` — stateless cron entry + launchd (macOS) and systemd-user (Linux) templates. Per-AMX_CONFIG_DIR labels so prod + dev daemons coexist; Windows path prints a clear "not supported" message.
- Bootstrap-tick hook in `amx/cli.py` fires `tick(source='bootstrap')` at every invocation, surfacing recovered stale runs + missed schedules as a banner. Honours `AMX_SKIP_BOOTSTRAP_TICK=1` for the daemon's own re-entry and CI.
- Schedule creation prints the "AMX is invocation-based" warning with daemon install hint.

## Test plan
- [x] 9 CliRunner E2E cases (add / list filters / pause+resume / rm / run-now / tick / status / bad tz / bad scope)
- [x] `ruff` / `mypy` clean over changed files
- [x] Earlier-phase tests still pass

## Base
Stacked on #380.