### PR TITLE
feat(scheduler): phase 5a — Studio REST routes + bootstrap report

### DIFF
--- a/amx/web/routers/schedules.py
+++ b/amx/web/routers/schedules.py
@@ -1,0 +1,290 @@
+"""Studio routes for scheduled runs.
+
+Mirrors the ``amx schedule`` / ``amx scheduler`` CLI surface so the
+SPA can drive the same flows: CRUD, pause/resume, run-now, tick, and
+a bootstrap report consumed by the catch-up banner.
+
+All routes are token-protected by the existing
+:class:`TokenAuthMiddleware` mounted at the app level.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from typing import Any, Literal
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel, Field
+
+from amx.runtime.worker import spawn_scheduled_worker
+from amx.scheduler.daemon_install import detect_daemon_state
+from amx.scheduler.tick import tick
+from amx.storage.sqlite_store import history_store
+
+router = APIRouter(prefix="/api/schedules", tags=["schedules"])
+scheduler_router = APIRouter(prefix="/api/scheduler", tags=["scheduler"])
+
+
+def _store() -> Any:
+    s = history_store()
+    if s is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="History store isn't initialized yet.",
+        )
+    return s
+
+
+# ── Models ──────────────────────────────────────────────────────────
+
+
+class ScheduleCreateRequest(BaseModel):
+    """Payload accepted by ``POST /api/schedules``.
+
+    ``fire_at_local`` is a wall-clock ``YYYY-MM-DDTHH:MM`` (or with
+    seconds) in ``fire_at_tz``. The server converts to canonical UTC
+    using ``zoneinfo``.
+    """
+
+    name: str = Field(min_length=1, max_length=200)
+    fire_at_local: str = Field(description="Wall-clock fire time, e.g. '2026-12-31T09:00'.")
+    fire_at_tz: str = Field(default="UTC", description="IANA tz id.")
+    db_profile: str
+    scope: dict[str, Any] = Field(description="{'mode':'all|schemas|tables', ...}.")
+    llm_profile: str
+    review_strategy: Literal["auto", "manual"] = "auto"
+
+
+class SchedulePatchRequest(BaseModel):
+    name: str | None = None
+    fire_at_local: str | None = None
+    fire_at_tz: str | None = None
+    db_profile: str | None = None
+    scope: dict[str, Any] | None = None
+    llm_profile: str | None = None
+    review_strategy: Literal["auto", "manual"] | None = None
+
+
+def _parse_fire_at(local: str, tz_name: str) -> float:
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unknown timezone: {tz_name!r}",
+        ) from exc
+    for fmt in ("%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M"):
+        try:
+            naive = datetime.strptime(local, fmt)
+            break
+        except ValueError:
+            continue
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unparseable fire_at_local: {local!r}",
+        )
+    return naive.replace(tzinfo=tz).astimezone(timezone.utc).timestamp()
+
+
+def _serialise(row: dict[str, Any]) -> dict[str, Any]:
+    if row is None:
+        return row
+    out = dict(row)
+    tz = ZoneInfo(out["fire_at_tz"]) if out.get("fire_at_tz") else timezone.utc
+    out["fire_at_local"] = (
+        datetime.fromtimestamp(out["fire_at_utc"], tz=timezone.utc)
+        .astimezone(tz)
+        .strftime("%Y-%m-%dT%H:%M")
+    )
+    return out
+
+
+# ── Schedule CRUD ───────────────────────────────────────────────────
+
+
+@router.get("")
+def list_schedules(
+    status_filter: str | None = None,
+    db_profile: str | None = None,
+    limit: int = 200,
+) -> dict[str, Any]:
+    s = _store()
+    statuses = None
+    if status_filter:
+        statuses = [piece.strip() for piece in status_filter.split(",") if piece.strip()]
+    rows = s.list_scheduled_runs(statuses=statuses, db_profile=db_profile, limit=limit)
+    return {"schedules": [_serialise(r) for r in rows]}
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def create_schedule(body: ScheduleCreateRequest) -> dict[str, Any]:
+    s = _store()
+    fire_at_utc = _parse_fire_at(body.fire_at_local, body.fire_at_tz)
+    sid = s.create_scheduled_run(
+        name=body.name,
+        fire_at_utc=fire_at_utc,
+        fire_at_tz=body.fire_at_tz,
+        db_profile=body.db_profile,
+        scope_json=json.dumps(body.scope),
+        llm_profile=body.llm_profile,
+        review_strategy=body.review_strategy,
+    )
+    return _serialise(s.get_scheduled_run(sid))
+
+
+@router.get("/{schedule_id}")
+def get_schedule(schedule_id: int) -> dict[str, Any]:
+    s = _store()
+    row = s.get_scheduled_run(schedule_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+    return _serialise(row)
+
+
+@router.patch("/{schedule_id}")
+def patch_schedule(schedule_id: int, body: SchedulePatchRequest) -> dict[str, Any]:
+    s = _store()
+    row = s.get_scheduled_run(schedule_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+    if row["status"] not in ("pending", "paused"):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"cannot edit a schedule in status={row['status']!r}",
+        )
+    patch: dict[str, Any] = {}
+    if body.name is not None:
+        patch["name"] = body.name
+    if body.fire_at_tz is not None:
+        patch["fire_at_tz"] = body.fire_at_tz
+    if body.fire_at_local is not None:
+        tz_name = body.fire_at_tz or row["fire_at_tz"]
+        patch["fire_at_utc"] = _parse_fire_at(body.fire_at_local, tz_name)
+    if body.db_profile is not None:
+        patch["db_profile"] = body.db_profile
+    if body.scope is not None:
+        patch["scope_json"] = json.dumps(body.scope)
+    if body.llm_profile is not None:
+        patch["llm_profile"] = body.llm_profile
+    if body.review_strategy is not None:
+        patch["review_strategy"] = body.review_strategy
+
+    try:
+        s.update_scheduled_run(schedule_id, patch=patch)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return _serialise(s.get_scheduled_run(schedule_id))
+
+
+@router.post("/{schedule_id}/pause")
+def pause_schedule(schedule_id: int) -> dict[str, Any]:
+    s = _store()
+    try:
+        s.set_scheduled_run_status(schedule_id, "paused")
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return _serialise(s.get_scheduled_run(schedule_id))
+
+
+@router.post("/{schedule_id}/resume")
+def resume_schedule(schedule_id: int) -> dict[str, Any]:
+    s = _store()
+    try:
+        s.set_scheduled_run_status(schedule_id, "pending")
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return _serialise(s.get_scheduled_run(schedule_id))
+
+
+@router.post("/{schedule_id}/run-now", status_code=status.HTTP_202_ACCEPTED)
+def run_now(schedule_id: int) -> dict[str, Any]:
+    s = _store()
+    if s.get_scheduled_run(schedule_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+
+    def spawn(payload: dict[str, Any]) -> int:
+        return spawn_scheduled_worker(payload, store=s, background=True)
+
+    report = tick(
+        store=s,
+        source="manual",
+        target_id=schedule_id,
+        spawn_worker=spawn,
+        now_utc=time.time(),
+    )
+    if not report.fired:
+        msg = report.failed_resolution[0][1] if report.failed_resolution else "unknown error"
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=msg)
+    return {"fired": report.fired}
+
+
+@router.delete("/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_schedule(schedule_id: int) -> None:
+    s = _store()
+    s.delete_scheduled_run(schedule_id)
+
+
+# ── Scheduler engine / daemon ──────────────────────────────────────
+
+
+@scheduler_router.get("/status")
+def scheduler_status_endpoint() -> dict[str, Any]:
+    s = _store()
+    pending = s.list_scheduled_runs(statuses=["pending"], limit=1000)
+    missed = s.list_scheduled_runs(statuses=["missed"], limit=1000)
+    paused = s.list_scheduled_runs(statuses=["paused"], limit=1000)
+    daemon = detect_daemon_state()
+    return {
+        "pending_count": len(pending),
+        "missed_count": len(missed),
+        "paused_count": len(paused),
+        "next_fire": _serialise(pending[0]) if pending else None,
+        "daemon": daemon,
+    }
+
+
+@scheduler_router.get("/bootstrap-report")
+def bootstrap_report_endpoint() -> dict[str, Any]:
+    """Return the bootstrap TickReport recorded at server startup.
+
+    The SPA reads this on first load to render the catch-up banner.
+    When no report has been recorded yet (e.g. test harness without
+    the lifespan hook), a empty report is returned.
+    """
+    from amx.web import server as _server_module
+
+    report = getattr(_server_module, "_bootstrap_report", None)
+    if report is None:
+        return {
+            "fired": [],
+            "failed_resolution": [],
+            "missed_for_review": [],
+            "stale_recovered": [],
+        }
+    return {
+        "fired": report.fired,
+        "failed_resolution": report.failed_resolution,
+        "missed_for_review": report.missed_for_review,
+        "stale_recovered": report.stale_recovered,
+    }
+
+
+@scheduler_router.post("/tick")
+def manual_tick_endpoint() -> dict[str, Any]:
+    """Admin / debug: trigger a daemon-mode tick from the SPA."""
+    s = _store()
+
+    def spawn(payload: dict[str, Any]) -> int:
+        return spawn_scheduled_worker(payload, store=s, background=True)
+
+    report = tick(store=s, source="daemon", spawn_worker=spawn, now_utc=time.time())
+    return {
+        "fired": report.fired,
+        "failed_resolution": report.failed_resolution,
+        "missed_for_review": report.missed_for_review,
+        "stale_recovered": report.stale_recovered,
+    }

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -35,11 +35,17 @@ from amx.web.routers import (
     profiles,
     rerun,
     runs,
+    schedules,
     style,
     system,
     system_ops,
 )
 from amx.web.security_headers import SecurityHeadersMiddleware
+
+# Module-level holder for the bootstrap TickReport (Phase 5a).
+# Populated by create_app() at lifespan start; consumed by the
+# /api/scheduler/bootstrap-report route to drive the catch-up banner.
+_bootstrap_report: object | None = None
 
 
 def _static_root() -> Path:
@@ -124,6 +130,8 @@ def create_app(
     app.include_router(rerun.router)
     app.include_router(installs.router)
     app.include_router(style.router)
+    app.include_router(schedules.router)
+    app.include_router(schedules.scheduler_router)
 
     # Re-Run snapshots are short-lived (worker deletes them in finally).
     # On startup, sweep anything older than 1h that a previous crashed
@@ -149,6 +157,23 @@ def create_app(
     except Exception:
         # Startup must never crash on a GC hiccup; the executor's own
         # cleanup keeps the table tidy regardless.
+        pass
+
+    # Scheduler bootstrap pass: surface stale runs + missed schedules
+    # for the catch-up banner. Pinned on the module object so the
+    # ``/api/scheduler/bootstrap-report`` route can read it without
+    # threading state through DI. Failures are swallowed so a broken
+    # scheduler never blocks Studio startup.
+    global _bootstrap_report
+    _bootstrap_report = None
+    try:
+        from amx.scheduler.tick import tick as _bootstrap_tick
+        from amx.storage.sqlite_store import history_store as _hs2
+
+        _hs_obj = _hs2()
+        if _hs_obj is not None:
+            _bootstrap_report = _bootstrap_tick(store=_hs_obj, source="bootstrap")
+    except Exception:
         pass
 
     root = static_root if static_root is not None else _static_root()

--- a/tests/web/test_schedules_router.py
+++ b/tests/web/test_schedules_router.py
@@ -1,0 +1,167 @@
+"""Tests for the /api/schedules and /api/scheduler Studio routes.
+
+These exercise the FastAPI surface end-to-end against a real
+SQLiteHistoryStore pinned as the module-level singleton, mirroring
+how the Studio process runs in production.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from amx.storage import sqlite_store as _store_module
+from amx.storage.sqlite_store import SQLiteHistoryStore
+from amx.web.routers.schedules import router as schedules_router
+from amx.web.routers.schedules import scheduler_router
+
+
+@pytest.fixture
+def app_with_store(tmp_path: Path):
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    _store_module._store = s
+
+    app = FastAPI()
+    app.include_router(schedules_router)
+    app.include_router(scheduler_router)
+
+    yield app, s
+    _store_module._store = None
+
+
+@pytest.fixture
+def client(app_with_store) -> TestClient:
+    app, _ = app_with_store
+    return TestClient(app)
+
+
+def _create_via_api(client: TestClient, **overrides):
+    body = {
+        "name": "test",
+        "fire_at_local": "2030-01-15T14:00",
+        "fire_at_tz": "Europe/Istanbul",
+        "db_profile": "prod_sf",
+        "scope": {"mode": "schemas", "schemas": ["public"]},
+        "llm_profile": "claude",
+        "review_strategy": "auto",
+    }
+    body.update(overrides)
+    return client.post("/api/schedules", json=body)
+
+
+def test_create_and_get(client: TestClient) -> None:
+    r = _create_via_api(client)
+    assert r.status_code == 201, r.text
+    sid = r.json()["id"]
+
+    g = client.get(f"/api/schedules/{sid}")
+    assert g.status_code == 200
+    body = g.json()
+    assert body["name"] == "test"
+    assert body["status"] == "pending"
+    assert body["fire_at_tz"] == "Europe/Istanbul"
+    # fire_at_local round-trips back to wall-clock in chosen tz
+    assert body["fire_at_local"].startswith("2030-01-15T14:00")
+
+
+def test_list_default_returns_pending(client: TestClient, app_with_store) -> None:
+    _, store = app_with_store
+    _create_via_api(client, name="pending-one")
+    rsp = client.get("/api/schedules")
+    assert rsp.status_code == 200
+    rows = rsp.json()["schedules"]
+    assert any(r["name"] == "pending-one" for r in rows)
+
+
+def test_patch_updates_fields(client: TestClient) -> None:
+    sid = _create_via_api(client).json()["id"]
+    r = client.patch(f"/api/schedules/{sid}", json={"name": "renamed"})
+    assert r.status_code == 200
+    assert r.json()["name"] == "renamed"
+
+
+def test_patch_rejects_running_schedule(client: TestClient, app_with_store) -> None:
+    _, store = app_with_store
+    sid = _create_via_api(client).json()["id"]
+    store.set_scheduled_run_status(sid, "running")
+    r = client.patch(f"/api/schedules/{sid}", json={"name": "x"})
+    assert r.status_code == 409
+
+
+def test_pause_resume_round_trip(client: TestClient, app_with_store) -> None:
+    _, store = app_with_store
+    sid = _create_via_api(client).json()["id"]
+    assert client.post(f"/api/schedules/{sid}/pause").status_code == 200
+    assert store.get_scheduled_run(sid)["status"] == "paused"
+    assert client.post(f"/api/schedules/{sid}/resume").status_code == 200
+    assert store.get_scheduled_run(sid)["status"] == "pending"
+
+
+def test_run_now_returns_fired(client: TestClient, app_with_store) -> None:
+    _, store = app_with_store
+    sid = _create_via_api(client).json()["id"]
+    r = client.post(f"/api/schedules/{sid}/run-now")
+    assert r.status_code == 202, r.text
+    assert sid in r.json()["fired"]
+    # Worker is background; just verify the schedule was transitioned.
+    final = store.get_scheduled_run(sid)
+    assert final["status"] in ("running", "completed")
+
+
+def test_delete_returns_204(client: TestClient, app_with_store) -> None:
+    _, store = app_with_store
+    sid = _create_via_api(client).json()["id"]
+    assert client.delete(f"/api/schedules/{sid}").status_code == 204
+    assert store.get_scheduled_run(sid) is None
+
+
+def test_scheduler_status_endpoint(client: TestClient) -> None:
+    _create_via_api(client)
+    r = client.get("/api/scheduler/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["pending_count"] >= 1
+    assert "daemon" in body
+
+
+def test_scheduler_bootstrap_report_default(client: TestClient) -> None:
+    r = client.get("/api/scheduler/bootstrap-report")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["missed_for_review"] == []
+
+
+def test_manual_tick_endpoint(client: TestClient, app_with_store) -> None:
+    _, store = app_with_store
+    # A past-due schedule the daemon would normally fire.
+    store.create_scheduled_run(
+        name="due-now",
+        fire_at_utc=time.time() - 60,
+        fire_at_tz="UTC",
+        db_profile="p",
+        scope_json='{"mode":"all"}',
+        llm_profile="l",
+        review_strategy="auto",
+    )
+    r = client.post("/api/scheduler/tick")
+    assert r.status_code == 200
+    assert r.json()["fired"]
+
+
+def test_create_rejects_bad_timezone(client: TestClient) -> None:
+    r = _create_via_api(client, fire_at_tz="Mars/OlympusMons")
+    assert r.status_code == 400
+
+
+def test_create_rejects_unparseable_fire_at(client: TestClient) -> None:
+    r = _create_via_api(client, fire_at_local="not-a-date")
+    assert r.status_code == 400
+
+
+def test_get_404_for_missing_id(client: TestClient) -> None:
+    assert client.get("/api/schedules/999999").status_code == 404


### PR DESCRIPTION
## Summary
- `/api/schedules` and `/api/scheduler` routers mounted into Studio.
- Lifespan hook records the bootstrap TickReport; `/api/scheduler/bootstrap-report` serves it.
- Pydantic-validated create/patch; tz round-trip in responses.

## Test plan
- 13 FastAPI TestClient cases; all earlier-phase tests still pass.

Stacked on #381.