### PR TITLE
feat(scheduler): phase 6 — Ask-agent read-only schedule tools

### DIFF
--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -423,11 +423,7 @@ class ToolBox:
                 # never collides with real lookups.
                 kind = str(payload.get("kind") or "")
                 cols = payload.get("columns")
-                if (
-                    kind != "discovery"
-                    and isinstance(cols, list)
-                    and len(cols) > 0
-                ):
+                if kind != "discovery" and isinstance(cols, list) and len(cols) > 0:
                     created_at = float(cached.get("created_at") or 0.0)
                     age = max(0.0, self._now() - created_at)
                     return (payload, "live_cache", age)
@@ -1798,6 +1794,68 @@ class ToolBox:
                     },
                 },
             },
+            # ── scheduled runs (read-only) ────────────────────────────
+            #
+            # Two tools the Ask agent can use to answer questions about
+            # the user's scheduled metadata runs. Read-only: the agent
+            # cannot create, edit, pause, or delete schedules from these
+            # tools -- direct the user to the Schedules page or `amx
+            # schedule` CLI for those actions.
+            {
+                "type": "function",
+                "function": {
+                    "name": "list_schedules",
+                    "description": (
+                        "Return upcoming, past, or paused scheduled metadata runs. "
+                        "Use this when the user asks about plans, upcoming runs, "
+                        "missed schedules, or the outcome of past scheduled runs. "
+                        "Each row includes id, name, fire_at_utc, fire_at_tz, "
+                        "status, db_profile, scope_json, llm_profile, "
+                        "review_strategy, triggered_run_id, and last_error."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "filter": {
+                                "type": "string",
+                                "enum": ["active", "past", "all"],
+                                "description": (
+                                    "'active' = pending/paused/missed/running "
+                                    "(default); 'past' = completed/failed/"
+                                    "cancelled; 'all' = everything."
+                                ),
+                            },
+                            "db_profile": {
+                                "type": "string",
+                                "description": "Optional DB profile filter.",
+                            },
+                        },
+                        "required": [],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_schedule",
+                    "description": (
+                        "Return the full record of a specific scheduled run "
+                        "by id, including any linked analysis_runs.id and "
+                        "last_error. Use when the user asks about a "
+                        "specific schedule the agent saw via list_schedules."
+                    ),
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "schedule_id": {
+                                "type": "integer",
+                                "description": "scheduled_runs.id",
+                            },
+                        },
+                        "required": ["schedule_id"],
+                    },
+                },
+            },
         ]
 
     # ------------------------------------------------------------------ invoke
@@ -2320,9 +2378,7 @@ class ToolBox:
             # bare MagicMock, which makes the call return a truthy
             # MagicMock that isn't iterable as expected.
             if isinstance(catalog_schemas, list) and catalog_schemas:
-                fresh_ts = max(
-                    (s.get("last_synced_at") or 0.0) for s in catalog_schemas
-                )
+                fresh_ts = max((s.get("last_synced_at") or 0.0) for s in catalog_schemas)
                 age = max(0.0, self._now() - fresh_ts) if fresh_ts > 0 else 0.0
                 return {
                     "database": self.cfg.db.database
@@ -2426,9 +2482,7 @@ class ToolBox:
                     "schema": target,
                     "catalog": None,
                     "found": True,
-                    "tables": [
-                        {"name": t["name"], "kind": "table"} for t in catalog_tables
-                    ],
+                    "tables": [{"name": t["name"], "kind": "table"} for t in catalog_tables],
                     "count": len(catalog_tables),
                     "source": "catalog",
                     "age_seconds": age,
@@ -2674,9 +2728,7 @@ class ToolBox:
             payload["warnings"] = warnings
         return payload
 
-    def _tool_find_table_by_name(
-        self, name: str, force_fresh: bool = False
-    ) -> dict[str, Any]:
+    def _tool_find_table_by_name(self, name: str, force_fresh: bool = False) -> dict[str, Any]:
         target = (name or "").strip()
         if not target:
             raise _ToolError("Argument 'name' is required.")
@@ -2908,9 +2960,7 @@ class ToolBox:
         # when the sweep ran. Per-match source is implicit:
         # ``from_catalog`` vs ``from_live_db`` already split the list.
         overall_source = (
-            "catalog" if catalog_paths and not live_paths else
-            "live" if live_paths else
-            "catalog"
+            "catalog" if catalog_paths and not live_paths else "live" if live_paths else "catalog"
         )
         return {
             "name": target,
@@ -3022,13 +3072,9 @@ class ToolBox:
                 scoped = self._connector_for_database(db_name) if db_name else db
                 try:
                     with self._scoped_catalog(scoped, cat_arg):
-                        profile = scoped.profile_table(
-                            schema_name, table_name, sample_size=0
-                        )
+                        profile = scoped.profile_table(schema_name, table_name, sample_size=0)
                     resolved_database = (
-                        db_name
-                        or str(getattr(scoped.cfg, "database", "") or "")
-                        or None
+                        db_name or str(getattr(scoped.cfg, "database", "") or "") or None
                     )
                     db = scoped
                     break
@@ -3170,10 +3216,7 @@ class ToolBox:
         # unpinned PostgreSQL it's the database where the table was
         # found during the sweep.
         try:
-            result["resolved_database"] = (
-                str(getattr(db.cfg, "database", "") or "")
-                or None
-            )
+            result["resolved_database"] = str(getattr(db.cfg, "database", "") or "") or None
         except Exception:
             result["resolved_database"] = None
         # If the cache branch ran, ``resolved_database`` was set from
@@ -6154,3 +6197,58 @@ class ToolBox:
                 "summarising every snippet here."
             ),
         }
+
+    # ── scheduled runs (read-only) ─────────────────────────────────────
+    #
+    # These two handlers back the ``list_schedules`` / ``get_schedule``
+    # tools registered in :meth:`schemas`. They are read-only by design:
+    # the agent answers questions about the user's plans but does not
+    # mutate them. Write actions (create / edit / pause / delete) stay
+    # on the Schedules page and the ``amx schedule`` CLI.
+
+    def _tool_list_schedules(
+        self,
+        filter: str = "active",  # noqa: A002 - matches the LLM tool schema
+        db_profile: str | None = None,
+    ) -> dict[str, Any]:
+        store = self._history_store()
+        if store is None:
+            return {"error": "history store not initialized", "schedules": []}
+        if filter == "past":
+            statuses = ["completed", "failed", "cancelled"]
+        elif filter == "all":
+            statuses = None
+        else:
+            # active is the default; everything that isn't terminal.
+            statuses = ["pending", "paused", "missed", "running"]
+        rows = store.list_scheduled_runs(statuses=statuses, db_profile=db_profile, limit=500)
+        return {
+            "filter": filter,
+            "db_profile": db_profile,
+            "count": len(rows),
+            "schedules": [
+                {
+                    "id": r["id"],
+                    "name": r["name"],
+                    "fire_at_utc": r["fire_at_utc"],
+                    "fire_at_tz": r["fire_at_tz"],
+                    "status": r["status"],
+                    "db_profile": r["db_profile"],
+                    "scope_json": r["scope_json"],
+                    "llm_profile": r["llm_profile"],
+                    "review_strategy": r["review_strategy"],
+                    "triggered_run_id": r.get("triggered_run_id"),
+                    "last_error": r.get("last_error"),
+                }
+                for r in rows
+            ],
+        }
+
+    def _tool_get_schedule(self, schedule_id: int) -> dict[str, Any]:
+        store = self._history_store()
+        if store is None:
+            return {"error": "history store not initialized"}
+        row = store.get_scheduled_run(int(schedule_id))
+        if row is None:
+            return {"error": f"no scheduled_runs row with id={schedule_id}"}
+        return {"schedule": row}

--- a/tests/agents/test_schedule_ask_tools.py
+++ b/tests/agents/test_schedule_ask_tools.py
@@ -1,0 +1,116 @@
+"""Verify the Ask-agent ``list_schedules`` / ``get_schedule`` tools.
+
+These confirm the JSON-schema entry exists for the LLM tool-list path
+and that ``ToolBox.invoke('list_schedules', ...)`` /
+``ToolBox.invoke('get_schedule', ...)`` go through the dispatcher and
+return read-only payloads. Real LLM round-trip is out of scope for a
+unit test; the tool registration + handler contract is what we care
+about.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from amx.search.agent_tools import ToolBox
+from amx.storage import sqlite_store as _store_module
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    _store_module._store = s
+    yield s
+    _store_module._store = None
+
+
+@pytest.fixture
+def toolbox(store: SQLiteHistoryStore) -> ToolBox:
+    """Build a minimal ToolBox that does not touch the live DB.
+
+    The ToolBox constructor wants a config + a catalog object. For the
+    schedule tools we only need ``_history_store`` to resolve to the
+    pinned singleton, so we patch ``__init__`` to skip the heavy setup.
+    """
+    box = ToolBox.__new__(ToolBox)  # type: ignore[call-arg]
+    # Minimal attributes used by invoke() + cache.
+    box._UNCACHED_TOOLS = frozenset()  # type: ignore[attr-defined]
+    box._tool_cache = {}  # type: ignore[attr-defined]
+    box._tool_cache_hits = 0  # type: ignore[attr-defined]
+    box.db_profiles = ()  # type: ignore[attr-defined]
+    box.cfg = MagicMock()
+    return box
+
+
+def _create_schedule(store: SQLiteHistoryStore, **kw):
+    defaults = {
+        "name": "test",
+        "fire_at_utc": time.time() + 3600,
+        "fire_at_tz": "Europe/Istanbul",
+        "db_profile": "prod_sf",
+        "scope_json": json.dumps({"mode": "all"}),
+        "llm_profile": "claude",
+        "review_strategy": "auto",
+    }
+    defaults.update(kw)
+    return store.create_scheduled_run(**defaults)
+
+
+def test_schemas_lists_list_schedules_and_get_schedule() -> None:
+    schemas = ToolBox.schemas()
+    names = {s["function"]["name"] for s in schemas}
+    assert "list_schedules" in names
+    assert "get_schedule" in names
+
+
+def test_list_schedules_default_returns_active(toolbox: ToolBox, store: SQLiteHistoryStore) -> None:
+    active = _create_schedule(store, name="upcoming")
+    done = _create_schedule(store, name="finished")
+    store.set_scheduled_run_status(done, "running")
+    store.set_scheduled_run_status(done, "completed")
+
+    result = json.loads(toolbox.invoke("list_schedules", "{}"))
+    ids = [r["id"] for r in result["schedules"]]
+    assert active in ids
+    assert done not in ids
+
+
+def test_list_schedules_past_filter(toolbox: ToolBox, store: SQLiteHistoryStore) -> None:
+    _create_schedule(store, name="upcoming")
+    done = _create_schedule(store, name="finished")
+    store.set_scheduled_run_status(done, "running")
+    store.set_scheduled_run_status(done, "completed")
+
+    result = json.loads(toolbox.invoke("list_schedules", json.dumps({"filter": "past"})))
+    ids = {r["id"] for r in result["schedules"]}
+    assert ids == {done}
+
+
+def test_list_schedules_filters_by_db_profile(toolbox: ToolBox, store: SQLiteHistoryStore) -> None:
+    a = _create_schedule(store, db_profile="prod_sf")
+    _create_schedule(store, db_profile="stg")
+    result = json.loads(toolbox.invoke("list_schedules", json.dumps({"db_profile": "prod_sf"})))
+    ids = {r["id"] for r in result["schedules"]}
+    assert ids == {a}
+
+
+def test_get_schedule_returns_full_record(toolbox: ToolBox, store: SQLiteHistoryStore) -> None:
+    sid = _create_schedule(store, name="detailed")
+    result = json.loads(toolbox.invoke("get_schedule", json.dumps({"schedule_id": sid})))
+    assert "schedule" in result
+    assert result["schedule"]["id"] == sid
+    assert result["schedule"]["name"] == "detailed"
+
+
+def test_get_schedule_returns_error_for_unknown_id(
+    toolbox: ToolBox, store: SQLiteHistoryStore
+) -> None:
+    result = json.loads(toolbox.invoke("get_schedule", json.dumps({"schedule_id": 99999})))
+    assert "error" in result


### PR DESCRIPTION
## Summary
Two new read-only tools on `amx.search.agent_tools.ToolBox` so the Ask agent can answer questions about scheduled runs:

- `list_schedules(filter='active|past|all', db_profile=None)` — upcoming/past/paused schedules.
- `get_schedule(schedule_id)` — full record + linked run + last_error.

Read-only by design; the agent never mutates schedules — write flows live on the CLI / Schedules page.

## Test plan
- 6 unit tests for the dispatcher contract.
- All earlier-phase tests still pass.

Stacked on #382.