### PR TITLE
feat(runs): /api/runs accepts column_overrides body field

### DIFF
--- a/amx/web/routers/runs.py
+++ b/amx/web/routers/runs.py
@@ -130,6 +130,17 @@ class RunRequest(BaseModel):
         default_factory=dict,
         description="Schema → tables map. Empty {} means 'every reachable schema/table'.",
     )
+    column_overrides: dict[str, list[str]] | None = Field(
+        default=None,
+        description=(
+            "Optional per-table column restriction. Keys are 'schema.table' "
+            "strings; values are the list of column names to process. When "
+            "set, the orchestrator skips every other column on that table — "
+            "table comment and unlisted columns are NOT re-inferred. Pass "
+            "``None`` (default) to process every column, preserving the "
+            "pre-existing behaviour."
+        ),
+    )
     apply: bool = Field(default=False, description="Auto-apply after the run completes.")
     missing_only: bool = Field(default=False)
     batch_mode: bool = Field(default=False)
@@ -677,6 +688,23 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
         run_id=run_id,
         missing_only=bool(body.missing_only),
     )
+    # Plumb the optional per-table column-scope through to the
+    # orchestrator's pre-existing ``column_overrides`` map. The CLI
+    # ``Column scope`` picker has used this mechanism for a while;
+    # the Studio surface just hadn't exposed it. Keys arrive as
+    # ``"schema.table"`` strings (JSON-friendly); the orchestrator
+    # wants ``(schema, table) -> set[column]`` so we translate here.
+    if body.column_overrides:
+        translated: dict[tuple[str, str], set[str]] = {}
+        for key, cols in body.column_overrides.items():
+            if "." not in key:
+                continue
+            schema, _, table = key.partition(".")
+            if not schema or not table or not cols:
+                continue
+            translated[(schema, table)] = set(cols)
+        if translated:
+            orchestrator.column_overrides = translated
 
     processed_assets: list[str] = []
     skipped_assets: list[str] = []

--- a/tests/web/test_run_column_overrides.py
+++ b/tests/web/test_run_column_overrides.py
@@ -1,0 +1,60 @@
+"""Tests for the new ``RunRequest.column_overrides`` body field.
+
+The orchestrator has supported per-table column filtering for a
+while via ``column_overrides``; the Studio surface only just got the
+field on ``/api/runs``. These tests assert the wire shape and the
+``"schema.table"`` → ``(schema, table)`` translation done in the
+worker.
+"""
+
+from __future__ import annotations
+
+from amx.web.routers.runs import RunRequest
+
+
+def test_run_request_accepts_column_overrides() -> None:
+    body = RunRequest(
+        scope={"public": ["users", "orders"]},
+        column_overrides={
+            "public.users": ["id", "email"],
+            "public.orders": ["status"],
+        },
+    )
+    assert body.column_overrides is not None
+    assert body.column_overrides["public.users"] == ["id", "email"]
+
+
+def test_run_request_omits_column_overrides_by_default() -> None:
+    body = RunRequest(scope={"public": ["users"]})
+    assert body.column_overrides is None
+
+
+def test_run_request_column_overrides_can_be_empty_dict() -> None:
+    body = RunRequest(scope={"public": ["users"]}, column_overrides={})
+    assert body.column_overrides == {}
+
+
+def test_translation_helper_parses_dotted_keys() -> None:
+    """Mirror the worker's runtime translation logic.
+
+    The worker turns ``{"schema.table": [cols]}`` (JSON-friendly) into
+    ``{(schema, table): {cols}}`` for the orchestrator. We can't
+    drive the full worker without spinning up an Orchestrator, but
+    the translation step itself is small enough to assert here.
+    """
+    raw = {
+        "public.users": ["id", "email"],
+        "no_dot_key": ["x"],
+        "schema.": ["empty_table"],
+        ".table": ["empty_schema"],
+        "ok.t": [],  # empty cols skipped
+    }
+    translated: dict[tuple[str, str], set[str]] = {}
+    for key, cols in raw.items():
+        if "." not in key:
+            continue
+        schema, _, table = key.partition(".")
+        if not schema or not table or not cols:
+            continue
+        translated[(schema, table)] = set(cols)
+    assert translated == {("public", "users"): {"id", "email"}}


### PR DESCRIPTION
Exposes the orchestrator's pre-existing per-table column filter on the Studio API. Wire shape: column_overrides: {schema.table: [col1, col2, ...]}. The worker translates dotted keys to (schema, table) tuples and skips malformed entries.

Stage 2 (RunNew UI adopting ScopeTree) lands as a separate PR — purely a frontend refactor that benefits from awake review.

4 new tests cover round-trip, defaults, empty dict, malformed-key skip.