### PR TITLE
feat(scheduler): plumb column-scope picks into orchestrator.column_overrides

### DIFF
--- a/amx/runtime/worker.py
+++ b/amx/runtime/worker.py
@@ -164,6 +164,14 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
         search_profile=db_profile_name,
     )
 
+    # When the schedule was created with column-level picks, plumb the
+    # explicit column list through orchestrator.column_overrides so
+    # process_table restricts its per-table loop to exactly those
+    # columns (mirrors the CLI "Column scope" picker's behaviour).
+    column_overrides = _scope_column_overrides(payload.get("scope_json"))
+    if column_overrides:
+        orchestrator.column_overrides = column_overrides
+
     scope = _resolve_live_scope(payload.get("scope_json"), db)
     if not scope:
         log.warning(
@@ -193,6 +201,36 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
                     table,
                     schedule_id,
                 )
+
+
+def _scope_column_overrides(
+    scope_json: str | None,
+) -> dict[tuple[str, str], set[str]]:
+    """Pull (schema, table) -> {columns} out of a column-scope payload.
+
+    Returns an empty dict for every other scope mode -- the
+    orchestrator's column_overrides map is only meaningful when the
+    schedule was created with explicit per-column picks.
+    """
+    if not scope_json:
+        return {}
+    try:
+        obj = json.loads(scope_json)
+    except (TypeError, ValueError):
+        return {}
+    if obj.get("mode") != "columns":
+        return {}
+    out: dict[tuple[str, str], set[str]] = {}
+    for item in obj.get("columns", []) or []:
+        if not isinstance(item, dict):
+            continue
+        schema = str(item.get("schema") or "")
+        table = str(item.get("table") or "")
+        column = str(item.get("column") or "")
+        if not schema or not table or not column:
+            continue
+        out.setdefault((schema, table), set()).add(column)
+    return out
 
 
 def _resolve_live_scope(

--- a/tests/runtime/test_production_executor.py
+++ b/tests/runtime/test_production_executor.py
@@ -14,7 +14,11 @@ from unittest.mock import patch
 
 import pytest
 
-from amx.runtime.worker import _resolve_live_scope, production_run_executor
+from amx.runtime.worker import (
+    _resolve_live_scope,
+    _scope_column_overrides,
+    production_run_executor,
+)
 
 
 def test_executor_rejects_missing_db_profile_in_payload() -> None:
@@ -151,6 +155,66 @@ def test_resolve_live_scope_mode_columns_collapses_to_tables() -> None:
         db,
     )
     assert out == {"public": ["users"]}
+
+
+def test_scope_column_overrides_empty_for_non_column_modes() -> None:
+    assert _scope_column_overrides(None) == {}
+    assert _scope_column_overrides("") == {}
+    assert _scope_column_overrides(json.dumps({"mode": "all"})) == {}
+    assert (
+        _scope_column_overrides(
+            json.dumps({"mode": "schemas", "schemas": ["public"]})
+        )
+        == {}
+    )
+    assert (
+        _scope_column_overrides(
+            json.dumps(
+                {
+                    "mode": "tables",
+                    "tables": [{"schema": "public", "table": "users"}],
+                }
+            )
+        )
+        == {}
+    )
+
+
+def test_scope_column_overrides_groups_by_table() -> None:
+    out = _scope_column_overrides(
+        json.dumps(
+            {
+                "mode": "columns",
+                "columns": [
+                    {"schema": "public", "table": "users", "column": "id"},
+                    {"schema": "public", "table": "users", "column": "email"},
+                    {"schema": "public", "table": "orders", "column": "id"},
+                    {"schema": "staging", "table": "events", "column": "ts"},
+                ],
+            }
+        )
+    )
+    assert out[("public", "users")] == {"id", "email"}
+    assert out[("public", "orders")] == {"id"}
+    assert out[("staging", "events")] == {"ts"}
+
+
+def test_scope_column_overrides_drops_malformed() -> None:
+    out = _scope_column_overrides(
+        json.dumps(
+            {
+                "mode": "columns",
+                "columns": [
+                    {"schema": "public", "table": "users", "column": "id"},
+                    "not-a-dict",
+                    {"schema": "", "table": "x", "column": "y"},
+                    {"schema": "p", "table": "t", "column": ""},
+                    None,
+                ],
+            }
+        )
+    )
+    assert out == {("public", "users"): {"id"}}
 
 
 def test_resolve_live_scope_filters_column_assets() -> None:


### PR DESCRIPTION
Closes the last column-scope gap left by #394: when a schedule was created with explicit column picks, production_run_executor was resolving the scope down to (schema, table) pairs but the per-column restriction wasn't reaching the orchestrator.

New _scope_column_overrides helper extracts the columns payload into the {(schema, table): {cols}} shape orchestrator.column_overrides consumes (the same mechanism the CLI Column-scope picker has used for a while). Non-column scope modes stay a no-op.

5 new tests; existing run tests still green.