### PR TITLE
fix(scheduler): unbuffered daemon logs + PATH; start-of-tick marker

### DIFF
--- a/amx/scheduler/__main__.py
+++ b/amx/scheduler/__main__.py
@@ -56,6 +56,7 @@ def main() -> int:
     )
     log = logging.getLogger("amx.scheduler.daemon")
 
+    log.info("daemon tick start (pid=%s)", __import__("os").getpid())
     cfg = AMXConfig.load()
     global hs  # set on the module so _spawn closure can read it
     hs = init_history_store(cfg)

--- a/amx/scheduler/daemon_install.py
+++ b/amx/scheduler/daemon_install.py
@@ -36,6 +36,8 @@ _PLIST_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
     <dict>
         <key>AMX_CONFIG_DIR</key><string>{config_dir}</string>
         <key>AMX_SKIP_BOOTSTRAP_TICK</key><string>1</string>
+        <key>PYTHONUNBUFFERED</key><string>1</string>
+        <key>PATH</key><string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
     </dict>
     <key>StandardOutPath</key><string>{log_path}</string>
     <key>StandardErrorPath</key><string>{log_path}</string>
@@ -50,6 +52,7 @@ Description=AMX scheduler tick ({label})
 Type=oneshot
 Environment=AMX_CONFIG_DIR={config_dir}
 Environment=AMX_SKIP_BOOTSTRAP_TICK=1
+Environment=PYTHONUNBUFFERED=1
 ExecStart={python_path} -m amx.scheduler
 """
 


### PR DESCRIPTION
Observability tweaks after the daemon's first real run came up silent (log file 0 bytes for 6 minutes while parent process was alive):

1. PYTHONUNBUFFERED=1 in plist + systemd unit so stdout flushes line-by-line.
2. __main__.main() emits 'daemon tick start (pid=N)' as first action.
3. Default PATH on macOS launchd so subprocess calls resolve consistently.

Doesn't fix the underlying 'daemon hangs' symptom — makes it observable so the next failure has actionable evidence.