### PR TITLE
feat(scheduler): all-OS daemon support + Studio-resident ticker

### DIFF
--- a/amx/scheduler/daemon_install.py
+++ b/amx/scheduler/daemon_install.py
@@ -151,6 +151,23 @@ def detect_daemon_state() -> dict[str, Any]:
         if service.exists() and timer.exists():
             return {"installed": True, "path": str(timer), "last_tick_log": log_str}
         return {"installed": False, "path": None, "last_tick_log": log_str}
+    if system == "Windows":
+        # ``schtasks /query`` returns 0 when the task exists.
+        try:
+            result = subprocess.run(
+                ["schtasks", "/query", "/tn", label],
+                check=False,
+                capture_output=True,
+            )
+            if result.returncode == 0:
+                return {
+                    "installed": True,
+                    "path": label,
+                    "last_tick_log": log_str,
+                }
+        except FileNotFoundError:
+            pass
+        return {"installed": False, "path": None, "last_tick_log": log_str}
     return {"installed": False, "path": None, "last_tick_log": log_str}
 
 
@@ -207,10 +224,20 @@ def install_daemon() -> dict[str, Any]:
             )
         )
         tmr_path.write_text(_SYSTEMD_TIMER.format(label=label, suffix=suffix))
+        # ``loginctl enable-linger`` keeps user-level systemd units
+        # running on headless / sshd-only servers where the user
+        # doesn't have an interactive session pinned. Best-effort:
+        # the call may fail without sudo on some distros, which is
+        # fine -- the timer still works for users who stay logged
+        # in interactively.
+        username = os.environ.get("USER", "")
         for cmd in (
             ["systemctl", "--user", "daemon-reload"],
             ["systemctl", "--user", "enable", "--now", tmr_path.name],
+            ["loginctl", "enable-linger", username] if username else None,
         ):
+            if cmd is None:
+                continue
             try:
                 subprocess.run(cmd, check=False, capture_output=True)
             except FileNotFoundError:
@@ -220,12 +247,69 @@ def install_daemon() -> dict[str, Any]:
             "path": str(tmr_path),
         }
 
+    if system == "Windows":
+        # Windows Task Scheduler equivalent: ``schtasks /create`` with
+        # a minute-recurring trigger. ``/sc minute /mo 1`` runs every
+        # 1 minute. The task runs as the current user (``/ru``)
+        # because the LLM-credential lookup pulls from that user's
+        # config dir; ``/rl LIMITED`` keeps it from auto-elevating.
+        # /f forces overwrite of any older task with the same name.
+        task_name = label  # e.g. "com.amx.scheduler"
+        # Wrap the python invocation so the task captures stdout to
+        # the same scheduler.log location as the other OSes.
+        log_path_w = log_path
+        username = os.environ.get("USERNAME", "")
+        # cmd.exe redirection: pipe stdout+stderr to the log file,
+        # append mode so consecutive ticks accumulate.
+        task_action = (
+            f'cmd.exe /c "set AMX_CONFIG_DIR={cfg} && '
+            f'set AMX_SKIP_BOOTSTRAP_TICK=1 && '
+            f'set PYTHONUNBUFFERED=1 && '
+            f'"{python_path}" -m amx.scheduler >> "{log_path_w}" 2>&1"'
+        )
+        cmd = [
+            "schtasks",
+            "/create",
+            "/sc",
+            "minute",
+            "/mo",
+            "1",
+            "/tn",
+            task_name,
+            "/tr",
+            task_action,
+            "/rl",
+            "LIMITED",
+            "/f",
+        ]
+        if username:
+            cmd.extend(["/ru", username])
+        try:
+            result = subprocess.run(cmd, check=False, capture_output=True)
+            ok = result.returncode == 0
+        except FileNotFoundError:
+            return {
+                "message": (
+                    "schtasks.exe not found. Daemon install requires "
+                    "Windows Task Scheduler (built into Windows 10/11)."
+                ),
+                "path": None,
+            }
+        return {
+            "message": (
+                f"Installed Windows scheduled task '{task_name}'."
+                if ok
+                else f"schtasks /create failed: {result.stderr.decode(errors='replace').strip()}"
+            ),
+            "path": task_name if ok else None,
+        }
+
     return {
         "message": (
-            "Daemon mode is not supported on this platform. "
-            "Schedules will still fire whenever AMX or Studio is "
-            "running (catch-up). For always-on scheduling, use AMX "
-            "on macOS or Linux."
+            f"Daemon mode is not supported on {system}. Schedules will "
+            "still fire whenever AMX or Studio is running (catch-up). "
+            "Studio's in-process scheduler also fires due schedules "
+            "on a 60s cadence whenever the Studio process is alive."
         ),
         "path": None,
     }
@@ -267,5 +351,23 @@ def uninstall_daemon() -> dict[str, Any]:
             if p.exists():
                 p.unlink()
         return {"message": f"Uninstalled systemd timer/service {tmr.name}."}
+
+    if system == "Windows":
+        try:
+            result = subprocess.run(
+                ["schtasks", "/delete", "/tn", label, "/f"],
+                check=False,
+                capture_output=True,
+            )
+            ok = result.returncode == 0
+        except FileNotFoundError:
+            return {"message": "schtasks.exe not found."}
+        return {
+            "message": (
+                f"Uninstalled Windows scheduled task '{label}'."
+                if ok
+                else f"No Windows scheduled task '{label}' was installed."
+            )
+        }
 
     return {"message": "Daemon mode is not supported on this platform."}

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -176,6 +176,86 @@ def create_app(
     except Exception:
         pass
 
+    # Studio-resident scheduler ticker.
+    #
+    # The launchd / systemd / Task-Scheduler daemons are the
+    # always-on path for firing schedules while AMX is closed, but
+    # they're prone to OS-specific permission quirks (macOS TCC
+    # blocks the launchd-spawned Python from opening user files;
+    # Linux user timers need ``loginctl enable-linger``; Windows
+    # Task Scheduler needs explicit ``/ru`` user). The Studio
+    # process itself runs in the user's interactive session with
+    # full TCC / keychain / env access -- if Studio is open, every
+    # 60s tick from inside the Studio event loop is the most
+    # reliable path to fire due schedules, regardless of OS.
+    #
+    # The two paths coexist: the OS daemon (when installed and
+    # working) fires while Studio is closed; the Studio-resident
+    # ticker takes over the moment Studio comes up. The tick is
+    # idempotent (``claim_due_schedule`` atomically transitions
+    # pending -> running) so the worst case of both paths racing
+    # is a no-op for one side.
+    @app.on_event("startup")
+    async def _start_studio_scheduler_loop() -> None:
+        import asyncio
+        import logging
+
+        from amx.runtime.worker import (
+            production_run_executor,
+            spawn_scheduled_worker,
+        )
+        from amx.scheduler.tick import tick as _periodic_tick
+        from amx.storage.sqlite_store import history_store as _hs
+
+        slog = logging.getLogger("amx.web.scheduler-loop")
+
+        async def _loop() -> None:
+            # Stagger the first tick so the lifespan bootstrap tick
+            # has finished writing its report before the periodic
+            # loop starts claiming due schedules.
+            await asyncio.sleep(5.0)
+            while True:
+                try:
+                    store = _hs()
+                    if store is None:
+                        slog.warning("history store unavailable, retrying")
+                    else:
+                        def _spawn(payload: dict, _store=store) -> int:
+                            return spawn_scheduled_worker(
+                                payload,
+                                store=_store,
+                                background=True,
+                                run_executor=production_run_executor,
+                            )
+
+                        report = _periodic_tick(
+                            store=store,
+                            source="daemon",
+                            spawn_worker=_spawn,
+                        )
+                        if report.fired or report.stale_recovered:
+                            slog.info(
+                                "studio scheduler tick: fired=%s stale_recovered=%s",
+                                report.fired,
+                                report.stale_recovered,
+                            )
+                except Exception:  # noqa: BLE001
+                    slog.exception("studio scheduler tick crashed")
+                await asyncio.sleep(60.0)
+
+        app.state.scheduler_task = asyncio.create_task(_loop())
+
+    @app.on_event("shutdown")
+    async def _stop_studio_scheduler_loop() -> None:
+        task = getattr(app.state, "scheduler_task", None)
+        if task is None:
+            return
+        task.cancel()
+        try:
+            await task
+        except Exception:  # noqa: BLE001
+            pass
+
     root = static_root if static_root is not None else _static_root()
     app.state.static_root = root
 


### PR DESCRIPTION
Brings the scheduler to feature-parity across macOS / Linux / Windows and adds a reliable in-process fallback that sidesteps OS-specific permission issues.

1) Studio-resident scheduler ticker: asyncio task that runs tick(source='daemon') every 60s for the lifetime of the Studio process. Idempotent vs the OS daemon (claim_due_schedule is atomic) so both paths coexist. Solves the macOS launchd-TCC hang because Studio runs in the user's interactive session with all grants.

2) Windows Task Scheduler support: schtasks /create /sc minute /mo 1 with /ru current user. Action wrapper sets env vars + redirects stdout to scheduler.log to match launchd / systemd layout. Uninstall + detect via schtasks /delete and /query.

3) Linux: loginctl enable-linger automated so user-timers keep firing on headless / ssh-only boxes.