### PR TITLE
fix(scheduler): persist database/catalog overlay on scheduled_runs

### DIFF
--- a/amx/runtime/worker.py
+++ b/amx/runtime/worker.py
@@ -128,6 +128,8 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
     # Local imports keep ``amx.runtime.worker`` lazily loaded -- agent
     # / DB / LLM stacks are heavy and tests that don't need them
     # shouldn't pay the import cost on every collection scan.
+    from dataclasses import replace
+
     from amx.agents.orchestrator import Orchestrator
     from amx.config import AMXConfig
     from amx.db.connector import DatabaseConnector
@@ -155,7 +157,23 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
             "no longer exists. Edit the schedule or recreate the profile."
         )
 
-    db = DatabaseConnector(db_cfg)
+    # Overlay the schedule's saved (database, catalog) picks on top of
+    # the profile so we connect to the exact DB the user picked in the
+    # ScopeTree -- the live-schemas picker uses the same overlay
+    # pattern in ``amx/web/routers/live_db.py::_connector_for_scope``.
+    # Without this, a Postgres profile with three DBs would always
+    # fire against whichever DB happens to be the profile default, so
+    # ``airline.<table>`` resolution raised NoSuchTableError.
+    overlay: dict[str, Any] = {}
+    overlay_database = payload.get("database")
+    overlay_catalog = payload.get("catalog")
+    if overlay_database:
+        overlay["database"] = str(overlay_database)
+    if overlay_catalog:
+        overlay["catalog"] = str(overlay_catalog)
+    scoped_cfg = replace(db_cfg, **overlay) if overlay else db_cfg
+
+    db = DatabaseConnector(scoped_cfg, profile_name=db_profile_name)
     llm = LLMProvider(llm_cfg)
     orchestrator = Orchestrator(
         db,
@@ -222,12 +240,12 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
     )
     beat_thread.start()
 
+    per_table_errors: list[str] = []
+    processed = 0
     try:
         for schema, tables in scope.items():
             for table in tables:
-                # Per-table heartbeat too, so any 60s+ table flips
-                # ``last_heartbeat_at`` even when the ticker is
-                # waiting on its sleep.
+                processed += 1
                 if hs is not None:
                     try:
                         hs.update_run_heartbeat(run_id)
@@ -237,15 +255,30 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
                     orchestrator.process_table(
                         schema, table, interactive_review=False
                     )
-                except Exception:  # noqa: BLE001 - keep going on per-table errors
+                except Exception as exc:  # noqa: BLE001 - keep going on per-table errors
                     log.exception(
                         "production_run_executor: %s.%s failed under schedule #%s",
                         schema,
                         table,
                         schedule_id,
                     )
+                    per_table_errors.append(
+                        f"{schema}.{table}: {type(exc).__name__}: {exc}"
+                    )
     finally:
         stop_beat.set()
+
+    # If every table errored, surface a real failure so the user sees
+    # the cause in Studio instead of a misleading "completed / 0
+    # results" row. Partial failures are logged but do not flip the
+    # run -- per-table run_results that did land are still useful.
+    if per_table_errors and len(per_table_errors) == processed:
+        summary = "; ".join(per_table_errors[:5])
+        if len(per_table_errors) > 5:
+            summary += f"; (+{len(per_table_errors) - 5} more)"
+        raise RuntimeError(
+            f"All {processed} table(s) in scope failed. {summary}"
+        )
 
 
 def _scope_column_overrides(

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -584,6 +584,8 @@ class SQLiteHistoryStore:
                     fire_at_tz TEXT NOT NULL,
                     status TEXT NOT NULL DEFAULT 'pending',
                     db_profile TEXT NOT NULL,
+                    database TEXT,
+                    catalog TEXT,
                     scope_json TEXT NOT NULL,
                     llm_profile TEXT NOT NULL,
                     review_strategy TEXT NOT NULL,
@@ -596,6 +598,7 @@ class SQLiteHistoryStore:
                 )
                 """
             )
+            self._ensure_scheduled_columns(conn)
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_scheduled_runs_status_fireat "
                 "ON scheduled_runs(status, fire_at_utc)"
@@ -685,6 +688,45 @@ class SQLiteHistoryStore:
                 "CREATE INDEX IF NOT EXISTS idx_analysis_runs_shared_uuid "
                 "ON analysis_runs(shared_uuid)"
             )
+
+    def _ensure_scheduled_columns(self, conn: Any) -> None:
+        """Idempotently add ``database`` / ``catalog`` to scheduled_runs.
+
+        Schedules created before this column landed are missing the
+        per-schedule DB / catalog overlay; the picker fetched live
+        schemas via ``/api/live/schemas?profile=…&database=…`` but the
+        ``database`` half was dropped on the way to the store, so at
+        fire time ``production_run_executor`` connected to the profile
+        default and ``airline.<table>`` resolutions raised
+        ``NoSuchTableError``. The two nullable columns let existing
+        rows survive untouched; on next Edit the user picks a
+        database and the next fire connects to the right DB.
+        """
+        try:
+            rows = conn.execute("PRAGMA table_info(scheduled_runs)").fetchall()
+            existing_cols = {str(r[1]) for r in rows}
+        except Exception as exc:
+            log.warning("Could not introspect scheduled_runs schema: %s", exc)
+            existing_cols = set()
+        for col_name, col_type in (
+            ("database", "TEXT"),
+            ("catalog", "TEXT"),
+        ):
+            if col_name in existing_cols:
+                continue
+            try:
+                conn.execute(
+                    f"ALTER TABLE scheduled_runs ADD COLUMN {col_name} {col_type}"
+                )
+                log.info(
+                    "Migrated scheduled_runs: added column %s %s",
+                    col_name,
+                    col_type,
+                )
+            except Exception as exc:
+                log.warning(
+                    "Could not add scheduled_runs.%s: %s", col_name, exc
+                )
         # ── apply_events: audit trail of every COMMENT actually written ──
         #
         # ``run_results.applied_at`` already says "this row was applied"
@@ -2380,6 +2422,8 @@ class SQLiteHistoryStore:
             "fire_at_utc",
             "fire_at_tz",
             "db_profile",
+            "database",
+            "catalog",
             "scope_json",
             "llm_profile",
             "review_strategy",
@@ -2397,24 +2441,37 @@ class SQLiteHistoryStore:
         scope_json: str,
         llm_profile: str,
         review_strategy: str,
+        database: str | None = None,
+        catalog: str | None = None,
         extra_args_json: str | None = None,
     ) -> int:
-        """Insert a new scheduled_runs row in status='pending'."""
+        """Insert a new scheduled_runs row in status='pending'.
+
+        ``database`` and ``catalog`` carry the picker's overlay so the
+        scheduler can rebuild the same connection at fire time (mirrors
+        the ``/api/live/schemas`` picker that ScopeTree drives). Both
+        are nullable: legacy rows + backends that don't expose a
+        database/catalog axis (e.g. SQLite single-file profiles) keep
+        the profile default.
+        """
         now = time.time()
         with self._lock, self._connect() as conn:
             cur = conn.execute(
                 """
                 INSERT INTO scheduled_runs (
                     name, fire_at_utc, fire_at_tz, status,
-                    db_profile, scope_json, llm_profile, review_strategy,
+                    db_profile, database, catalog,
+                    scope_json, llm_profile, review_strategy,
                     extra_args_json, created_at, updated_at
-                ) VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     name,
                     fire_at_utc,
                     fire_at_tz,
                     db_profile,
+                    database,
+                    catalog,
                     scope_json,
                     llm_profile,
                     review_strategy,

--- a/amx/web/routers/schedules.py
+++ b/amx/web/routers/schedules.py
@@ -53,6 +53,18 @@ class ScheduleCreateRequest(BaseModel):
     fire_at_local: str = Field(description="Wall-clock fire time, e.g. '2026-12-31T09:00'.")
     fire_at_tz: str = Field(default="UTC", description="IANA tz id.")
     db_profile: str
+    database: str | None = Field(
+        default=None,
+        description=(
+            "Per-schedule DB overlay -- mirrors the ScopeTree picker's "
+            "``database`` axis. Required for backends whose schema "
+            "list depends on database (Postgres/MySQL/SQL Server)."
+        ),
+    )
+    catalog: str | None = Field(
+        default=None,
+        description="Per-schedule catalog overlay (Unity Catalog etc.).",
+    )
     scope: dict[str, Any] = Field(description="{'mode':'all|schemas|tables', ...}.")
     llm_profile: str
     review_strategy: Literal["auto", "manual"] = "auto"
@@ -63,6 +75,8 @@ class SchedulePatchRequest(BaseModel):
     fire_at_local: str | None = None
     fire_at_tz: str | None = None
     db_profile: str | None = None
+    database: str | None = None
+    catalog: str | None = None
     scope: dict[str, Any] | None = None
     llm_profile: str | None = None
     review_strategy: Literal["auto", "manual"] | None = None
@@ -129,6 +143,8 @@ def create_schedule(body: ScheduleCreateRequest) -> dict[str, Any]:
         fire_at_utc=fire_at_utc,
         fire_at_tz=body.fire_at_tz,
         db_profile=body.db_profile,
+        database=body.database,
+        catalog=body.catalog,
         scope_json=json.dumps(body.scope),
         llm_profile=body.llm_profile,
         review_strategy=body.review_strategy,
@@ -166,6 +182,13 @@ def patch_schedule(schedule_id: int, body: SchedulePatchRequest) -> dict[str, An
         patch["fire_at_utc"] = _parse_fire_at(body.fire_at_local, tz_name)
     if body.db_profile is not None:
         patch["db_profile"] = body.db_profile
+    if body.database is not None:
+        # Empty string means "clear the overlay" (revert to profile
+        # default); persist as SQL NULL so the row matches a fresh
+        # create with no database picked.
+        patch["database"] = body.database or None
+    if body.catalog is not None:
+        patch["catalog"] = body.catalog or None
     if body.scope is not None:
         patch["scope_json"] = json.dumps(body.scope)
     if body.llm_profile is not None:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -825,6 +825,12 @@ export interface ScheduleRow {
   fire_at_local: string;
   status: string;
   db_profile: string;
+  // Per-schedule DB / catalog overlay. Null for legacy rows created
+  // before the picker started persisting this field — those rows
+  // connect to the profile default at fire time and need a re-save
+  // via the Edit dialog to start firing against the right DB.
+  database: string | null;
+  catalog: string | null;
   scope_json: string;
   llm_profile: string;
   review_strategy: string;
@@ -841,6 +847,8 @@ export interface ScheduleCreatePayload {
   fire_at_local: string;
   fire_at_tz: string;
   db_profile: string;
+  database?: string | null;
+  catalog?: string | null;
   scope: Record<string, unknown>;
   llm_profile: string;
   review_strategy?: "auto" | "manual";

--- a/frontend/src/routes/Schedules.tsx
+++ b/frontend/src/routes/Schedules.tsx
@@ -118,7 +118,13 @@ function NewScheduleDialog({
   );
   const [fireAtTz, setFireAtTz] = useState(editing?.fire_at_tz ?? browserTz());
   const [dbProfile, setDbProfile] = useState(editing?.db_profile ?? "");
-  const [database, setDatabase] = useState("");
+  // Hydrate ``database`` from the loaded row when editing -- mirrors
+  // the picker's ``database`` axis. Falling back to ``catalog`` keeps
+  // catalog-backend schedules (Unity Catalog etc.) round-trippable
+  // through the same dropdown.
+  const [database, setDatabase] = useState(
+    editing?.database ?? editing?.catalog ?? "",
+  );
   const [scopePicks, setScopePicks] = useState<SchemaPick[]>([]);
   const [llmProfile, setLlmProfile] = useState(editing?.llm_profile ?? "");
   const [reviewStrategy, setReviewStrategy] = useState<"auto" | "manual">(
@@ -229,6 +235,12 @@ function NewScheduleDialog({
         fire_at_local: fireAtLocal,
         fire_at_tz: fireAtTz,
         db_profile: dbProfile,
+        // Persist the picker's ``database`` axis so the scheduler
+        // rebuilds the same connection at fire time. Catalog-backend
+        // profiles funnel the same dropdown value into ``catalog`` so
+        // a Unity Catalog schedule round-trips correctly too.
+        database: isCatalogBackend ? null : database || null,
+        catalog: isCatalogBackend ? database || null : null,
         scope: buildScope(),
         llm_profile: llmProfile,
         review_strategy: reviewStrategy,
@@ -575,10 +587,36 @@ export default function Schedules() {
       {
         id: "db",
         header: "DB",
-        sortValue: (row) => row.db_profile,
-        cell: (row) => (
-          <span className="text-ink-dim">{row.db_profile}</span>
-        ),
+        sortValue: (row) => `${row.db_profile}/${row.database ?? row.catalog ?? ""}`,
+        cell: (row) => {
+          // Surface the (profile, database) pair so the user can see
+          // which DB a schedule targets at a glance. A schedule with
+          // ``database=null`` is a legacy row created before the
+          // overlay was persisted; flag it so the user knows the
+          // next fire will use the profile default (and almost
+          // certainly miss the picker's tables).
+          const overlay = row.database ?? row.catalog;
+          if (overlay) {
+            return (
+              <span className="text-ink-dim">
+                {row.db_profile}
+                <span className="text-ink-muted"> · </span>
+                <span className="font-mono text-xs text-ink">{overlay}</span>
+              </span>
+            );
+          }
+          return (
+            <span className="text-ink-dim">
+              {row.db_profile}
+              <span
+                className="ml-2 rounded border border-warning/40 bg-warning/10 px-1.5 py-0.5 text-[10px] font-medium text-warning"
+                title="No database picked. Edit the schedule and pick one — otherwise the next fire connects to the profile default and may not find the scheduled tables."
+              >
+                no db
+              </span>
+            </span>
+          );
+        },
         hideOnMobile: true,
       },
       {

--- a/tests/scheduler/test_database_overlay.py
+++ b/tests/scheduler/test_database_overlay.py
@@ -1,0 +1,155 @@
+"""Tests for the ``(database, catalog)`` overlay on ``scheduled_runs``.
+
+The picker is database-scoped (ScopeTree fetches schemas via
+``/api/live/schemas?profile=…&database=…``) so the schedule needs the
+``database`` half persisted alongside the profile. Without it the
+scheduler would fire against the profile default at run time and the
+saved schema picks would resolve in the wrong DB.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def test_create_persists_database_overlay(store: SQLiteHistoryStore) -> None:
+    sid = store.create_scheduled_run(
+        name="airline-meta",
+        fire_at_utc=1_700_000_000.0,
+        fire_at_tz="Europe/Istanbul",
+        db_profile="local-postgre",
+        database="bird",
+        catalog=None,
+        scope_json=json.dumps({"mode": "tables", "tables": []}),
+        llm_profile="claude",
+        review_strategy="auto",
+    )
+    row = store.get_scheduled_run(sid)
+    assert row is not None
+    assert row["db_profile"] == "local-postgre"
+    assert row["database"] == "bird"
+    assert row["catalog"] is None
+
+
+def test_create_persists_catalog_overlay(store: SQLiteHistoryStore) -> None:
+    sid = store.create_scheduled_run(
+        name="lakehouse-refresh",
+        fire_at_utc=1_700_000_000.0,
+        fire_at_tz="UTC",
+        db_profile="dbr",
+        database=None,
+        catalog="main",
+        scope_json=json.dumps({"mode": "all"}),
+        llm_profile="claude",
+        review_strategy="auto",
+    )
+    row = store.get_scheduled_run(sid)
+    assert row is not None
+    assert row["catalog"] == "main"
+    assert row["database"] is None
+
+
+def test_create_without_overlay_keeps_both_null(
+    store: SQLiteHistoryStore,
+) -> None:
+    sid = store.create_scheduled_run(
+        name="legacy-style",
+        fire_at_utc=1_700_000_000.0,
+        fire_at_tz="UTC",
+        db_profile="sqlite-local",
+        scope_json=json.dumps({"mode": "all"}),
+        llm_profile="claude",
+        review_strategy="auto",
+    )
+    row = store.get_scheduled_run(sid)
+    assert row is not None
+    assert row["database"] is None
+    assert row["catalog"] is None
+
+
+def test_update_can_set_and_clear_database(
+    store: SQLiteHistoryStore,
+) -> None:
+    sid = store.create_scheduled_run(
+        name="repair-flow",
+        fire_at_utc=1_700_000_000.0,
+        fire_at_tz="UTC",
+        db_profile="local-postgre",
+        scope_json=json.dumps({"mode": "all"}),
+        llm_profile="claude",
+        review_strategy="auto",
+    )
+    # Fix-up flow: user edits a legacy schedule and picks the right DB.
+    store.update_scheduled_run(sid, patch={"database": "bird"})
+    assert store.get_scheduled_run(sid)["database"] == "bird"
+
+    # Clearing reverts to the profile default.
+    store.update_scheduled_run(sid, patch={"database": None})
+    assert store.get_scheduled_run(sid)["database"] is None
+
+
+def test_idempotent_migration_on_legacy_table(tmp_path: Path) -> None:
+    """A pre-existing scheduled_runs table missing ``database`` /
+    ``catalog`` gets the columns added on next ``init()`` without
+    losing rows.
+    """
+    db_path = tmp_path / "legacy.db"
+    s1 = SQLiteHistoryStore(db_path)
+    s1.init()
+    # Simulate a legacy install: drop the new columns by recreating
+    # the table without them, keeping a single legacy row.
+    with s1._lock, s1._connect() as conn:  # type: ignore[attr-defined]
+        conn.execute("ALTER TABLE scheduled_runs RENAME TO scheduled_runs_old")
+        conn.execute(
+            """
+            CREATE TABLE scheduled_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                fire_at_utc REAL NOT NULL,
+                fire_at_tz TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                db_profile TEXT NOT NULL,
+                scope_json TEXT NOT NULL,
+                llm_profile TEXT NOT NULL,
+                review_strategy TEXT NOT NULL,
+                extra_args_json TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                fired_at REAL,
+                triggered_run_id INTEGER,
+                last_error TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO scheduled_runs (
+                name, fire_at_utc, fire_at_tz, db_profile,
+                scope_json, llm_profile, review_strategy,
+                created_at, updated_at
+            ) VALUES ('legacy', 1, 'UTC', 'p', '{}', 'l', 'auto', 1, 1)
+            """
+        )
+        conn.execute("DROP TABLE scheduled_runs_old")
+
+    # Re-init: the migration helper must add the two columns without
+    # erroring and the legacy row must survive.
+    s2 = SQLiteHistoryStore(db_path)
+    s2.init()
+    rows = s2.list_scheduled_runs()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "legacy"
+    assert rows[0]["database"] is None
+    assert rows[0]["catalog"] is None


### PR DESCRIPTION
## Summary
- ScopeTree picker is database-scoped but the schedule payload dropped the `database` axis, so fires connected to the profile default and raised silent `NoSuchTableError` (visible as "completed / 0 results")
- Persist `database` + `catalog` on `scheduled_runs`; reapply via `dataclasses.replace` at fire time (same pattern as `_connector_for_scope`)
- Idempotent `ALTER TABLE ADD COLUMN` migration; legacy rows survive and show a "no db" warning chip in the Studio list so the user can repair via Edit
- `production_run_executor` now raises when every table in scope errors, so the run row gets a real `error_text` instead of an empty "completed" — surfaces the root cause for legacy rows until they're re-saved

## Test plan
- [x] `pytest tests/scheduler tests/storage tests/web -q` → 424 passed
- [x] new `tests/scheduler/test_database_overlay.py` covers create + patch round-trip, both axes, null defaults, and idempotent migration against a legacy table layout
- [x] `tsc --noEmit` clean
- [ ] Studio E2E (manual): edit existing schedule #4, pick database with `airline` schema, save, run-now → expect run to populate `run_results` instead of failing silently