### PR TITLE
fix(catalog): drop ghost profiles + treat zero-table sync as failure

### DIFF
--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -218,6 +218,35 @@ def sync_profile_skeleton(cfg, profile: str, catalog) -> dict:
         summary["error"] = str(exc)
         return summary
 
+    # ``list_schemas`` succeeded but returned zero rows. Treat this as a
+    # failure (not a silent success) so the freshness pill renders a
+    # Retry CTA + actionable error instead of "never · stale" with no
+    # explanation. The most common cause on Databricks is a profile
+    # without a catalog pinned; on 2-level backends it's a permission
+    # gap. Tailor the message so the user knows exactly what to check.
+    if not schemas:
+        if db_backend == "databricks":
+            error_msg = (
+                "Connected but no schemas were visible. Pin a catalog on the "
+                "profile (Settings → DB profile) or check that your warehouse "
+                "permissions expose at least one schema."
+            )
+        else:
+            error_msg = (
+                "Connected but no schemas were visible. Check that the active "
+                "database is correct and the connection user has at least "
+                "``USAGE`` on one schema."
+            )
+        log.warning(
+            "Skeleton sync for %s returned empty schemas - marking failed",
+            profile,
+        )
+        catalog.start_skeleton_sync(profile, total_tables=0)
+        catalog.finish_skeleton_sync(profile, ok=False, error=error_msg)
+        summary["state"] = "failed"
+        summary["error"] = error_msg
+        return summary
+
     # Step 2: pass 1 — count tables across all schemas. Lets the UI
     # show ``Syncing 0 / N…`` from the first tick rather than
     # ``Syncing… N unknown``.

--- a/amx/web/routers/catalog.py
+++ b/amx/web/routers/catalog.py
@@ -243,12 +243,29 @@ def catalog_freshness(cfg: AMXConfig = Depends(get_cfg)) -> dict[str, Any]:
     now = _time.time()
     stale_after_sec = 24 * 60 * 60
     state_by_profile = {str(r["db_profile"] or ""): r for r in state_rows}
+    # Filter to profiles the user actually has configured. ``catalog_entities``
+    # row keys are profile names that may include tombstones — names like
+    # the historical ``"default"`` fallback or a profile the user has since
+    # deleted from their config. The freshness pill should match the user's
+    # mental model of *current* profiles; orphan rows stay on disk in case
+    # the user re-adds a profile with the same name later, but they no
+    # longer show up in the dropdown.
+    valid_profiles: set[str] | None = None
+    if cfg is not None:
+        profile_map = getattr(cfg, "db_profiles", None)
+        if hasattr(profile_map, "keys"):
+            valid_profiles = {str(k) for k in profile_map}
     profiles: list[dict[str, Any]] = []
     stale_count = 0
     syncing_count = 0
     seen: set[str] = set()
     for row in rows:
         name = str(row["db_profile"] or "")
+        if valid_profiles is not None and name not in valid_profiles:
+            # Tombstone — skip. The state-row loop below applies the same
+            # filter so a leftover ``catalog_profile_state`` entry for a
+            # deleted profile doesn't sneak back in via the second pass.
+            continue
         seen.add(name)
         last = float(row["last_synced_at"] or 0.0)
         age = now - last if last else None
@@ -288,6 +305,10 @@ def catalog_freshness(cfg: AMXConfig = Depends(get_cfg)) -> dict[str, Any]:
     # until the very first row landed.
     for name, state_row in state_by_profile.items():
         if name in seen:
+            continue
+        if valid_profiles is not None and name not in valid_profiles:
+            # Same tombstone filter as above — a stale state row for a
+            # deleted profile must not surface in the pill.
             continue
         state_value = str(state_row["state"])
         if state_value == "syncing":

--- a/tests/test_catalog_cache_hardening.py
+++ b/tests/test_catalog_cache_hardening.py
@@ -262,6 +262,8 @@ def test_catalog_freshness_endpoint_shape(tmp_path: Path) -> None:
     store = SQLiteHistoryStore(db_path)
     ss._store = store  # noqa: SLF001 — module-level singleton
     try:
+        # cfg=None disables the ghost-profile filter so the legacy
+        # behaviour (every profile surfaces) is still covered.
         payload = catalog_router.catalog_freshness(cfg=None)
     finally:
         ss._store = None  # noqa: SLF001
@@ -280,3 +282,51 @@ def test_catalog_freshness_endpoint_shape(tmp_path: Path) -> None:
         "stale",
     }
     assert expected_keys.issubset(profiles["fresh-p"].keys())
+
+
+def test_catalog_freshness_filters_ghost_profiles(tmp_path: Path) -> None:
+    """Profiles with catalog rows but not in ``cfg.db_profiles`` (the
+    user-reported ``default`` tombstone) are dropped from the pill.
+    They remain in ``catalog_entities`` on disk in case the user
+    re-adds a profile with the same name, but they don't clutter the
+    dropdown."""
+    db_path = tmp_path / "history.db"
+    SQLiteHistoryStore(db_path).init()
+    now = time.time()
+    with sqlite3.connect(db_path) as conn:
+        # One ghost row (legacy ``default`` profile that's no longer
+        # in the user's config) + one real row.
+        for db_profile in ("default", "local-postgre"):
+            conn.execute(
+                """
+                INSERT INTO catalog_entities (
+                    db_profile, schema_name, table_name, entity_kind, last_synced_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (db_profile, "public", "t", "table", now - 60),
+            )
+
+    import amx.web.routers.catalog as catalog_router
+    from amx.storage import sqlite_store as ss
+
+    store = SQLiteHistoryStore(db_path)
+    ss._store = store  # noqa: SLF001
+
+    class _Cfg:
+        # Only ``local-postgre`` is in the active config.
+        db_profiles = {"local-postgre": object()}
+
+    try:
+        payload = catalog_router.catalog_freshness(cfg=_Cfg())
+    finally:
+        ss._store = None  # noqa: SLF001
+
+    names = {p["profile"] for p in payload["profiles"]}
+    assert names == {"local-postgre"}
+    # Ghost stays on disk — re-adding ``default`` later should pick
+    # those rows back up.
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM catalog_entities WHERE db_profile = 'default'"
+        ).fetchone()
+    assert int(row[0]) == 1

--- a/tests/test_catalog_skeleton_sync.py
+++ b/tests/test_catalog_skeleton_sync.py
@@ -161,6 +161,52 @@ def test_failure_path_marks_state_failed(
     assert fresh_catalog.is_profile_fully_synced("prof-a") is False
 
 
+def test_empty_schemas_marks_state_failed(
+    fresh_catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``list_schemas`` returning ``[]`` without raising is treated as
+    a failure, not a silent done. The user-reported scenario: a
+    Databricks profile without a catalog pinned succeeds at connect
+    but enumerates zero schemas. The previous behaviour flipped the
+    pill to ``never · stale`` with no Retry signal; this branch is
+    why we now mark the state as failed with a backend-specific
+    actionable message."""
+    connector = _StubConnector(schemas=[], assets={})
+    _stub_build_connector(monkeypatch, connector)
+
+    summary = sync_profile_skeleton(_StubCfg(), "prof-a", fresh_catalog)
+    assert summary["state"] == "failed"
+    assert "no schemas" in summary["error"].lower()
+
+    state = fresh_catalog.get_profile_state("prof-a")
+    assert state["state"] == "failed"
+    assert "no schemas" in state["last_error"].lower()
+    assert fresh_catalog.is_profile_fully_synced("prof-a") is False
+
+
+def test_empty_schemas_databricks_message(
+    fresh_catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Databricks-backed profiles get a tailored error mentioning the
+    catalog pin — the #1 reason ``list_schemas`` returns ``[]`` on UC
+    setups."""
+    connector = _StubConnector(schemas=[], assets={})
+    _stub_build_connector(monkeypatch, connector)
+
+    class _DatabricksCfg:
+        class _DB:
+            backend = "databricks"
+            database = ""
+            catalog = ""
+            project = ""
+
+        db = _DB()
+
+    summary = sync_profile_skeleton(_DatabricksCfg(), "prof-dbr", fresh_catalog)
+    assert summary["state"] == "failed"
+    assert "catalog" in summary["error"].lower()
+
+
 def test_completeness_gate_window(
     fresh_catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

PR #416 wired the freshness pill but two rough edges showed up on the user's actual install:

**1. Ghost ``default`` profile in the dropdown.** A profile named ``default`` showed up with "5 h ago" even though the user never created one. Root cause: legacy ``catalog_entities.db_profile = 'default'`` rows from an earlier session where ``cfg.active_db_profile`` defaulted to the literal string. The freshness route grouped by ``db_profile`` and surfaced everything, including profiles no longer in ``cfg.db_profiles``.

**Fix**: filter the freshness response to ``cfg.db_profiles`` keys. Orphan rows stay on disk in case the user re-adds a profile with the same name later, but they don't clutter the pill.

**2. Empty-schemas sync silently succeeds.** Clicking Sync-all on a Databricks profile without a catalog pinned briefly showed the progress bar, then flipped the row to ``never · stale`` with no Retry signal. The trace: ``list_schemas()`` returned ``[]`` without raising → ``total_tables=0`` → upsert loop ran zero times → ``finish_skeleton_sync(ok=True)`` flipped state to ``done`` with no entities. The pill rendered "never · stale" because ``entity_count`` was 0.

**Fix**: an empty ``list_schemas()`` is now classified as a failure with a backend-specific actionable error:
* Databricks → ``"Connected but no schemas were visible. Pin a catalog on the profile (Settings → DB profile) or check that your warehouse permissions expose at least one schema."``
* 2-level backends → ``"Connected but no schemas were visible. Check that the active database is correct and the connection user has at least USAGE on one schema."``

The pill renders the error + Retry button via the existing PR #416 surface; no frontend change needed.

## Test plan

- [x] ``pytest tests/test_catalog_skeleton_sync.py tests/test_catalog_cache_hardening.py`` — 16 tests pass (3 new: empty-schemas generic + Databricks-tailored + ghost filter).
- [x] ``pytest --ignore=tests/runtime/test_chroma_concurrent_writes.py`` — full 1938-test suite green.
- [x] ``ruff check amx tests && ruff format --check amx tests`` — clean.
- [x] Live smoke: ``GET /api/catalog/freshness`` after deploy returns only ``["local-postgre", "dbr-oyk"]`` — the ``default`` ghost is filtered out.
- [ ] Manual #1: Catalog dropdown shows only the user's two real profiles, no ``default`` row.
- [ ] Manual #2: Click Sync all. dbr-oyk runs briefly, then flips to ``failed`` with the Databricks-tailored error text + a Retry button. No more "never · stale" confusion.
- [ ] Manual #3: Pin a catalog on dbr-oyk's profile, click Retry. State flips to ``done`` with the real table count.