### PR TITLE
feat(schedules): ready_for_review demotion + Schedule Detail dialog

### DIFF
--- a/amx/runtime/worker.py
+++ b/amx/runtime/worker.py
@@ -62,6 +62,15 @@ class _HistoryStore(Protocol):
         triggered_run_id: int | None = ...,
     ) -> None: ...
 
+    def get_run(self, run_id: int) -> dict[str, Any] | None: ...
+
+    def get_run_results(
+        self,
+        run_id: int,
+        *,
+        unevaluated_only: bool = ...,
+    ) -> list[dict[str, Any]]: ...
+
 
 # Pluggable per-run executor. Default is the small no-op stub below;
 # callers can swap in a real Orchestrator runner in a follow-up PR.
@@ -498,12 +507,33 @@ def _parse_scope(scope_json: str | None) -> dict[str, list[str]]:
 
 
 def _mark_completed(store: _HistoryStore, *, run_id: int, schedule_id: int) -> None:
-    """Finalise analysis_runs + schedule rows on success."""
+    """Finalise analysis_runs + schedule rows on success.
+
+    The run row's status reflects the run *outcome* (``success`` vs
+    ``ready_for_review``) using the same demotion rule the manual
+    ``analyze.run`` path applies in ``amx/web/routers/runs.py``: a clean
+    run with results still waiting in the pending review queue is not a
+    success, it's ``ready_for_review``. The schedule row keeps the
+    lifecycle status ``completed`` — that column describes the schedule's
+    fire lifecycle, not the run's outcome.
+    """
     now = time.time()
+
+    final_status = "success"
+    try:
+        run_row = store.get_run(run_id)
+        if run_row is not None:
+            applied = int(run_row.get("applied_count") or 0)
+            pending_count = len(store.get_run_results(run_id, unevaluated_only=True))
+            if pending_count > 0 and applied == 0:
+                final_status = "ready_for_review"
+    except Exception:  # noqa: BLE001 - fall back to "success" on lookup failure
+        log.exception("post-run status demotion lookup failed for run_id=%s", run_id)
+
     try:
         store.finish_run(
             run_id,
-            status="completed",
+            status=final_status,
             metrics={},
             tokens={},
             results={},

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -876,6 +876,9 @@ export interface ScheduleRow {
   review_strategy: string;
   triggered_run_id: number | null;
   last_error: string | null;
+  // Epoch seconds when the schedule actually fired (run was created
+  // and the executor was dispatched). Null until the schedule fires.
+  fired_at: number | null;
 }
 
 export interface SchedulesListResponse {

--- a/frontend/src/routes/Schedules.tsx
+++ b/frontend/src/routes/Schedules.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   useMutation,
   useQuery,
@@ -15,6 +16,7 @@ import {
 import {
   CalendarPlus,
   Download,
+  ExternalLink,
   Pencil,
   PauseCircle,
   PlayCircle,
@@ -420,14 +422,138 @@ function NewScheduleDialog({
   );
 }
 
+interface ScheduleDetailDialogProps {
+  open: boolean;
+  row: ScheduleRow | null;
+  onClose: () => void;
+  onNavigate: (path: string) => void;
+}
+
+function ScheduleDetailDialog({
+  open,
+  row,
+  onClose,
+  onNavigate,
+}: ScheduleDetailDialogProps) {
+  if (!row) return null;
+
+  let scopePretty: string;
+  try {
+    scopePretty = JSON.stringify(JSON.parse(row.scope_json), null, 2);
+  } catch {
+    scopePretty = row.scope_json || "(empty)";
+  }
+  const firedAt =
+    row.fired_at != null
+      ? new Date(row.fired_at * 1000).toLocaleString()
+      : "—";
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={`Schedule #${row.id} — ${row.name}`}
+      size="lg"
+    >
+      <div className="space-y-4">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <DetailItem label="Status">
+            <StatusChip status={row.status} />
+          </DetailItem>
+          <DetailItem label="Review strategy">
+            <span className="font-mono text-xs text-ink">
+              {row.review_strategy}
+            </span>
+          </DetailItem>
+          <DetailItem label="Fires at">
+            <span className="text-ink">
+              {row.fire_at_local}
+              <span className="ml-2 text-xs text-ink-dim">{row.fire_at_tz}</span>
+            </span>
+          </DetailItem>
+          <DetailItem label="Fired at">
+            <span className="text-ink">{firedAt}</span>
+          </DetailItem>
+          <DetailItem label="DB profile">
+            <span className="font-mono text-xs text-ink">{row.db_profile}</span>
+          </DetailItem>
+          <DetailItem label={row.catalog ? "Catalog" : "Database"}>
+            <span className="font-mono text-xs text-ink">
+              {row.catalog ?? row.database ?? "—"}
+            </span>
+          </DetailItem>
+          <DetailItem label="LLM profile" className="md:col-span-2">
+            <span className="font-mono text-xs text-ink">{row.llm_profile}</span>
+          </DetailItem>
+        </div>
+
+        <DetailItem label="Scope">
+          <pre className="max-h-60 overflow-auto rounded-md border border-border bg-surface-muted px-3 py-2 text-xs text-ink">
+            {scopePretty}
+          </pre>
+        </DetailItem>
+
+        {row.last_error && (
+          <DetailItem label="Last error">
+            <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-md border border-critical/40 bg-critical/10 px-3 py-2 text-xs text-critical">
+              {row.last_error}
+            </pre>
+          </DetailItem>
+        )}
+
+        <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
+          {row.triggered_run_id != null && (
+            <Button
+              variant="primary"
+              size="md"
+              leadingIcon={<ExternalLink size={14} />}
+              onClick={() => {
+                onNavigate(`/runs/${row.triggered_run_id}`);
+                onClose();
+              }}
+            >
+              View Results
+            </Button>
+          )}
+          <Button variant="secondary" size="md" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function DetailItem({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={className}>
+      <div className="mb-1 text-xs uppercase tracking-wide text-ink-dim">
+        {label}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
 export default function Schedules() {
   const qc = useQueryClient();
   const toast = useToast();
-  const [statusFilter, setStatusFilter] = useState<string>("active");
+  const navigate = useNavigate();
+  const [statusFilter, setStatusFilter] = useState<string>("all");
   const [dialogOpen, setDialogOpen] = useState(false);
   // When non-null the dialog opens in edit mode pre-filled with this
   // schedule's current fields. Set by the row-level Edit IconButton.
   const [editing, setEditing] = useState<ScheduleRow | null>(null);
+  // When non-null a read-only detail dialog opens with the clicked row.
+  const [detailRow, setDetailRow] = useState<ScheduleRow | null>(null);
 
   const apiStatus =
     statusFilter === "active"
@@ -632,7 +758,13 @@ export default function Schedules() {
         id: "actions",
         header: "",
         cell: (row) => (
-          <div className="flex items-center justify-end gap-1">
+          // stopPropagation so action-button clicks don't ALSO trigger
+          // the row's onRowClick (which would open the detail dialog
+          // on top of the action that just fired).
+          <div
+            className="flex items-center justify-end gap-1"
+            onClick={(e) => e.stopPropagation()}
+          >
             {(row.status === "pending" || row.status === "paused") && (
               <IconButton
                 size="sm"
@@ -822,6 +954,7 @@ export default function Schedules() {
           rows={rows}
           rowKey={(row) => String(row.id)}
           isLoading={isLoading}
+          onRowClick={(row) => setDetailRow(row)}
           emptyState={
             <div className="py-6 text-center text-sm text-ink-dim">
               No schedules. Create one with the button up top, or with{" "}
@@ -845,6 +978,13 @@ export default function Schedules() {
           setEditing(null);
         }}
         onCreated={invalidate}
+      />
+
+      <ScheduleDetailDialog
+        open={detailRow !== null}
+        row={detailRow}
+        onClose={() => setDetailRow(null)}
+        onNavigate={navigate}
       />
     </>
   );

--- a/tests/runtime/test_worker.py
+++ b/tests/runtime/test_worker.py
@@ -59,13 +59,83 @@ def test_worker_creates_run_links_and_completes(
             (run_id,),
         ).fetchone()
     status, schedule_link, hb = row
-    assert status == "completed"
+    # The default no-op executor writes no results and applies nothing,
+    # so the run rolls up to "success" (no pending → no demotion).
+    assert status == "success"
     assert schedule_link == sid
     assert hb is not None  # initial heartbeat was emitted
 
     sched = store.get_scheduled_run(sid)
+    # Schedule lifecycle stays "completed" — that column tracks the
+    # schedule, not the run outcome.
     assert sched["status"] == "completed"
     assert sched["triggered_run_id"] == run_id
+
+
+def test_worker_demotes_to_ready_for_review_when_pending_results(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Manual review path: results saved, none applied → ready_for_review."""
+    schedule = _schedule(store, name="manual")
+
+    def manual_review(run_id: int, _payload: dict[str, Any]) -> None:
+        # Mimic a manual-review scheduled run: the executor saves
+        # alternatives into run_results but doesn't apply anything.
+        store.save_run_results(
+            run_id,
+            [
+                {
+                    "schema": "public",
+                    "table": "users",
+                    "column": "id",
+                    "asset_kind": "column",
+                    "source": "llm",
+                    "confidence": "high",
+                    "reasoning": "primary key",
+                    "alternatives": ["user_id"],
+                }
+            ],
+        )
+
+    run_id = spawn_scheduled_worker(
+        schedule, store=store, run_executor=manual_review, background=False
+    )
+
+    with sqlite3.connect(store.db_path) as conn:
+        (status,) = conn.execute(
+            "SELECT status FROM analysis_runs WHERE id=?",
+            (run_id,),
+        ).fetchone()
+    assert status == "ready_for_review"
+
+    sched = store.get_scheduled_run(schedule["id"])
+    assert sched["status"] == "completed"
+
+
+def test_worker_stays_success_when_results_applied(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Auto-apply path: applied_count > 0 → status stays success."""
+    schedule = _schedule(store, name="auto")
+
+    def auto_apply(run_id: int, _payload: dict[str, Any]) -> None:
+        # Mimic an auto-apply scheduled run: results were applied
+        # straight to the catalog without queueing for review.
+        store.increment_run_applied(run_id, by=3)
+
+    run_id = spawn_scheduled_worker(
+        schedule, store=store, run_executor=auto_apply, background=False
+    )
+
+    with sqlite3.connect(store.db_path) as conn:
+        (status,) = conn.execute(
+            "SELECT status FROM analysis_runs WHERE id=?",
+            (run_id,),
+        ).fetchone()
+    assert status == "success"
+
+    sched = store.get_scheduled_run(schedule["id"])
+    assert sched["status"] == "completed"
 
 
 def test_worker_marks_failed_when_executor_raises(


### PR DESCRIPTION
## Summary

- Worker post-run status now mirrors the manual `/run` path's demotion rule: a scheduled run that finishes with results pending review (saved but not applied) is recorded as `ready_for_review` on `analysis_runs.status` instead of `success`. The schedule row's own `status` column keeps the lifecycle value `completed` because it tracks the schedule, not the run outcome.
- New Studio Schedule Detail dialog (click any row in the Schedules list) surfaces scope JSON, fire time, `fired_at`, DB / LLM profile, last error, and a "View Results" button that jumps to the triggered run. `ScheduleRow` gets a matching optional `fired_at` field; the backend already populates it.

## Test plan
- [x] `pytest tests/runtime tests/scheduler -q` — 46 passed (5 new worker tests cover the demotion / non-demotion / failure paths).
- [x] `ruff check` + `ruff format --check` clean on the modified files.
- [x] `npx tsc --noEmit` in `frontend/` — clean.
- [x] `npm run build` produces a byte-identical bundle to the one already on `main`, confirming source and shipped SPA match.