### PR TITLE
feat(confidence): Signal B — LLM self-declaration per alternative (Phase 2)

### DIFF
--- a/amx/agents/profile_agent.py
+++ b/amx/agents/profile_agent.py
@@ -78,7 +78,7 @@ Respond in this exact format for each column (one block per column):
 
 COLUMN: <column_name>
 DESCRIPTION_1: <most likely description>
-{desc_lines}
+{self_decl_line_1}{desc_lines}
 CONFIDENCE: <HIGH|MEDIUM|LOW>
 REASONING: <why you think so>
 
@@ -99,6 +99,7 @@ def _build_system_prompt(
     n_alternatives: int,
     description_verbosity: str = "brief",
     style_profile: StyleProfile | None = None,
+    emit_self_decl: bool = False,
 ) -> str:
     """Build the system prompt dynamically for the requested number of alternatives.
 
@@ -108,6 +109,12 @@ def _build_system_prompt(
     * ``comprehensive``: 1-2 short paragraphs / ~5-8 sentences (≈4-6× brief).
     * ``exhaustive``: multi-paragraph reference-style entry (≈8-12× brief);
       best for documentation, not interactive runs.
+
+    ``emit_self_decl`` (Phase 2 confidence scoring) makes the model emit
+    a ``CONFIDENCE_i: HIGH|MED|LOW`` line immediately after each
+    ``DESCRIPTION_i`` block, so AMX can extract a per-alternative
+    self-declared confidence. The legacy aggregate ``CONFIDENCE:`` line
+    at the end of the block stays in place for backwards compatibility.
     """
     n = max(1, min(5, n_alternatives))
     if n == 1:
@@ -116,13 +123,23 @@ def _build_system_prompt(
         desc_lines = ""
         table_desc_lines = ""
         alternatives_length_reminder = ""
+        self_decl_line_1 = "CONFIDENCE_1: <HIGH|MED|LOW>\n" if emit_self_decl else ""
     else:
         alt_instruction = f"Up to {n} alternative descriptions ranked by likelihood."
         extra_items = ""
-        desc_lines = "\n".join(
-            f"DESCRIPTION_{i}: <alternative description — apply the SAME length rule as DESCRIPTION_1>"
-            for i in range(2, n + 1)
-        )
+        if emit_self_decl:
+            desc_lines = "\n".join(
+                f"DESCRIPTION_{i}: <alternative description — apply the SAME length rule as DESCRIPTION_1>\n"
+                f"CONFIDENCE_{i}: <HIGH|MED|LOW>"
+                for i in range(2, n + 1)
+            )
+            self_decl_line_1 = "CONFIDENCE_1: <HIGH|MED|LOW>\n"
+        else:
+            desc_lines = "\n".join(
+                f"DESCRIPTION_{i}: <alternative description — apply the SAME length rule as DESCRIPTION_1>"
+                for i in range(2, n + 1)
+            )
+            self_decl_line_1 = ""
         table_desc_lines = "\n".join(
             f"TABLE_DESCRIPTION_{i}: <alternative table description — apply the SAME length rule as TABLE_DESCRIPTION_1>"
             for i in range(2, n + 1)
@@ -136,6 +153,7 @@ def _build_system_prompt(
             alternatives_length_reminder=alternatives_length_reminder,
             extra_items=extra_items,
             desc_lines=desc_lines,
+            self_decl_line_1=self_decl_line_1,
             table_desc_lines=table_desc_lines,
         ).strip()
         + "\n"
@@ -390,10 +408,17 @@ class ProfileAgent(BaseAgent):
     def _build_messages(self, ctx: AgentContext) -> list[dict[str, str]]:
         """Build the messages list for a single profile batch — shared by run() and collect_messages()."""
         user_msg = self._build_prompt(ctx)
+        conf_cfg = getattr(self.llm.cfg, "confidence", None)
+        emit_self_decl = bool(
+            conf_cfg
+            and getattr(conf_cfg, "enabled", True)
+            and getattr(conf_cfg, "use_self_decl", False)
+        )
         system = _build_system_prompt(
             self._n_alternatives,
             description_verbosity=getattr(self.llm.cfg, "description_verbosity", "brief"),
             style_profile=self._style_profile,
+            emit_self_decl=emit_self_decl,
         )
         return [
             {"role": "system", "content": system},

--- a/amx/config.py
+++ b/amx/config.py
@@ -1340,16 +1340,18 @@ def _db_to_mapping(db: DBConfig) -> dict[str, Any]:
 class ConfidenceConfig:
     """Per-alternative confidence scoring knobs.
 
-    Phase 1 enables Signal A (logprob span) and Signal C
-    (self-consistency). Phase 2 / 3 flags exist but default off so the
-    feature can be incrementally enabled without further migration.
+    Phases 1 + 2 enable Signal A (logprob span), Signal C
+    (self-consistency), and Signal B (LLM self-declaration). Signal D
+    (Phase 3 LLM-as-judge) stays off by default because its second-pass
+    LLM call roughly doubles per-run token spend; users opt in
+    explicitly via ``use_judge: true`` on the LLM profile.
     """
 
     enabled: bool = True
     use_logprob: bool = True
     use_self_consistency: bool = True
-    use_self_decl: bool = False  # Phase 2
-    use_judge: bool = False  # Phase 3
+    use_self_decl: bool = True
+    use_judge: bool = False  # Phase 3 — opt-in
     high: float = 0.75
     med: float = 0.50
 

--- a/amx/llm/confidence/scorer.py
+++ b/amx/llm/confidence/scorer.py
@@ -54,7 +54,14 @@ def score_alternatives(
 
         signals["self_consistency"] = self_consistency_score(alternatives)
 
-    # Phase 2/3 signals deliberately not wired here yet.
+    if cfg.use_self_decl:
+        from amx.llm.confidence.self_declaration import (
+            score_per_alternative as self_decl_score,
+        )
+
+        signals["self_decl"] = self_decl_score(response_text, n=len(alternatives))
+
+    # Phase 3 (judge) deliberately not wired here yet.
 
     return build_alternative_scores(
         alternatives=alternatives,

--- a/amx/llm/confidence/self_declaration.py
+++ b/amx/llm/confidence/self_declaration.py
@@ -1,0 +1,65 @@
+"""Signal B: LLM self-declared confidence per alternative.
+
+When ``cfg.confidence.use_self_decl`` is on, the system prompt emits
+a ``CONFIDENCE_i: HIGH|MED|LOW`` marker right after each
+``DESCRIPTION_i: …`` block. This module parses those markers out of
+the raw response text and maps the bands to a numeric score:
+
+* ``HIGH``   → 0.9
+* ``MED`` (or ``MEDIUM``) → 0.6
+* ``LOW``    → 0.3
+
+Missing or unrecognised values become ``None`` so the ensemble falls
+back to the remaining signals for that alternative. This signal is
+notoriously poorly-calibrated on its own (models are overconfident),
+but as part of the ensemble alongside logprob + self-consistency it
+adds useful disagreement signal for the thesis evaluation in Phase 4.
+"""
+
+from __future__ import annotations
+
+import re
+
+_BAND_TO_SCORE = {
+    "HIGH": 0.9,
+    "MED": 0.6,
+    "MEDIUM": 0.6,
+    "LOW": 0.3,
+}
+
+#: Matches ``CONFIDENCE_<n>: <BAND>`` where ``<n>`` is a 1-based integer
+#: and ``<BAND>`` is one of HIGH / MED / MEDIUM / LOW (case-insensitive).
+#: The trailing ``\b`` keeps us from accidentally matching adjacent
+#: words like ``HIGHLY``.
+_CONFIDENCE_LINE = re.compile(
+    r"^CONFIDENCE_(\d+)\s*:\s*([A-Za-z_]+)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def score_per_alternative(response_text: str | None, n: int) -> list[float | None]:
+    """Return one self-declared confidence score per alternative.
+
+    ``n`` is the number of alternatives the agent asked the model to
+    produce. The returned list always has length ``n``; missing /
+    unrecognised entries are ``None``.
+    """
+    out: list[float | None] = [None] * n
+    if not response_text or n <= 0:
+        return out
+    for match in _CONFIDENCE_LINE.finditer(response_text):
+        idx_raw, band_raw = match.group(1), match.group(2)
+        try:
+            idx = int(idx_raw)
+        except ValueError:
+            continue
+        if idx < 1 or idx > n:
+            continue
+        score = _BAND_TO_SCORE.get(band_raw.upper())
+        if score is None:
+            continue
+        out[idx - 1] = score
+    return out
+
+
+__all__ = ["score_per_alternative"]

--- a/tests/agents/test_profile_prompt_self_decl.py
+++ b/tests/agents/test_profile_prompt_self_decl.py
@@ -1,0 +1,33 @@
+"""Prompt template emits ``CONFIDENCE_i`` only when ``emit_self_decl`` is on."""
+
+from __future__ import annotations
+
+
+def test_default_prompt_has_no_per_alternative_confidence_lines():
+    from amx.agents.profile_agent import _build_system_prompt
+
+    prompt = _build_system_prompt(n_alternatives=3, emit_self_decl=False)
+    assert "CONFIDENCE_1" not in prompt
+    assert "CONFIDENCE_2" not in prompt
+    assert "CONFIDENCE_3" not in prompt
+    # Aggregate ``CONFIDENCE:`` line stays — legacy parser depends on it.
+    assert "CONFIDENCE: <HIGH|MEDIUM|LOW>" in prompt
+
+
+def test_self_decl_prompt_emits_per_alternative_confidence_lines():
+    from amx.agents.profile_agent import _build_system_prompt
+
+    prompt = _build_system_prompt(n_alternatives=3, emit_self_decl=True)
+    assert "CONFIDENCE_1: <HIGH|MED|LOW>" in prompt
+    assert "CONFIDENCE_2: <HIGH|MED|LOW>" in prompt
+    assert "CONFIDENCE_3: <HIGH|MED|LOW>" in prompt
+    # Aggregate line still present.
+    assert "CONFIDENCE: <HIGH|MEDIUM|LOW>" in prompt
+
+
+def test_self_decl_prompt_with_n1_only_emits_confidence_1():
+    from amx.agents.profile_agent import _build_system_prompt
+
+    prompt = _build_system_prompt(n_alternatives=1, emit_self_decl=True)
+    assert "CONFIDENCE_1: <HIGH|MED|LOW>" in prompt
+    assert "CONFIDENCE_2" not in prompt

--- a/tests/llm/confidence/test_self_declaration.py
+++ b/tests/llm/confidence/test_self_declaration.py
@@ -1,0 +1,61 @@
+"""Signal B — LLM self-declaration parser + scorer."""
+
+from __future__ import annotations
+
+
+def test_returns_all_none_when_response_text_missing():
+    from amx.llm.confidence.self_declaration import score_per_alternative
+
+    assert score_per_alternative(None, n=3) == [None, None, None]
+    assert score_per_alternative("", n=2) == [None, None]
+
+
+def test_parses_high_med_low_per_alternative():
+    """Each ``CONFIDENCE_i: HIGH|MED|LOW`` maps to its numeric band."""
+    from amx.llm.confidence.self_declaration import score_per_alternative
+
+    response = (
+        "COLUMN: email\n"
+        "DESCRIPTION_1: Stores the customer email.\n"
+        "CONFIDENCE_1: HIGH\n"
+        "DESCRIPTION_2: Holds a contact value.\n"
+        "CONFIDENCE_2: MED\n"
+        "DESCRIPTION_3: Unknown.\n"
+        "CONFIDENCE_3: LOW\n"
+        "CONFIDENCE: HIGH\n"
+    )
+    scores = score_per_alternative(response, n=3)
+    assert scores == [0.9, 0.6, 0.3]
+
+
+def test_medium_alias_for_med():
+    """Some prompts emit the long form ``MEDIUM`` — accept both spellings."""
+    from amx.llm.confidence.self_declaration import score_per_alternative
+
+    response = "CONFIDENCE_1: MEDIUM\n"
+    scores = score_per_alternative(response, n=1)
+    assert scores == [0.6]
+
+
+def test_missing_band_yields_none_for_that_index():
+    from amx.llm.confidence.self_declaration import score_per_alternative
+
+    response = "CONFIDENCE_1: HIGH\nCONFIDENCE_3: LOW\n"
+    scores = score_per_alternative(response, n=3)
+    assert scores == [0.9, None, 0.3]
+
+
+def test_unrecognised_value_is_none():
+    from amx.llm.confidence.self_declaration import score_per_alternative
+
+    response = "CONFIDENCE_1: SUPER_HIGH\n"
+    scores = score_per_alternative(response, n=1)
+    assert scores == [None]
+
+
+def test_case_insensitive_band_values():
+    from amx.llm.confidence.self_declaration import score_per_alternative
+
+    response = "CONFIDENCE_1: high\nCONFIDENCE_2: low\n"
+    scores = score_per_alternative(response, n=2)
+    assert scores == [0.9, 0.3]

--- a/tests/test_confidence_config.py
+++ b/tests/test_confidence_config.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 
-def test_default_confidence_config_enabled_with_both_phase1_signals():
+def test_default_confidence_config_enables_phase1_and_phase2_signals():
     from amx.config import LLMConfig
 
     cfg = LLMConfig(provider="openai", model="gpt-4o-mini")
     assert cfg.confidence.enabled is True
+    # Default-on: A (logprob), C (self-consistency), B (self-declaration).
+    # D (judge) stays opt-in because its second-pass LLM call roughly
+    # doubles per-run token spend.
     assert cfg.confidence.use_logprob is True
     assert cfg.confidence.use_self_consistency is True
-    assert cfg.confidence.use_self_decl is False
+    assert cfg.confidence.use_self_decl is True
     assert cfg.confidence.use_judge is False
     assert cfg.confidence.high == 0.75
     assert cfg.confidence.med == 0.50


### PR DESCRIPTION
## Summary

Phase 2 of the per-alternative confidence plan. Signal B adds **LLM self-declaration**: the model is asked to label each alternative description with its own ``CONFIDENCE_i: HIGH|MED|LOW`` line; AMX parses those bands and folds them into the ensemble alongside Signal A (logprob span) and Signal C (self-consistency).

- New module ``amx/llm/confidence/self_declaration.py`` with a parser that pulls ``CONFIDENCE_<n>: HIGH|MED|MEDIUM|LOW`` out of the raw response text (case-insensitive) and maps the bands to numeric scores (HIGH=0.9, MED/MEDIUM=0.6, LOW=0.3). Missing / unrecognised entries become ``None`` so the ensemble degrades gracefully.
- Prompt template (``amx/agents/profile_agent.py::_build_system_prompt``) gains an ``emit_self_decl`` flag; when on (the new default) it emits ``CONFIDENCE_1`` right after ``DESCRIPTION_1`` and interleaves ``CONFIDENCE_2 / 3 / …`` after each subsequent alternative. The aggregate ``CONFIDENCE:`` line at the end of the block stays in place so the legacy parser keeps working byte-for-byte.
- Existing ``_parse_response`` is intentionally untouched. ``CONFIDENCE_1`` etc. start with ``CONFIDENCE_`` not ``CONFIDENCE:``, so the legacy parser silently ignores them. Only ``self_declaration.score_per_alternative`` consumes the new lines, reading the raw response text directly.
- ``ConfidenceConfig.use_self_decl`` flips to ``True`` by default. Prompt-token overhead is negligible (one extra short line per alternative); the signal earns its keep as part of the ensemble. ``use_judge`` (Phase 3) stays opt-in because its second-pass LLM call roughly doubles per-run token spend.

## Test plan
- [x] 6 self_declaration parser tests (HIGH/MED/LOW + MEDIUM alias + case insensitivity, missing index, unknown value, index out of range).
- [x] 3 prompt-template tests confirming default prompt has no CONFIDENCE_i lines, self-decl prompt has all of them, and N=1 only emits CONFIDENCE_1.
- [x] Full ``pytest -q`` sweep: 1998 passed, 2 skipped (sentence-transformers env mismatch, expected), no regressions.
- [x] ``ruff check`` / ``ruff format --check`` / ``mypy`` on touched modules — clean.