### PR TITLE
feat(confidence): Signal D LLM-as-judge + /history eval-confidence harness (Phases 3 & 4)

### DIFF
--- a/amx/agents/base.py
+++ b/amx/agents/base.py
@@ -77,12 +77,16 @@ def apply_confidence_signals(
     logprobs_content: list | None,
     response_text: str | None,
     cfg,
+    llm: object | None = None,
 ) -> list[MetadataSuggestion]:
     """Populate ``suggestion_scores`` with per-alternative confidence rows.
 
     Best-effort: any failure (missing optional dep, signal raised, etc.)
     is swallowed — the suggestions list is returned unchanged on error
     so an analysis run is never aborted by a scoring regression.
+
+    ``llm`` is required only when Signal D (LLM-as-judge) is on; for
+    Phase 1 / 2 callers can omit it and the judge silently skips.
 
     Note: the legacy aggregate fields (``confidence`` and
     ``logprob_score``) keep being maintained by
@@ -103,6 +107,7 @@ def apply_confidence_signals(
                 logprobs_content=logprobs_content,
                 response_text=response_text,
                 cfg=cfg,
+                llm=llm,
             )
         except Exception:
             s.suggestion_scores = None

--- a/amx/agents/profile_agent.py
+++ b/amx/agents/profile_agent.py
@@ -509,6 +509,7 @@ class ProfileAgent(BaseAgent):
                 logprobs_content=_logprobs,
                 response_text=response,
                 cfg=self.llm.cfg.confidence,
+                llm=self.llm,
             )
         except Exception as exc:
             log.warning("Confidence signal scoring failed: %s", exc)

--- a/amx/cli.py
+++ b/amx/cli.py
@@ -24,6 +24,7 @@ from amx.cli_support.commands.db import (
 )
 from amx.cli_support.commands.docs import register_docs_commands
 from amx.cli_support.commands.doctor import register_doctor_command
+from amx.cli_support.commands.eval_confidence import register_eval_confidence_command
 from amx.cli_support.commands.history import register_history_commands
 from amx.cli_support.commands.history_store import register_history_store_commands
 from amx.cli_support.commands.manual import register_manual_commands
@@ -406,6 +407,7 @@ def main(ctx: click.Context, cfg_path: str | None, debug: bool) -> None:
 
 history_group = register_history_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_compare_command(history_group, pass_config=pass_config, log_event=_log_app_event)
+register_eval_confidence_command(history_group, pass_config=pass_config, log_event=_log_app_event)
 register_search_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_doctor_command(main, pass_config=pass_config, log_event=_log_app_event)
 register_chat_session_commands(main, pass_config=pass_config, log_event=_log_app_event)

--- a/amx/cli_support/commands/eval_confidence.py
+++ b/amx/cli_support/commands/eval_confidence.py
@@ -1,0 +1,105 @@
+"""``/history eval-confidence`` — measure each confidence signal against the user's accepted choice."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import click
+
+from amx.config import AMXConfig
+from amx.eval.confidence import compute_metrics, render_markdown
+from amx.storage.sqlite_store import history_store, parse_alternatives_json
+from amx.utils.console import error, info, success
+
+LogEvent = Callable[..., None]
+
+
+def _load_rows(hs: Any) -> list[dict[str, Any]]:
+    """Pull every ``run_results`` row with a non-empty ``accepted`` value.
+
+    The history store exposes ``get_all_run_results`` on the SQLite
+    backend; we fall back to scanning per-run when only ``list_runs``
+    is available so the harness still works on older shared-store
+    backends.
+    """
+    if hasattr(hs, "get_all_run_results"):
+        candidate_rows = hs.get_all_run_results()
+    else:
+        candidate_rows = []
+        for run in hs.list_runs(limit=None):
+            candidate_rows.extend(hs.get_run_results(int(run["id"])))
+
+    out: list[dict[str, Any]] = []
+    for row in candidate_rows:
+        accepted = row.get("accepted") or row.get("chosen_description")
+        if not accepted:
+            continue
+        parsed = parse_alternatives_json(row.get("alternatives_json"))
+        if not parsed:
+            continue
+        out.append({"alternatives": parsed, "accepted": accepted})
+    return out
+
+
+def register_eval_confidence_command(
+    history_group: click.Group,
+    *,
+    pass_config: Callable[[Callable[..., Any]], Callable[..., Any]],
+    log_event: LogEvent,
+) -> None:
+    """Attach ``/history eval-confidence`` to the ``/history`` namespace."""
+
+    @history_group.command("eval-confidence")
+    @click.option(
+        "--output",
+        "output_path",
+        type=click.Path(dir_okay=False, writable=True, resolve_path=True),
+        default=None,
+        help="Where to write the Markdown report. Defaults to "
+        "``~/.amx/reports/confidence-eval-<timestamp>.md``.",
+    )
+    @pass_config
+    def eval_confidence(cfg: AMXConfig, output_path: str | None) -> None:
+        """Compute per-signal top-1 / top-2 accuracy on reviewed runs and write a Markdown report."""
+        hs = history_store()
+        if hs is None:
+            error("History store is not initialized.")
+            return
+
+        rows = _load_rows(hs)
+        metrics = compute_metrics(rows)
+
+        if output_path is None:
+            reports_dir = Path(os.path.expanduser("~/.amx/reports"))
+            reports_dir.mkdir(parents=True, exist_ok=True)
+            ts = time.strftime("%Y%m%dT%H%M%S")
+            output_path = str(reports_dir / f"confidence-eval-{ts}.md")
+
+        report_md = render_markdown(metrics)
+        Path(output_path).write_text(report_md, encoding="utf-8")
+
+        info(f"Sample count: {metrics['sample_count']}")
+        for name, m in (metrics.get("signals") or {}).items():
+            info(
+                f"  {name}: top-1 {m['top1_accuracy']:.2%} · top-2 {m['top2_accuracy']:.2%} "
+                f"(n={m['scored_rows']})"
+            )
+        success(f"Wrote report to {output_path}")
+
+        log_event(
+            event_type="eval_confidence",
+            status="success",
+            command="history.eval-confidence",
+            details={
+                "sample_count": metrics["sample_count"],
+                "signals": list((metrics.get("signals") or {}).keys()),
+                "output_path": output_path,
+            },
+        )
+
+
+__all__ = ["register_eval_confidence_command"]

--- a/amx/eval/confidence.py
+++ b/amx/eval/confidence.py
@@ -1,0 +1,174 @@
+"""Confidence-signal evaluation harness.
+
+Reads ``run_results`` rows where the user has chosen one of the
+alternatives (``accepted IS NOT NULL``) and treats that choice as
+ground truth. For each available confidence signal — logprob,
+self-consistency, self-declaration, judge, and the combined ensemble
+— computes:
+
+* **Top-1 accuracy**: the signal's highest-scored alternative matches
+  the user-accepted text.
+* **Top-2 accuracy**: the user-accepted text is among the signal's
+  two highest-scored alternatives.
+
+These are the same metrics the thesis evaluation chapter quotes, so
+the harness doubles as a research artefact. Rows where a particular
+signal has no scores (e.g. Anthropic + logprob) are excluded from
+that signal's denominator only; other signals continue to count.
+
+The Markdown renderer turns the metric dict into a report suitable
+for pasting into the chapter or sharing with reviewers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+_SIGNAL_KEYS = ("logprob", "self_consistency", "self_decl", "judge")
+
+
+def _row_score_for_signal(alternatives: list[dict[str, Any]], signal: str) -> list[float | None]:
+    """Pull one signal's scores out of a parsed alternatives list.
+
+    ``ensemble`` lives on the row itself (one field per alternative);
+    every other key lives under ``alternative["scores"]``.
+    """
+    out: list[float | None] = []
+    for alt in alternatives:
+        if signal == "ensemble":
+            v = alt.get("ensemble")
+        else:
+            scores = alt.get("scores") or {}
+            v = scores.get(signal)
+        out.append(float(v) if isinstance(v, (int, float)) else None)
+    return out
+
+
+def _rank_indices(scores: list[float | None]) -> list[int]:
+    """Return indices of ``scores`` sorted highest-first, ties broken
+    by original position."""
+    return sorted(
+        (i for i, s in enumerate(scores) if s is not None),
+        key=lambda i: (-(scores[i] or 0.0), i),
+    )
+
+
+def _accepted_index(alternatives: list[dict[str, Any]], accepted: str) -> int | None:
+    for idx, alt in enumerate(alternatives):
+        if (alt.get("text") or "").strip() == accepted.strip():
+            return idx
+    return None
+
+
+def compute_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute per-signal top-1 / top-2 accuracy across ``rows``.
+
+    Each row must carry an ``alternatives`` list (parsed JSON) and an
+    ``accepted`` string. Rows without a non-empty ``accepted``, or
+    whose ``accepted`` text does not match any alternative, are
+    excluded from the harness entirely (``sample_count`` denominator).
+
+    Returns a dict with:
+
+        {
+          "generated_at": <ISO 8601 UTC timestamp>,
+          "sample_count": <usable rows>,
+          "signals": {
+              "<signal>": {
+                  "scored_rows": <rows where signal had at least one non-None score>,
+                  "top1_accuracy": <float in [0, 1] or None>,
+                  "top2_accuracy": <float in [0, 1] or None>,
+              },
+              …
+          }
+        }
+    """
+    usable: list[tuple[list[dict[str, Any]], int]] = []
+    for row in rows:
+        accepted = (row.get("accepted") or "").strip()
+        if not accepted:
+            continue
+        alts = row.get("alternatives") or []
+        if not isinstance(alts, list) or not alts:
+            continue
+        idx = _accepted_index(alts, accepted)
+        if idx is None:
+            continue
+        usable.append((alts, idx))
+
+    sample_count = len(usable)
+    signals: dict[str, Any] = {}
+    for signal in (*_SIGNAL_KEYS, "ensemble"):
+        scored = 0
+        top1 = 0
+        top2 = 0
+        for alts, accepted_idx in usable:
+            ranks = _rank_indices(_row_score_for_signal(alts, signal))
+            if not ranks:
+                continue
+            scored += 1
+            if ranks[0] == accepted_idx:
+                top1 += 1
+            if accepted_idx in ranks[:2]:
+                top2 += 1
+        if scored == 0:
+            continue
+        signals[signal] = {
+            "scored_rows": scored,
+            "top1_accuracy": top1 / scored,
+            "top2_accuracy": top2 / scored,
+        }
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "sample_count": sample_count,
+        "signals": signals,
+    }
+
+
+def render_markdown(metrics: dict[str, Any]) -> str:
+    """Turn ``compute_metrics`` output into a Markdown report."""
+    lines = [
+        "# Confidence Evaluation Report",
+        "",
+        f"- Generated at: `{metrics.get('generated_at', 'n/a')}`",
+        f"- Sample count (rows with `accepted` matching an alternative): "
+        f"**{metrics.get('sample_count', 0)}**",
+        "",
+    ]
+    signals = metrics.get("signals") or {}
+    if not signals:
+        lines.append("No usable rows for evaluation. Apply some reviewed runs first.")
+        return "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            "## Summary",
+            "",
+            "| Signal | Scored rows | Top-1 accuracy | Top-2 accuracy |",
+            "|---|---:|---:|---:|",
+        ]
+    )
+    for name, m in signals.items():
+        lines.append(
+            f"| `{name}` | {m['scored_rows']} | "
+            f"{m['top1_accuracy']:.2%} | {m['top2_accuracy']:.2%} |"
+        )
+    lines.append("")
+
+    for name, m in signals.items():
+        lines.extend(
+            [
+                f"## {name}",
+                "",
+                f"- Scored rows: {m['scored_rows']}",
+                f"- Top-1 accuracy: {m['top1_accuracy']:.4f}",
+                f"- Top-2 accuracy: {m['top2_accuracy']:.4f}",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+__all__ = ["compute_metrics", "render_markdown"]

--- a/amx/llm/confidence/judge.py
+++ b/amx/llm/confidence/judge.py
@@ -1,0 +1,129 @@
+"""Signal D: LLM-as-judge second-pass ranking.
+
+When ``cfg.confidence.use_judge`` is on, the orchestrator issues a
+second LLM call after the alternatives are produced, asking the model
+to rank them best-to-worst. The rank position is normalised to a
+``[0, 1]`` score (rank 1 → ``1.0``, rank N → ``0.0``) and folded into
+the ensemble alongside the other signals.
+
+To mitigate position bias the alternatives are shuffled before being
+shown to the judge; the shuffle is seeded for reproducible tests but
+defaults to a fresh seed at runtime so consecutive runs of the same
+input still get a fair re-shuffle.
+
+Cost: roughly doubles the per-suggestion token spend, which is why
+``use_judge`` defaults to ``False`` and is intended as an opt-in for
+power users / research evaluations rather than the default path.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from typing import Any
+
+from amx.utils.logging import get_logger
+
+log = get_logger("confidence.judge")
+
+#: Match ``RANKING:`` followed by a comma-separated list of 1-based ints.
+#: Tolerates whitespace, trailing commas, and surrounding bullets / numbering.
+_RANKING_LINE = re.compile(
+    r"^RANKING\s*:\s*([0-9,\s]+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _build_prompt(shuffled: list[str]) -> str:
+    """Format the judge prompt with one alternative per numbered line."""
+    lines = [
+        "You are evaluating candidate descriptions for one database column.",
+        "Rank the alternatives below from MOST to LEAST accurate / informative.",
+        "Respond with a single ``RANKING:`` line listing the indices (1-based)",
+        "in best-to-worst order, separated by commas. Example for 3 inputs:",
+        "    RANKING: 2, 1, 3",
+        "Add a short ``REASONING:`` line if useful, but the RANKING is required.",
+        "",
+        "Alternatives:",
+    ]
+    for idx, text in enumerate(shuffled, start=1):
+        lines.append(f"{idx}. {text}")
+    return "\n".join(lines)
+
+
+def _parse_ranking(response_text: str, n: int) -> list[int]:
+    """Return the 1-based ranking parsed out of the response, or ``[]``."""
+    match = _RANKING_LINE.search(response_text or "")
+    if not match:
+        return []
+    raw = match.group(1)
+    out: list[int] = []
+    for piece in raw.split(","):
+        piece = piece.strip()
+        if not piece:
+            continue
+        try:
+            idx = int(piece)
+        except ValueError:
+            continue
+        if 1 <= idx <= n and idx not in out:
+            out.append(idx)
+    return out
+
+
+def score_per_alternative(
+    alternatives: list[str],
+    llm: Any,
+    *,
+    seed: int | None = None,
+    shuffle: bool = True,
+) -> list[float | None]:
+    """Return one judge-derived score per alternative, aligned by index.
+
+    ``llm`` is an object with a ``.chat(messages, ...)`` method matching
+    :class:`amx.llm.provider.LLMProvider`'s contract; the judge call
+    uses a single user message containing the ranking prompt.
+
+    ``shuffle`` is on by default to mitigate position bias from the
+    judge; pass ``False`` in tests where the assertion needs the
+    identity mapping between ``RANKING:`` indices and ``alternatives``.
+
+    A failure inside the LLM call yields ``[None, …]`` of length N so
+    the run is never aborted by a judge regression; the ensemble
+    downstream degrades gracefully to the remaining signals.
+    """
+    n = len(alternatives)
+    if n == 0:
+        return []
+    if n == 1:
+        return [1.0]
+
+    shuffled_indices = list(range(n))
+    if shuffle:
+        rng = random.Random(seed)
+        rng.shuffle(shuffled_indices)
+    shuffled = [alternatives[i] for i in shuffled_indices]
+    prompt = _build_prompt(shuffled)
+
+    try:
+        result = llm.chat([{"role": "user", "content": prompt}])
+        response_text = getattr(result, "content", "") or ""
+    except Exception as exc:  # pragma: no cover — environmental
+        log.warning("Judge LLM call failed: %s", exc)
+        return [None] * n
+
+    ranking_in_shuffled = _parse_ranking(response_text, n)
+    if not ranking_in_shuffled:
+        return [None] * n
+
+    # ``ranking_in_shuffled`` ranks the *shuffled* positions; map each
+    # back to the original alternative index.
+    out: list[float | None] = [None] * n
+    denom = max(1, n - 1)
+    for rank, shuffled_idx in enumerate(ranking_in_shuffled):
+        original_idx = shuffled_indices[shuffled_idx - 1]
+        out[original_idx] = (n - 1 - rank) / denom
+    return out
+
+
+__all__ = ["score_per_alternative"]

--- a/amx/llm/confidence/scorer.py
+++ b/amx/llm/confidence/scorer.py
@@ -19,15 +19,21 @@ def score_alternatives(
     logprobs_content: list | None,
     response_text: str | None,
     cfg: ConfidenceConfig,
+    llm: object | None = None,
 ) -> list[AlternativeScore]:
-    """Compute Phase 1 confidence signals for one suggestion block.
+    """Compute per-alternative confidence signals for one suggestion block.
 
-    Both signals are best-effort: a failure inside one signal yields
-    a column of ``None`` values for that signal, never an exception
+    Every signal is best-effort: a failure inside one signal yields a
+    column of ``None`` values for that signal, never an exception
     propagated to the caller. The orchestrator is wrapped in
-    ``apply_confidence_signals`` (Task 7) which itself swallows
-    unexpected exceptions so a regression in this module cannot
-    abort an analysis run.
+    ``apply_confidence_signals`` which itself swallows unexpected
+    exceptions so a regression in this module cannot abort an
+    analysis run.
+
+    ``llm`` is required only when ``cfg.use_judge`` is on (Signal D
+    issues a second LLM call). When ``llm`` is ``None`` and the judge
+    is enabled, the judge signal is skipped silently and the ensemble
+    falls back to the other active signals.
     """
     if not cfg.enabled or not alternatives:
         return build_alternative_scores(
@@ -61,7 +67,10 @@ def score_alternatives(
 
         signals["self_decl"] = self_decl_score(response_text, n=len(alternatives))
 
-    # Phase 3 (judge) deliberately not wired here yet.
+    if cfg.use_judge and llm is not None:
+        from amx.llm.confidence.judge import score_per_alternative as judge_score
+
+        signals["judge"] = judge_score(alternatives, llm=llm)
 
     return build_alternative_scores(
         alternatives=alternatives,

--- a/tests/eval/test_confidence_eval.py
+++ b/tests/eval/test_confidence_eval.py
@@ -1,0 +1,140 @@
+"""Confidence eval harness — accuracy of each signal vs. ``accepted``."""
+
+from __future__ import annotations
+
+
+def _row(alts, accepted, **extra):
+    """Build one already-parsed run_results row for the eval engine."""
+    return {"alternatives": alts, "accepted": accepted, **extra}
+
+
+def _alt(text, *, logprob=None, self_consistency=None, self_decl=None, judge=None, ensemble=None):
+    return {
+        "text": text,
+        "scores": {
+            "logprob": logprob,
+            "self_consistency": self_consistency,
+            "self_decl": self_decl,
+            "judge": judge,
+        },
+        "ensemble": ensemble,
+        "band": None,
+    }
+
+
+def test_zero_rows_returns_empty_metrics():
+    from amx.eval.confidence import compute_metrics
+
+    metrics = compute_metrics([])
+    assert metrics["sample_count"] == 0
+    assert metrics["signals"] == {}
+
+
+def test_skips_rows_without_accepted():
+    from amx.eval.confidence import compute_metrics
+
+    rows = [
+        _row([_alt("a", logprob=0.9), _alt("b", logprob=0.1)], accepted=None),
+        _row([_alt("a", logprob=0.9), _alt("b", logprob=0.1)], accepted=""),
+    ]
+    metrics = compute_metrics(rows)
+    assert metrics["sample_count"] == 0
+
+
+def test_skips_rows_where_accepted_does_not_match_any_alternative():
+    """If the user edited the description before applying, the text won't
+    line up — those rows are excluded from the accuracy denominator."""
+    from amx.eval.confidence import compute_metrics
+
+    rows = [
+        _row(
+            [_alt("a", logprob=0.9), _alt("b", logprob=0.1)],
+            accepted="user-edited text",
+        ),
+    ]
+    metrics = compute_metrics(rows)
+    assert metrics["sample_count"] == 0
+
+
+def test_top1_top2_for_single_signal():
+    """Two rows, both with logprob favouring alt-0; user accepted alt-0
+    in row 1 and alt-1 in row 2. Top-1 accuracy = 50 %; top-2 = 100 %."""
+    from amx.eval.confidence import compute_metrics
+
+    rows = [
+        _row(
+            [_alt("a", logprob=0.9), _alt("b", logprob=0.1)],
+            accepted="a",
+        ),
+        _row(
+            [_alt("a", logprob=0.9), _alt("b", logprob=0.1)],
+            accepted="b",
+        ),
+    ]
+    metrics = compute_metrics(rows)
+    assert metrics["sample_count"] == 2
+    logprob_metrics = metrics["signals"]["logprob"]
+    assert logprob_metrics["top1_accuracy"] == 0.5
+    assert logprob_metrics["top2_accuracy"] == 1.0
+    assert logprob_metrics["scored_rows"] == 2
+
+
+def test_signal_skips_rows_where_scores_are_all_none():
+    """When a signal isn't available on a row (e.g. Anthropic + logprob),
+    that row doesn't count against the signal's denominator."""
+    from amx.eval.confidence import compute_metrics
+
+    rows = [
+        _row(
+            [_alt("a", logprob=0.9), _alt("b", logprob=0.1)],
+            accepted="a",
+        ),
+        # Second row has logprob signal missing entirely.
+        _row(
+            [_alt("a"), _alt("b")],
+            accepted="a",
+        ),
+    ]
+    metrics = compute_metrics(rows)
+    logprob_metrics = metrics["signals"]["logprob"]
+    assert logprob_metrics["scored_rows"] == 1
+    assert logprob_metrics["top1_accuracy"] == 1.0
+
+
+def test_ensemble_signal_is_first_class_metric():
+    """The aggregated ``ensemble`` score gets its own row in the report."""
+    from amx.eval.confidence import compute_metrics
+
+    rows = [
+        _row(
+            [_alt("a", ensemble=0.8), _alt("b", ensemble=0.2)],
+            accepted="a",
+        ),
+        _row(
+            [_alt("a", ensemble=0.3), _alt("b", ensemble=0.7)],
+            accepted="b",
+        ),
+    ]
+    metrics = compute_metrics(rows)
+    ens = metrics["signals"]["ensemble"]
+    assert ens["scored_rows"] == 2
+    assert ens["top1_accuracy"] == 1.0
+
+
+def test_render_markdown_emits_signal_section_per_signal():
+    """The renderer produces a Markdown report with one section per
+    signal that has at least one scored row."""
+    from amx.eval.confidence import compute_metrics, render_markdown
+
+    rows = [
+        _row(
+            [_alt("a", logprob=0.9, self_consistency=0.7, ensemble=0.8)],
+            accepted="a",
+        ),
+    ]
+    md = render_markdown(compute_metrics(rows))
+    assert "# Confidence Evaluation Report" in md
+    assert "## logprob" in md
+    assert "## self_consistency" in md
+    assert "## ensemble" in md
+    assert "self_decl" not in md  # no scored rows → omitted

--- a/tests/llm/confidence/test_judge.py
+++ b/tests/llm/confidence/test_judge.py
@@ -1,0 +1,96 @@
+"""Signal D — LLM-as-judge second-pass ranking."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _fake_llm(response_text: str):
+    """Return a SimpleNamespace mimicking just the ``.chat`` API surface used by judge."""
+    chat = MagicMock(
+        return_value=SimpleNamespace(
+            content=response_text,
+            usage={"input_tokens": 20, "output_tokens": 5},
+            logprobs=None,
+            finish_reason="stop",
+            confidence_score=None,
+            tool_calls=None,
+            thinking_content="",
+            thinking_tokens=0,
+        )
+    )
+    return SimpleNamespace(chat=chat)
+
+
+def test_empty_alternatives_returns_empty():
+    from amx.llm.confidence.judge import score_per_alternative
+
+    assert score_per_alternative([], llm=_fake_llm("")) == []
+
+
+def test_n_equals_1_returns_degenerate_one():
+    """With a single alternative there is nothing to rank against; the
+    judge skips the LLM call entirely and returns ``1.0``."""
+    from amx.llm.confidence.judge import score_per_alternative
+
+    llm = _fake_llm("RANKING: 1")
+    out = score_per_alternative(["only one"], llm=llm)
+    assert out == [1.0]
+    llm.chat.assert_not_called()
+
+
+def test_rank_parsed_into_normalised_scores():
+    """Three alternatives ranked ``2 > 1 > 3`` map to scores
+    ``[0.5, 1.0, 0.0]`` after (n - rank) / (n - 1) normalisation."""
+    from amx.llm.confidence.judge import score_per_alternative
+
+    # Judge picks ALT-2 best, then ALT-1, then ALT-3.
+    response = "RANKING: 2, 1, 3\nREASONING: alt 2 is most specific."
+    llm = _fake_llm(response)
+    out = score_per_alternative(
+        ["Alpha description.", "Beta description.", "Gamma description."],
+        llm=llm,
+        shuffle=False,  # test asserts identity mapping
+    )
+    assert out == [0.5, 1.0, 0.0]
+    assert llm.chat.call_count == 1
+
+
+def test_partial_ranking_fills_missing_with_none():
+    """Judge returns fewer indices than N → missing alternatives score
+    ``None``; the ensemble downstream falls back to the remaining signals
+    for those rows."""
+    from amx.llm.confidence.judge import score_per_alternative
+
+    response = "RANKING: 2"
+    llm = _fake_llm(response)
+    out = score_per_alternative(
+        ["Alpha.", "Beta.", "Gamma."],
+        llm=llm,
+        shuffle=False,
+    )
+    # ALT-2 ranked best (score 1.0); the other two unranked.
+    assert out[1] == 1.0
+    assert out[0] is None
+    assert out[2] is None
+
+
+def test_unparseable_response_returns_all_none():
+    """When the LLM emits something the judge cannot parse, every
+    alternative gets ``None``."""
+    from amx.llm.confidence.judge import score_per_alternative
+
+    llm = _fake_llm("I refuse to rank these. None of them make sense.")
+    out = score_per_alternative(["a", "b"], llm=llm, seed=0)
+    assert out == [None, None]
+
+
+def test_llm_failure_returns_all_none():
+    """``LLMProvider.chat`` raising propagates as a silent ``None`` row
+    so an analysis run is never aborted by a judge regression."""
+    from amx.llm.confidence.judge import score_per_alternative
+
+    llm = SimpleNamespace(chat=MagicMock(side_effect=RuntimeError("boom")))
+    out = score_per_alternative(["a", "b"], llm=llm, seed=0)
+    assert out == [None, None]


### PR DESCRIPTION
## Summary

Phases 3 and 4 of the per-alternative confidence plan, shipped as a single PR for momentum.

### Phase 3 — Signal D (LLM-as-judge)
- ``amx/llm/confidence/judge.py``: a ``score_per_alternative(alternatives, llm)`` that issues a second LLM call asking the model to rank the N alternatives best-to-worst. Rank position normalises to a [0, 1] score (rank 1 → 1.0, rank N → 0.0).
- Position bias mitigation: the alternatives are shuffled before being shown to the judge. Shuffle is opt-out (``shuffle=False``) for test fixtures that want the identity mapping.
- Threaded through the orchestrator: ``score_alternatives`` and ``apply_confidence_signals`` both gain an optional ``llm`` parameter so the Profile Agent can pass its own LLM provider in for the second-pass call.
- Defaults to ``use_judge=False`` because its second-pass LLM call roughly doubles per-suggestion token spend. Users opt in via ``llm_profiles.<name>.confidence.use_judge: true``.

### Phase 4 — Eval harness (``/history eval-confidence``)
- ``amx/eval/confidence.py``: a pure-Python ``compute_metrics`` function that reads parsed ``run_results`` rows, treats ``accepted`` as ground truth, and reports per-signal top-1 / top-2 accuracy (one row per signal, including the ensemble).
- Markdown renderer turns that metric dict into a self-contained report — sample count, summary table, and one section per signal — that drops straight into the thesis evaluation chapter.
- ``/history eval-confidence`` slash command writes the report to ``~/.amx/reports/confidence-eval-<timestamp>.md`` by default, or to ``--output <path>`` if provided. The console summary echoes the per-signal numbers so reviewers see them without opening the file.
- Rows where a particular signal has no scores (e.g. Anthropic + logprob) are excluded from that signal's denominator only — other signals still count for the same row.

### Test plan
- [x] 6 judge tests cover empty input, N=1 degenerate, identity-mapped ranking (shuffle disabled), partial ranking, unparseable response, and LLM-raises swallowed safely.
- [x] 7 eval-harness tests cover empty input, rows without ``accepted``, mismatching ``accepted``, top-1 / top-2 math, signal-missing exclusion, the ensemble metric, and the Markdown renderer.
- [x] Full ``pytest -q``: 2011 passed, 2 skipped (sentence-transformers env mismatch, expected), no regressions.
- [x] ``ruff check`` / ``ruff format --check`` / ``mypy`` on touched modules — clean.

This is the final Phase of the per-alternative confidence plan (see ``/Users/omeryasirkucuk/.claude/plans/ethereal-sauteeing-stonebraker.md`` for the original spec).