### PR TITLE
feat(storage): dogfood metadata standard on local SQLite history

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,42 @@ We use [Conventional Commits](https://www.conventionalcommits.org/) so that rele
 
 A `BREAKING CHANGE:` footer (or `feat!:` / `fix!:`) triggers a major bump.
 
+## Database schema conventions
+
+AMX is a metadata-generation tool. Its own internal databases (the
+local SQLite history store at `~/.amx/history.db` and the shared
+warehouse-hosted history schema bootstrapped by `/history-store enable`)
+must meet the same "every table and column has a meaningful description"
+bar that AMX enforces on user data.
+
+A single source of truth lives at `amx/storage/schema_descriptions.py`.
+Both stores read their descriptions from there:
+
+- `amx/storage/sqlite_store.py` writes one row per (table, column) into
+  the `_amx_schema_descriptions` sidecar table at every `init()` so the
+  local store ships descriptions even though SQLite has no native
+  `COMMENT ON`.
+- `amx/storage/shared_schema.py` passes the same strings to
+  `Column(comment=...)` so warehouse backends emit `COMMENT ON COLUMN`
+  natively.
+
+**When you add a new table or column to either store, the matching
+entry in `amx/storage/schema_descriptions.py` is mandatory in the same
+commit.** Empty strings, `TODO`, or placeholder text do not count. CI
+enforces this through two test files:
+
+- `tests/test_local_schema_comments.py` — every PRAGMA-reported column
+  in the local SQLite store has a non-empty description and the sidecar
+  table is populated correctly.
+- `tests/test_shared_schema_comments.py` — every `Column(comment=)` in
+  the shared SQLAlchemy schema is non-empty and the DDL emits
+  `COMMENT ON` statements on every supported backend.
+
+If either test starts failing, write the description — do not skip the
+test or weaken the assertion. A missing description is a release
+blocker because the first thing reviewers do when evaluating AMX is
+inspect the metadata of AMX's own DB.
+
 ## Tests
 
 ```bash

--- a/amx/storage/schema_descriptions.py
+++ b/amx/storage/schema_descriptions.py
@@ -1,0 +1,1122 @@
+"""Single source of truth for AMX-internal table/column descriptions.
+
+AMX is a metadata-generation tool whose product thesis is "every database
+table and column should ship with a meaningful description." Its own
+internal storage must meet that bar. This module holds the canonical
+description strings for every table AMX creates in:
+
+* the **local** SQLite history store at ``~/.amx/history.db`` (created
+  on first run by :class:`amx.storage.sqlite_store.SQLiteHistoryStore`).
+  Descriptions land in the sidecar table ``_amx_schema_descriptions``
+  populated idempotently at every startup, since SQLite has no native
+  ``COMMENT ON`` syntax.
+* the **shared** warehouse-hosted history store bootstrapped by
+  ``/history-store enable`` (declared in
+  :mod:`amx.storage.shared_schema` as SQLAlchemy ``Column(comment=…)``
+  annotations, which emit ``COMMENT ON COLUMN`` / ``COMMENT ON TABLE``
+  on every backend that supports them).
+
+Both stores import their description strings from here so they cannot
+drift. ``tests/test_local_schema_comments.py`` and
+``tests/test_shared_schema_comments.py`` enforce that every declared
+column has an entry, no entry is orphaned, and the two stores agree
+byte-for-byte on overlapping columns.
+
+When adding a new table or column to either store, the matching entry
+in :data:`SCHEMA_DESCRIPTIONS` is mandatory in the same commit — see
+the "Database schema conventions" section of ``CONTRIBUTING.md``.
+"""
+
+from __future__ import annotations
+
+# ── Attribution column descriptions reused across multiple tables ──────────
+# Pulled out as module-level constants so the same string is not
+# duplicated across every table that carries provenance metadata.
+
+ATTRIBUTION_CREATED_BY = (
+    "OS username (or AMX_USER override) of the principal that wrote this row. "
+    "Populated on every shared-mode write so '/history-store list-team' can answer "
+    "'who ran what?'."
+)
+ATTRIBUTION_HOSTNAME = (
+    "Machine that wrote this row. Part of the (hostname, local_id) provenance pair "
+    "that lets the dual-write coordinator re-find the shared row when a later UPDATE "
+    "(e.g. finish_run) fires from the same machine."
+)
+ATTRIBUTION_CLIENT_VERSION = (
+    "AMX version string (e.g. '0.12.1') of the client that wrote this row. Used by "
+    "/doctor and post-mortems to correlate row shape changes with client upgrades."
+)
+ATTRIBUTION_LOCAL_ID = (
+    "Corresponding INT id in the writer machine's local SQLite history.db. Scoped "
+    "by hostname so two machines can both have local_id=5 without collision; lets "
+    "the dual-write coordinator locate the shared row for in-flight UPDATEs."
+)
+
+
+# ── Database-level descriptions ────────────────────────────────────────────
+
+LOCAL_DATABASE_DESCRIPTION = (
+    "AMX local history store. Created on first run by SQLiteHistoryStore at "
+    "~/.amx/history.db. Holds per-machine analysis run history, per-asset LLM "
+    "alternatives, catalog search index, scheduled runs, apply audit trail, "
+    "and various caches used to keep the CLI and Studio responsive. In shared "
+    "mode the dual-write coordinator mirrors a subset of these tables into the "
+    "warehouse-hosted AMX schema (see amx.storage.shared_schema). The sidecar "
+    "table _amx_schema_descriptions records this description plus one row per "
+    "table and column for queryability."
+)
+
+SHARED_SCHEMA_COMMENT = (
+    "AMX shared run-history schema. Created by AMX (Agentic Metadata "
+    "Extractor) via /history-store enable. Holds cross-machine analysis "
+    "history, per-asset LLM alternatives, app events, agent session "
+    "state, and a schema version stamp so multiple AMX clients can "
+    "share run history under one warehouse. See "
+    "https://github.com/omeryasirkucuk/amx for details."
+)
+
+
+# ── Per-table column descriptions ──────────────────────────────────────────
+# Each entry maps a column name to its description. The ``__table__`` key
+# (sentinel, not a real column) holds the table-level description.
+#
+# Tables that appear in **both** the local SQLite store and the shared
+# SQLAlchemy store list every column from the union of the two — local-only
+# and shared-only columns coexist in the same dict because the table is
+# the natural grouping. Each store reads only the columns it actually
+# declares; the cross-store test (test_local_schema_comments.py) asserts
+# that columns present in BOTH carry the same description.
+
+SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
+    # ── analysis_runs (local + shared) ────────────────────────────────────
+    "analysis_runs": {
+        "__table__": (
+            "One row per AMX analysis run (/run, /run-apply, /ask, "
+            "doc-analyze, code-analyze). Captures the inputs (scope, "
+            "profiles, settings) and outputs (results, metrics, errors) of "
+            "an LLM-driven metadata generation. Joined to run_results for "
+            "per-asset alternatives. Read by /list, /show, /stats, /compare."
+        ),
+        "id": (
+            "UUID v4 primary key. Surfaced as a short prefix in CLI output "
+            "(/list, /show, /results, /review, /compare). UUID rather than "
+            "INT autoincrement because shared mode admits concurrent writers "
+            "from multiple machines."
+        ),
+        "started_at": (
+            "UTC timestamp when the agent run began. Indexed for "
+            "last-N-days filters in /list and /stats."
+        ),
+        "ended_at": (
+            "UTC timestamp when the run finished. NULL while a run is in "
+            "flight; also NULL for runs killed mid-flight by Ctrl-C."
+        ),
+        "duration_sec": (
+            "Wall-clock seconds between started_at and ended_at. Convenience "
+            "column so /stats does not have to recompute it on every read."
+        ),
+        "status": (
+            "Lifecycle state of the run: running | completed | failed | "
+            "cancelled. Drives /list filters and the colored status badge."
+        ),
+        "command": (
+            "Top-level CLI command that triggered the run: run | run-apply | "
+            "ask | doc-analyze | code-analyze. Distinguishes batch metadata "
+            "generation from one-off Q&A in /stats breakdowns."
+        ),
+        "mode": (
+            "Sub-mode chosen at the run picker: human-review | auto-apply | "
+            "confidence-threshold | dry-run."
+        ),
+        "db_backend": (
+            "Backend of the analyzed DB profile: postgresql | snowflake | "
+            "bigquery | databricks | mssql | mysql | oracle | redshift. "
+            "Enables /compare --by db_backend cross-backend audits."
+        ),
+        "db_profile": (
+            "Named DB profile used for this run (see /db-profiles). Multi-"
+            "profile runs (0.11+) record the first profile here and the "
+            "full list in scope_json.profiles."
+        ),
+        "llm_provider": (
+            "LLM vendor: openai | anthropic | gemini | openrouter | "
+            "deepseek | ollama | …. Distinct from llm_model which records "
+            "the specific model id."
+        ),
+        "llm_model": (
+            "Specific model id served by llm_provider — e.g. 'gpt-4o', "
+            "'claude-sonnet-4-20250514', 'openai/gpt-4o-mini' on OpenRouter."
+        ),
+        "scope_json": (
+            "JSON describing the analyzed scope: {schemas, tables, columns, "
+            "asset_kinds, profiles}. /compare reads this to find prior runs "
+            "of the same assets for side-by-side pivots."
+        ),
+        "metrics_json": (
+            "JSON of run metrics — counts, per-stage timings, retries, "
+            "skipped assets. Free-form so newer agents can add fields "
+            "without a schema bump."
+        ),
+        "tokens_json": (
+            "JSON of token usage broken down by phase: "
+            "{prompt, completion, cached, reasoning, total}. Drives /stats "
+            "cost reporting and /compare --by tokens."
+        ),
+        "results_json": (
+            "JSON summary of run outputs (counts, top-level rollups). "
+            "Per-asset detail lives in run_results joined on run_id."
+        ),
+        "error_text": (
+            "Stack trace or error message when status='failed'. NULL on successful runs."
+        ),
+        "selected_count": (
+            "Assets the user selected at the run picker. First step of the "
+            "selected → planned → processed → applied funnel."
+        ),
+        "planned_count": (
+            "Assets that survived post-selection filtering (already-good "
+            "comments skipped, unsupported asset kinds dropped, etc.)."
+        ),
+        "processed_count": (
+            "Assets the LLM successfully produced descriptions for. "
+            "planned_count - processed_count = LLM/network failures."
+        ),
+        "applied_count": (
+            "Assets whose chosen description was written to the live DB "
+            "via COMMENT ON. processed_count - applied_count = approved-"
+            "but-not-yet-applied (when running without --apply)."
+        ),
+        "review_strategy": (
+            "How alternatives were chosen: human | auto-best | "
+            "confidence-threshold. Affects how to read evaluated_at on "
+            "joined run_results rows."
+        ),
+        "llm_profile": (
+            "Named LLM profile used for this run (see /llm-profiles). "
+            "Captures the user-facing handle; concrete provider/model "
+            "values are mirrored in llm_provider/llm_model."
+        ),
+        "doc_profile": (
+            "Named document profile that supplied RAG evidence (see "
+            "/doc-profiles). NULL when /docs was not used in this run."
+        ),
+        "code_profile": (
+            "Named code profile that supplied code-evidence (see "
+            "/code-profiles). NULL when /code was not used in this run."
+        ),
+        "settings_json": (
+            "Snapshot of LLM settings at run time — temperature, "
+            "prompt_detail, n_alternatives, llm_batch_size, "
+            "description_verbosity, logprob_thresholds. Drives "
+            "/compare --by settings pivots so changes can be A/B-attributed."
+        ),
+        "created_by": ATTRIBUTION_CREATED_BY,
+        "hostname": ATTRIBUTION_HOSTNAME,
+        "client_version": ATTRIBUTION_CLIENT_VERSION,
+        "local_id": ATTRIBUTION_LOCAL_ID,  # shared-only
+        "shared_uuid": (  # local-only
+            "When a row was pulled down from the team's shared store via "
+            "/history-store pull-from-shared, this holds the UUID PK of the "
+            "corresponding shared row. NULL for runs created locally. Lets "
+            "re-pull be idempotent: we look up by shared_uuid before insert."
+        ),
+        "triggered_by_schedule_id": (  # local-only
+            "Foreign-key-by-convention to scheduled_runs.id when this run "
+            "was fired by the scheduler. NULL for ad-hoc runs and for runs "
+            "created before the scheduled-runs feature shipped."
+        ),
+        "last_heartbeat_at": (  # local-only
+            "UTC epoch seconds of the most recent heartbeat from the run "
+            "orchestrator while a run is in flight. Consumed by the stale-"
+            "run recovery path to fail runs whose host crashed mid-flight. "
+            "NULL for completed runs and for runs created before this column."
+        ),
+    },
+    # ── run_results (local + shared) ──────────────────────────────────────
+    "run_results": {
+        "__table__": (
+            "Per-asset LLM alternatives generated during an analysis_runs "
+            "invocation. One row per (asset, alternative) — a column with "
+            "3 alternatives produces 3 rows. Captures the alternative payload, "
+            "confidence, evaluation/apply state, and a back-pointer to the run."
+        ),
+        "id": "UUID v4 primary key for this (asset, alternative) row.",
+        "run_id": (
+            "Foreign-key-by-convention to analysis_runs.id. Not a hard FK "
+            "because shared mode admits replication lag — a result row can "
+            "land before its parent run row when two writers race."
+        ),
+        "saved_at": (
+            "UTC timestamp when this alternative was persisted. Distinct "
+            "from analysis_runs.started_at when the LLM streams alternatives "
+            "across the run window."
+        ),
+        "schema_name": "Schema (or dataset/database) of the asset described.",
+        "table_name": "Table or view name of the asset described.",
+        "column_name": (
+            "Column name when asset_kind='column'. NULL when asset_kind='table' "
+            "(the alternative describes the table itself)."
+        ),
+        "asset_kind": (
+            "What this row describes: table | view | materialized_view | "
+            "column. Drives which COMMENT ON variant is emitted on apply."
+        ),
+        "source": (
+            "Which agent produced this alternative: profile | doc | code | "
+            "combined | manual. Lets /compare and /review filter by source "
+            "of evidence."
+        ),
+        "confidence": (
+            "Bucketed quality label derived from logprob_score against the "
+            "/logprob-thresholds settings: high | medium | low. Used by "
+            "/review filters and the human-review UI."
+        ),
+        "logprob_score": (
+            "Normalized average log-probability of the description tokens "
+            "(-1..0). Higher = the LLM was more confident in the wording."
+        ),
+        "raw_logprob": "Sum of log-probabilities (unnormalized) backing logprob_score.",
+        "token_count": "Token length of the alternative description.",
+        "model_version": (
+            "Specific model id that produced this alternative (e.g. "
+            "'gpt-4o-2024-11-20'). May differ from analysis_runs.llm_model "
+            "when the user switches mid-run."
+        ),
+        "reasoning": (
+            "Optional reasoning trace from a reasoning model (o-series, "
+            "claude with thinking, deepseek-reasoner). NULL for normal "
+            "chat models."
+        ),
+        "alternatives_json": (
+            "Ordered JSON list of alternative description strings the LLM "
+            "produced for this asset. The /review picker presents these; "
+            "chosen_description records which one was selected."
+        ),
+        "evaluated_at": (
+            "UTC timestamp when a human (or auto-best) picked one of the "
+            "alternatives. NULL = pending review."
+        ),
+        "applied_at": (
+            "UTC timestamp when chosen_description was written to the live "
+            "DB via COMMENT ON. NULL = approved but not yet applied (or "
+            "never approved)."
+        ),
+        "chosen_description": (
+            "The specific alternative selected at evaluation time. Empty "
+            "string when evaluation='rejected'."
+        ),
+        "evaluation": (
+            "Outcome of human/auto review: approved | rejected | edited. "
+            "'edited' means the user accepted an alternative but modified "
+            "the wording before apply."
+        ),
+        "catalog_status": (
+            "Sync state with the /search catalog: pending | indexed | stale "
+            "| skipped. Drives /search rebuild incremental updates."
+        ),
+        "catalog_indexed_at": "UTC timestamp of the last /search-catalog index for this row.",
+        "db_applied_status": (
+            "Result of the COMMENT ON write to the live DB: success | "
+            "skipped | failed. Empty string until apply is attempted."
+        ),
+        "effective_source_kind": (
+            "What actually became the column's description after evaluation: "
+            "same labels as `source` plus 'manual-edit'. Distinct from "
+            "`source` because a user may approve a doc-sourced alternative "
+            "after a manual edit."
+        ),
+        "superseded_at": (
+            "Set when a newer run produces a better description for the same "
+            "asset. Lets /history filters hide stale rows without deleting "
+            "them — full audit trail preserved."
+        ),
+        "rejection_reason": (
+            "Free-text reason captured at evaluation time when "
+            "evaluation='rejected'. Surfaced by /review for retrospectives."
+        ),
+        "hostname": ATTRIBUTION_HOSTNAME,
+        "local_id": ATTRIBUTION_LOCAL_ID,  # shared-only
+        "created_by": ATTRIBUTION_CREATED_BY,  # local-only on run_results
+        "shared_uuid": (  # local-only
+            "UUID PK of the corresponding shared-store row when this row was "
+            "pulled down via /history-store pull-from-shared. NULL for rows "
+            "created locally. Indexed to keep re-pulls idempotent."
+        ),
+        "parent_result_id": (  # local-only
+            "When this row is a re-run of an earlier one, points back to the "
+            "original run_results.id. NULL for original (rerun_seq=0) rows."
+        ),
+        "rerun_seq": (  # local-only
+            "0 for the original row, 1+ for successive re-runs in the chain. "
+            "Lets the history drawer order re-run alternatives chronologically."
+        ),
+        "user_instructions": (  # local-only
+            "Optional free-text addendum the user typed in the re-run modal. "
+            "Surfaced next to the alternatives in /history and Studio so the "
+            "audit trail explains why the re-run was requested."
+        ),
+        "citations_json": (  # local-only
+            "JSON-encoded list[{source, chunk_idx, score, snippet}] of "
+            "RAG-derived citations backing this alternative. NULL on legacy "
+            "rows and non-RAG sources — callers treat NULL and [] alike."
+        ),
+    },
+    # ── app_events (local + shared) ───────────────────────────────────────
+    "app_events": {
+        "__table__": (
+            "Append-only structured event log surfaced by /events. Records CLI "
+            "lifecycle events (connection tests, syncs, doctor checks, errors) "
+            "for audit and debugging. Distinct from analysis_runs which logs "
+            "LLM agent invocations."
+        ),
+        "id": "UUID v4 primary key for the event.",
+        "created_at": "UTC timestamp the event fired. Indexed for /events recent-first ordering.",
+        "event_type": (
+            "Coarse event family: cli | db | llm | doc | code | error | "
+            "history-store. Lets /events filter by subsystem."
+        ),
+        "status": "Severity of the event: info | warn | error.",
+        "command": "CLI command (or sub-action) that was running when the event fired.",
+        "details_json": (
+            "Free-form JSON payload — varies per event_type. Examples: "
+            "{profile, backend} for db connect, {model, latency_ms} for "
+            "llm calls, {error_class, traceback} for errors."
+        ),
+        "created_by": ATTRIBUTION_CREATED_BY,  # shared-only
+        "hostname": ATTRIBUTION_HOSTNAME,  # shared-only
+        "client_version": ATTRIBUTION_CLIENT_VERSION,  # shared-only
+    },
+    # ── session_state (local + shared) ────────────────────────────────────
+    "session_state": {
+        "__table__": (
+            "Namespaced key/value storage used by StateManager for inter-turn "
+            "agent memory within /ask conversational sessions. Composite primary "
+            "key (namespace, key_name, hostname) so a teammate's state under "
+            "the same namespace does not clobber yours in shared mode."
+        ),
+        "namespace": (
+            "Logical grouping for related keys (e.g. 'ask_session_42' or "
+            "'review_state'). Lets multiple StateManager instances share a "
+            "table without colliding."
+        ),
+        "key_name": "Key within the namespace.",
+        "hostname": (  # NOTE: not generic ATTRIBUTION_HOSTNAME — session_state
+            # has its own semantics because hostname participates in the
+            # composite primary key.
+            "Writer machine. Part of the composite PK so a teammate's state "
+            "under the same (namespace, key_name) does not clobber yours in "
+            "shared mode. Empty string when running in single-user mode."
+        ),
+        "value_json": "JSON-serialized value associated with (namespace, key_name, hostname).",
+        "updated_at": "UTC timestamp of the last write to this row.",
+        "created_by": ATTRIBUTION_CREATED_BY,  # shared-only
+    },
+    # ── schema_meta (shared only) ─────────────────────────────────────────
+    "schema_meta": {
+        "__table__": (
+            "Single-row version stamp written at /history-store enable bootstrap. "
+            "Newer AMX clients bump schema_version on first write; older clients "
+            "refuse to write into a schema bumped beyond what they know about, "
+            "mirroring the AMXConfig schema_version guard."
+        ),
+        "id": (
+            "Singleton sentinel — always 1. The PK exists only because every "
+            "table needs one; this table holds at most one row."
+        ),
+        "schema_version": (
+            "Current version of the AMX shared-store schema. Older clients "
+            "refuse to write when this is higher than what they were built "
+            "against, mirroring the AMXConfig schema_version compatibility "
+            "guard."
+        ),
+        "created_at": "UTC timestamp when /history-store enable first bootstrapped this schema.",
+        "created_by_client_version": "AMX version string of the client that ran the bootstrap.",
+    },
+    # ── style_profiles (local + shared) ───────────────────────────────────
+    "style_profiles": {
+        "__table__": (
+            "One row per LLM profile containing the derived StyleProfile that "
+            "summarises the user's description writing conventions. The profile "
+            "is injected into run-time prompts to keep generated descriptions "
+            "consistent with the existing corpus style."
+        ),
+        "id": "Surrogate primary key.",
+        "llm_profile": (
+            "Name of the LLM profile this style record belongs to. "
+            "Matches the llm_profile key used in AMXConfig."
+        ),
+        "source_ref": (
+            "Fully-qualified reference to the table or column set whose "
+            "comments were used to derive this profile (e.g. "
+            "'warehouse.sales.orders')."
+        ),
+        "source_db_kind": (
+            "Database kind identifier of the source (e.g. 'snowflake', "
+            "'duckdb', 'bigquery'). Stored for diagnostic and audit purposes."
+        ),
+        "profile_json": (
+            "JSON-serialised StyleProfile dataclass. Deserialised by "
+            "StyleProfile.from_json() on read."
+        ),
+        "enabled": (
+            "Whether this style profile is active (1) or disabled (0). "
+            "Disabled profiles are stored but not injected into prompts."
+        ),
+        "sample_count": (
+            "Number of source description samples that were analysed to "
+            "produce the profile. Used as a confidence indicator."
+        ),
+        "created_at": (
+            "Stored as TEXT representation of a Unix timestamp float, "
+            "mirroring the local SQLite schema."
+        ),
+        "updated_at": (
+            "Stored as TEXT representation of a Unix timestamp float, "
+            "mirroring the local SQLite schema."
+        ),
+    },
+    # ── rerun_context_snapshots (local only) ──────────────────────────────
+    "rerun_context_snapshots": {
+        "__table__": (
+            "Short-lived per-target snapshots written when a re-run job starts. "
+            "Each row freezes the AgentContext for one target item so every "
+            "parallel agent in the job sees identical inputs. Garbage-collected "
+            "by the orchestrator when the parent job reaches a terminal state "
+            "(done | failed | cancelled)."
+        ),
+        "snapshot_id": "Opaque text identifier for this snapshot. Primary key.",
+        "job_id": (
+            "Identifier of the re-run job that owns this snapshot. Indexed so "
+            "the orchestrator can sweep every snapshot for a finished job in "
+            "one query."
+        ),
+        "target_result_id": (
+            "run_results.id of the row this re-run targets. The snapshot's "
+            "payload_json freezes the AgentContext built around this asset."
+        ),
+        "payload_json": (
+            "JSON-encoded AgentContext for this target — DB schema, prior "
+            "descriptions, RAG citations, prompt template, settings. Read by "
+            "every parallel agent in the job; never mutated after write."
+        ),
+        "created_at": (
+            "UTC epoch seconds the snapshot was written. Indexed for the "
+            "orchestrator's stale-snapshot sweep."
+        ),
+    },
+    # ── run_context_cache (local only) ────────────────────────────────────
+    "run_context_cache": {
+        "__table__": (
+            "Persistent table-level context built at first run and reused on "
+            "subsequent re-runs to skip live profile_table introspection. "
+            "Keyed on (db_profile, database, schema, table). Entries are "
+            "dropped after a row's COMMENT lands on the live DB, and a 24h "
+            "TTL guards against silently serving stale schema after the user "
+            "altered the table out-of-band."
+        ),
+        "cache_key": (
+            "Deterministic hash of (db_profile, database, schema, table). "
+            "Primary key. Lets lookups skip a multi-column WHERE."
+        ),
+        "db_profile": "DB profile under which the context was gathered.",
+        "database_name": (
+            "Database (or catalog name on backends that distinguish them) the "
+            "cached table lives in. Empty string on backends without that level."
+        ),
+        "schema_name": "Schema name of the cached table.",
+        "table_name": "Table name being cached.",
+        "payload_json": (
+            "JSON-encoded table context: column types, sample values, profile "
+            "histograms, FK edges, prior descriptions. Consumed by the re-run "
+            "orchestrator to skip live introspection."
+        ),
+        "source_run_id": (
+            "analysis_runs.id of the run that built this context entry. "
+            "Lets /history trace where a cached payload originated."
+        ),
+        "created_at": "UTC epoch seconds the entry was written.",
+        "expires_at": (
+            "UTC epoch seconds at which the entry should be treated as "
+            "stale. Indexed so the periodic eviction pass is O(log n)."
+        ),
+    },
+    # ── column_comments_cache (local only) ────────────────────────────────
+    "column_comments_cache": {
+        "__table__": (
+            "Per-table cache of existing COMMENT values fetched from the live "
+            "DB. Avoids the per-table DESCRIBE EXTENDED loop that hit 30s+ on "
+            "large Databricks warehouses. A single COMMENT write invalidates "
+            "just the row that changed; TTL is the second line of defence "
+            "against DBA-edited comments that AMX never sees."
+        ),
+        "cache_key": ("Deterministic hash of (db_profile, database, schema, table). Primary key."),
+        "db_profile": "DB profile the cached comments belong to.",
+        "database_name": "Database/catalog the cached table is in. Empty string on flat backends.",
+        "schema_name": "Schema name of the cached table.",
+        "table_name": "Table name being cached.",
+        "table_comment": (
+            "Existing COMMENT ON TABLE value at fetch time, or NULL if the table had no comment."
+        ),
+        "columns_json": (
+            "JSON map of {column_name: existing_comment_or_null} captured at "
+            "fetch time. Drives the missing-only filter so AMX does not "
+            "re-describe assets that already have a comment."
+        ),
+        "kind": (
+            "Asset kind on the live DB: TABLE | VIEW | MATERIALIZED_VIEW. "
+            "Distinguishes how to emit COMMENT ON on apply."
+        ),
+        "fetched_at": "UTC epoch seconds when the snapshot was fetched.",
+        "expires_at": "UTC epoch seconds at which the entry becomes stale. Indexed.",
+        "bulk_filled": (
+            "1 when this entry came from a bulk_schema_metadata call that, by "
+            "contract, returned every table in the schema (so list_assets can "
+            "read from the cache directly). 0 when it came from a per-table "
+            "fallback; the cache is then incomplete for the schema."
+        ),
+    },
+    # ── schemas_cache (local only) ────────────────────────────────────────
+    "schemas_cache": {
+        "__table__": (
+            "Per-catalog cache of schema-level metadata (schema name + "
+            "comment). Absorbs the slow per-schema DESCRIBE/pg_namespace "
+            "loop the sidebar used to fire on catalog expand. Filled in one "
+            "round-trip by bulk_catalog_metadata."
+        ),
+        "cache_key": (
+            "Deterministic hash of (db_profile, database, catalog, schema). Primary key."
+        ),
+        "db_profile": "DB profile the cached schema belongs to.",
+        "database_name": "Database name. Empty string on flat backends.",
+        "catalog_name": "Catalog name on three-tier backends. Empty string elsewhere.",
+        "schema_name": "Schema name being cached.",
+        "schema_comment": "Existing COMMENT ON SCHEMA value, or NULL if the schema has none.",
+        "bulk_filled": (
+            "1 when filled by a bulk_catalog_metadata call covering the whole "
+            "catalog (cache can be trusted for list_schemas). 0 when filled "
+            "from a per-schema fallback."
+        ),
+        "fetched_at": "UTC epoch seconds the entry was fetched.",
+        "expires_at": "UTC epoch seconds at which the entry becomes stale. Indexed.",
+    },
+    # ── catalog_entities (local only) ─────────────────────────────────────
+    "catalog_entities": {
+        "__table__": (
+            "Search index of every database asset AMX has seen across all DB "
+            "profiles. One row per (profile, database, schema, table, column?) "
+            "tuple. Powers /search, /ask asset lookups, and the Studio catalog "
+            "tree. Synced from the live DB via sync_profile_skeleton."
+        ),
+        "id": "Surrogate INT primary key. Foreign-key target for catalog_descriptions.",
+        "db_profile": "DB profile this entity belongs to.",
+        "db_backend": (
+            "Backend of the owning DB profile (postgresql | snowflake | …). "
+            "Mirrors analysis_runs.db_backend so /search filters by backend "
+            "without a join."
+        ),
+        "database_name": "Database/catalog name. Empty string on flat backends.",
+        "schema_name": "Schema name. Empty string when the entity is database-level.",
+        "table_name": "Table name. Empty string when the entity is schema-level.",
+        "column_name": "Column name. NULL for non-column entities (database/schema/table).",
+        "entity_kind": (
+            "Granularity: database | schema | table | column. Drives how "
+            "/search interprets the row and which COMMENT ON variant to emit."
+        ),
+        "asset_kind": (
+            "Specific kind when entity_kind='table': table | view | "
+            "materialized_view. Empty/'table' default for non-table entities."
+        ),
+        "dtype": "Column data type when entity_kind='column'. Empty string otherwise.",
+        "nullable": "1 if the column accepts NULLs, 0 otherwise. Meaningless for non-columns.",
+        "pk_flag": "1 if the column is part of the primary key, 0 otherwise.",
+        "fk_flag": "1 if the column is part of a foreign key, 0 otherwise.",
+        "row_count": (
+            "Approximate row count when entity_kind='table'. 0 for non-tables "
+            "and for backends that don't expose the stat cheaply."
+        ),
+        "search_text": (
+            "Synthesised search blob (path + dtype + descriptions + "
+            "relationships) used as the FTS payload. Empty until first sync."
+        ),
+        "current_confidence": (
+            "Confidence bucket of the effective description: high | medium | "
+            "low. Empty when no description has been written."
+        ),
+        "effective_status": (
+            "Lifecycle status of the effective description: pending | "
+            "applied | superseded | rejected. Empty when no description exists."
+        ),
+        "effective_source_kind": (
+            "Source of the effective description: profile | doc | code | "
+            "combined | manual | manual-edit. Empty when no description exists."
+        ),
+        "effective_description_id": (
+            "catalog_descriptions.id of the row currently treated as the "
+            "effective description for this entity. NULL when there is none."
+        ),
+        "updated_at": "UTC epoch seconds of the last write to this row.",
+        "last_synced_at": "UTC epoch seconds of the last sync_profile_skeleton touch.",
+        "last_code_sync_at": (
+            "UTC epoch seconds of the last code-context sync (lineage usage, "
+            "test references). NULL on entities never touched by /code."
+        ),
+    },
+    # ── catalog_descriptions (local only) ─────────────────────────────────
+    "catalog_descriptions": {
+        "__table__": (
+            "All descriptions ever generated or imported for a catalog_entities "
+            "row, with full audit trail. The 'effective' one is pointed at by "
+            "catalog_entities.effective_description_id; superseded ones stay "
+            "for rollback and /history."
+        ),
+        "id": "Surrogate INT primary key.",
+        "entity_id": (
+            "Foreign key to catalog_entities.id. Indexed jointly with "
+            "created_at DESC for fast 'latest descriptions for this entity' "
+            "lookups."
+        ),
+        "description_text": "The description string itself.",
+        "source_kind": (
+            "How the description was produced: profile | doc | code | "
+            "combined | manual | manual-edit | imported."
+        ),
+        "source_agent": (
+            "Agent identifier when source_kind is LLM-produced "
+            "(e.g. 'profile-agent-v2'). Empty string for manual / imported "
+            "rows."
+        ),
+        "confidence": ("Quality bucket: high | medium | low. Empty for manual / imported."),
+        "logprob_score": (
+            "Normalized log-probability of the LLM-produced tokens (-1..0). "
+            "NULL for manual / imported."
+        ),
+        "reasoning": (
+            "Optional reasoning trace from a reasoning model. Empty string "
+            "for non-reasoning models."
+        ),
+        "run_id": (
+            "analysis_runs.id of the run that produced this description. "
+            "NULL for imported / manual rows."
+        ),
+        "result_id": (
+            "run_results.id of the alternative this description came from. "
+            "NULL for imported / manual rows."
+        ),
+        "created_at": "UTC epoch seconds when the description was created.",
+        "superseded": (
+            "1 once a newer description for the same entity takes over the "
+            "effective slot. 0 while still candidate or effective. Lets "
+            "/history hide stale rows without deleting them."
+        ),
+        "indexed": "1 once the description has been folded into search_text. 0 until then.",
+        "indexed_at": "UTC epoch seconds of the last indexing. NULL if never indexed.",
+        "applied_to_db": (
+            "1 once the description has been written to the live DB via COMMENT ON. 0 otherwise."
+        ),
+        "applied_at": "UTC epoch seconds of the COMMENT ON write. NULL if not applied.",
+        "chosen_description": (
+            "1 marks the row currently treated as the effective description "
+            "for the entity. At most one row per entity has this flag set."
+        ),
+    },
+    # ── catalog_entities_fts (local only, FTS5 virtual table) ─────────────
+    "catalog_entities_fts": {
+        "__table__": (
+            "SQLite FTS5 virtual table mirroring the search-relevant columns "
+            "of catalog_entities. Rows are kept in sync by sync.py at every "
+            "catalog_entities write site. content='' (contentless) so no "
+            "triggers are needed. Falls back gracefully when the host SQLite "
+            "lacks FTS5."
+        ),
+        "db_profile": (
+            "DB profile the indexed entity belongs to. UNINDEXED so MATCH "
+            "queries don't try to tokenize profile names."
+        ),
+        "column_name": "Column name of the indexed entity. Tokenized for MATCH.",
+        "table_name": "Table name of the indexed entity. Tokenized for MATCH.",
+        "schema_name": "Schema name of the indexed entity. Tokenized for MATCH.",
+        "search_text": (
+            "Synthesised search blob mirroring catalog_entities.search_text. "
+            "The dominant signal source for concept-search MATCH ranking."
+        ),
+    },
+    # ── catalog_profile_state (local only) ────────────────────────────────
+    "catalog_profile_state": {
+        "__table__": (
+            "Per-DB-profile completeness state for the catalog skeleton sync. "
+            "The cache-first read path (sidebar, schedule pickers, Ask tools) "
+            "gates on state='done' so a partially-synced catalog never "
+            "surfaces to the user as the full picture. Upserted by "
+            "sync_profile_skeleton at start / progress / finish."
+        ),
+        "db_profile": "DB profile this state row tracks. Primary key.",
+        "state": (
+            "Sync lifecycle: none | running | done | failed. Cache-first reads only trust 'done'."
+        ),
+        "total_tables": "Total tables the current sync intends to touch.",
+        "processed_tables": "Tables synced so far in the current sync.",
+        "started_at": "UTC epoch seconds the current sync began. NULL when state='none'.",
+        "finished_at": "UTC epoch seconds the current sync completed. NULL while running.",
+        "last_full_sync_at": (
+            "UTC epoch seconds of the last successful 'done' transition. "
+            "Drives /sync recency hints."
+        ),
+        "last_error": (
+            "Error message captured when state='failed'. Empty string for successful syncs."
+        ),
+    },
+    # ── catalog_relationships (local only) ────────────────────────────────
+    "catalog_relationships": {
+        "__table__": (
+            "Edges between catalog_entities rows — FK references, lineage, "
+            "co-occurrence, semantic similarity. Drives 'related to' lookups "
+            "in /ask and the Studio entity drawer."
+        ),
+        "id": "Surrogate INT primary key.",
+        "from_entity_id": "Source entity. Indexed jointly with to_entity_id and relationship_type.",
+        "to_entity_id": "Destination entity.",
+        "relationship_type": (
+            "Edge kind: fk | lineage_source | lineage_target | co_occurs | "
+            "semantic_similar. Drives how /ask presents the edge in narratives."
+        ),
+        "score": (
+            "Strength of the edge in 0..1. 1.0 for hard FKs, lower for inferred relationships."
+        ),
+        "source": (
+            "How the edge was discovered: db_introspect | code_static | "
+            "code_runtime | doc_inferred | embedding. Empty until populated."
+        ),
+        "details_json": (
+            "JSON payload with edge-specific evidence — referenced columns "
+            "for FKs, source files/lines for code edges, similarity scores "
+            "for embeddings."
+        ),
+        "last_seen": (
+            "UTC epoch seconds of the last sync that observed this edge. "
+            "Edges not seen for >30 days are eligible for pruning."
+        ),
+    },
+    # ── catalog_usage_evidence (local only) ───────────────────────────────
+    "catalog_usage_evidence": {
+        "__table__": (
+            "Per-entity usage evidence collected from code scans, log "
+            "analysis, and dashboard introspection. Drives 'used by' panels "
+            "in Studio and confidence boosters in the LLM prompt."
+        ),
+        "id": "Surrogate INT primary key.",
+        "db_profile": (
+            "DB profile the evidence belongs to. Empty string for profile-agnostic evidence."
+        ),
+        "entity_id": (
+            "catalog_entities.id this evidence row attaches to. NULL when "
+            "the asset has been observed but does not (yet) exist in the "
+            "catalog."
+        ),
+        "source_kind": (
+            "Where the evidence came from: code_static | code_runtime | dashboard | log | doc."
+        ),
+        "evidence_type": (
+            "What kind of usage: select | join | filter | groupby | aggregate | reference."
+        ),
+        "source_path": (
+            "File path or URL where the evidence was found. Empty string when not applicable."
+        ),
+        "count_value": "Integer count when the evidence is quantitative (e.g. # of query references).",
+        "score_value": "Numeric score 0..1 when the evidence is qualitative (e.g. relevance).",
+        "sample_snippets_json": (
+            "JSON list of representative snippets (e.g. SQL fragments) "
+            "captured for surfacing in the UI. Defaults to [] when none."
+        ),
+        "last_seen": (
+            "UTC epoch seconds the evidence was last observed. Old evidence "
+            "is pruned by the catalog GC pass."
+        ),
+    },
+    # ── catalog_sync_jobs (local only) ────────────────────────────────────
+    "catalog_sync_jobs": {
+        "__table__": (
+            "Audit log of every catalog sync invocation. One row per "
+            "/search sync (full or incremental) and per scheduled background "
+            "sync. Powers /search status reports and post-mortems."
+        ),
+        "id": "Surrogate INT primary key.",
+        "db_profile": "DB profile that was synced.",
+        "job_type": (
+            "Sync kind: full | incremental | code_sync | usage_sync. Drives "
+            "how /search status interprets the counters."
+        ),
+        "scope_json": (
+            "JSON describing the scope: schemas/tables targeted. Empty "
+            "object for whole-profile syncs."
+        ),
+        "started_at": (
+            "UTC epoch seconds the job started. Indexed jointly with "
+            "db_profile DESC for fast 'latest sync per profile' lookups."
+        ),
+        "completed_at": "UTC epoch seconds the job finished. NULL while in flight.",
+        "status": "Lifecycle: running | done | failed | cancelled.",
+        "inserted_count": "Catalog rows inserted by the job.",
+        "updated_count": "Catalog rows updated by the job.",
+        "error_text": "Error message when status='failed'. Empty string on success.",
+    },
+    # ── search_settings (local only) ──────────────────────────────────────
+    "search_settings": {
+        "__table__": (
+            "Per-DB-profile key/value store for search-related knobs "
+            "(threshold weights, boost lists, opt-outs). One row per "
+            "(profile, key) — settings are scoped so different profiles "
+            "can be tuned independently."
+        ),
+        "id": "Surrogate INT primary key.",
+        "db_profile": "DB profile this setting applies to.",
+        "key_name": "Setting key. Uniqueness is (db_profile, key_name).",
+        "value_text": "Setting value, serialized as text. Callers parse per-key.",
+        "updated_at": "UTC epoch seconds of the last write.",
+    },
+    # ── chat_sessions (local only) ────────────────────────────────────────
+    "chat_sessions": {
+        "__table__": (
+            "One row per /ask conversational session. Holds the session "
+            "metadata; individual turns live in chat_turns joined on "
+            "session_id. Read by /ask --resume and the Studio chat tab."
+        ),
+        "id": "Surrogate INT primary key.",
+        "db_profile": "DB profile the session is bound to.",
+        "llm_profile": "LLM profile used for the session.",
+        "started_at": "UTC epoch seconds the session began.",
+        "last_active_at": (
+            "UTC epoch seconds of the most recent turn. Indexed jointly "
+            "with (db_profile, llm_profile) so /ask --resume can find "
+            "the most recent session per (profile, model)."
+        ),
+        "ended_at": "UTC epoch seconds when the session was explicitly closed. NULL while open.",
+        "title": (
+            "Optional human-friendly title for the session. NULL until the "
+            "user (or the auto-titler) sets one."
+        ),
+        "turn_count": "Number of chat_turns rows attached to this session.",
+        "total_tokens": (
+            "Running total of LLM tokens consumed by this session — sum of "
+            "chat_turns.tokens_json totals."
+        ),
+        "compaction_state_json": (
+            "JSON state of the conversation compactor (which turns were "
+            "summarised, residual context, etc.). NULL when no compaction "
+            "has happened yet."
+        ),
+        "scope_profiles_json": (
+            "JSON list of additional DB profiles the session has access "
+            "to beyond db_profile. NULL on legacy single-profile sessions."
+        ),
+        "focus_profile": (
+            "DB profile the session is currently focused on (subset of "
+            "scope_profiles_json + db_profile). NULL on legacy sessions."
+        ),
+    },
+    # ── chat_turns (local only) ───────────────────────────────────────────
+    "chat_turns": {
+        "__table__": (
+            "Individual turns within a chat_sessions row. One row per user "
+            "question + agent response cycle, plus tool-call subturns. "
+            "Joined to analysis_runs when a turn triggered a /run-style "
+            "agent invocation."
+        ),
+        "id": "Surrogate INT primary key.",
+        "session_id": (
+            "Foreign key to chat_sessions.id. ON DELETE CASCADE so closing "
+            "a session sweeps its turns."
+        ),
+        "run_id": (
+            "analysis_runs.id when the turn invoked an agent run. NULL for "
+            "plain Q&A turns that did not touch the metadata pipeline."
+        ),
+        "turn_index": (
+            "0-based ordinal of the turn within the session. Indexed "
+            "jointly with session_id for ORDER BY turn_index."
+        ),
+        "role": "Speaker: user | assistant | tool.",
+        "question": "Verbatim user question for role='user'. NULL otherwise.",
+        "answer_summary": (
+            "Short summary of the assistant response for role='assistant'. "
+            "Full response is reconstructable from plan_json + tool outputs."
+        ),
+        "intent": (
+            "Classified intent of the turn (e.g. 'describe_column', "
+            "'explain_lineage', 'compare_runs'). NULL when the classifier "
+            "did not run."
+        ),
+        "topic": (
+            "Detected topic (e.g. 'orders', 'auth'). NULL when the topic tagger did not run."
+        ),
+        "confidence": "Confidence bucket for the intent classification: high | medium | low.",
+        "tables_json": (
+            "JSON list of fully-qualified table refs the turn touched. "
+            "Defaults to [] when no tables were referenced."
+        ),
+        "columns_json": (
+            "JSON list of fully-qualified column refs the turn touched. Defaults to []."
+        ),
+        "plan_json": (
+            "JSON of the agent's plan/trace for the turn — tool calls, "
+            "intermediate thoughts, citations. NULL on plain Q&A."
+        ),
+        "tokens_json": (
+            "JSON of token usage for this turn — {prompt, completion, "
+            "cached, total}. NULL when token accounting was unavailable."
+        ),
+        "request_id": (
+            "Opaque request id correlating this turn with provider-side "
+            "logs (OpenAI/Anthropic request id). NULL when unknown."
+        ),
+        "created_at": "UTC epoch seconds the turn was recorded.",
+        "estimated_tokens": (
+            "Token count estimated by the local tokenizer (used for "
+            "compaction triggers). 0 until estimated."
+        ),
+        "compacted_at": (
+            "UTC epoch seconds when the conversation compactor folded "
+            "this turn into a summary. NULL while still verbatim."
+        ),
+    },
+    # ── scheduled_runs (local only) ───────────────────────────────────────
+    "scheduled_runs": {
+        "__table__": (
+            "One row per one-shot scheduled metadata run, created via "
+            "`amx schedule` (CLI) and the Studio Schedules page. The tick "
+            "engine reads pending rows whose fire_at_utc has elapsed and "
+            "transitions them through the documented state machine."
+        ),
+        "id": "Surrogate INT primary key.",
+        "name": "Human-friendly schedule name shown in /schedule list and Studio.",
+        "fire_at_utc": "Canonical UTC epoch seconds when the run should fire. Indexed.",
+        "fire_at_tz": (
+            "IANA tz id the user picked for display and DST handling. The "
+            "scheduler always uses fire_at_utc; this field is presentational."
+        ),
+        "status": (
+            "Lifecycle: pending | firing | fired | failed | cancelled. "
+            "Indexed jointly with fire_at_utc for the tick engine sweep."
+        ),
+        "db_profile": "DB profile the scheduled run will analyze. Indexed.",
+        "database": (
+            "Database/catalog overlay for the scheduled run. NULL means "
+            "'use the profile's default'. Required for backends that "
+            "distinguish multiple databases per profile."
+        ),
+        "catalog": (
+            "Catalog overlay for three-tier backends (Databricks, Snowflake). "
+            "NULL means 'use the profile's default'."
+        ),
+        "scope_json": (
+            "JSON describing the high-level scope (schema/table names). "
+            "Resolved against the live DB at fire time, so new tables "
+            "under a scheduled schema are picked up automatically; "
+            "missing entities surface as a clean failure with last_error "
+            "populated."
+        ),
+        "llm_profile": "LLM profile to use for the run.",
+        "review_strategy": "How alternatives should be evaluated: human | auto-best | confidence-threshold.",
+        "extra_args_json": (
+            "JSON of additional CLI flags to pass at fire time. NULL when no overrides are needed."
+        ),
+        "created_at": "UTC epoch seconds the schedule was created.",
+        "updated_at": "UTC epoch seconds of the last edit.",
+        "fired_at": "UTC epoch seconds the tick engine fired the schedule. NULL until firing.",
+        "triggered_run_id": (
+            "analysis_runs.id of the run created by this schedule. NULL until "
+            "fired; populated even on failed runs so the audit trail is intact."
+        ),
+        "last_error": (
+            "Error message when status='failed'. NULL on success and on "
+            "schedules that have not fired yet."
+        ),
+    },
+    # ── apply_events (local only) ─────────────────────────────────────────
+    "apply_events": {
+        "__table__": (
+            "Audit trail of every COMMENT actually written to a live DB. "
+            "One row per successful COMMENT ON. Old comments are stored "
+            "verbatim so /history rollback can restore them "
+            "character-for-character. Powers Studio's Recent Applies panel."
+        ),
+        "id": "Surrogate INT primary key.",
+        "applied_at": "UTC epoch seconds the COMMENT ON was executed. Indexed DESC.",
+        "run_id": (
+            "analysis_runs.id of the run that owns this apply. NULL on "
+            "manual /apply invocations outside a run."
+        ),
+        "result_id": (
+            "run_results.id of the row whose chosen_description was "
+            "written. NULL on manual /apply invocations."
+        ),
+        "profile_name": "DB profile the comment was written against.",
+        "schema_name": "Schema of the asset that received the comment.",
+        "table_name": "Table of the asset. Empty string for schema-level comments.",
+        "column_name": "Column of the asset. NULL for table/schema-level comments.",
+        "asset_kind": "Kind of asset: table | view | materialized_view | column | schema.",
+        "old_comment": (
+            "Previous COMMENT ON value before the overwrite, captured "
+            "verbatim. NULL when the asset had no prior comment."
+        ),
+        "new_comment": "The comment that was written. Source of truth for /history rollback.",
+        "applied_by": "OS username (or AMX_USER override) that triggered the apply.",
+        "hostname": "Machine that ran the apply.",
+        "sql_template": (
+            "Templated COMMENT ON SQL emitted for the apply, with the "
+            "comment body redacted (used for /doctor and post-mortems)."
+        ),
+    },
+    # ── _amx_schema_descriptions (the sidecar itself) ─────────────────────
+    # Self-describing: the sidecar records its own description rows too.
+    "_amx_schema_descriptions": {
+        "__table__": (
+            "AMX's own metadata sidecar. One row per (object_kind, schema, "
+            "table, column) recording the canonical description of every "
+            "table and column in this database. Populated idempotently from "
+            "amx.storage.schema_descriptions on every SQLiteHistoryStore "
+            "init() so descriptions stay in lock-step with the schema. "
+            "Equivalent to pg_description for backends without native "
+            "COMMENT ON support."
+        ),
+        "object_kind": (
+            "What this row describes: database | table | column. The three "
+            "form a hierarchy reflected in the (schema_name, table_name, "
+            "column_name) composite key, with empty strings standing in for "
+            "the absent levels."
+        ),
+        "schema_name": (
+            "SQLite schema name. Always 'main' for the local store; the "
+            "column exists so the sidecar shape mirrors pg_description and "
+            "stays portable if AMX ever uses ATTACH DATABASE."
+        ),
+        "table_name": (
+            "Table the row describes (column rows reuse their owning table's "
+            "name). Empty string for the database-level row."
+        ),
+        "column_name": (
+            "Column the row describes. Empty string for database- and table-level rows."
+        ),
+        "description": (
+            "Canonical description text from amx.storage.schema_descriptions. "
+            "Never empty: a missing description fails CI before the row "
+            "could be written."
+        ),
+        "updated_at": (
+            "UTC epoch seconds of the last (re-)populate. Bumped on every "
+            "SQLiteHistoryStore.init() so /doctor can detect descriptions "
+            "that never refresh."
+        ),
+    },
+}
+
+
+__all__ = [
+    "ATTRIBUTION_CREATED_BY",
+    "ATTRIBUTION_HOSTNAME",
+    "ATTRIBUTION_CLIENT_VERSION",
+    "ATTRIBUTION_LOCAL_ID",
+    "LOCAL_DATABASE_DESCRIPTION",
+    "SHARED_SCHEMA_COMMENT",
+    "SCHEMA_DESCRIPTIONS",
+]

--- a/amx/storage/shared_schema.py
+++ b/amx/storage/shared_schema.py
@@ -51,6 +51,11 @@ from sqlalchemy import (
 )
 from sqlalchemy.types import TypeDecorator, TypeEngine
 
+from amx.storage.schema_descriptions import (
+    SCHEMA_DESCRIPTIONS,
+    SHARED_SCHEMA_COMMENT,
+)
+
 
 class _JSONAsText(TypeDecorator):
     """JSON stored as TEXT for backends without a native JSON column type.
@@ -112,18 +117,12 @@ def _portable_json() -> TypeEngine:
 # matches the user-facing nomenclature in docs/CLI prompts.
 DEFAULT_HISTORY_SCHEMA = "AMX"
 
-# Comment text written to the schema (namespace) itself via
+# Schema comment text written to the namespace itself via
 # ``COMMENT ON SCHEMA``. ``MetaData`` does not carry schema-level
 # annotations natively, so :meth:`DatabaseAdapter.create_history_schema`
-# emits this explicitly after ``CREATE SCHEMA``.
-DEFAULT_HISTORY_SCHEMA_COMMENT = (
-    "AMX shared run-history schema. Created by AMX (Agentic Metadata "
-    "Extractor) via /history-store enable. Holds cross-machine analysis "
-    "history, per-asset LLM alternatives, app events, agent session "
-    "state, and a schema version stamp so multiple AMX clients can "
-    "share run history under one warehouse. See "
-    "https://github.com/omeryasirkucuk/amx for details."
-)
+# emits this explicitly after ``CREATE SCHEMA``. Lives in the shared
+# source-of-truth module so the local SQLite sidecar can stay aligned.
+DEFAULT_HISTORY_SCHEMA_COMMENT = SHARED_SCHEMA_COMMENT
 
 # All client versions writing into a shared store record this as their
 # ``schema_version`` so an older client refuses to write into a schema
@@ -131,29 +130,18 @@ DEFAULT_HISTORY_SCHEMA_COMMENT = (
 SHARED_SCHEMA_VERSION = 1
 
 
-# ── Per-column comment text ───────────────────────────────────────────────
-# Pulled out as constants so the same string isn't duplicated across
-# attribution columns on every table.
+def _desc(table: str, column: str | None = None) -> str:
+    """Look up the canonical description for a table or column.
 
-_ATTRIBUTION_CREATED_BY = (
-    "OS username (or AMX_USER override) of the principal that wrote this row. "
-    "Populated on every shared-mode write so '/history-store list-team' can answer "
-    "'who ran what?'."
-)
-_ATTRIBUTION_HOSTNAME = (
-    "Machine that wrote this row. Part of the (hostname, local_id) provenance pair "
-    "that lets the dual-write coordinator re-find the shared row when a later UPDATE "
-    "(e.g. finish_run) fires from the same machine."
-)
-_ATTRIBUTION_CLIENT_VERSION = (
-    "AMX version string (e.g. '0.12.1') of the client that wrote this row. Used by "
-    "/doctor and post-mortems to correlate row shape changes with client upgrades."
-)
-_ATTRIBUTION_LOCAL_ID = (
-    "Corresponding INT id in the writer machine's local SQLite history.db. Scoped "
-    "by hostname so two machines can both have local_id=5 without collision; lets "
-    "the dual-write coordinator locate the shared row for in-flight UPDATEs."
-)
+    Single accessor for ``SCHEMA_DESCRIPTIONS`` so every ``comment=``
+    site in this module reads from the same source the local SQLite
+    store reads. Raises ``KeyError`` on a missing entry — that failure
+    surfaces in CI via :mod:`tests.test_shared_schema_comments` rather
+    than silently shipping an empty comment.
+    """
+    if column is None:
+        return SCHEMA_DESCRIPTIONS[table]["__table__"]
+    return SCHEMA_DESCRIPTIONS[table][column]
 
 
 def build_metadata(schema: str | None = None) -> MetaData:
@@ -163,6 +151,10 @@ def build_metadata(schema: str | None = None) -> MetaData:
     different deployments may pick different schema names, and SQLAlchemy
     bakes the schema into each ``Table`` at construction time. Tests and
     the bootstrap path each get their own ``MetaData`` for isolation.
+
+    All ``comment=`` strings here are looked up from
+    :mod:`amx.storage.schema_descriptions` so the shared schema cannot
+    drift from the local SQLite sidecar — see ``CONTRIBUTING.md``.
     """
     md = MetaData(schema=schema or DEFAULT_HISTORY_SCHEMA)
 
@@ -170,540 +162,207 @@ def build_metadata(schema: str | None = None) -> MetaData:
     Table(
         "analysis_runs",
         md,
-        Column(
-            "id",
-            String(36),
-            primary_key=True,
-            comment=(
-                "UUID v4 primary key. Surfaced as a short prefix in CLI output "
-                "(/list, /show, /results, /review, /compare). UUID rather than "
-                "INT autoincrement because shared mode admits concurrent writers "
-                "from multiple machines."
-            ),
-        ),
+        Column("id", String(36), primary_key=True, comment=_desc("analysis_runs", "id")),
         Column(
             "started_at",
             DateTime(timezone=True),
             nullable=False,
             index=True,
-            comment=(
-                "UTC timestamp when the agent run began. Indexed for "
-                "last-N-days filters in /list and /stats."
-            ),
+            comment=_desc("analysis_runs", "started_at"),
         ),
-        Column(
-            "ended_at",
-            DateTime(timezone=True),
-            comment=(
-                "UTC timestamp when the run finished. NULL while a run is in "
-                "flight; also NULL for runs killed mid-flight by Ctrl-C."
-            ),
-        ),
-        Column(
-            "duration_sec",
-            Float,
-            comment=(
-                "Wall-clock seconds between started_at and ended_at. Convenience "
-                "column so /stats does not have to recompute it on every read."
-            ),
-        ),
-        Column(
-            "status",
-            String(40),
-            nullable=False,
-            comment=(
-                "Lifecycle state of the run: running | completed | failed | "
-                "cancelled. Drives /list filters and the colored status badge."
-            ),
-        ),
-        Column(
-            "command",
-            String(80),
-            nullable=False,
-            comment=(
-                "Top-level CLI command that triggered the run: run | run-apply | "
-                "ask | doc-analyze | code-analyze. Distinguishes batch metadata "
-                "generation from one-off Q&A in /stats breakdowns."
-            ),
-        ),
-        Column(
-            "mode",
-            String(40),
-            comment=(
-                "Sub-mode chosen at the run picker: human-review | auto-apply | "
-                "confidence-threshold | dry-run."
-            ),
-        ),
-        Column(
-            "db_backend",
-            String(40),
-            comment=(
-                "Backend of the analyzed DB profile: postgresql | snowflake | "
-                "bigquery | databricks | mssql | mysql | oracle | redshift. "
-                "Enables /compare --by db_backend cross-backend audits."
-            ),
-        ),
-        Column(
-            "db_profile",
-            String(120),
-            comment=(
-                "Named DB profile used for this run (see /db-profiles). Multi-"
-                "profile runs (0.11+) record the first profile here and the "
-                "full list in scope_json.profiles."
-            ),
-        ),
-        Column(
-            "llm_provider",
-            String(40),
-            comment=(
-                "LLM vendor: openai | anthropic | gemini | openrouter | "
-                "deepseek | ollama | …. Distinct from llm_model which records "
-                "the specific model id."
-            ),
-        ),
-        Column(
-            "llm_model",
-            String(120),
-            comment=(
-                "Specific model id served by llm_provider — e.g. 'gpt-4o', "
-                "'claude-sonnet-4-20250514', 'openai/gpt-4o-mini' on OpenRouter."
-            ),
-        ),
-        Column(
-            "scope_json",
-            _portable_json(),
-            comment=(
-                "JSON describing the analyzed scope: {schemas, tables, columns, "
-                "asset_kinds, profiles}. /compare reads this to find prior runs "
-                "of the same assets for side-by-side pivots."
-            ),
-        ),
-        Column(
-            "metrics_json",
-            _portable_json(),
-            comment=(
-                "JSON of run metrics — counts, per-stage timings, retries, "
-                "skipped assets. Free-form so newer agents can add fields "
-                "without a schema bump."
-            ),
-        ),
-        Column(
-            "tokens_json",
-            _portable_json(),
-            comment=(
-                "JSON of token usage broken down by phase: "
-                "{prompt, completion, cached, reasoning, total}. Drives /stats "
-                "cost reporting and /compare --by tokens."
-            ),
-        ),
-        Column(
-            "results_json",
-            _portable_json(),
-            comment=(
-                "JSON summary of run outputs (counts, top-level rollups). "
-                "Per-asset detail lives in run_results joined on run_id."
-            ),
-        ),
-        Column(
-            "error_text",
-            Text,
-            comment=("Stack trace or error message when status='failed'. NULL on successful runs."),
-        ),
+        Column("ended_at", DateTime(timezone=True), comment=_desc("analysis_runs", "ended_at")),
+        Column("duration_sec", Float, comment=_desc("analysis_runs", "duration_sec")),
+        Column("status", String(40), nullable=False, comment=_desc("analysis_runs", "status")),
+        Column("command", String(80), nullable=False, comment=_desc("analysis_runs", "command")),
+        Column("mode", String(40), comment=_desc("analysis_runs", "mode")),
+        Column("db_backend", String(40), comment=_desc("analysis_runs", "db_backend")),
+        Column("db_profile", String(120), comment=_desc("analysis_runs", "db_profile")),
+        Column("llm_provider", String(40), comment=_desc("analysis_runs", "llm_provider")),
+        Column("llm_model", String(120), comment=_desc("analysis_runs", "llm_model")),
+        Column("scope_json", _portable_json(), comment=_desc("analysis_runs", "scope_json")),
+        Column("metrics_json", _portable_json(), comment=_desc("analysis_runs", "metrics_json")),
+        Column("tokens_json", _portable_json(), comment=_desc("analysis_runs", "tokens_json")),
+        Column("results_json", _portable_json(), comment=_desc("analysis_runs", "results_json")),
+        Column("error_text", Text, comment=_desc("analysis_runs", "error_text")),
         Column(
             "selected_count",
             Integer,
             nullable=False,
             default=0,
-            comment=(
-                "Assets the user selected at the run picker. First step of the "
-                "selected → planned → processed → applied funnel."
-            ),
+            comment=_desc("analysis_runs", "selected_count"),
         ),
         Column(
             "planned_count",
             Integer,
             nullable=False,
             default=0,
-            comment=(
-                "Assets that survived post-selection filtering (already-good "
-                "comments skipped, unsupported asset kinds dropped, etc.)."
-            ),
+            comment=_desc("analysis_runs", "planned_count"),
         ),
         Column(
             "processed_count",
             Integer,
             nullable=False,
             default=0,
-            comment=(
-                "Assets the LLM successfully produced descriptions for. "
-                "planned_count - processed_count = LLM/network failures."
-            ),
+            comment=_desc("analysis_runs", "processed_count"),
         ),
         Column(
             "applied_count",
             Integer,
             nullable=False,
             default=0,
-            comment=(
-                "Assets whose chosen description was written to the live DB "
-                "via COMMENT ON. processed_count - applied_count = approved-"
-                "but-not-yet-applied (when running without --apply)."
-            ),
+            comment=_desc("analysis_runs", "applied_count"),
         ),
-        Column(
-            "review_strategy",
-            String(40),
-            comment=(
-                "How alternatives were chosen: human | auto-best | "
-                "confidence-threshold. Affects how to read evaluated_at on "
-                "joined run_results rows."
-            ),
-        ),
-        Column(
-            "llm_profile",
-            String(120),
-            comment=(
-                "Named LLM profile used for this run (see /llm-profiles). "
-                "Captures the user-facing handle; concrete provider/model "
-                "values are mirrored in llm_provider/llm_model."
-            ),
-        ),
-        Column(
-            "doc_profile",
-            String(120),
-            comment=(
-                "Named document profile that supplied RAG evidence (see "
-                "/doc-profiles). NULL when /docs was not used in this run."
-            ),
-        ),
-        Column(
-            "code_profile",
-            String(120),
-            comment=(
-                "Named code profile that supplied code-evidence (see "
-                "/code-profiles). NULL when /code was not used in this run."
-            ),
-        ),
-        Column(
-            "settings_json",
-            _portable_json(),
-            comment=(
-                "Snapshot of LLM settings at run time — temperature, "
-                "prompt_detail, n_alternatives, llm_batch_size, "
-                "description_verbosity, logprob_thresholds. Drives "
-                "/compare --by settings pivots so changes can be A/B-attributed."
-            ),
-        ),
-        Column("created_by", String(120), comment=_ATTRIBUTION_CREATED_BY),
-        Column("hostname", String(255), comment=_ATTRIBUTION_HOSTNAME),
-        Column("client_version", String(40), comment=_ATTRIBUTION_CLIENT_VERSION),
-        Column("local_id", BigInteger, comment=_ATTRIBUTION_LOCAL_ID),
+        Column("review_strategy", String(40), comment=_desc("analysis_runs", "review_strategy")),
+        Column("llm_profile", String(120), comment=_desc("analysis_runs", "llm_profile")),
+        Column("doc_profile", String(120), comment=_desc("analysis_runs", "doc_profile")),
+        Column("code_profile", String(120), comment=_desc("analysis_runs", "code_profile")),
+        Column("settings_json", _portable_json(), comment=_desc("analysis_runs", "settings_json")),
+        Column("created_by", String(120), comment=_desc("analysis_runs", "created_by")),
+        Column("hostname", String(255), comment=_desc("analysis_runs", "hostname")),
+        Column("client_version", String(40), comment=_desc("analysis_runs", "client_version")),
+        Column("local_id", BigInteger, comment=_desc("analysis_runs", "local_id")),
         Index("ix_analysis_runs_started_at", "started_at"),
         Index("ix_analysis_runs_local_lookup", "hostname", "local_id"),
-        comment=(
-            "One row per AMX analysis run (/run, /run-apply, /ask, "
-            "doc-analyze, code-analyze). Captures the inputs (scope, "
-            "profiles, settings) and outputs (results, metrics, errors) of "
-            "an LLM-driven metadata generation. Joined to run_results for "
-            "per-asset alternatives. Read by /list, /show, /stats, /compare."
-        ),
+        comment=_desc("analysis_runs"),
     )
 
     # ── run_results: per-asset LLM alternatives + review state ─────────────
     Table(
         "run_results",
         md,
-        Column(
-            "id",
-            String(36),
-            primary_key=True,
-            comment="UUID v4 primary key for this (asset, alternative) row.",
-        ),
+        Column("id", String(36), primary_key=True, comment=_desc("run_results", "id")),
         Column(
             "run_id",
             String(36),
             nullable=False,
             index=True,
-            comment=(
-                "Foreign-key-by-convention to analysis_runs.id. Not a hard FK "
-                "because shared mode admits replication lag — a result row can "
-                "land before its parent run row when two writers race."
-            ),
+            comment=_desc("run_results", "run_id"),
         ),
         Column(
             "saved_at",
             DateTime(timezone=True),
             nullable=False,
-            comment=(
-                "UTC timestamp when this alternative was persisted. Distinct "
-                "from analysis_runs.started_at when the LLM streams alternatives "
-                "across the run window."
-            ),
+            comment=_desc("run_results", "saved_at"),
         ),
         Column(
             "schema_name",
             String(255),
             nullable=False,
-            comment="Schema (or dataset/database) of the asset described.",
+            comment=_desc("run_results", "schema_name"),
         ),
         Column(
             "table_name",
             String(255),
             nullable=False,
-            comment="Table or view name of the asset described.",
+            comment=_desc("run_results", "table_name"),
         ),
-        Column(
-            "column_name",
-            String(255),
-            comment=(
-                "Column name when asset_kind='column'. NULL when asset_kind='table' "
-                "(the alternative describes the table itself)."
-            ),
-        ),
+        Column("column_name", String(255), comment=_desc("run_results", "column_name")),
         Column(
             "asset_kind",
             String(40),
             nullable=False,
             default="table",
-            comment=(
-                "What this row describes: table | view | materialized_view | "
-                "column. Drives which COMMENT ON variant is emitted on apply."
-            ),
+            comment=_desc("run_results", "asset_kind"),
         ),
-        Column(
-            "source",
-            String(40),
-            nullable=False,
-            comment=(
-                "Which agent produced this alternative: profile | doc | code | "
-                "combined | manual. Lets /compare and /review filter by source "
-                "of evidence."
-            ),
-        ),
+        Column("source", String(40), nullable=False, comment=_desc("run_results", "source")),
         Column(
             "confidence",
             String(20),
             nullable=False,
-            comment=(
-                "Bucketed quality label derived from logprob_score against the "
-                "/logprob-thresholds settings: high | medium | low. Used by "
-                "/review filters and the human-review UI."
-            ),
+            comment=_desc("run_results", "confidence"),
         ),
-        Column(
-            "logprob_score",
-            Float,
-            comment=(
-                "Normalized average log-probability of the description tokens "
-                "(-1..0). Higher = the LLM was more confident in the wording."
-            ),
-        ),
-        Column(
-            "raw_logprob",
-            Float,
-            comment="Sum of log-probabilities (unnormalized) backing logprob_score.",
-        ),
-        Column(
-            "token_count",
-            Integer,
-            comment="Token length of the alternative description.",
-        ),
+        Column("logprob_score", Float, comment=_desc("run_results", "logprob_score")),
+        Column("raw_logprob", Float, comment=_desc("run_results", "raw_logprob")),
+        Column("token_count", Integer, comment=_desc("run_results", "token_count")),
         Column(
             "model_version",
             String(120),
             nullable=False,
             default="",
-            comment=(
-                "Specific model id that produced this alternative (e.g. "
-                "'gpt-4o-2024-11-20'). May differ from analysis_runs.llm_model "
-                "when the user switches mid-run."
-            ),
+            comment=_desc("run_results", "model_version"),
         ),
-        Column(
-            "reasoning",
-            Text,
-            comment=(
-                "Optional reasoning trace from a reasoning model (o-series, "
-                "claude with thinking, deepseek-reasoner). NULL for normal "
-                "chat models."
-            ),
-        ),
+        Column("reasoning", Text, comment=_desc("run_results", "reasoning")),
         Column(
             "alternatives_json",
             _portable_json(),
             nullable=False,
-            comment=(
-                "Ordered JSON list of alternative description strings the LLM "
-                "produced for this asset. The /review picker presents these; "
-                "chosen_description records which one was selected."
-            ),
+            comment=_desc("run_results", "alternatives_json"),
         ),
         Column(
-            "evaluated_at",
-            DateTime(timezone=True),
-            comment=(
-                "UTC timestamp when a human (or auto-best) picked one of the "
-                "alternatives. NULL = pending review."
-            ),
+            "evaluated_at", DateTime(timezone=True), comment=_desc("run_results", "evaluated_at")
         ),
-        Column(
-            "applied_at",
-            DateTime(timezone=True),
-            comment=(
-                "UTC timestamp when chosen_description was written to the live "
-                "DB via COMMENT ON. NULL = approved but not yet applied (or "
-                "never approved)."
-            ),
-        ),
-        Column(
-            "chosen_description",
-            Text,
-            comment=(
-                "The specific alternative selected at evaluation time. Empty "
-                "string when evaluation='rejected'."
-            ),
-        ),
-        Column(
-            "evaluation",
-            String(40),
-            comment=(
-                "Outcome of human/auto review: approved | rejected | edited. "
-                "'edited' means the user accepted an alternative but modified "
-                "the wording before apply."
-            ),
-        ),
+        Column("applied_at", DateTime(timezone=True), comment=_desc("run_results", "applied_at")),
+        Column("chosen_description", Text, comment=_desc("run_results", "chosen_description")),
+        Column("evaluation", String(40), comment=_desc("run_results", "evaluation")),
         Column(
             "catalog_status",
             String(40),
             nullable=False,
             default="",
-            comment=(
-                "Sync state with the /search catalog: pending | indexed | stale "
-                "| skipped. Drives /search rebuild incremental updates."
-            ),
+            comment=_desc("run_results", "catalog_status"),
         ),
         Column(
             "catalog_indexed_at",
             DateTime(timezone=True),
-            comment="UTC timestamp of the last /search-catalog index for this row.",
+            comment=_desc("run_results", "catalog_indexed_at"),
         ),
         Column(
             "db_applied_status",
             String(40),
             nullable=False,
             default="",
-            comment=(
-                "Result of the COMMENT ON write to the live DB: success | "
-                "skipped | failed. Empty string until apply is attempted."
-            ),
+            comment=_desc("run_results", "db_applied_status"),
         ),
         Column(
             "effective_source_kind",
             String(40),
             nullable=False,
             default="",
-            comment=(
-                "What actually became the column's description after evaluation: "
-                "same labels as `source` plus 'manual-edit'. Distinct from "
-                "`source` because a user may approve a doc-sourced alternative "
-                "after a manual edit."
-            ),
+            comment=_desc("run_results", "effective_source_kind"),
         ),
         Column(
             "superseded_at",
             DateTime(timezone=True),
-            comment=(
-                "Set when a newer run produces a better description for the same "
-                "asset. Lets /history filters hide stale rows without deleting "
-                "them — full audit trail preserved."
-            ),
+            comment=_desc("run_results", "superseded_at"),
         ),
         Column(
             "rejection_reason",
             Text,
             nullable=False,
             default="",
-            comment=(
-                "Free-text reason captured at evaluation time when "
-                "evaluation='rejected'. Surfaced by /review for retrospectives."
-            ),
+            comment=_desc("run_results", "rejection_reason"),
         ),
-        Column("hostname", String(255), comment=_ATTRIBUTION_HOSTNAME),
-        Column("local_id", BigInteger, comment=_ATTRIBUTION_LOCAL_ID),
+        Column("hostname", String(255), comment=_desc("run_results", "hostname")),
+        Column("local_id", BigInteger, comment=_desc("run_results", "local_id")),
         Index("ix_run_results_asset", "schema_name", "table_name", "column_name"),
         Index("ix_run_results_local_lookup", "hostname", "local_id"),
-        comment=(
-            "Per-asset LLM alternatives generated during an analysis_runs "
-            "invocation. One row per (asset, alternative) — a column with "
-            "3 alternatives produces 3 rows. Captures the alternative payload, "
-            "confidence, evaluation/apply state, and a back-pointer to the run."
-        ),
+        comment=_desc("run_results"),
     )
 
     # ── app_events: append-only event log ─────────────────────────────────
     Table(
         "app_events",
         md,
-        Column(
-            "id",
-            String(36),
-            primary_key=True,
-            comment="UUID v4 primary key for the event.",
-        ),
+        Column("id", String(36), primary_key=True, comment=_desc("app_events", "id")),
         Column(
             "created_at",
             DateTime(timezone=True),
             nullable=False,
             index=True,
-            comment="UTC timestamp the event fired. Indexed for /events recent-first ordering.",
+            comment=_desc("app_events", "created_at"),
         ),
-        Column(
-            "event_type",
-            String(80),
-            nullable=False,
-            comment=(
-                "Coarse event family: cli | db | llm | doc | code | error | "
-                "history-store. Lets /events filter by subsystem."
-            ),
-        ),
-        Column(
-            "status",
-            String(40),
-            nullable=False,
-            comment="Severity of the event: info | warn | error.",
-        ),
-        Column(
-            "command",
-            String(120),
-            nullable=False,
-            comment="CLI command (or sub-action) that was running when the event fired.",
-        ),
-        Column(
-            "details_json",
-            _portable_json(),
-            comment=(
-                "Free-form JSON payload — varies per event_type. Examples: "
-                "{profile, backend} for db connect, {model, latency_ms} for "
-                "llm calls, {error_class, traceback} for errors."
-            ),
-        ),
-        Column("created_by", String(120), comment=_ATTRIBUTION_CREATED_BY),
-        Column("hostname", String(255), comment=_ATTRIBUTION_HOSTNAME),
-        Column("client_version", String(40), comment=_ATTRIBUTION_CLIENT_VERSION),
+        Column("event_type", String(80), nullable=False, comment=_desc("app_events", "event_type")),
+        Column("status", String(40), nullable=False, comment=_desc("app_events", "status")),
+        Column("command", String(120), nullable=False, comment=_desc("app_events", "command")),
+        Column("details_json", _portable_json(), comment=_desc("app_events", "details_json")),
+        Column("created_by", String(120), comment=_desc("app_events", "created_by")),
+        Column("hostname", String(255), comment=_desc("app_events", "hostname")),
+        Column("client_version", String(40), comment=_desc("app_events", "client_version")),
         Index("ix_app_events_created_at", "created_at"),
-        comment=(
-            "Append-only structured event log surfaced by /events. Records CLI "
-            "lifecycle events (connection tests, syncs, doctor checks, errors) "
-            "for audit and debugging. Distinct from analysis_runs which logs "
-            "LLM agent invocations."
-        ),
+        comment=_desc("app_events"),
     )
 
     # ── session_state: namespaced key/value storage ───────────────────────
-    # Used by ``StateManager`` for inter-turn agent memory. In shared
-    # mode it lets the team (or the same user across machines) share
-    # session checkpoints. ``hostname`` is part of the PK so two
-    # machines can hold independent state under the same namespace/key.
     Table(
         "session_state",
         md,
@@ -711,98 +370,63 @@ def build_metadata(schema: str | None = None) -> MetaData:
             "namespace",
             String(120),
             primary_key=True,
-            comment=(
-                "Logical grouping for related keys (e.g. 'ask_session_42' or "
-                "'review_state'). Lets multiple StateManager instances share a "
-                "table without colliding."
-            ),
+            comment=_desc("session_state", "namespace"),
         ),
         Column(
             "key_name",
             String(255),
             primary_key=True,
-            comment="Key within the namespace.",
+            comment=_desc("session_state", "key_name"),
         ),
         Column(
             "hostname",
             String(255),
             primary_key=True,
             default="",
-            comment=(
-                "Writer machine. Part of the composite PK so a teammate's state "
-                "under the same (namespace, key_name) does not clobber yours in "
-                "shared mode. Empty string when running in single-user mode."
-            ),
+            comment=_desc("session_state", "hostname"),
         ),
         Column(
             "value_json",
             _portable_json(),
             nullable=False,
-            comment="JSON-serialized value associated with (namespace, key_name, hostname).",
+            comment=_desc("session_state", "value_json"),
         ),
         Column(
             "updated_at",
             DateTime(timezone=True),
             nullable=False,
-            comment="UTC timestamp of the last write to this row.",
+            comment=_desc("session_state", "updated_at"),
         ),
-        Column("created_by", String(120), comment=_ATTRIBUTION_CREATED_BY),
-        comment=(
-            "Namespaced key/value storage used by StateManager for inter-turn "
-            "agent memory within /ask conversational sessions. Composite primary "
-            "key (namespace, key_name, hostname) so a teammate's state under "
-            "the same namespace does not clobber yours in shared mode."
-        ),
+        Column("created_by", String(120), comment=_desc("session_state", "created_by")),
+        comment=_desc("session_state"),
     )
 
-    # ── schema_meta: version stamp so older clients refuse to write ──────
-    # Single-row table. The /history-store enable bootstrap inserts
-    # version=SHARED_SCHEMA_VERSION; a newer client bumps it on its
-    # first write; an older client refuses to write when it sees a
-    # higher version than it knows about (mirrors the AMXConfig
-    # schema_version guard).
+    # ── schema_meta: single-row version stamp ────────────────────────────
     Table(
         "schema_meta",
         md,
-        Column(
-            "id",
-            Integer,
-            primary_key=True,
-            comment=(
-                "Singleton sentinel — always 1. The PK exists only because every "
-                "table needs one; this table holds at most one row."
-            ),
-        ),
+        Column("id", Integer, primary_key=True, comment=_desc("schema_meta", "id")),
         Column(
             "schema_version",
             Integer,
             nullable=False,
-            comment=(
-                "Current version of the AMX shared-store schema. Older clients "
-                "refuse to write when this is higher than what they were built "
-                "against, mirroring the AMXConfig schema_version compatibility "
-                "guard."
-            ),
+            comment=_desc("schema_meta", "schema_version"),
         ),
         Column(
             "created_at",
             DateTime(timezone=True),
             nullable=False,
-            comment="UTC timestamp when /history-store enable first bootstrapped this schema.",
+            comment=_desc("schema_meta", "created_at"),
         ),
         Column(
             "created_by_client_version",
             String(40),
-            comment="AMX version string of the client that ran the bootstrap.",
+            comment=_desc("schema_meta", "created_by_client_version"),
         ),
-        comment=(
-            "Single-row version stamp written at /history-store enable bootstrap. "
-            "Newer AMX clients bump schema_version on first write; older clients "
-            "refuse to write into a schema bumped beyond what they know about, "
-            "mirroring the AMXConfig schema_version guard."
-        ),
+        comment=_desc("schema_meta"),
     )
 
+    # ── style_profiles: derived description-style profiles ────────────────
     Table(
         "style_profiles",
         md,
@@ -811,83 +435,59 @@ def build_metadata(schema: str | None = None) -> MetaData:
             Integer,
             primary_key=True,
             autoincrement=True,
-            comment="Surrogate primary key.",
+            comment=_desc("style_profiles", "id"),
         ),
         Column(
             "llm_profile",
             String(256),
             nullable=False,
             unique=True,
-            comment=(
-                "Name of the LLM profile this style record belongs to. "
-                "Matches the llm_profile key used in AMXConfig."
-            ),
+            comment=_desc("style_profiles", "llm_profile"),
         ),
         Column(
             "source_ref",
             String(1024),
             nullable=False,
-            comment=(
-                "Fully-qualified reference to the table or column set whose "
-                "comments were used to derive this profile (e.g. "
-                "'warehouse.sales.orders')."
-            ),
+            comment=_desc("style_profiles", "source_ref"),
         ),
         Column(
             "source_db_kind",
             String(64),
             nullable=False,
-            comment=(
-                "Database kind identifier of the source (e.g. 'snowflake', "
-                "'duckdb', 'bigquery'). Stored for diagnostic and audit purposes."
-            ),
+            comment=_desc("style_profiles", "source_db_kind"),
         ),
         Column(
             "profile_json",
             Text,
             nullable=False,
-            comment=(
-                "JSON-serialised StyleProfile dataclass. Deserialised by "
-                "StyleProfile.from_json() on read."
-            ),
+            comment=_desc("style_profiles", "profile_json"),
         ),
         Column(
             "enabled",
             Integer,
             nullable=False,
             default=1,
-            comment=(
-                "Whether this style profile is active (1) or disabled (0). "
-                "Disabled profiles are stored but not injected into prompts."
-            ),
+            comment=_desc("style_profiles", "enabled"),
         ),
         Column(
             "sample_count",
             Integer,
             nullable=False,
-            comment=(
-                "Number of source description samples that were analysed to "
-                "produce the profile. Used as a confidence indicator."
-            ),
+            comment=_desc("style_profiles", "sample_count"),
         ),
         Column(
             "created_at",
             Text,
             nullable=False,
-            comment="Stored as TEXT representation of a Unix timestamp float, mirroring the local SQLite schema.",
+            comment=_desc("style_profiles", "created_at"),
         ),
         Column(
             "updated_at",
             Text,
             nullable=False,
-            comment="Stored as TEXT representation of a Unix timestamp float, mirroring the local SQLite schema.",
+            comment=_desc("style_profiles", "updated_at"),
         ),
-        comment=(
-            "One row per LLM profile containing the derived StyleProfile that "
-            "summarises the user's description writing conventions. The profile "
-            "is injected into run-time prompts to keep generated descriptions "
-            "consistent with the existing corpus style."
-        ),
+        comment=_desc("style_profiles"),
     )
 
     return md

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -10,9 +10,21 @@ import time
 from pathlib import Path
 from typing import Any
 
+from amx.storage.schema_descriptions import (
+    LOCAL_DATABASE_DESCRIPTION,
+    SCHEMA_DESCRIPTIONS,
+)
 from amx.utils.logging import get_logger
 
 log = get_logger("storage.sqlite")
+
+# Sidecar table that holds the description of every table and column in the
+# local history DB. SQLite has no native ``COMMENT ON``; this table is the
+# queryable equivalent of ``pg_description``. Populated idempotently at the
+# end of :meth:`SQLiteHistoryStore.init` from
+# :data:`amx.storage.schema_descriptions.SCHEMA_DESCRIPTIONS` so descriptions
+# stay in lock-step with the schema across upgrades.
+_SCHEMA_DESCRIPTIONS_TABLE = "_amx_schema_descriptions"
 
 
 def parse_alternatives_json(raw):
@@ -786,6 +798,98 @@ class SQLiteHistoryStore:
                 "CREATE INDEX IF NOT EXISTS idx_scheduled_runs_db_profile "
                 "ON scheduled_runs(db_profile)"
             )
+            # Last step: populate the metadata sidecar so every table created
+            # above carries a queryable description. Must run after all
+            # CREATE TABLE / ALTER TABLE statements so PRAGMA table_info
+            # returns the final column set.
+            self._populate_schema_descriptions(conn)
+
+    def _populate_schema_descriptions(self, conn: Any) -> None:
+        """Create and idempotently populate the metadata sidecar table.
+
+        Creates ``_amx_schema_descriptions`` (if missing) and writes one row
+        per (object_kind, schema, table, column) using ``INSERT OR REPLACE``.
+        Descriptions are sourced from
+        :data:`amx.storage.schema_descriptions.SCHEMA_DESCRIPTIONS`, which is
+        also the single source of truth read by
+        :mod:`amx.storage.shared_schema`.
+
+        Runs on every :meth:`init` call so new strings authored in the SoT
+        propagate to existing installs on next boot. The PK on
+        (object_kind, schema_name, table_name, column_name) guarantees the
+        operation is O(rows) and free of duplicates.
+
+        Tables that are missing on this install (older schemas, partial
+        migrations) are silently skipped — the next ``init`` after the
+        ``CREATE TABLE`` lands will pick them up.
+        """
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {_SCHEMA_DESCRIPTIONS_TABLE} (
+                object_kind TEXT NOT NULL,
+                schema_name TEXT NOT NULL DEFAULT '',
+                table_name  TEXT NOT NULL DEFAULT '',
+                column_name TEXT NOT NULL DEFAULT '',
+                description TEXT NOT NULL,
+                updated_at  REAL NOT NULL,
+                PRIMARY KEY (object_kind, schema_name, table_name, column_name)
+            )
+            """
+        )
+        now = time.time()
+        # Database-level row.
+        conn.execute(
+            f"INSERT OR REPLACE INTO {_SCHEMA_DESCRIPTIONS_TABLE} "
+            f"(object_kind, schema_name, table_name, column_name, description, updated_at) "
+            f"VALUES (?, ?, ?, ?, ?, ?)",
+            ("database", "", "", "", LOCAL_DATABASE_DESCRIPTION, now),
+        )
+        # Set of tables that actually exist in this DB. Includes virtual
+        # tables (FTS5) but excludes SQLite shadow tables and tables not
+        # yet created on this install.
+        existing_names: set[str] = set()
+        try:
+            existing_names = {
+                str(r[0])
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'"
+                ).fetchall()
+            }
+        except Exception as exc:
+            log.warning("Could not enumerate sqlite_master for description sync: %s", exc)
+        for table_name, fields in SCHEMA_DESCRIPTIONS.items():
+            if table_name not in existing_names:
+                continue
+            table_desc = fields.get("__table__")
+            if table_desc:
+                conn.execute(
+                    f"INSERT OR REPLACE INTO {_SCHEMA_DESCRIPTIONS_TABLE} "
+                    f"(object_kind, schema_name, table_name, column_name, description, updated_at) "
+                    f"VALUES (?, ?, ?, ?, ?, ?)",
+                    ("table", "main", table_name, "", table_desc, now),
+                )
+            try:
+                live_cols = [
+                    str(r[1]) for r in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+                ]
+            except Exception as exc:
+                log.warning("Could not PRAGMA table_info(%s): %s", table_name, exc)
+                live_cols = []
+            for col_name in live_cols:
+                col_desc = fields.get(col_name)
+                if not col_desc:
+                    # Missing description for a real column is a contract
+                    # violation enforced by tests/test_local_schema_comments.py.
+                    # Skip silently here so the boot path stays resilient; CI
+                    # will fail the offending PR before it lands.
+                    continue
+                conn.execute(
+                    f"INSERT OR REPLACE INTO {_SCHEMA_DESCRIPTIONS_TABLE} "
+                    f"(object_kind, schema_name, table_name, column_name, description, updated_at) "
+                    f"VALUES (?, ?, ?, ?, ?, ?)",
+                    ("column", "main", table_name, col_name, col_desc, now),
+                )
 
     def _ensure_run_columns(self, conn: Any) -> None:
         """Idempotently add the v0.5.2 reporting columns to analysis_runs.

--- a/tests/test_local_schema_comments.py
+++ b/tests/test_local_schema_comments.py
@@ -1,0 +1,231 @@
+"""Dogfooding tests: AMX's own local SQLite history store must ship descriptions.
+
+Companion to ``tests/test_shared_schema_comments.py`` for the local SQLite
+DB at ``~/.amx/history.db``. SQLite has no native ``COMMENT ON`` syntax,
+so descriptions live in the ``_amx_schema_descriptions`` sidecar table
+populated at :meth:`SQLiteHistoryStore.init` time from
+:data:`amx.storage.schema_descriptions.SCHEMA_DESCRIPTIONS`.
+
+AMX's product thesis is "every table and column should ship with a
+meaningful description." These tests pin that AMX's *own* internal
+storage meets that bar. If a contributor adds a new table or column to
+``amx/storage/sqlite_store.py`` without a matching entry in
+``schema_descriptions.py``, the tests below fail fast — preventing the
+embarrassment of shipping a metadata tool that does not annotate its
+own outputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amx.storage.schema_descriptions import SCHEMA_DESCRIPTIONS
+from amx.storage.shared_schema import build_metadata
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+# FTS5 creates shadow tables named ``<fts>_data``, ``_idx``, ``_content``,
+# ``_docsize``, ``_config`` that show up in sqlite_master with type='table'.
+# These are SQLite implementation details, not AMX-owned tables, and have
+# no place in SCHEMA_DESCRIPTIONS.
+_FTS_SHADOW_PREFIXES = ("catalog_entities_fts_",)
+
+
+def _is_shadow(name: str) -> bool:
+    return any(name.startswith(p) for p in _FTS_SHADOW_PREFIXES)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    db = SQLiteHistoryStore(tmp_path / "history.db")
+    db.init()
+    return db
+
+
+def _real_tables_and_columns(store: SQLiteHistoryStore) -> dict[str, list[str]]:
+    """Return ``{table_name: [columns]}`` for every AMX-owned table in the DB.
+
+    FTS5 shadow tables are excluded — they are SQLite implementation
+    details, not part of AMX's declared schema.
+    """
+    with store._connect() as conn:
+        names = [
+            str(r[0])
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'"
+            ).fetchall()
+            if not _is_shadow(str(r[0]))
+        ]
+        out: dict[str, list[str]] = {}
+        for table in names:
+            cols = [str(r[1]) for r in conn.execute(f"PRAGMA table_info({table})").fetchall()]
+            out[table] = cols
+    return out
+
+
+def test_every_real_table_has_a_description(store: SQLiteHistoryStore) -> None:
+    """Every table SQLiteHistoryStore.init() creates has a ``__table__`` entry."""
+    live = _real_tables_and_columns(store)
+    missing: list[str] = []
+    for table_name in live:
+        entry = SCHEMA_DESCRIPTIONS.get(table_name)
+        if entry is None or not (entry.get("__table__") or "").strip():
+            missing.append(table_name)
+    assert not missing, (
+        "Tables created by SQLiteHistoryStore.init() but missing a __table__ "
+        "description in amx/storage/schema_descriptions.py: "
+        f"{missing}"
+    )
+
+
+def test_every_real_column_has_a_description(store: SQLiteHistoryStore) -> None:
+    """Every PRAGMA-reported column has a SCHEMA_DESCRIPTIONS entry."""
+    live = _real_tables_and_columns(store)
+    missing: list[str] = []
+    for table, cols in live.items():
+        fields = SCHEMA_DESCRIPTIONS.get(table, {})
+        for col in cols:
+            if not (fields.get(col) or "").strip():
+                missing.append(f"{table}.{col}")
+    assert not missing, (
+        f"{len(missing)} live SQLite columns missing a description "
+        f"in amx/storage/schema_descriptions.py (first 10): {missing[:10]}"
+    )
+
+
+def test_sidecar_is_populated(store: SQLiteHistoryStore) -> None:
+    """The ``_amx_schema_descriptions`` sidecar gets the expected row counts."""
+    live = _real_tables_and_columns(store)
+    with store._connect() as conn:
+        rows = conn.execute(
+            "SELECT object_kind, COUNT(*) FROM _amx_schema_descriptions GROUP BY object_kind"
+        ).fetchall()
+    by_kind = {str(r[0]): int(r[1]) for r in rows}
+    assert by_kind.get("database", 0) == 1, "missing database-level description row"
+    # +1 for the sidecar table itself (it self-describes).
+    expected_tables = len(live)
+    assert by_kind.get("table", 0) == expected_tables, (
+        f"sidecar 'table' row count {by_kind.get('table', 0)} != live table count {expected_tables}"
+    )
+    expected_columns = sum(len(cols) for cols in live.values())
+    assert by_kind.get("column", 0) == expected_columns, (
+        f"sidecar 'column' row count {by_kind.get('column', 0)} "
+        f"!= live column count {expected_columns}"
+    )
+
+
+def test_sidecar_descriptions_are_non_empty(store: SQLiteHistoryStore) -> None:
+    """No row in the sidecar carries an empty description string."""
+    with store._connect() as conn:
+        empties = [
+            (str(r[0]), str(r[1]), str(r[2]), str(r[3]))
+            for r in conn.execute(
+                "SELECT object_kind, schema_name, table_name, column_name "
+                "FROM _amx_schema_descriptions "
+                "WHERE description IS NULL OR TRIM(description) = ''"
+            ).fetchall()
+        ]
+    assert not empties, f"Sidecar rows with empty description: {empties}"
+
+
+def test_no_orphan_schema_descriptions_entries(store: SQLiteHistoryStore) -> None:
+    """Every SCHEMA_DESCRIPTIONS column entry for a real local table must
+    correspond to an actual column either in the local SQLite store or the
+    shared SQLAlchemy store (some columns are local-only, some shared-only).
+    """
+    live = _real_tables_and_columns(store)
+    md = build_metadata("AMX")
+    shared_cols_by_table: dict[str, set[str]] = {
+        t.name: {c.name for c in t.columns} for t in md.tables.values()
+    }
+    orphans: list[str] = []
+    for table, fields in SCHEMA_DESCRIPTIONS.items():
+        if table not in live and table not in shared_cols_by_table:
+            # Table is declared in SoT but doesn't exist in any store yet.
+            # Could be an in-development table — flag it.
+            orphans.append(f"<table:{table}>")
+            continue
+        live_cols = set(live.get(table, []))
+        shared_cols = shared_cols_by_table.get(table, set())
+        for col_name in fields:
+            if col_name == "__table__":
+                continue
+            if col_name not in live_cols and col_name not in shared_cols:
+                orphans.append(f"{table}.{col_name}")
+    assert not orphans, (
+        "Orphan SCHEMA_DESCRIPTIONS entries (do not match any real local or "
+        f"shared schema column): {orphans}"
+    )
+
+
+def test_local_and_shared_agree_on_overlapping_columns(
+    store: SQLiteHistoryStore,
+) -> None:
+    """For tables that exist in both stores, columns present in BOTH must
+    carry the same description string byte-for-byte. Catches drift if a
+    contributor hardcodes a comment back into shared_schema.py instead of
+    sourcing it from SCHEMA_DESCRIPTIONS.
+    """
+    live = _real_tables_and_columns(store)
+    md = build_metadata("AMX")
+    mismatches: list[str] = []
+    for table in md.tables.values():
+        if table.name not in live:
+            continue
+        live_cols = set(live[table.name])
+        for col in table.columns:
+            if col.name not in live_cols:
+                continue
+            local_desc = SCHEMA_DESCRIPTIONS[table.name].get(col.name) or ""
+            shared_desc = col.comment or ""
+            if local_desc != shared_desc:
+                mismatches.append(
+                    f"{table.name}.{col.name}: local={local_desc!r} vs shared={shared_desc!r}"
+                )
+    assert not mismatches, (
+        f"Local and shared descriptions diverge for {len(mismatches)} "
+        f"overlapping columns (first 5): {mismatches[:5]}"
+    )
+
+
+def test_database_level_description_present(store: SQLiteHistoryStore) -> None:
+    """The single ``object_kind='database'`` row has the canonical text."""
+    from amx.storage.schema_descriptions import LOCAL_DATABASE_DESCRIPTION
+
+    with store._connect() as conn:
+        row = conn.execute(
+            "SELECT description FROM _amx_schema_descriptions WHERE object_kind = 'database'"
+        ).fetchone()
+    assert row is not None, "no database-level description row in sidecar"
+    assert str(row[0]) == LOCAL_DATABASE_DESCRIPTION
+
+
+def test_idempotent_repopulate(store: SQLiteHistoryStore) -> None:
+    """Re-running init() does not duplicate sidecar rows."""
+    with store._connect() as conn:
+        first_count = int(
+            conn.execute("SELECT COUNT(*) FROM _amx_schema_descriptions").fetchone()[0]
+        )
+    store.init()
+    store.init()
+    with store._connect() as conn:
+        second_count = int(
+            conn.execute("SELECT COUNT(*) FROM _amx_schema_descriptions").fetchone()[0]
+        )
+    assert first_count == second_count, (
+        f"Re-init() changed sidecar row count: {first_count} -> {second_count}"
+    )
+
+
+def _connect_signature_is_unchanged(store: SQLiteHistoryStore) -> Any:
+    """Sanity-check the private API this test file leans on still exists."""
+    # If this attribute disappears, every other test in this module is
+    # already failing — this only exists to give a clearer error message.
+    return store._connect
+
+
+def test_internal_api_still_present(store: SQLiteHistoryStore) -> None:
+    assert callable(_connect_signature_is_unchanged(store))


### PR DESCRIPTION
## Summary

- AMX is a metadata-generation tool, but its own local SQLite history store at `~/.amx/history.db` was shipping with no machine-readable descriptions on any table or column. The shared warehouse schema (`shared_schema.py`) already meets that bar via SQLAlchemy `Column(comment=)`; the local SQLite half does not, because SQLite has no native `COMMENT ON`.
- New single source of truth at `amx/storage/schema_descriptions.py` covers every table AMX creates (22 tables, 268 columns). Both stores now read from it so local and shared cannot drift.
- `sqlite_store.py` writes the descriptions into a new `_amx_schema_descriptions` sidecar table at `init()` time — equivalent to `pg_description`, queryable with plain SQL. Idempotent: existing installs pick up the descriptions on next boot, no migration required.

## What changed

- **`amx/storage/schema_descriptions.py`** (new) — pure-data SoT.
- **`amx/storage/sqlite_store.py`** — adds `_populate_schema_descriptions(conn)` called at the end of `init()`. ~50 ms on first boot, single `INSERT OR REPLACE` pass.
- **`amx/storage/shared_schema.py`** — every `comment=` site now reads from `SCHEMA_DESCRIPTIONS` via a small `_desc(table, col)` helper. `DEFAULT_HISTORY_SCHEMA_COMMENT` continues to be exported for `amx/db/adapters/base.py`.
- **`tests/test_local_schema_comments.py`** (new, 9 tests) — every PRAGMA-reported column has a non-empty description, no orphans, sidecar row counts match live tables, local ↔ shared descriptions agree byte-for-byte on overlapping columns, populate is idempotent under re-init.
- **`CONTRIBUTING.md`** — new "Database schema conventions" section pins the contract for future contributors.

## Test plan

- [x] `pytest tests/test_local_schema_comments.py tests/test_shared_schema_comments.py -v` — 14/14 pass.
- [x] Full suite: `pytest -ra` — 2020 passed, 2 skipped (pre-existing `sentence_transformers` import skip).
- [x] `ruff check amx tests` — clean.
- [x] `ruff format amx tests` — clean.
- [x] Fresh-install smoke (in-memory tmpdir): 1 database row + 22 tables + 268 columns populated; sample descriptions render correctly.
- [x] No "paid" string in any changed file (per house rule).
- [x] No Turkish in any tracked file (per house rule).

## Verification commands

```bash
pytest tests/test_local_schema_comments.py tests/test_shared_schema_comments.py -v
sqlite3 ~/.amx/history.db "SELECT object_kind, COUNT(*) FROM _amx_schema_descriptions GROUP BY object_kind"
# Expected:
#   column|268
#   database|1
#   table|22
```