### PR TITLE
fix(confidence): carry suggestion_scores through merge / generate / rerun paths

### DIFF
--- a/amx/agents/_orchestrator/rerun.py
+++ b/amx/agents/_orchestrator/rerun.py
@@ -38,7 +38,13 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any
 
-from amx.agents.base import AgentContext, Confidence, MetadataSuggestion, apply_logprob_confidence
+from amx.agents.base import (
+    AgentContext,
+    Confidence,
+    MetadataSuggestion,
+    apply_confidence_signals,
+    apply_logprob_confidence,
+)
 from amx.agents.code_agent import CodeAgent
 from amx.agents.profile_agent import ProfileAgent
 from amx.agents.rag_agent import RAGAgent
@@ -489,6 +495,16 @@ def _persist_rerun_row(
         raise RerunContextError("Target row is missing a chain id.")
     rerun_seq = hs.next_rerun_seq(int(chain_root))
 
+    # Carry per-alternative confidence rows so re-run rows render the
+    # same SC / LP / SD / JU badge as the original run. Upstream re-run
+    # executors (``rerun_one_item``) call ``apply_confidence_signals``
+    # before handing the suggestion to this helper, so the attribute is
+    # already populated when present. Falling back to ``None`` is fine —
+    # the storage layer then emits the legacy ``list[str]`` payload.
+    alternative_scores: list[dict] | None = None
+    if getattr(suggestion, "suggestion_scores", None):
+        alternative_scores = [score.to_json() for score in suggestion.suggestion_scores]
+
     row = {
         "schema": suggestion.schema,
         "table": suggestion.table,
@@ -501,6 +517,7 @@ def _persist_rerun_row(
         "model_version": model_name,
         "reasoning": suggestion.reasoning,
         "alternatives": suggestion.suggestions,
+        "alternative_scores": alternative_scores,
         "parent_result_id": int(chain_root),
         "rerun_seq": int(rerun_seq),
         "user_instructions": (user_instructions or "").strip() or None,
@@ -713,6 +730,23 @@ def rerun_items(
                             },
                         )
                     continue
+
+                # Re-run rows must carry the per-alternative confidence
+                # badge just like first-pass rows. The re-run helpers
+                # don't return the underlying LLM response_text /
+                # logprobs, so logprob and self_decl gracefully fall
+                # back to ``score=None``; self_consistency and judge
+                # work end-to-end on the alternatives alone.
+                try:
+                    apply_confidence_signals(
+                        suggestions=[suggestion],
+                        logprobs_content=None,
+                        response_text=None,
+                        cfg=cfg.llm,
+                        llm=llm,
+                    )
+                except Exception as exc:  # pragma: no cover — defensive
+                    log.warning("Rerun confidence scoring failed: %s", exc)
 
                 new_id, rerun_seq = _persist_rerun_row(
                     new_run_id=new_run_id,

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -11,7 +11,13 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from typing import Any
 
-from amx.agents.base import AgentContext, Confidence, MetadataSuggestion, apply_logprob_confidence
+from amx.agents.base import (
+    AgentContext,
+    Confidence,
+    MetadataSuggestion,
+    apply_confidence_signals,
+    apply_logprob_confidence,
+)
 from amx.agents.code_agent import CodeAgent
 from amx.agents.profile_agent import ProfileAgent
 from amx.agents.rag_agent import RAGAgent
@@ -1435,15 +1441,33 @@ class Orchestrator:
                 cap=cap,
             )
 
-        merged.extend(
-            apply_logprob_confidence(
-                merge_results,
-                result.logprobs,
-                high_threshold=self.llm.cfg.logprob_high,
-                medium_threshold=self.llm.cfg.logprob_medium,
-                response_text=result.content,
-            )
+        merged_with_logprob = apply_logprob_confidence(
+            merge_results,
+            result.logprobs,
+            high_threshold=self.llm.cfg.logprob_high,
+            medium_threshold=self.llm.cfg.logprob_medium,
+            response_text=result.content,
         )
+        # Re-score per-alternative confidence on the merged candidates.
+        # The merge step builds fresh ``MetadataSuggestion(source="combined")``
+        # objects whose ``.suggestions`` list may differ from any single
+        # sub-agent's output, so per-alternative scores attached upstream
+        # would no longer align. Running ``apply_confidence_signals``
+        # here re-embeds (self_consistency), reparses (self_decl), or
+        # re-ranks (judge) the merged candidate set. Best-effort: any
+        # failure is swallowed and the row falls back to the legacy
+        # ``list[str]`` payload.
+        try:
+            apply_confidence_signals(
+                suggestions=merged_with_logprob,
+                logprobs_content=result.logprobs,
+                response_text=result.content,
+                cfg=self.llm.cfg,
+                llm=self.llm,
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning("Post-merge confidence scoring failed: %s", exc)
+        merged.extend(merged_with_logprob)
         return merged
 
     def _merge_fill_up(

--- a/amx/web/routers/generate.py
+++ b/amx/web/routers/generate.py
@@ -603,6 +603,37 @@ def _record_and_queue(
 
     response["run_id"] = int(run_id)
 
+    # Score the alternatives so the singleshot generate row carries the
+    # same structured ``alternatives_json`` payload that ``/analyze`` runs
+    # produce. Self-consistency needs no LLM context (just embeds the
+    # alternatives); the other signals fall back to ``score=None`` here
+    # because we don't keep the LLM response_text / logprobs on this path.
+    alternative_scores: list[dict] | None = None
+    try:
+        from amx.agents.base import Confidence as _C
+        from amx.agents.base import MetadataSuggestion, apply_confidence_signals
+
+        synthetic = MetadataSuggestion(
+            schema=schema,
+            table=table,
+            column=column,
+            suggestions=list(alternatives),
+            confidence=_C.MEDIUM,
+            reasoning="",
+            source="generate.singleshot",
+        )
+        apply_confidence_signals(
+            suggestions=[synthetic],
+            logprobs_content=None,
+            response_text=None,
+            cfg=cfg.llm,
+            llm=None,
+        )
+        if synthetic.suggestion_scores:
+            alternative_scores = [score.to_json() for score in synthetic.suggestion_scores]
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("Singleshot confidence scoring failed: %s", exc)
+
     try:
         result_ids = hs.save_run_results(
             run_id,
@@ -615,6 +646,7 @@ def _record_and_queue(
                     "source": "generate.singleshot",
                     "confidence": Confidence.MEDIUM.value,
                     "alternatives": alternatives,
+                    "alternative_scores": alternative_scores,
                     "reasoning": "",
                 }
             ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,15 +134,13 @@ quality = [
 ]
 bertscore = [
     "bert-score>=0.3",
-    # Pin transformers above 4.55 so it accepts tokenizers >= 0.22 —
-    # without this floor, an older transformers (e.g. 4.51.x) sticks
-    # around in the user's env after another package upgrades
-    # tokenizers, and pip's resolver flags the mismatch with a noisy
-    # post-install ERROR ("transformers 4.51.3 requires
-    # tokenizers<0.22, but you have tokenizers 0.22.2 which is
-    # incompatible"). The mismatch is harmless at runtime but the
-    # message scares users who think the install actually failed.
-    "transformers>=4.56",
+    # Pin transformers >= 4.57 so it accepts tokenizers >= 0.22 —
+    # transformers 4.56 still capped tokenizers at < 0.22, which made
+    # sentence-transformers fail to load at runtime ("tokenizers >=
+    # 0.21, < 0.22 is required ... found tokenizers == 0.22.2") in any
+    # long-running process that imported transformers via another
+    # path (e.g. chromadb's bundled MiniLM) before sentence-transformers.
+    "transformers>=4.57",
 ]
 cloud-sources = [
     "boto3>=1.34",
@@ -170,7 +168,7 @@ local-embeddings = [
     # resolver mismatch surfaces here when a previously-pinned
     # transformers stays at 4.51.x while tokenizers gets bumped to
     # 0.22.x.
-    "transformers>=4.56",
+    "transformers>=4.57",
 ]
 # ── Database backend extras ───────────────────────────────────────────────
 # Each backend's drivers live in their own extra so the default install
@@ -241,7 +239,7 @@ all = [
     # older transformers (4.51.x, tokenizers<0.22 spec) installed
     # while bert-score / sentence-transformers pull tokenizers 0.22+
     # and the resolver flags the mismatch on every install.
-    "transformers>=4.56",
+    "transformers>=4.57",
     "sentence-transformers>=3.0",
     "boto3>=1.34",
     "google-api-python-client>=2.0",


### PR DESCRIPTION
## Summary

After the single-signal pivot (PR #427) shipped, production runs were still landing in ``run_results`` with the legacy flat ``list[str]`` payload — no HIGH / MED / LOW badge anywhere in Studio even when ``confidence_signal: self_consistency`` was active. Three write paths were skipping ``apply_confidence_signals`` and one environment-side ``transformers`` floor was letting the live Studio process fall back to the legacy payload.

### Code-path fixes

1. **Orchestrator merge** — ``_merge_suggestions`` builds a fresh ``MetadataSuggestion(source="combined")`` whenever 2+ sub-agents fire for the same column. The new object did not copy ``suggestion_scores`` from the sub-agent inputs, so ``_save_merged_suggestions`` saw ``None`` and wrote legacy JSON. The merge now re-runs ``apply_confidence_signals`` on the merged candidate list using the merge LLM's ``response_text`` + ``logprobs``, so self-consistency re-embeds the merged set, judge re-ranks it, and self_decl / logprob fall back gracefully.

2. **Singleshot generate** — ``amx/web/routers/generate.py`` built the row dict by hand and omitted ``alternative_scores`` entirely. The endpoint now synthesises a ``MetadataSuggestion``, scores it, and emits the structured payload.

3. **Re-run** — ``amx/agents/_orchestrator/rerun.py`` never scored the re-run suggestion before persistence. ``rerun_items`` now calls ``apply_confidence_signals`` ahead of ``_persist_rerun_row``, and the persistence helper threads ``alternative_scores`` into the row dict.

### Environment fix

4. **Transformers floor** — ``pyproject.toml`` bumps the ``transformers`` pin from 4.56 to 4.57 under ``local-embeddings``, ``bertscore``, and ``all`` extras. 4.56 still capped ``tokenizers < 0.22`` and caused ``sentence-transformers`` to fail to load inside long-running Studio processes that imported ``transformers`` through chromadb first. The live Studio log showed repeated ``Self-consistency model load failed: tokenizers>=0.21,<0.22 …`` warnings until the bump took effect.

### Test plan
- [x] ``pytest -q`` — 2036 passed, 3 skipped (sentence-transformers env mismatch on this dev box; the same mismatch the ``transformers`` bump resolves in CI / production).
- [x] ``ruff check`` / ``ruff format --check`` clean.
- [x] ``mypy`` shows the same pre-existing 7 errors on ``amx/agents/orchestrator.py``; no new errors from this branch.
- [ ] Post-deploy: trigger a fresh ``/analyze`` run with ``confidence_signal: self_consistency`` on a multi-column table → every alternative gets a ``SC: HIGH 0.xx`` / ``MED`` / ``LOW`` pill, no missing badges. DB row's ``alternatives_json`` is the structured shape.
- [ ] Re-run one alternative via the row's Re-Run button → new row also carries a structured payload + badge.
- [ ] ``tail ~/.amx/logs/studio-47821.log`` shows zero ``Self-consistency model load failed`` lines after deploy.