### PR TITLE
fix(history): list_apply_events delegate on DualWriteHistoryStore

### DIFF
--- a/amx/storage/dual_write.py
+++ b/amx/storage/dual_write.py
@@ -516,6 +516,18 @@ class DualWriteHistoryStore:
     def list_recent_events(self, limit: int = 30) -> list[dict[str, Any]]:
         return self.local.list_recent_events(limit)
 
+    def list_apply_events(
+        self,
+        *,
+        run_id: int | None = None,
+        profile_name: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        # Read-only audit timeline; SQLite is the source of truth.
+        # Powers the Studio Audit page and the Landing recent-applies
+        # tile via ``/api/history/apply-events``.
+        return self.local.list_apply_events(run_id=run_id, profile_name=profile_name, limit=limit)
+
     def get_session_state(self, namespace: str, key: str, default: Any = None) -> Any:
         return self.local.get_session_state(namespace, key, default)
 

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -66,6 +66,11 @@ def test_schedule_add_creates_row(cli) -> None:
             "schema:public",
             "--llm",
             "claude",
+            # Pass --strategy explicitly so the non-interactive
+            # CliRunner doesn't hit the click.prompt for "Review
+            # strategy" and Abort on empty stdin (Python < 3.14).
+            "--strategy",
+            "auto",
         ],
         catch_exceptions=False,
     )
@@ -214,6 +219,8 @@ def test_schedule_add_rejects_bad_timezone(cli) -> None:
             "all",
             "--llm",
             "l",
+            "--strategy",
+            "auto",
         ],
     )
     assert result.exit_code != 0

--- a/tests/test_dual_write_outbox.py
+++ b/tests/test_dual_write_outbox.py
@@ -155,3 +155,16 @@ def test_reads_come_from_local(dual: DualWriteHistoryStore) -> None:
     )
     listed = dual.list_recent_runs(limit=5, command_filter="analyze.run")
     assert any(r["id"] == rid for r in listed)
+
+
+def test_list_apply_events_delegates_to_local(
+    dual: DualWriteHistoryStore,
+) -> None:
+    # Regression guard: ``/api/history/apply-events`` and the Landing
+    # tile both call ``list_apply_events`` on the active store; when
+    # shared mode is on, the active store is a ``DualWriteHistoryStore``
+    # which used to bubble up ``AttributeError`` because the delegate
+    # was missing here. The empty-list shape is what the route forwards
+    # as ``{events: [], count: 0}``.
+    assert dual.list_apply_events() == []
+    assert dual.list_apply_events(run_id=42, profile_name="prod", limit=5) == []


### PR DESCRIPTION
## Summary

`/api/history/apply-events` was 500'ing for every Studio session running in shared / dual-write mode because `DualWriteHistoryStore` did not implement `list_apply_events`. The route called it via `self.local.list_apply_events(...)`, which dispatched through `__getattr__` and surfaced as `AttributeError: 'DualWriteHistoryStore' object has no attribute 'list_apply_events'. Did you mean: 'list_recent_events'?`.

This had been silently failing in production; the global query-error toast added in #428 made it visible.

Two changes:

- **Backend (root fix)**: add the missing `list_apply_events` delegate on `DualWriteHistoryStore`, mirroring the existing `list_recent_events` pattern (reads delegate to the local SQLite store, which is the source of truth in dual-write mode). Regression test in `tests/test_dual_write_outbox.py`.
- **Frontend**: tag the Landing recent-applies tile query with `meta: { silentError: true }`. It's a background count for a subtitle chip that already degrades gracefully to `0` — not user-actionable, no need to toast on every Landing render.

## Test plan

- [x] `pytest tests/test_dual_write_outbox.py::test_list_apply_events_delegates_to_local`
- [x] `npm run build` clean
- [ ] After deploy: open Landing, then Audit — no more 500 toast; Audit table renders apply rows.