### PR TITLE
fix(studio): web runs beat heartbeat so stale-recovery skips them

### DIFF
--- a/amx/web/routers/runs.py
+++ b/amx/web/routers/runs.py
@@ -445,6 +445,52 @@ def _build_progress_callback(job: Job) -> Callable[[ReviewResult, str, int, int,
     return _on_progress
 
 
+def _start_heartbeat_ticker(
+    hs: Any,
+    run_id: int,
+    *,
+    interval_sec: float = 60.0,
+) -> tuple[threading.Event, threading.Thread]:
+    """Keep ``analysis_runs.last_heartbeat_at`` fresh for a live web run.
+
+    The scheduler loop's ``recover_stale_runs`` sweep treats a NULL
+    ``last_heartbeat_at`` as immediately stale, so a Studio run that
+    never beats gets flipped to ``failed`` ~60s after the worker
+    started even though its worker thread is still alive. The first
+    beat fires synchronously before the helper returns so the NULL
+    window is closed by the time the worker proceeds; subsequent beats
+    run on a daemon thread until the caller sets the returned event.
+
+    Mirrors the inline pattern in ``amx/runtime/worker.py`` that
+    protects scheduled runs from the same sweep.
+    """
+    stop = threading.Event()
+
+    def _tick() -> None:
+        while not stop.is_set():
+            try:
+                hs.update_run_heartbeat(run_id)
+            except Exception:  # noqa: BLE001 - never crash the ticker
+                log.exception("web heartbeat ticker failed for run_id=%s", run_id)
+            stop.wait(interval_sec)
+
+    # First beat synchronously so ``recover_stale_runs`` never sees a
+    # NULL ``last_heartbeat_at`` for this row (the load-bearing reason
+    # this helper exists).
+    try:
+        hs.update_run_heartbeat(run_id)
+    except Exception:  # noqa: BLE001
+        log.exception("web heartbeat first beat failed for run_id=%s", run_id)
+
+    thread = threading.Thread(
+        target=_tick,
+        name=f"amx-web-heartbeat-{run_id}",
+        daemon=True,
+    )
+    thread.start()
+    return stop, thread
+
+
 def _run_worker(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
     """Drive a headless ``/run`` from AMX Studio.
 
@@ -602,10 +648,12 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
         )
 
     run_id: int | None = None
+    heartbeat_stop: threading.Event | None = None
+    heartbeat_thread: threading.Thread | None = None
     hs = history_store()
     if hs is not None:
         try:
-            run_id = hs.create_run(
+            created_run_id: int = hs.create_run(
                 command="analyze.run",
                 mode="batch" if use_batch else "chat",
                 db_backend=effective_backend,
@@ -639,11 +687,16 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
                     ),
                 },
             )
+            run_id = created_run_id
             # Bind the persistent run id to the live Job so the run
             # detail page can find this still-running worker by
             # numeric run id (Runs list → click row → /runs/{id}).
-            job.run_id = int(run_id)
-            emit(job.queue, "run.created", {"run_id": int(run_id)})
+            job.run_id = created_run_id
+            emit(job.queue, "run.created", {"run_id": created_run_id})
+            # Close the NULL-heartbeat window before recover_stale_runs
+            # can sweep this freshly-inserted row. The ticker is torn
+            # down at the end of _run_worker_body.
+            heartbeat_stop, heartbeat_thread = _start_heartbeat_ticker(hs, created_run_id)
         except Exception as exc:
             log.warning("Could not persist run history: %s", exc)
 
@@ -1078,6 +1131,14 @@ def _run_worker_body(cfg: AMXConfig, job: Job, body: RunRequest) -> None:
                 "job.failed",
                 {"error": final_error_text or "Run failed", "summary": summary},
             )
+
+    # The analysis_runs row is now terminal, so the scheduler sweep
+    # won't touch it whether or not the ticker keeps beating; stop the
+    # daemon thread so it doesn't outlive the worker.
+    if heartbeat_stop is not None:
+        heartbeat_stop.set()
+    if heartbeat_thread is not None:
+        heartbeat_thread.join(timeout=2.0)
 
 
 def _fail_job(job: Job, message: str) -> None:

--- a/tests/web/test_run_heartbeat_ticker.py
+++ b/tests/web/test_run_heartbeat_ticker.py
@@ -1,0 +1,118 @@
+"""Studio-driven web runs must beat ``analysis_runs.last_heartbeat_at``.
+
+Background: ``_run_worker_body`` previously left ``last_heartbeat_at``
+NULL for the lifetime of a Studio run. The scheduler loop's
+``recover_stale_runs`` sweep treats a NULL heartbeat as immediately
+stale (see ``amx/storage/sqlite_store.py``), so on the first tick (~60s
+after Studio boot) any in-flight Studio run was flipped to ``failed``
+while its worker thread was still alive — the run later flipped back
+to ``ready_for_review`` once the worker called ``finish_run``. Users
+saw a brief "failed" badge that disappeared after 5-10 seconds.
+
+The helper exercised here keeps ``last_heartbeat_at`` fresh so the
+sweep skips the row. Wiring into ``_run_worker_body`` is covered by
+the existing integration suites.
+"""
+
+from __future__ import annotations
+
+import time
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+from amx.web.routers.runs import _start_heartbeat_ticker
+
+
+def _fresh_run(store: SQLiteHistoryStore) -> int:
+    return store.create_run(
+        command="analyze.run",
+        mode="chat",
+        db_backend="postgresql",
+        db_profile="p",
+        llm_provider="openai",
+        llm_model="gpt-test",
+        scope={"public": ["orders"]},
+    )
+
+
+def test_start_heartbeat_ticker_writes_first_beat_immediately(tmp_path) -> None:
+    """Closes the NULL window that lets ``recover_stale_runs`` sweep
+    a brand-new Studio run before its worker has done anything."""
+    store = SQLiteHistoryStore(tmp_path / "history.db")
+    store.init()
+    run_id = _fresh_run(store)
+
+    stop, thread = _start_heartbeat_ticker(store, run_id, interval_sec=60.0)
+    try:
+        with store._connect() as conn:
+            row = conn.execute(
+                "SELECT last_heartbeat_at FROM analysis_runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()
+        assert row is not None
+        assert row[0] is not None, "first heartbeat must land before the ticker returns"
+    finally:
+        stop.set()
+        thread.join(timeout=2.0)
+    assert not thread.is_alive()
+
+
+def test_start_heartbeat_ticker_keeps_beating_until_stop(tmp_path) -> None:
+    """The looped beat must push ``last_heartbeat_at`` forward so a
+    long Studio run doesn't get swept after its first 60s window."""
+    store = SQLiteHistoryStore(tmp_path / "history.db")
+    store.init()
+    run_id = _fresh_run(store)
+
+    stop, thread = _start_heartbeat_ticker(store, run_id, interval_sec=0.05)
+    try:
+        time.sleep(0.2)
+        with store._connect() as conn:
+            first = conn.execute(
+                "SELECT last_heartbeat_at FROM analysis_runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()[0]
+        time.sleep(0.2)
+        with store._connect() as conn:
+            second = conn.execute(
+                "SELECT last_heartbeat_at FROM analysis_runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()[0]
+    finally:
+        stop.set()
+        thread.join(timeout=2.0)
+
+    assert second is not None
+    assert first is not None
+    assert second > first, "ticker must keep bumping last_heartbeat_at while alive"
+
+
+def test_start_heartbeat_ticker_survives_store_failure(tmp_path) -> None:
+    """A transient store error must not crash the ticker thread —
+    otherwise one bad write would silently re-introduce the NULL
+    heartbeat window the sweep punishes."""
+
+    store = SQLiteHistoryStore(tmp_path / "history.db")
+    store.init()
+    run_id = _fresh_run(store)
+
+    calls: list[int] = []
+
+    def flaky(self_run_id: int, *, now_utc: float | None = None) -> None:  # noqa: ARG001
+        calls.append(self_run_id)
+        if len(calls) == 1:
+            raise RuntimeError("simulated transient")
+        store.__class__.update_run_heartbeat(store, self_run_id, now_utc=now_utc)
+
+    class _FlakyStore:
+        def update_run_heartbeat(self, rid: int, *, now_utc: float | None = None) -> None:
+            flaky(rid, now_utc=now_utc)
+
+    stop, thread = _start_heartbeat_ticker(_FlakyStore(), run_id, interval_sec=0.05)
+    try:
+        time.sleep(0.25)
+    finally:
+        stop.set()
+        thread.join(timeout=2.0)
+
+    assert len(calls) >= 2, "ticker should have retried after the first beat raised"
+    assert not thread.is_alive()


### PR DESCRIPTION
## Summary
- Studio's `_run_worker_body` never bumped `analysis_runs.last_heartbeat_at`, so the in-process scheduler's `recover_stale_runs` sweep (which treats `NULL` as immediately stale) flipped active web runs to `failed` on its first 60s tick. The row later flipped back to `ready_for_review` once the worker called `finish_run`, producing the brief "failed → ready" badge users saw.
- Add a heartbeat ticker (mirroring the inline pattern in `amx/runtime/worker.py`): synchronous first beat right after `create_run` to close the `NULL` window, daemon thread bumps every 60s, stop event tears it down once the row is terminal.

## Test plan
- [x] `pytest tests/web/test_run_heartbeat_ticker.py` — first beat lands before helper returns, ticker keeps bumping, transient store errors don't kill the thread.
- [x] `pytest -q --ignore=tests/perf` — 2040 passed.
- [x] `ruff check amx tests` / `ruff format --check amx tests`.
- [x] `mypy amx/web/routers/runs.py` clean (the three preexisting `int | None` arg-type errors on this file are also fixed in the same touch).