### PR TITLE
fix(history): count review/partial-applied runs toward success rate

### DIFF
--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -2619,8 +2619,15 @@ class SQLiteHistoryStore:
             total_runs = conn.execute(
                 f"SELECT COUNT(*) AS n FROM analysis_runs {where}", params
             ).fetchone()["n"]
+            # "Success rate" reads as "did the analysis finish without
+            # erroring?" — not "did the user apply the suggestions?".
+            # ``ready_for_review`` and ``applied_partial`` both mean the
+            # pipeline ran to completion; treating them as non-success
+            # made the Overview tile stick at 0% for users who reviewed
+            # rather than auto-applied.
             ok_runs = conn.execute(
-                "SELECT COUNT(*) AS n FROM analysis_runs WHERE status = 'success'"
+                "SELECT COUNT(*) AS n FROM analysis_runs WHERE status IN"
+                " ('success', 'applied_partial', 'ready_for_review', 'completed')"
                 + (" AND command = ?" if command_filter else ""),
                 params,
             ).fetchone()["n"]

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -328,7 +328,9 @@ function StatCard({
  * Compute success rate from the stats payload. Backend ships
  * `total_runs` / `success_runs` (canonical) — falls back to the
  * legacy `total` / `success` aliases if those ever come back.
- * Ready-for-review and cancelled runs both count against success.
+ * `success_runs` covers any run that finished the analysis without
+ * erroring (success, ready_for_review, applied_partial, completed);
+ * only failed / cancelled / still-running runs count against the rate.
  */
 function successRate(stats: unknown): string {
   if (!stats || typeof stats !== "object") return "—";

--- a/tests/test_history_stats_success_rate.py
+++ b/tests/test_history_stats_success_rate.py
@@ -1,0 +1,57 @@
+"""Regression test for the Overview ``success rate`` tile.
+
+A run that finished the analysis pipeline without erroring should
+count toward ``success_runs`` regardless of whether the user went on
+to apply the suggestions. Earlier the SQL only matched literal
+``status = 'success'`` rows, so a reviewer who never auto-applied
+saw ``0%`` even on a perfectly healthy install.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _seed_run(store: SQLiteHistoryStore, *, status: str) -> int:
+    run_id = store.create_run(
+        command="analyze.run",
+        mode="auto",
+        db_backend="sqlite",
+        db_profile="test",
+        llm_provider="openai",
+        llm_model="gpt-4o-mini",
+        scope={"public": ["t1"]},
+        selected_count=1,
+        planned_count=1,
+    )
+    store.update_run_status(run_id, status)
+    return run_id
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(db_path=tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def test_success_rate_includes_review_and_partial_applied(
+    store: SQLiteHistoryStore,
+) -> None:
+    _seed_run(store, status="success")
+    _seed_run(store, status="ready_for_review")
+    _seed_run(store, status="applied_partial")
+    _seed_run(store, status="completed")
+    _seed_run(store, status="failed")
+    _seed_run(store, status="cancelled")
+
+    stats = store.stats()
+
+    assert stats["total_runs"] == 6
+    assert stats["success_runs"] == 4
+    assert stats["failed_runs"] == 1
+    assert stats["ready_for_review_runs"] == 1


### PR DESCRIPTION
## Summary
- Overview "Success rate" tile read 0% even on installs where every run finished cleanly — the `stats()` SQL only treated literal `status='success'` as a numerator, so `ready_for_review` / `applied_partial` rows (the common steady state for reviewers) were counted as non-success.
- Widen the numerator to include any "analysis finished without erroring" status (`success`, `applied_partial`, `ready_for_review`, `completed`). `failed` / `cancelled` / `running` stay out.
- Tile now reflects runner health, not apply-button usage. On the reporter's DB (21 analyze.run rows, 2 `failed`, 19 cleanly finished) the tile now reads `90%` instead of `0%`.
- New `tests/test_history_stats_success_rate.py` seeds one row per status and locks the semantics.

## Test plan
- [x] `python -m pytest tests/test_history_stats_success_rate.py -v` — 1 passed
- [x] `python -m pytest tests/test_history_migration.py tests/test_history_store_capability_gating.py tests/test_history_store_lazy_bootstrap.py -q` — 24 passed
- [x] `ruff check` / `ruff format --check` on changed files — clean
- [ ] Deploy via `~/amx-remote/scripts/deploy.sh`, refresh `/overview`, confirm tile flips from `0%` to a sensible value against live data