### PR TITLE
feat(cli): override picker parity — add alternatives_mode + confidence_signal

### DIFF
--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -10,7 +10,12 @@ from typing import Any
 
 import click
 
-from amx.config import AMXConfig, LLMConfig
+from amx.config import (
+    ALTERNATIVES_MODE_CHOICES,
+    CONFIDENCE_SIGNAL_CHOICES,
+    AMXConfig,
+    LLMConfig,
+)
 from amx.storage.sqlite_store import history_store
 from amx.utils.console import (
     ask,
@@ -201,6 +206,32 @@ def _maybe_apply_llm_overrides_interactively(
     )
     if changed:
         overrides["thinking_budget"] = ivalue
+
+    info("Alternatives diversity (Enter to keep current):")
+    # ``alternatives_mode`` only has an effect when N >= 2; mirror Studio's
+    # tile-disabled rule by skipping the prompt when the *effective*
+    # n_alternatives for this run is 1 (either the profile default or a
+    # value the user just lowered to 1 in the picker above).
+    effective_n_alt = overrides.get("n_alternatives", original_llm.n_alternatives)
+    if effective_n_alt and int(effective_n_alt) > 1:
+        changed, svalue = _ask_optional_choice(
+            "  Alternatives mode (semantic = paraphrase / lexical = shared vocab, shifted meaning)",
+            current=original_llm.alternatives_mode,
+            choices=list(ALTERNATIVES_MODE_CHOICES),
+        )
+        if changed:
+            overrides["alternatives_mode"] = svalue
+    # ``confidence_signal`` stays meaningful even at N == 1: a single
+    # alternative still surfaces a confidence band (SC degrades to 1.0,
+    # logprob still scores the spanning tokens, judge is a no-op the
+    # scorer handles gracefully). Always prompt.
+    changed, svalue = _ask_optional_choice(
+        "  Confidence signal",
+        current=original_llm.confidence_signal,
+        choices=list(CONFIDENCE_SIGNAL_CHOICES),
+    )
+    if changed:
+        overrides["confidence_signal"] = svalue
 
     info("Confidence thresholds (token probability 0.0-1.0):")
     changed, value = _ask_optional_float(
@@ -1121,6 +1152,12 @@ def execute_analyze_run(
                             "logprob_high": float(getattr(cfg.llm, "logprob_high", 0.0) or 0.0),
                             "logprob_medium": float(getattr(cfg.llm, "logprob_medium", 0.0) or 0.0),
                             "force_logprobs": bool(getattr(cfg.llm, "force_logprobs", True)),
+                            # Per-run override picker fields — captured
+                            # post-override so ``/history show <run>``
+                            # reports the effective values actually used
+                            # to generate this run's alternatives.
+                            "alternatives_mode": getattr(cfg.llm, "alternatives_mode", ""),
+                            "confidence_signal": getattr(cfg.llm, "confidence_signal", ""),
                             "dedup_used": bool(use_dedup),
                             "missing_only": bool(missing_only),
                             "review_strategy": review_strategy,

--- a/amx/cli_support/commands/history.py
+++ b/amx/cli_support/commands/history.py
@@ -238,6 +238,13 @@ def register_history_commands(
             "llm_provider": row.get("llm_provider"),
             "llm_model": row.get("llm_model"),
             "scope": row.get("scope_json"),
+            # ``settings_json`` captures the effective LLM config at run-time
+            # — including any per-run override picked from the interactive
+            # gate (``Override LLM settings for this run? [y/N]`` in
+            # ``analyze_flow.py``). Surfacing it here lets ``/history show``
+            # explain why a given run produced what it produced, even when
+            # the saved profile has since drifted from those values.
+            "settings": row.get("settings_json"),
             "metrics": row.get("metrics_json"),
             "tokens": row.get("tokens_json"),
             "results": row.get("results_json"),

--- a/tests/test_analyze_llm_overrides.py
+++ b/tests/test_analyze_llm_overrides.py
@@ -196,3 +196,209 @@ def test_override_gate_walks_choice_fields(cfg_with_profile, monkeypatch) -> Non
     }
     assert cfg_with_profile.llm.prompt_detail == "detailed"
     assert cfg_with_profile.llm.description_verbosity == "comprehensive"
+
+
+# ── Picker parity: alternatives_mode + confidence_signal ───────────────
+#
+# Pins the picker's coverage of the two knobs added for parity with the
+# Studio "Advanced LLM settings" override panel. Studio's
+# ``LLMOverrides`` Pydantic model already accepts both fields; this
+# block makes sure the CLI's interactive picker (the parity surface) does
+# the same. Per the user spec, CLI per-run flags stay out of scope so
+# scripted ``/run`` invocations remain reproducible from ``config.yml``
+# alone.
+
+
+def _all_numeric_blank(monkeypatch) -> None:
+    """Helper: monkeypatch ``ask`` to return blank (= accept default)
+    for every numeric prompt the picker walks."""
+    monkeypatch.setattr(analyze_flow, "ask", lambda *_a, **_k: "")
+
+
+def test_override_gate_walks_alternatives_mode_when_n_gt_1(cfg_with_profile, monkeypatch) -> None:
+    """When the effective ``n_alternatives`` is 2 or more, the picker
+    prompts for ``alternatives_mode`` and the chosen value lands in the
+    derived ``LLMConfig`` without mutating the saved profile."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(analyze_flow, "confirm", lambda *_a, **_k: True)
+    _all_numeric_blank(monkeypatch)
+
+    seen_alt_mode_prompt = False
+
+    def fake_choice(question: str, choices: list[str], *, default: str = "", **_k):
+        nonlocal seen_alt_mode_prompt
+        if "alternatives mode" in question.lower():
+            seen_alt_mode_prompt = True
+            assert set(choices) == {"semantic", "lexical"}, (
+                "alternatives_mode picker must offer exactly the Definition 1 choices"
+            )
+            return "lexical"
+        return default
+
+    monkeypatch.setattr(analyze_flow, "ask_choice", fake_choice)
+
+    saved_llm = cfg_with_profile.llm
+    restore, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
+
+    assert seen_alt_mode_prompt, "picker did not prompt for alternatives_mode"
+    assert applied.get("alternatives_mode") == "lexical"
+    assert cfg_with_profile.llm.alternatives_mode == "lexical"
+    # Saved profile stays untouched — the picker only swaps the derived
+    # config onto cfg.llm.
+    assert saved_llm.alternatives_mode == "semantic"
+
+    restore()
+    assert cfg_with_profile.llm is saved_llm
+
+
+def test_override_gate_skips_alternatives_mode_when_n_is_1(cfg_with_profile, monkeypatch) -> None:
+    """When the user lowers ``n_alternatives`` to 1 in the picker, the
+    next prompt jumps past ``alternatives_mode`` — mirrors Studio's
+    tile-disabled rule. The override dict carries the new ``n`` but no
+    ``alternatives_mode`` entry."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(analyze_flow, "confirm", lambda *_a, **_k: True)
+
+    answers = iter(
+        [
+            "",  # temperature
+            "",  # max_tokens
+            "1",  # n_alternatives → 1 (effective n becomes 1)
+            "",  # column_batch_size
+            "",  # thinking_budget
+            "",  # logprob_high
+            "",  # logprob_medium
+            "",  # custom_input
+            "",  # custom_output
+        ]
+    )
+    monkeypatch.setattr(analyze_flow, "ask", lambda *_a, **_k: next(answers, ""))
+
+    asked_alt_mode = False
+
+    def fake_choice(question: str, choices: list[str], *, default: str = "", **_k):
+        nonlocal asked_alt_mode
+        if "alternatives mode" in question.lower():
+            asked_alt_mode = True
+        return default
+
+    monkeypatch.setattr(analyze_flow, "ask_choice", fake_choice)
+
+    _, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
+
+    assert applied == {"n_alternatives": 1}
+    assert "alternatives_mode" not in applied, (
+        "alternatives_mode must be skipped when effective n is 1"
+    )
+    assert asked_alt_mode is False
+
+
+def test_override_gate_walks_confidence_signal(cfg_with_profile, monkeypatch) -> None:
+    """``confidence_signal`` prompt fires regardless of ``n`` (a single
+    alternative still carries a confidence band)."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(analyze_flow, "confirm", lambda *_a, **_k: True)
+    _all_numeric_blank(monkeypatch)
+
+    seen_signal_prompt = False
+
+    def fake_choice(question: str, choices: list[str], *, default: str = "", **_k):
+        nonlocal seen_signal_prompt
+        if "confidence signal" in question.lower():
+            seen_signal_prompt = True
+            assert "self_consistency" in choices and "judge" in choices
+            return "judge"
+        return default
+
+    monkeypatch.setattr(analyze_flow, "ask_choice", fake_choice)
+
+    saved_llm = cfg_with_profile.llm
+    _, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
+
+    assert seen_signal_prompt, "picker did not prompt for confidence_signal"
+    assert applied.get("confidence_signal") == "judge"
+    assert cfg_with_profile.llm.confidence_signal == "judge"
+    # Saved profile retains the LLMConfig default (self_consistency).
+    assert saved_llm.confidence_signal == "self_consistency"
+
+
+def test_override_gate_keep_default_for_new_fields(cfg_with_profile, monkeypatch) -> None:
+    """Pressing Enter on both new rows leaves neither field in the
+    applied dict — the picker only records what the user actually
+    changed."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(analyze_flow, "confirm", lambda *_a, **_k: True)
+    _all_numeric_blank(monkeypatch)
+
+    monkeypatch.setattr(
+        analyze_flow,
+        "ask_choice",
+        lambda _q, _choices, *, default="", **_k: default,
+    )
+
+    _, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
+    assert "alternatives_mode" not in applied
+    assert "confidence_signal" not in applied
+
+
+def test_override_summary_line_includes_new_overrides(
+    cfg_with_profile, monkeypatch, capsys
+) -> None:
+    """The ``Applied per-run overrides: ...`` line is dict-driven and
+    must surface the two new keys when overridden."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(analyze_flow, "confirm", lambda *_a, **_k: True)
+    _all_numeric_blank(monkeypatch)
+
+    printed_lines: list[str] = []
+
+    def fake_info(msg: str, *args, **kwargs) -> None:
+        printed_lines.append(str(msg))
+
+    monkeypatch.setattr(analyze_flow, "info", fake_info)
+
+    def fake_choice(question: str, choices: list[str], *, default: str = "", **_k):
+        if "alternatives mode" in question.lower():
+            return "lexical"
+        if "confidence signal" in question.lower():
+            return "judge"
+        return default
+
+    monkeypatch.setattr(analyze_flow, "ask_choice", fake_choice)
+
+    _, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
+    assert applied == {
+        "alternatives_mode": "lexical",
+        "confidence_signal": "judge",
+    }
+    summary = next(
+        (line for line in printed_lines if line.startswith("Applied per-run overrides")), None
+    )
+    assert summary is not None, "summary line missing from picker output"
+    assert "alternatives_mode=lexical" in summary
+    assert "confidence_signal=judge" in summary
+
+
+def test_override_gate_non_interactive_does_not_prompt_for_new_fields(
+    cfg_with_profile, monkeypatch
+) -> None:
+    """Scripted ``/run`` invocations (non-TTY) must never see the new
+    prompts — the picker short-circuits at the TTY check. Regression
+    pin for the reproducibility contract: ``config.yml`` plus a
+    non-interactive run produces deterministic output."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        analyze_flow,
+        "ask_choice",
+        lambda *_a, **_k: pytest.fail("ask_choice must not run in non-TTY mode"),
+    )
+    monkeypatch.setattr(
+        analyze_flow,
+        "ask",
+        lambda *_a, **_k: pytest.fail("ask must not run in non-TTY mode"),
+    )
+
+    saved_llm = cfg_with_profile.llm
+    _, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
+    assert applied == {}
+    assert cfg_with_profile.llm is saved_llm


### PR DESCRIPTION
## Summary

The CLI's interactive override gate (\"Override LLM settings for this run? [y/N]\") covered 11 of 13 LLM knobs the Studio RunNew → Advanced LLM settings panel accepts. Two were missing: \`alternatives_mode\` (shipped in PR #441) and \`confidence_signal\`. This closes the parity gap.

## Audit table (CLI picker vs Studio LLMOverrides)

| LLMOverrides field | Picker before | Picker after |
|---|---|---|
| temperature, max_tokens, n_alternatives, column_batch_size, prompt_detail, description_verbosity, thinking_budget | ✅ | ✅ |
| logprob_high, logprob_medium | ✅ | ✅ |
| custom_input_cost_per_mtok, custom_output_cost_per_mtok | ✅ | ✅ |
| **alternatives_mode** | ❌ | ✅ (conditional on effective n > 1) |
| **confidence_signal** | ❌ | ✅ |

## Design contract

* CLI picker = interactive parity surface with Studio. Scripted \`/run\` invocations remain fully profile-driven — per-run CLI flags (\`--alternatives-mode\` etc.) deliberately out of scope to preserve config.yml-only reproducibility.
* \`alternatives_mode\` skip when effective \`n_alternatives\` is 1 mirrors Studio's tile-disabled rule.
* Resolution unchanged: \`dataclasses.replace\` builds a derived \`LLMConfig\`; saved profile on disk is never written; restore closure bounces \`cfg.llm\` back on exit.
* \`settings_json\` snapshot at history-write time gains both fields so \`/history show <run>\` reports the effective per-run values (overrides + profile).

## Test plan

- [x] \`uv run pytest tests/test_analyze_llm_overrides.py -v\` — 11 passed (5 existing + 6 new)
- [x] \`uv run pytest tests/ -q --ignore=tests/integration\` — 2150 passed, 9 skipped (env), 0 failed
- [x] \`uv run ruff check --fix . && uv run ruff format .\` — clean
- [ ] Manual smoke (post-deploy): \`amx-dev\` REPL → \`/run\` → answer \`y\` → lower n to 1 → next row jumps past alternatives_mode (skip rule) → restart, n=3 → row appears, pick lexical → switch signal to judge → confirm summary line shows both, \`run_results.alternatives_mode = lexical\` per row, \`~/.amx-dev/config.yml\` byte-identical before/after, \`/history show <run>\` includes \"settings\": { ..., alternatives_mode: lexical, confidence_signal: judge }