### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,138 @@
+name: Bug report
+description: Something in AMX is broken, crashes, or behaves unexpectedly.
+title: "bug: <short description>"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more reproduction detail you can share, the faster we can land a fix.
+
+        Before filing, please:
+        - Check the [open issues](https://github.com/omeryasirkucuk/amx/issues) to avoid duplicates.
+        - Upgrade to the latest release (`pip install --upgrade amx-cli`) and confirm the bug still reproduces.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear, concise description of the bug.
+      placeholder: e.g. `/run sales.orders` crashes with a TypeError after the Profile sub-agent finishes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Exact steps to reproduce, ideally as a numbered list. Include any commands you ran inside the REPL.
+      placeholder: |
+        1. `pip install amx-cli==0.14.0`
+        2. `amx`
+        3. `/setup` ... pick Postgres profile
+        4. `/run sales.orders`
+        5. Observe the traceback below.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / traceback
+      description: |
+        Paste any relevant output. Run with `AMX_LOG_LEVEL=debug` if you can. Redact secrets, connection strings, warehouse IDs, and customer data before pasting.
+      render: shell
+
+  - type: input
+    id: amx-version
+    attributes:
+      label: AMX version
+      description: Output of `amx --version`.
+      placeholder: 0.14.0
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python --version`.
+      placeholder: 3.11.7
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows (WSL)
+        - Windows (native)
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Database engine
+      description: The engine the bug reproduces against. Pick `Not applicable` if the bug is engine-independent.
+      options:
+        - Not applicable
+        - PostgreSQL
+        - MySQL
+        - Snowflake
+        - Databricks
+        - BigQuery
+        - Oracle
+        - SQL Server (MSSQL)
+        - Redshift
+        - DuckDB
+        - ClickHouse
+        - SQLite
+        - Other (specify below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: llm-provider
+    attributes:
+      label: LLM provider
+      description: Which provider was active when the bug occurred. Pick `Not applicable` if the bug is provider-independent.
+      options:
+        - Not applicable
+        - Anthropic
+        - OpenAI
+        - Google (Gemini / Vertex)
+        - Azure OpenAI
+        - AWS Bedrock
+        - Ollama (local)
+        - Other (specify below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else worth knowing — non-default config, network setup, custom adapter, recent upgrade, etc.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I redacted secrets, hostnames, and customer data from the logs above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://amxcli.com/
+    about: Installation, quickstart, configuration, supported engines and providers.
+  - name: Quickstart
+    url: https://amxcli.com/getting-started/quickstart/
+    about: Five-minute walkthrough from install to your first reviewed comment.
+  - name: Troubleshooting
+    url: https://amxcli.com/troubleshooting/
+    about: FAQ, diagnostics, and common errors before filing a bug.
+  - name: Changelog
+    url: https://amxcli.com/changelog/
+    about: What changed in each release.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+name: Feature request
+description: Suggest a new capability, command, adapter, or improvement.
+title: "feat: <short description>"
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to propose an improvement. Concrete user stories help us prioritise.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What pain point or missing capability are you running into today? Describe the situation, not the solution.
+      placeholder: e.g. When I run AMX against a Snowflake warehouse with row-access policies, the Profile sub-agent reads zero rows and produces low-confidence drafts.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like AMX to do? Sketch the UX (REPL command, flag, output, etc.) if you have one in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you have tried or other designs you weighed.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of AMX does this touch?
+      options:
+        - REPL / CLI UX
+        - Profile sub-agent (schema, stats, samples)
+        - RAG sub-agent (ingested docs)
+        - Code sub-agent (repo mining)
+        - Orchestrator / ranking
+        - Database adapter (new engine, or behaviour of an existing one)
+        - LLM provider integration
+        - Configuration / profiles
+        - Studio (web UI)
+        - Documentation
+        - Release / packaging
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Screenshots, mockups, links to related issues, or anything else that helps explain the idea.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,41 @@
+name: Question / Help
+description: Ask a usage question or report something you cannot tell is a bug.
+title: "question: <short description>"
+labels: ["question", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Quick first stops:
+        - [Documentation](https://amxcli.com/)
+        - [Quickstart](https://amxcli.com/getting-started/quickstart/)
+        - [Troubleshooting / FAQ](https://amxcli.com/troubleshooting/)
+
+        If a bug is involved, please use the Bug report template instead — it has fields we need for triage.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What are you trying to do, and where did you get stuck?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Commands, config snippets, docs sections you have already consulted.
+
+  - type: input
+    id: amx-version
+    attributes:
+      label: AMX version
+      description: Output of `amx --version` (if relevant).
+      placeholder: 0.14.0
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else worth knowing.


### PR DESCRIPTION
## Summary

Adds structured YAML issue forms so reporters land in a guided form instead of a blank textbox.

- `bug_report.yml` — reproduction steps, AMX/Python versions, OS, DB engine + LLM provider dropdowns, secret-redaction confirmation.
- `feature_request.yml` — problem / proposal / alternatives + area dropdown (Profile / RAG / Code / Orchestrator / adapter / Studio / ...).
- `question.yml` — lightweight Q&A with docs / quickstart / FAQ links.
- `config.yml` — disables blank issues, surfaces Docs, Quickstart, Troubleshooting, and Changelog as `contact_links` pointing at `amxcli.com`.

## Test plan

- [x] Files validate as GitHub issue forms (YAML).
- [x] No Turkish text in tracked content.
- [x] All doc links use `amxcli.com`.
- [ ] Manual: after merge, open "New issue" on GitHub and confirm the three templates render.

## Risk

Low — only `.github/ISSUE_TEMPLATE/` files; no runtime or schema impact.