### PR TITLE
feat(rag): collection identity v2 — record embedding_dim + port mismatch to Catalog Search

### DIFF
--- a/amx/codebase/code_rag.py
+++ b/amx/codebase/code_rag.py
@@ -34,18 +34,19 @@ COLLECTION = "amx_code"
 # Schema version for the code RAG collection metadata. Bumped when the
 # metadata shape changes in a way old AMX cannot read. Mirrors the
 # value used by the docs RAG store so the two indexes evolve together.
-_AMX_CODE_SCHEMA_VERSION = 1
+# v2 added ``embedding_dim`` — older collections still work; the field
+# is backfilled silently on first reopen.
+_AMX_CODE_SCHEMA_VERSION = 2
 
 
 class CodeEmbeddingMismatch(RuntimeError):
-    """Raised when the active embedding provider does not match the
+    """Raised when the active embedding identity does not match the
     one used to populate the existing ``amx_code`` collection.
 
-    The collection metadata records the provider/model used at first
-    create. If the user later switches embedding providers (via
-    ``/embeddings``) the existing vectors are in a different semantic
-    space, so retrieval would silently degrade. Raising here forces an
-    explicit reindex or revert decision.
+    PR-B (this commit) added ``recorded_dim`` / ``active_dim`` —
+    optional, default ``0``. ``0`` on either side disables the dim
+    half of the check (keeps backward-compat for pre-PR-B collections
+    whose metadata has no ``embedding_dim`` key).
     """
 
     def __init__(
@@ -55,15 +56,22 @@ class CodeEmbeddingMismatch(RuntimeError):
         recorded_model: str,
         active_provider: str,
         active_model: str,
+        recorded_dim: int = 0,
+        active_dim: int = 0,
     ) -> None:
         self.recorded_provider = recorded_provider
         self.recorded_model = recorded_model
         self.active_provider = active_provider
         self.active_model = active_model
+        self.recorded_dim = int(recorded_dim or 0)
+        self.active_dim = int(active_dim or 0)
+        dim_suffix = ""
+        if self.recorded_dim and self.active_dim and self.recorded_dim != self.active_dim:
+            dim_suffix = f" (dim {self.recorded_dim} -> {self.active_dim})"
         super().__init__(
             f"Code RAG collection was indexed with provider={recorded_provider} "
             f"model={recorded_model}. Current config says provider={active_provider} "
-            f"model={active_model}. "
+            f"model={active_model}{dim_suffix}. "
             "Run `/code-refresh` to rebuild the collection with the active provider, "
             "or update the embedding profile to match the indexed model."
         )
@@ -285,12 +293,20 @@ def _open_collection(
     docs-path implementation. Raises :class:`CodeEmbeddingMismatch`
     when the recorded provider/model disagree with the active config.
     """
+    # PR-B: resolve and record the embedding dim alongside provider /
+    # model so silent-corruption switches (same model id, different
+    # vector size) get caught at reopen.
+    from amx.rag_core.collection_identity import infer_dimension
+
+    embedding_dim = infer_dimension(embedding_provider, embedding_model, embedding_function)
+
     kwargs: dict[str, Any] = {
         "name": COLLECTION,
         "metadata": {
             "hnsw:space": "cosine",
             "embedding_provider": embedding_provider,
             "embedding_model": embedding_model,
+            "embedding_dim": int(embedding_dim),
             "amx_schema_version": _AMX_CODE_SCHEMA_VERSION,
         },
     }
@@ -301,21 +317,43 @@ def _open_collection(
     existing_meta = dict(coll.metadata or {})
     recorded_provider = existing_meta.get("embedding_provider")
     recorded_model = existing_meta.get("embedding_model")
+    try:
+        recorded_dim = int(existing_meta.get("embedding_dim", 0) or 0)
+    except (TypeError, ValueError):
+        recorded_dim = 0
     if recorded_provider and recorded_model:
-        if recorded_provider != embedding_provider or recorded_model != embedding_model:
+        dim_mismatch = recorded_dim > 0 and embedding_dim > 0 and recorded_dim != embedding_dim
+        if (
+            recorded_provider != embedding_provider
+            or recorded_model != embedding_model
+            or dim_mismatch
+        ):
             raise CodeEmbeddingMismatch(
                 recorded_provider=str(recorded_provider),
                 recorded_model=str(recorded_model),
                 active_provider=str(embedding_provider),
                 active_model=str(embedding_model),
+                recorded_dim=recorded_dim,
+                active_dim=embedding_dim,
             )
+        if recorded_dim == 0 and embedding_dim > 0:
+            # Upgrade legacy v1 metadata so the next reopen has the dim
+            # for comparison.
+            merged = {k: v for k, v in existing_meta.items() if not str(k).startswith("hnsw:")}
+            merged["embedding_dim"] = int(embedding_dim)
+            merged["amx_schema_version"] = _AMX_CODE_SCHEMA_VERSION
+            try:
+                coll.modify(metadata=merged)
+            except Exception as exc:
+                log.warning("Could not upgrade code RAG collection metadata dim: %s", exc)
     else:
-        # Pre-PR-beta collection — backfill metadata silently. Strip
+        # Pre-PR-B collection — backfill metadata silently. Strip
         # ``hnsw:*`` keys before modify(): Chroma rejects construction-
         # time parameters even when the value is unchanged.
         merged = {k: v for k, v in existing_meta.items() if not str(k).startswith("hnsw:")}
         merged["embedding_provider"] = embedding_provider
         merged["embedding_model"] = embedding_model
+        merged["embedding_dim"] = int(embedding_dim)
         merged["amx_schema_version"] = _AMX_CODE_SCHEMA_VERSION
         try:
             coll.modify(metadata=merged)

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -51,14 +51,19 @@ class RAGQueryTimeout(TimeoutError):
 
 
 class EmbeddingProviderMismatch(RuntimeError):
-    """Raised when the active embedding provider does not match the
+    """Raised when the active embedding identity does not match the
     one used to populate the existing Chroma collection.
 
-    The collection metadata records the provider/model used at first
-    create. If the user later switches embedding providers (via
-    ``/embeddings``) the existing vectors are in a different
-    semantic space, so retrieval would silently degrade. Raising
-    here forces an explicit reindex or revert decision.
+    The collection metadata records the provider/model/dim used at
+    first create. If the user later switches embedding providers (via
+    ``/embeddings``) the existing vectors are in a different semantic
+    space, so retrieval would silently degrade. Raising here forces
+    an explicit reindex or revert decision.
+
+    PR-B (this commit) added ``recorded_dim`` / ``active_dim`` —
+    optional, default ``0``. ``0`` on either side disables the dim
+    half of the check (keeps backward-compat for pre-PR-B collections
+    whose metadata has no ``embedding_dim`` key).
     """
 
     def __init__(
@@ -68,23 +73,32 @@ class EmbeddingProviderMismatch(RuntimeError):
         recorded_model: str,
         active_provider: str,
         active_model: str,
+        recorded_dim: int = 0,
+        active_dim: int = 0,
     ) -> None:
         self.recorded_provider = recorded_provider
         self.recorded_model = recorded_model
         self.active_provider = active_provider
         self.active_model = active_model
+        self.recorded_dim = int(recorded_dim or 0)
+        self.active_dim = int(active_dim or 0)
+        dim_suffix = ""
+        if self.recorded_dim and self.active_dim and self.recorded_dim != self.active_dim:
+            dim_suffix = f" (dim {self.recorded_dim} -> {self.active_dim})"
         super().__init__(
             f"Docs RAG collection was indexed with provider={recorded_provider} "
             f"model={recorded_model}. Current config says provider={active_provider} "
-            f"model={active_model}. "
+            f"model={active_model}{dim_suffix}. "
             "Run `/docs reindex` to rebuild the collection with the active provider, "
             "or update the embedding profile to match the indexed model."
         )
 
 
 # Schema version for the docs RAG collection metadata. Bumped when the
-# metadata shape changes in a way old AMX cannot read.
-_AMX_RAG_SCHEMA_VERSION = 1
+# metadata shape changes in a way old AMX cannot read. v2 added
+# ``embedding_dim`` — older collections still work; the field is
+# backfilled silently on first reopen.
+_AMX_RAG_SCHEMA_VERSION = 2
 
 
 def _resolve_active_embedding(cfg: Any | None = None) -> tuple[str, str, EmbeddingFunction | None]:
@@ -247,8 +261,17 @@ class RAGStore:
             if embedding_function is None:
                 embedding_function = resolved_ef
 
+        # PR-B: resolve the dim alongside provider/model so the
+        # collection records the full identity triple. ``0`` means
+        # "unknown" — disables the dim half of the mismatch check
+        # without breaking anything.
+        from amx.rag_core.collection_identity import infer_dimension
+
+        embedding_dim = infer_dimension(embedding_provider, embedding_model, embedding_function)
+
         self.embedding_provider = embedding_provider
         self.embedding_model = embedding_model
+        self.embedding_dim = embedding_dim
         self.embedding_function = embedding_function
 
         kwargs: dict[str, Any] = {
@@ -257,6 +280,7 @@ class RAGStore:
                 "hnsw:space": "cosine",
                 "embedding_provider": embedding_provider,
                 "embedding_model": embedding_model,
+                "embedding_dim": int(embedding_dim),
                 "amx_schema_version": _AMX_RAG_SCHEMA_VERSION,
             },
         }
@@ -271,20 +295,49 @@ class RAGStore:
         #
         # * If the existing collection has recorded provider/model
         #   that DON'T match the active config → raise mismatch.
+        # * If recorded provider+model match but recorded dim differs
+        #   from a non-zero active dim → raise. (PR-B addition; catches
+        #   the silent-corruption case where two providers expose the
+        #   same model name string with different vector dimensions.)
+        # * If recorded dim is 0 (legacy v1 metadata) but active dim is
+        #   non-zero → backfill the dim onto the collection so future
+        #   reopens get the tighter check.
         # * If it has no recorded provider/model (pre-PR-B
-        #   collection) → backfill the metadata now; do NOT force a
-        #   reindex (grandfather rule from the design spec).
+        #   collection) → backfill the full metadata now; do NOT force
+        #   a reindex (grandfather rule from the design spec).
         existing_meta = dict(self.collection.metadata or {})
         recorded_provider = existing_meta.get("embedding_provider")
         recorded_model = existing_meta.get("embedding_model")
+        try:
+            recorded_dim = int(existing_meta.get("embedding_dim", 0) or 0)
+        except (TypeError, ValueError):
+            recorded_dim = 0
         if recorded_provider and recorded_model:
-            if recorded_provider != embedding_provider or recorded_model != embedding_model:
+            dim_mismatch = recorded_dim > 0 and embedding_dim > 0 and recorded_dim != embedding_dim
+            if (
+                recorded_provider != embedding_provider
+                or recorded_model != embedding_model
+                or dim_mismatch
+            ):
                 raise EmbeddingProviderMismatch(
                     recorded_provider=str(recorded_provider),
                     recorded_model=str(recorded_model),
                     active_provider=str(embedding_provider),
                     active_model=str(embedding_model),
+                    recorded_dim=recorded_dim,
+                    active_dim=embedding_dim,
                 )
+            if recorded_dim == 0 and embedding_dim > 0:
+                # Upgrade legacy v1 metadata to record the dim so the
+                # next reopen has it for comparison. Same modify()
+                # pattern as the full backfill below.
+                merged = {k: v for k, v in existing_meta.items() if not str(k).startswith("hnsw:")}
+                merged["embedding_dim"] = int(embedding_dim)
+                merged["amx_schema_version"] = _AMX_RAG_SCHEMA_VERSION
+                try:
+                    self.collection.modify(metadata=merged)
+                except Exception as exc:
+                    log.warning("Could not upgrade RAG collection metadata dim: %s", exc)
         else:
             # Pre-existing collection without metadata — write it now
             # so future opens have something to compare against.
@@ -294,6 +347,7 @@ class RAGStore:
             merged = {k: v for k, v in existing_meta.items() if not str(k).startswith("hnsw:")}
             merged["embedding_provider"] = embedding_provider
             merged["embedding_model"] = embedding_model
+            merged["embedding_dim"] = int(embedding_dim)
             merged["amx_schema_version"] = _AMX_RAG_SCHEMA_VERSION
             try:
                 self.collection.modify(metadata=merged)

--- a/amx/rag_core/__init__.py
+++ b/amx/rag_core/__init__.py
@@ -1,0 +1,11 @@
+"""Shared helpers for the retrieval pipelines.
+
+The Document RAG (``amx.docs.rag``), Code RAG (``amx.codebase.code_rag``),
+and Catalog Search (``amx.search.index``) pipelines re-implement
+variations of the same Chroma-backed retrieval loop. This package
+collects the genuinely shared bits so a single fix can cover all three.
+
+For now the only resident is :mod:`amx.rag_core.collection_identity`,
+which standardises the metadata recorded on every collection and the
+mismatch-vs-active-config check that runs at reopen.
+"""

--- a/amx/rag_core/collection_identity.py
+++ b/amx/rag_core/collection_identity.py
@@ -1,0 +1,296 @@
+"""Chroma collection identity: what was used to build the vectors.
+
+Every persistent Chroma collection AMX writes records three facts on
+its metadata:
+
+- ``embedding_provider`` — ``"minilm"``, ``"openai_compatible"``,
+  ``"sentence_transformers"``.
+- ``embedding_model`` — the model id within that provider.
+- ``embedding_dim`` — the vector dimensionality, when we know it
+  ahead of time. ``0`` means \"unknown / legacy collection\" and
+  disables the dim half of the mismatch check (provider+model still
+  apply). Recording the dimension catches the silent-corruption case
+  where two providers happen to share a model name string but emit
+  different-sized vectors — a real failure mode that the original
+  provider+model-only check missed.
+
+The mismatch policy:
+
+- If the active config matches all three recorded fields → pass.
+- If recorded dim is ``0`` (legacy) but provider+model match → pass
+  AND backfill the dim onto the collection so future reopens get the
+  stronger check.
+- If recorded provider/model are missing entirely (pre-PR-B
+  collection) → silently backfill all three. The grandfather rule
+  from the original docs-RAG implementation.
+- Anything else → raise :class:`CollectionIdentityMismatch` with a
+  pipeline-specific recovery hint (``/docs reindex``,
+  ``/code-refresh``, ``/search rebuild``).
+
+The shared module exists so Catalog Search can adopt the same
+identity contract — historically it recorded nothing and silently
+re-embedded on provider swap (https://github.com/omeryasirkucuk/amx/issues/454
+PR-B). Document RAG and Code RAG keep their own exception types as
+deprecated aliases (see ``amx.docs.rag.EmbeddingProviderMismatch``,
+``amx.codebase.code_rag.CodeEmbeddingMismatch``) for any external
+caller that imports them by name; new code should raise the unified
+:class:`CollectionIdentityMismatch` instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from amx.utils.logging import get_logger
+
+log = get_logger("rag_core.collection_identity")
+
+
+# Well-known embedding dimensions. The dispatch is intentionally tiny:
+# the only provider whose model dimension AMX can predict offline
+# without instantiating the embedding function is MiniLM. Everything
+# else is reported as 0 (unknown) until the embedding function exposes
+# a dimension attribute or until a future PR adds a probe call.
+_KNOWN_DIMENSIONS: dict[tuple[str, str], int] = {
+    ("minilm", "minilm-l6-v2"): 384,
+}
+
+
+@dataclass(frozen=True)
+class CollectionIdentity:
+    """Triple that uniquely identifies the vector space a Chroma
+    collection lives in.
+
+    The dim field is optional in the sense that ``0`` means "I don't
+    know yet"; the mismatch check degrades to provider+model-only when
+    either side reports ``0``.
+    """
+
+    embedding_provider: str
+    embedding_model: str
+    embedding_dim: int = 0
+
+    @classmethod
+    def from_active(
+        cls,
+        provider: str,
+        model: str,
+        embedding_function: Any | None = None,
+    ) -> CollectionIdentity:
+        """Build an identity from the active config + (optional)
+        live embedding function.
+
+        Looks up the dimension via :func:`infer_dimension`, which uses
+        a static dispatch first and falls back to a ``dim`` attribute
+        on the embedding function (``MiniLMEmbedding.dim``, custom
+        sentence-transformers wrappers, …).
+        """
+        return cls(
+            embedding_provider=provider,
+            embedding_model=model,
+            embedding_dim=infer_dimension(provider, model, embedding_function),
+        )
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Project the identity onto the dict shape Chroma persists in
+        collection metadata. Keys are stable; renaming any of them is
+        a breaking change requiring a schema bump."""
+        return {
+            "embedding_provider": self.embedding_provider,
+            "embedding_model": self.embedding_model,
+            "embedding_dim": int(self.embedding_dim),
+        }
+
+
+def infer_dimension(
+    provider: str,
+    model: str,
+    embedding_function: Any | None = None,
+) -> int:
+    """Return the embedding dimension if known, else ``0``.
+
+    Resolution order:
+
+    1. Static dispatch on ``(provider, model)`` for well-known combos
+       (just MiniLM today; future PRs may add cross-encoder probes).
+    2. ``embedding_function.dim`` attribute (the
+       :class:`amx.search.embeddings.MiniLMEmbedding` wrapper exposes
+       it; custom wrappers may too).
+    3. ``embedding_function._st.get_sentence_embedding_dimension()``
+       for ``SentenceTransformer``-backed wrappers — the model object
+       always knows its own output dim once instantiated.
+
+    Returning ``0`` rather than raising lets the mismatch check fall
+    back to provider+model comparison without breaking offline-only
+    OpenAI-compat setups that would otherwise need a network probe.
+    """
+    static = _KNOWN_DIMENSIONS.get((provider.lower(), model.lower()))
+    if static:
+        return int(static)
+    if embedding_function is not None:
+        attr = getattr(embedding_function, "dim", None)
+        if isinstance(attr, int) and attr > 0:
+            return int(attr)
+        inner = getattr(embedding_function, "_st", None)
+        if inner is not None:
+            try:
+                d = int(inner.get_sentence_embedding_dimension())
+            except Exception:
+                d = 0
+            if d > 0:
+                return d
+    return 0
+
+
+class CollectionIdentityMismatch(RuntimeError):
+    """Raised when a Chroma collection's recorded identity disagrees
+    with the active config.
+
+    The exception fields expose both the recorded and the active
+    triple so callers (CLI doctor, error formatters) can render the
+    diff cleanly. The ``recovery_hint`` carries the pipeline-specific
+    \"how to fix\" string (`/docs reindex`, `/code-refresh`,
+    `/search rebuild`).
+    """
+
+    def __init__(
+        self,
+        *,
+        recorded: CollectionIdentity,
+        active: CollectionIdentity,
+        recovery_hint: str,
+    ) -> None:
+        self.recorded = recorded
+        self.active = active
+        self.recovery_hint = recovery_hint
+        diff_parts: list[str] = []
+        if recorded.embedding_provider != active.embedding_provider:
+            diff_parts.append(
+                f"provider: {recorded.embedding_provider!r} → {active.embedding_provider!r}"
+            )
+        if recorded.embedding_model != active.embedding_model:
+            diff_parts.append(f"model: {recorded.embedding_model!r} → {active.embedding_model!r}")
+        if (
+            recorded.embedding_dim
+            and active.embedding_dim
+            and recorded.embedding_dim != active.embedding_dim
+        ):
+            diff_parts.append(f"dim: {recorded.embedding_dim} → {active.embedding_dim}")
+        diff = "; ".join(diff_parts) or "identity changed"
+        super().__init__(
+            f"Vector collection was indexed with a different embedding identity "
+            f"({diff}). {recovery_hint}"
+        )
+
+
+def _read_identity(meta: dict[str, Any]) -> CollectionIdentity | None:
+    """Reconstruct a :class:`CollectionIdentity` from collection
+    metadata. Returns ``None`` when provider/model are missing — the
+    \"legacy collection\" case that should be backfilled, not raised
+    on."""
+    provider = meta.get("embedding_provider")
+    model = meta.get("embedding_model")
+    if not provider or not model:
+        return None
+    dim_raw = meta.get("embedding_dim", 0)
+    try:
+        dim = int(dim_raw) if dim_raw is not None else 0
+    except (TypeError, ValueError):
+        dim = 0
+    return CollectionIdentity(
+        embedding_provider=str(provider),
+        embedding_model=str(model),
+        embedding_dim=dim,
+    )
+
+
+def reconcile_identity(
+    collection: Any,
+    active: CollectionIdentity,
+    *,
+    schema_version: int,
+    schema_version_key: str = "amx_schema_version",
+    recovery_hint: str,
+) -> None:
+    """Write or verify the identity on ``collection``.
+
+    Called once per ``RAGStore`` / ``CodeIndex`` / ``SearchIndex``
+    construction, after ``get_or_create_collection``.
+
+    Behaviour:
+
+    - Existing collection with full identity matching active → no-op.
+    - Existing collection with provider/model match but dim mismatch
+      → raise.
+    - Existing collection with provider/model match and dim missing
+      (legacy) → backfill the dim and schema version silently.
+    - Existing collection with no identity at all → backfill all three
+      + the schema version.
+    - First create (no metadata yet) → metadata was already set by
+      ``get_or_create_collection``; nothing to do here.
+
+    Raises :class:`CollectionIdentityMismatch` on a real conflict.
+    """
+    # Defensive: some tests inject fake Chroma collection objects that
+    # do not expose a ``metadata`` attribute. Treat that as
+    # "no identity recorded, nothing we can do" and bail without
+    # raising — the rest of the test wires what it needs to.
+    raw_meta = getattr(collection, "metadata", None)
+    if raw_meta is None and not hasattr(collection, "modify"):
+        return
+    meta = dict(raw_meta or {})
+    recorded = _read_identity(meta)
+
+    if recorded is None:
+        # Legacy / first-open collection: stamp identity now so future
+        # reopens have something to compare against.
+        _backfill(collection, meta, active, schema_version, schema_version_key)
+        return
+
+    provider_or_model_changed = (
+        recorded.embedding_provider != active.embedding_provider
+        or recorded.embedding_model != active.embedding_model
+    )
+    dim_changed = (
+        recorded.embedding_dim > 0
+        and active.embedding_dim > 0
+        and recorded.embedding_dim != active.embedding_dim
+    )
+    if provider_or_model_changed or dim_changed:
+        raise CollectionIdentityMismatch(
+            recorded=recorded,
+            active=active,
+            recovery_hint=recovery_hint,
+        )
+
+    # Same provider+model, but the recorded dim is unknown (0) while
+    # the active dim is now knowable — upgrade the metadata so the
+    # check tightens on next reopen.
+    if recorded.embedding_dim == 0 and active.embedding_dim > 0:
+        _backfill(collection, meta, active, schema_version, schema_version_key)
+
+
+def _backfill(
+    collection: Any,
+    existing_meta: dict[str, Any],
+    active: CollectionIdentity,
+    schema_version: int,
+    schema_version_key: str,
+) -> None:
+    """Write the active identity + schema version onto the collection.
+
+    Strips ``hnsw:*`` keys before calling ``collection.modify`` —
+    Chroma rejects construction-time parameters in ``modify(metadata=)``
+    even when the value is unchanged.
+    """
+    merged = {k: v for k, v in existing_meta.items() if not str(k).startswith("hnsw:")}
+    merged.update(active.to_metadata())
+    merged[schema_version_key] = schema_version
+    modify = getattr(collection, "modify", None)
+    if modify is None:
+        return
+    try:
+        modify(metadata=merged)
+    except Exception as exc:  # noqa: BLE001 — best-effort backfill
+        log.warning("Could not backfill collection identity metadata: %s", exc)

--- a/amx/search/index.py
+++ b/amx/search/index.py
@@ -29,7 +29,55 @@ _ensure("rag")
 import chromadb  # noqa: E402
 from chromadb.api.types import EmbeddingFunction  # noqa: E402
 
+from amx.rag_core.collection_identity import (  # noqa: E402
+    CollectionIdentity,
+    reconcile_identity,
+)
+from amx.utils.logging import get_logger  # noqa: E402
+
+log = get_logger("search.index")
+
 _LEGACY_COLLECTION_NAME = "amx_search"
+
+# PR-B: schema version pinned at 1 because Catalog Search has never
+# recorded an embedding identity before — this is the first version
+# that does. v1 here is independent of docs / code RAG's v2.
+_AMX_SEARCH_SCHEMA_VERSION = 1
+
+
+def _resolve_search_identity(
+    embedding_function: EmbeddingFunction | None,
+    cfg: Any | None = None,
+) -> CollectionIdentity:
+    """Return the (provider, model, dim) triple to stamp on this
+    process's Catalog Search collections.
+
+    Reads from ``cfg.embedding`` first (the same source docs / code
+    RAG use). Falls back to MiniLM defaults so a missing config never
+    blocks rebuild. The embedding function is consulted for its
+    ``dim`` attribute when the static dispatch can't resolve it.
+    """
+    if cfg is None:
+        try:
+            from amx.config import AMXConfig
+
+            cfg = AMXConfig.load()
+        except Exception:
+            cfg = None
+
+    embedding = getattr(cfg, "embedding", None) if cfg is not None else None
+    kind = "minilm"
+    model = "minilm-l6-v2"
+    if embedding is not None:
+        candidate_kind = (getattr(embedding, "kind", "") or "minilm").lower().strip()
+        candidate_model = getattr(embedding, "model", "") or ""
+        if candidate_kind not in {"", "minilm", "default", "minilm-l6-v2"}:
+            if candidate_model:
+                kind = candidate_kind
+                model = candidate_model
+            # else fall through to MiniLM (matches the embeddings
+            # module's behaviour when a non-default kind has no model).
+    return CollectionIdentity.from_active(kind, model, embedding_function)
 
 
 def _collection_name_for(db_profile: str) -> str:
@@ -63,6 +111,7 @@ class SearchIndex:
         persist_dir: str | None = None,
         *,
         embedding_function: EmbeddingFunction | None = None,
+        cfg: Any | None = None,
     ) -> None:
         self.persist_dir = persist_dir or str(Path.home() / ".amx" / "chroma_db")
         Path(self.persist_dir).mkdir(parents=True, exist_ok=True)
@@ -74,6 +123,16 @@ class SearchIndex:
 
             embedding_function = get_default_embedding_function()
         self.embedding_function = embedding_function
+        # PR-B: resolve and record the embedding identity so /search
+        # rebuild after an /embeddings swap no longer silently
+        # re-embeds with a mismatched provider. Identity is per
+        # process — every per-profile collection records the same
+        # provider/model/dim. Mismatch raises
+        # :class:`CollectionIdentityMismatch` on the next /search
+        # rebuild attempt; recovery is the same `/search rebuild`
+        # flow, which now matches docs RAG's /docs reindex and code
+        # RAG's /code-refresh in semantics.
+        self._identity = _resolve_search_identity(embedding_function, cfg=cfg)
         self._collections: dict[str, Any] = {}
         # Eagerly construct the legacy collection (empty profile key) so the
         # historical ``self.collection`` attribute keeps working for callers
@@ -85,19 +144,42 @@ class SearchIndex:
 
         Cached after first access so we do not pay Chroma's
         ``get_or_create_collection`` cost on every upsert / query.
+
+        PR-B: every collection is stamped with the active embedding
+        identity at create time and reconciled with the recorded
+        identity on reopen via
+        :func:`amx.rag_core.collection_identity.reconcile_identity`.
+        Mismatch raises with the user-facing recovery hint
+        ``/search rebuild``.
         """
         cache_key = db_profile or ""
         cached = self._collections.get(cache_key)
         if cached is not None:
             return cached
         name = _collection_name_for(db_profile)
+        identity_meta = self._identity.to_metadata()
         kwargs: dict[str, Any] = {
             "name": name,
-            "metadata": {"hnsw:space": "cosine", "amx_db_profile": db_profile},
+            "metadata": {
+                "hnsw:space": "cosine",
+                "amx_db_profile": db_profile,
+                **identity_meta,
+                "amx_schema_version": _AMX_SEARCH_SCHEMA_VERSION,
+            },
         }
         if self.embedding_function is not None:
             kwargs["embedding_function"] = self.embedding_function
         col = self.client.get_or_create_collection(**kwargs)
+        reconcile_identity(
+            col,
+            self._identity,
+            schema_version=_AMX_SEARCH_SCHEMA_VERSION,
+            recovery_hint=(
+                "Run `/search rebuild` to repopulate the catalog with the active "
+                "embedding provider, or revert the embedding profile to match the "
+                "indexed identity."
+            ),
+        )
         self._collections[cache_key] = col
         return col
 

--- a/tests/test_code_storage_correctness.py
+++ b/tests/test_code_storage_correctness.py
@@ -105,7 +105,60 @@ def test_collection_records_embedding_metadata_on_create(tmp_path: Path) -> None
     meta = dict(coll.metadata or {})
     assert meta.get("embedding_provider") == "minilm"
     assert meta.get("embedding_model") == "minilm-l6-v2"
-    assert meta.get("amx_schema_version") == 1
+    # PR-B: schema bumped to v2 across docs + code RAG; ``embedding_dim``
+    # added for MiniLM (well-known = 384). Older v1 metadata gets
+    # upgraded silently on reopen — see test_legacy_dim_backfilled below.
+    assert meta.get("amx_schema_version") == 2
+    assert meta.get("embedding_dim") == 384
+
+
+def test_legacy_v1_code_collection_dim_backfilled_on_reopen(tmp_path: Path) -> None:
+    """v1 metadata (no ``embedding_dim``) reopens cleanly and the dim
+    is back-filled silently on next open — mirrors the docs-RAG test
+    in test_rag_storage_correctness.py."""
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    client = chromadb.PersistentClient(path=str(persist))
+    client.get_or_create_collection(
+        name=COLLECTION,
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_provider": "minilm",
+            "embedding_model": "minilm-l6-v2",
+            "amx_schema_version": 1,
+        },
+    )
+    _seed_collection(persist, provider="minilm", model="minilm-l6-v2")
+    coll = client.get_collection(COLLECTION)
+    meta = dict(coll.metadata or {})
+    assert meta.get("embedding_dim") == 384
+    assert meta.get("amx_schema_version") == 2
+
+
+def test_dim_mismatch_raises_code_embedding_mismatch(tmp_path: Path) -> None:
+    """Same provider/model strings but a recorded dim that disagrees
+    with the active dim raises. Catches the silent-corruption case
+    where two providers expose the same model id with different
+    vector dimensions."""
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    client = chromadb.PersistentClient(path=str(persist))
+    client.get_or_create_collection(
+        name=COLLECTION,
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_provider": "minilm",
+            "embedding_model": "minilm-l6-v2",
+            "embedding_dim": 768,
+            "amx_schema_version": 2,
+        },
+    )
+    with pytest.raises(CodeEmbeddingMismatch) as excinfo:
+        _seed_collection(persist, provider="minilm", model="minilm-l6-v2")
+    msg = str(excinfo.value)
+    assert "dim 768 -> 384" in msg
+    assert excinfo.value.recorded_dim == 768
+    assert excinfo.value.active_dim == 384
 
 
 # ── mismatch raises ──────────────────────────────────────────────────

--- a/tests/test_rag_storage_correctness.py
+++ b/tests/test_rag_storage_correctness.py
@@ -64,7 +64,11 @@ def test_collection_records_embedding_metadata_on_create(tmp_path: Path) -> None
     meta = dict(store.collection.metadata or {})
     assert meta.get("embedding_provider") == "minilm"
     assert meta.get("embedding_model") == "minilm-l6-v2"
-    assert meta.get("amx_schema_version") == 1
+    # PR-B: schema bumped to v2, ``embedding_dim`` added for MiniLM
+    # (well-known = 384). Older v1 metadata gets upgraded silently
+    # on reopen — see ``test_pre_existing_collection_*``.
+    assert meta.get("amx_schema_version") == 2
+    assert meta.get("embedding_dim") == 384
 
 
 # ── Fix 3: mismatch raises ────────────────────────────────────────────
@@ -145,6 +149,98 @@ def test_ingest_idempotent_on_unchanged_file(tmp_path: Path) -> None:
     store.ingest([doc])
     second = sorted(_ids_for_source(store, doc.path))
     assert first == second
+
+
+# ── PR-B: dim recorded + dim-mismatch detection ──────────────────────
+
+
+def test_collection_records_embedding_dim_for_minilm(tmp_path: Path) -> None:
+    """MiniLM has a well-known 384-dim output; PR-B records it on
+    collection metadata so a later provider swap that happens to
+    preserve provider/model strings but change dim is caught."""
+    store = _make_store(tmp_path / "chroma", provider="minilm", model="minilm-l6-v2")
+    meta = dict(store.collection.metadata or {})
+    assert meta.get("embedding_dim") == 384
+
+
+def test_legacy_v1_collection_dim_backfilled_on_reopen(tmp_path: Path) -> None:
+    """A v1 metadata layout (no embedding_dim) reopens cleanly and
+    the dim is back-filled silently on next open."""
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    # Simulate a v1 collection: provider+model recorded, no dim.
+    client = chromadb.PersistentClient(path=str(persist))
+    client.get_or_create_collection(
+        name="amx_docs",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_provider": "minilm",
+            "embedding_model": "minilm-l6-v2",
+            "amx_schema_version": 1,
+        },
+    )
+    store = _make_store(persist, provider="minilm", model="minilm-l6-v2")
+    meta = dict(store.collection.metadata or {})
+    assert meta.get("embedding_dim") == 384
+    assert meta.get("amx_schema_version") == 2
+
+
+def test_dim_mismatch_raises_even_when_provider_model_match(tmp_path: Path) -> None:
+    """If somehow a collection is recorded with a dim that disagrees
+    with the active embedder's dim, raise the structured mismatch —
+    same provider/model string is no longer sufficient to call it a
+    match."""
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    # Seed metadata with a deliberately-wrong dim (768 instead of 384)
+    # to simulate the silent-corruption case (e.g. provider rotated
+    # model internals while keeping the same id).
+    client = chromadb.PersistentClient(path=str(persist))
+    client.get_or_create_collection(
+        name="amx_docs",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_provider": "minilm",
+            "embedding_model": "minilm-l6-v2",
+            "embedding_dim": 768,
+            "amx_schema_version": 2,
+        },
+    )
+    with pytest.raises(EmbeddingProviderMismatch) as excinfo:
+        _make_store(persist, provider="minilm", model="minilm-l6-v2")
+    msg = str(excinfo.value)
+    assert "dim 768 -> 384" in msg
+    assert excinfo.value.recorded_dim == 768
+    assert excinfo.value.active_dim == 384
+
+
+def test_dim_zero_on_either_side_disables_dim_check(tmp_path: Path) -> None:
+    """If the recorded collection has a non-zero dim but the active
+    side reports 0 (unknown), the dim check is bypassed — never raise
+    on an inferred-zero. Same logic the other way round."""
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    client = chromadb.PersistentClient(path=str(persist))
+    client.get_or_create_collection(
+        name="amx_docs",
+        metadata={
+            "hnsw:space": "cosine",
+            "embedding_provider": "openai_compatible",
+            "embedding_model": "text-embedding-3-small",
+            "embedding_dim": 1536,
+            "amx_schema_version": 2,
+        },
+    )
+    # Reopen with provider/model matching but active dim unknown
+    # (OpenAI-compatible reports 0 today). Must NOT raise.
+    store = _make_store(
+        persist,
+        provider="openai_compatible",
+        model="text-embedding-3-small",
+    )
+    meta = dict(store.collection.metadata or {})
+    # Recorded dim is preserved (not overwritten to 0).
+    assert meta.get("embedding_dim") == 1536
 
 
 # ── Fix 4: callers surface the mismatch as a run error ────────────────

--- a/tests/test_search_index_identity.py
+++ b/tests/test_search_index_identity.py
@@ -1,0 +1,159 @@
+"""Catalog Search (``amx.search.index.SearchIndex``) identity tests — PR-B.
+
+Catalog Search historically recorded no embedding identity on its
+Chroma collections; ``/search rebuild`` after an ``/embeddings`` swap
+silently re-embedded with whatever provider was active, with no
+warning that the existing vectors lived in a different semantic space.
+PR-B closes that gap by:
+
+1. Stamping ``embedding_provider`` / ``embedding_model`` /
+   ``embedding_dim`` / ``amx_schema_version`` on every per-profile
+   collection at create time.
+2. Reconciling on reopen via
+   :func:`amx.rag_core.collection_identity.reconcile_identity` — raises
+   :class:`CollectionIdentityMismatch` when the recorded triple
+   disagrees with the active config.
+3. Grandfather rule: legacy collections that lack identity metadata
+   are silently back-filled on first reopen (no forced rebuild).
+
+These tests pin those behaviours so a future refactor cannot
+re-introduce silent re-embed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import chromadb
+import pytest
+
+from amx.rag_core.collection_identity import CollectionIdentityMismatch
+from amx.search.index import SearchIndex, _collection_name_for
+
+
+def test_default_index_records_identity_on_legacy_collection(tmp_path: Path) -> None:
+    """A fresh SearchIndex creates the legacy (empty-profile)
+    collection and stamps the active embedding identity onto it."""
+    index = SearchIndex(persist_dir=str(tmp_path / "chroma"))
+    meta = dict(index.collection.metadata or {})
+    assert meta.get("embedding_provider") == "minilm"
+    assert meta.get("embedding_model") == "minilm-l6-v2"
+    assert meta.get("embedding_dim") == 384
+    assert meta.get("amx_schema_version") == 1
+
+
+def test_per_profile_collection_carries_identity(tmp_path: Path) -> None:
+    """Every per-profile collection (not just the legacy one) records
+    the identity. Two profiles produce two collections, both stamped."""
+    index = SearchIndex(persist_dir=str(tmp_path / "chroma"))
+    col_a = index._collection_for("profile_a")
+    col_b = index._collection_for("profile_b")
+    for col in (col_a, col_b):
+        meta = dict(col.metadata or {})
+        assert meta.get("embedding_provider") == "minilm"
+        assert meta.get("embedding_dim") == 384
+
+
+def test_legacy_collection_without_identity_is_grandfathered(tmp_path: Path) -> None:
+    """A pre-PR-B Catalog Search collection (no identity metadata)
+    reopens cleanly. The identity is back-filled silently — never
+    forced into a rebuild."""
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    # Seed a legacy v0 collection directly via Chroma — only
+    # ``hnsw:space`` and the AMX profile key, no embedding identity.
+    client = chromadb.PersistentClient(path=str(persist))
+    legacy_name = _collection_name_for("")
+    client.get_or_create_collection(
+        name=legacy_name,
+        metadata={"hnsw:space": "cosine", "amx_db_profile": ""},
+    )
+    # Reopening through SearchIndex must NOT raise — and must record
+    # the identity so future opens have something to compare against.
+    index = SearchIndex(persist_dir=str(persist))
+    meta = dict(index.collection.metadata or {})
+    assert meta.get("embedding_provider") == "minilm"
+    assert meta.get("embedding_model") == "minilm-l6-v2"
+    assert meta.get("embedding_dim") == 384
+
+
+def test_provider_swap_raises_collection_identity_mismatch(tmp_path: Path) -> None:
+    """A collection stamped with one provider, re-opened by an index
+    configured for another, raises the structured mismatch with a
+    ``/search rebuild`` recovery hint. This is the failure the previous
+    silent-re-embed behaviour hid."""
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    client = chromadb.PersistentClient(path=str(persist))
+    legacy_name = _collection_name_for("")
+    # Seed with an explicitly different provider (openai_compatible /
+    # text-embedding-3-small / dim 1536).
+    client.get_or_create_collection(
+        name=legacy_name,
+        metadata={
+            "hnsw:space": "cosine",
+            "amx_db_profile": "",
+            "embedding_provider": "openai_compatible",
+            "embedding_model": "text-embedding-3-small",
+            "embedding_dim": 1536,
+            "amx_schema_version": 1,
+        },
+    )
+    with pytest.raises(CollectionIdentityMismatch) as excinfo:
+        SearchIndex(persist_dir=str(persist))
+    msg = str(excinfo.value)
+    assert "/search rebuild" in msg
+    # provider changed AND model changed AND dim changed.
+    assert excinfo.value.recorded.embedding_provider == "openai_compatible"
+    assert excinfo.value.active.embedding_provider == "minilm"
+
+
+def test_dim_mismatch_alone_raises(tmp_path: Path) -> None:
+    """Same provider/model strings but a recorded dim that disagrees
+    with the active dim still raises. Catches the rotation-with-same-
+    name corruption case."""
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    client = chromadb.PersistentClient(path=str(persist))
+    legacy_name = _collection_name_for("")
+    # Provider/model match MiniLM but record the wrong dim.
+    client.get_or_create_collection(
+        name=legacy_name,
+        metadata={
+            "hnsw:space": "cosine",
+            "amx_db_profile": "",
+            "embedding_provider": "minilm",
+            "embedding_model": "minilm-l6-v2",
+            "embedding_dim": 768,
+            "amx_schema_version": 1,
+        },
+    )
+    with pytest.raises(CollectionIdentityMismatch) as excinfo:
+        SearchIndex(persist_dir=str(persist))
+    msg = str(excinfo.value)
+    assert "dim: 768" in msg or "dim 768 -> 384" in msg
+
+
+def test_dim_zero_on_either_side_is_a_match(tmp_path: Path) -> None:
+    """Recorded dim ``0`` (legacy v1 metadata) plus active dim that
+    can be inferred (MiniLM = 384) is treated as a match. The dim is
+    upgraded silently on this open so subsequent reopens get the
+    stronger check."""
+    persist = tmp_path / "chroma"
+    persist.mkdir(parents=True, exist_ok=True)
+    client = chromadb.PersistentClient(path=str(persist))
+    legacy_name = _collection_name_for("")
+    client.get_or_create_collection(
+        name=legacy_name,
+        metadata={
+            "hnsw:space": "cosine",
+            "amx_db_profile": "",
+            "embedding_provider": "minilm",
+            "embedding_model": "minilm-l6-v2",
+            "embedding_dim": 0,
+            "amx_schema_version": 1,
+        },
+    )
+    index = SearchIndex(persist_dir=str(persist))
+    meta = dict(index.collection.metadata or {})
+    assert meta.get("embedding_dim") == 384


### PR DESCRIPTION
## Summary

Closes two gaps from the RAG architecture rollout (omeryasirkucuk/amx#454, PR-B):

1. **`embedding_dim` wasn't recorded anywhere.** Docs/Code RAG's
   mismatch check compared `(provider, model)` strings only. Two
   providers exposing the same model id with different vector
   dimensions would silently corrupt the index. Now every
   collection stores `embedding_dim` and the mismatch check raises
   when both sides have a known dim and they disagree.
2. **Catalog Search recorded no identity at all.** `/search rebuild`
   after an `/embeddings` swap silently re-embedded with a mismatched
   provider. Now per-profile collections stamp the identity at create
   time and reconcile on reopen — `CollectionIdentityMismatch` with
   a `/search rebuild` recovery hint, identical UX to `/docs reindex`
   and `/code-refresh`.

New module `amx/rag_core/collection_identity.py` exposes
`CollectionIdentity`, `infer_dimension`, `reconcile_identity`, and
`CollectionIdentityMismatch`. Docs/Code RAG keep their existing
exception classes with new optional `recorded_dim` / `active_dim`
kwargs for back-compat.

## Backward compatibility

- Pre-PR-B docs / code collections (no `embedding_dim` key) reopen
  cleanly; the dim is back-filled silently on first reopen.
- Pre-PR-B Catalog Search collections (no identity metadata at all)
  reopen cleanly; the identity is back-filled silently.
- `dim = 0` on either side disables the dim half of the check —
  OpenAI-compat setups that can't infer dim offline keep working.

## Schema versions

- Docs RAG: `_AMX_RAG_SCHEMA_VERSION` bumped 1 → 2.
- Code RAG: `_AMX_CODE_SCHEMA_VERSION` bumped 1 → 2.
- Catalog Search: introduces `_AMX_SEARCH_SCHEMA_VERSION = 1` (its
  first version — historically recorded nothing).

## Eval baseline

`tests/eval/baselines/docs_baseline.json` is unchanged. The audit
classified this as a mechanical step with no retrieval-behaviour
delta; baseline regeneration confirmed (no diff). The CI gate from
PR #453 enforces this.

## Tests

- `tests/test_rag_storage_correctness.py` — +4 dim cases (record on
  create, legacy backfill, dim mismatch, dim-zero passthrough).
- `tests/test_code_storage_correctness.py` — +2 dim cases, schema-
  version assertion bumped to 2.
- `tests/test_search_index_identity.py` (new) — 6 cases covering
  record-on-create, per-profile stamping, legacy grandfathering,
  provider/model mismatch, dim-only mismatch, dim-zero passthrough.

## Test plan

- [x] `pytest tests/eval/ tests/test_rag_storage_correctness.py tests/test_code_storage_correctness.py tests/test_search_index_identity.py` — 58/58 pass locally.
- [x] `pytest --ignore=tests/web --ignore=tests/perf` — 1917 pass, 9 skipped (pre-existing), 0 fail.
- [x] `ruff check amx tests` clean.
- [x] `ruff format --check amx tests` clean.
- [x] Baseline regenerates identically — no retrieval-behaviour delta.
- [ ] CI matrix green on this PR.

## Related

- Tracking issue: omeryasirkucuk/amx#454 (PR-B checklist item).
- Unblocks PR-C (Code RAG default switch to jina-embeddings-v2-base-code,
  which requires this dim-aware mismatch check to safely trigger
  `/code-refresh`).