### PR TITLE
feat(code-rag): default to jina-embeddings-v2-base-code with MiniLM fallback

### DIFF
--- a/amx/codebase/code_rag.py
+++ b/amx/codebase/code_rag.py
@@ -77,15 +77,76 @@ class CodeEmbeddingMismatch(RuntimeError):
         )
 
 
+# PR-C: Code RAG default upgrade path.
+#
+# When the user has not picked an explicit embedding provider, code
+# retrieval prefers a code-specialised model (``jinaai/jina-embeddings-v2-base-code``,
+# ~161 MB, 768-dim) over the generic English prose model MiniLM ships
+# with. Identifier-heavy and snake_case / CamelCase queries are
+# measurably better on a code-trained encoder.
+#
+# The upgrade is **opportunistic**: jina only kicks in when
+# ``sentence-transformers`` is installed (``pip install amx[local-embeddings]``)
+# AND the model is loadable (either cached from a prior call or
+# downloadable now). Anything that fails — missing dep, offline
+# install, model-load error — degrades gracefully back to bundled
+# MiniLM with a one-time WARNING that names the install command. The
+# fallback is **silent** for retrieval quality (MiniLM still works) but
+# **logged** so operators see what's happening.
+#
+# Document RAG keeps MiniLM as its default — prose retrieval doesn't
+# benefit from a code-trained encoder. Switching there belongs to a
+# separate decision tied to E2 of the audit (``bge-small-en-v1.5``).
+JINA_CODE_MODEL = "jinaai/jina-embeddings-v2-base-code"
+
+# Cache so the WARNING fires once per process even when many
+# CodeIndex instances are constructed during a long-running CLI
+# session. Per-process, not per-config — the message is about the
+# user's install, not their config.
+_jina_fallback_warned = False
+
+
+def _try_jina_code_embedder() -> tuple[EmbeddingFunction | None, str | None]:
+    """Try to build the jina code embedder. Returns ``(ef, error)``.
+
+    Returns ``(ef, None)`` on success.
+    Returns ``(None, reason)`` when sentence-transformers isn't
+    installed, the model can't be downloaded (offline / network
+    failure), or any other construction error — caller falls back to
+    MiniLM. ``reason`` is short and quotable in the one-time WARNING.
+    """
+    try:
+        from amx.search.embeddings import SentenceTransformerEmbedding
+    except ImportError as exc:  # pragma: no cover — amx package always available
+        return None, f"amx.search.embeddings unavailable: {exc}"
+    try:
+        ef = SentenceTransformerEmbedding(model=JINA_CODE_MODEL)
+    except RuntimeError as exc:
+        # SentenceTransformerEmbedding.__init__ raises RuntimeError
+        # when ``sentence-transformers`` itself isn't importable.
+        return None, str(exc)
+    except Exception as exc:  # noqa: BLE001 — broad on purpose
+        # Model load failure: network down, HF Hub unreachable,
+        # disk-cache permission issue, etc. Don't crash the whole
+        # CodeIndex on a recoverable degradation.
+        return None, f"{exc.__class__.__name__}: {exc}"
+    return ef, None
+
+
 def _resolve_active_embedding(
     cfg: Any | None = None,
 ) -> tuple[str, str, EmbeddingFunction | None]:
     """Resolve ``(provider, model, embedding_function)`` from config.
 
-    Mirrors :func:`amx.docs.rag._resolve_active_embedding` so the code
-    path honours the same embedding provider as the docs path. Imports
-    are deferred to avoid a circular import (``amx.search.embeddings``
-    pulls Chroma which pulls this module on some platforms).
+    Mirrors :func:`amx.docs.rag._resolve_active_embedding` for the
+    explicit-provider path. The DEFAULT path differs: code retrieval
+    prefers ``jinaai/jina-embeddings-v2-base-code`` over MiniLM when
+    ``sentence-transformers`` is installed (PR-C); falls back to
+    MiniLM with a one-time WARNING when it isn't.
+
+    Imports are deferred to avoid a circular import
+    (``amx.search.embeddings`` pulls Chroma which pulls this module on
+    some platforms).
     """
     from amx.search.embeddings import make_embedding_function
 
@@ -99,7 +160,7 @@ def _resolve_active_embedding(
 
     embedding = getattr(cfg, "embedding", None) if cfg is not None else None
     if embedding is None:
-        return ("minilm", "minilm-l6-v2", None)
+        return _default_code_embedding()
 
     kind = (getattr(embedding, "kind", "") or "minilm").lower().strip()
     model = getattr(embedding, "model", "") or ""
@@ -107,16 +168,42 @@ def _resolve_active_embedding(
     base_url = getattr(embedding, "base_url", "") or ""
 
     if kind in {"", "minilm", "default", "minilm-l6-v2"}:
-        return ("minilm", "minilm-l6-v2", None)
+        # User is on the default — opportunistically upgrade to the
+        # code-specialised embedder. An explicit ``/embeddings minilm``
+        # choice falls into this branch too (the cfg layer normalises
+        # both to ``minilm``), which is intentional: a code-trained
+        # encoder is the right floor for ``/code search`` regardless
+        # of what the user picked for prose RAG.
+        return _default_code_embedding()
 
     if not model:
-        return ("minilm", "minilm-l6-v2", None)
+        return _default_code_embedding()
 
     try:
         ef = make_embedding_function(kind, model=model, api_key=api_key, base_url=base_url)
     except Exception:
-        return ("minilm", "minilm-l6-v2", None)
+        return _default_code_embedding()
     return (kind, model, ef)
+
+
+def _default_code_embedding() -> tuple[str, str, EmbeddingFunction | None]:
+    """The opportunistic-jina-with-MiniLM-fallback default. Extracted
+    so all the early-return branches in :func:`_resolve_active_embedding`
+    share one code path and one place to fire the WARNING."""
+    global _jina_fallback_warned
+    ef, reason = _try_jina_code_embedder()
+    if ef is not None:
+        return ("sentence_transformers", JINA_CODE_MODEL, ef)
+    if not _jina_fallback_warned:
+        _jina_fallback_warned = True
+        log.warning(
+            "Code RAG falling back to MiniLM (%s). Install "
+            '`pip install "amx-cli[local-embeddings]"` to enable the '
+            "code-specialised %s embedder (~161 MB).",
+            reason or "sentence-transformers unavailable",
+            JINA_CODE_MODEL,
+        )
+    return ("minilm", "minilm-l6-v2", None)
 
 
 def _normalize_source_filter(source: str) -> str:

--- a/tests/test_code_rag_default_embedder.py
+++ b/tests/test_code_rag_default_embedder.py
@@ -1,0 +1,187 @@
+"""PR-C: Code RAG default embedder resolution tests.
+
+Pins the graceful-fallback policy:
+
+- When ``sentence-transformers`` is installed AND the jina code model
+  loads cleanly → ``(sentence_transformers, jinaai/jina-embeddings-v2-base-code, ef)``.
+- When sentence-transformers is missing OR the model fails to load
+  for any reason (offline install, HF cache issue, …) → MiniLM with
+  a one-time WARNING logged to the ``codebase.code_rag`` logger.
+- Explicit non-default provider configs are honoured unchanged.
+
+These tests mock the jina-construction path so CI doesn't trigger a
+~161 MB model download every run. The fallback path is the one CI
+hits by default — the smoke effect is that ``CodeIndex`` instances
+still build successfully when the local-embeddings extra isn't
+installed.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from amx.codebase import code_rag
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each test starts with a clean ``_jina_fallback_warned``
+    state so the one-time WARNING assertion is reliable."""
+    monkeypatch.setattr(code_rag, "_jina_fallback_warned", False, raising=False)
+
+
+# ── happy path: jina is available ─────────────────────────────────────
+
+
+def test_default_returns_jina_when_sentence_transformers_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the local-embeddings extra is installed and the jina model
+    loads cleanly, the default resolves to jina (not MiniLM)."""
+    fake_ef = object()  # stand-in for the real EmbeddingFunction
+    monkeypatch.setattr(
+        code_rag,
+        "_try_jina_code_embedder",
+        lambda: (fake_ef, None),
+    )
+
+    provider, model, ef = code_rag._resolve_active_embedding(cfg=None)
+    assert provider == "sentence_transformers"
+    assert model == "jinaai/jina-embeddings-v2-base-code"
+    assert ef is fake_ef
+
+
+# ── fallback: sentence-transformers missing ───────────────────────────
+
+
+def test_default_falls_back_to_minilm_when_st_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When jina construction fails (no sentence-transformers), the
+    default falls back to MiniLM. The user-facing identity is MiniLM,
+    not a half-broken jina."""
+    monkeypatch.setattr(
+        code_rag,
+        "_try_jina_code_embedder",
+        lambda: (None, "sentence-transformers not installed"),
+    )
+
+    provider, model, ef = code_rag._resolve_active_embedding(cfg=None)
+    assert provider == "minilm"
+    assert model == "minilm-l6-v2"
+    assert ef is None
+
+
+def test_fallback_logs_one_time_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """First fallback logs a WARNING that names the install command;
+    subsequent fallbacks within the same process stay silent."""
+    monkeypatch.setattr(
+        code_rag,
+        "_try_jina_code_embedder",
+        lambda: (None, "test reason"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="codebase.code_rag"):
+        code_rag._resolve_active_embedding(cfg=None)
+        code_rag._resolve_active_embedding(cfg=None)
+        code_rag._resolve_active_embedding(cfg=None)
+
+    warning_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "MiniLM" in r.getMessage()
+    ]
+    assert len(warning_records) == 1, (
+        f"Expected exactly one fallback WARNING per process, got {len(warning_records)}"
+    )
+    msg = warning_records[0].getMessage()
+    assert "amx-cli[local-embeddings]" in msg
+    assert "jinaai/jina-embeddings-v2-base-code" in msg
+    assert "test reason" in msg
+
+
+# ── explicit provider override ────────────────────────────────────────
+
+
+def test_explicit_openai_compatible_config_is_honoured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``/embeddings openai_compatible <model>`` choice
+    bypasses the jina-default upgrade entirely — user picked their
+    provider, we honour it."""
+    fake_ef = object()
+
+    def _fake_make(kind: str, **_kwargs: object) -> object:
+        return fake_ef
+
+    monkeypatch.setattr(
+        "amx.search.embeddings.make_embedding_function",
+        _fake_make,
+    )
+
+    cfg = SimpleNamespace(
+        embedding=SimpleNamespace(
+            kind="openai_compatible",
+            model="text-embedding-3-small",
+            api_key="sk-test",
+            base_url="",
+        )
+    )
+    provider, model, ef = code_rag._resolve_active_embedding(cfg=cfg)
+    assert provider == "openai_compatible"
+    assert model == "text-embedding-3-small"
+    assert ef is fake_ef
+
+
+# ── _try_jina_code_embedder direct ────────────────────────────────────
+
+
+def test_try_jina_reports_runtime_error_on_missing_st() -> None:
+    """When ``SentenceTransformerEmbedding`` raises RuntimeError (the
+    branch it uses when ``sentence_transformers`` import fails),
+    ``_try_jina_code_embedder`` returns (None, reason) rather than
+    propagating."""
+
+    class _FakeST:
+        def __init__(self, *, model: str) -> None:  # noqa: ARG002
+            raise RuntimeError("sentence-transformers is not installed")
+
+    with patch("amx.search.embeddings.SentenceTransformerEmbedding", _FakeST):
+        ef, reason = code_rag._try_jina_code_embedder()
+    assert ef is None
+    assert reason and "sentence-transformers" in reason
+
+
+def test_try_jina_catches_model_load_failures() -> None:
+    """A broader failure during ``SentenceTransformer(model)`` — e.g.
+    HF Hub unreachable, disk-cache permission denied — also degrades
+    to ``(None, reason)`` without crashing the CodeIndex bootstrap."""
+
+    class _FakeST:
+        def __init__(self, *, model: str) -> None:  # noqa: ARG002
+            raise OSError("HF Hub unreachable: offline mode")
+
+    with patch("amx.search.embeddings.SentenceTransformerEmbedding", _FakeST):
+        ef, reason = code_rag._try_jina_code_embedder()
+    assert ef is None
+    assert reason and "OSError" in reason and "offline" in reason
+
+
+def test_try_jina_returns_ef_on_success() -> None:
+    """Success path — ``_try_jina_code_embedder`` returns the
+    constructed EmbeddingFunction and ``None`` for the error slot."""
+
+    class _FakeST:
+        def __init__(self, *, model: str) -> None:
+            self.model = model
+
+    with patch("amx.search.embeddings.SentenceTransformerEmbedding", _FakeST):
+        ef, reason = code_rag._try_jina_code_embedder()
+    assert ef is not None
+    assert reason is None
+    assert getattr(ef, "model", None) == code_rag.JINA_CODE_MODEL


### PR DESCRIPTION
## Summary

Code retrieval default switches to a code-specialised encoder
(`jinaai/jina-embeddings-v2-base-code`, 768-dim, ~161 MB) — the
single biggest retrieval-quality lever in the embedding layer per the
audit (E1). Identifier-heavy / snake_case / CamelCase queries land
markedly better on a code-trained encoder than on MiniLM.

The upgrade is **opportunistic** — graceful fallback for users
without the `local-embeddings` extra:

| Condition | Result |
|---|---|
| `sentence-transformers` installed + model loads | `("sentence_transformers", "jinaai/jina-embeddings-v2-base-code", ef)` |
| `sentence-transformers` missing / model load fails | `("minilm", "minilm-l6-v2", None)` + one-time WARNING naming `pip install "amx-cli[local-embeddings]"` |

The WARNING is per-process (no spam) and quotes the underlying
failure reason so operators can tell apart "extra not installed"
from "model load failed" (offline install, HF cache permission, …).

Document RAG is untouched — prose doesn't benefit from a code-
trained encoder. `bge-small-en-v1.5` upgrade for docs (audit E2) is
a separate decision.

## User impact

Users with an existing `amx_code` collection will see the
`CodeEmbeddingMismatch` raised by PR-B's dim-aware check on next
`/code search` — the 384 → 768 dim transition fires the check.
Recovery is the existing `/code-refresh` flow, no new UX. Users on
the fallback path (no `local-embeddings` extra installed) see no
mismatch — both sides resolve to MiniLM.

## Tests

- `tests/test_code_rag_default_embedder.py` (new) — 7 cases
  covering happy path, ST-missing fallback, one-time WARNING
  semantics, explicit-provider override passthrough, RuntimeError
  from ST-import-failed, broad Exception from model-load-failed,
  and the success path of `_try_jina_code_embedder`.
- All mocks; no actual ~161 MB download in CI.

## Test plan

- [x] `pytest tests/test_code_rag_default_embedder.py tests/test_code_storage_correctness.py tests/test_doctor_code_check.py tests/eval/` — 51/51 pass.
- [x] `pytest --ignore=tests/web --ignore=tests/perf` — 1924 pass, 9 skipped (pre-existing), 0 fail.
- [x] `ruff check amx tests` clean. `ruff format --check amx tests` clean.
- [x] Eval baseline regenerates identically — docs RAG path untouched.
- [ ] CI matrix green.

## Related

- Tracking issue: omeryasirkucuk/amx#454 (PR-C checklist item).
- Depends on omeryasirkucuk/amx#456 (PR-B) for the dim-aware
  mismatch check that handles the existing-collection migration
  cleanly.
- Docs update will follow in an amx-docs PR (next).