### PR TITLE
feat(docs-rag): format-dispatching chunker — Markdown header awareness (F1.1)

### DIFF
--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -30,12 +30,11 @@ from langchain_community.document_loaders import (  # noqa: E402
     TextLoader,
     UnstructuredExcelLoader,
     UnstructuredHTMLLoader,
-    UnstructuredMarkdownLoader,
     UnstructuredPowerPointLoader,
 )
-from langchain_text_splitters import RecursiveCharacterTextSplitter  # noqa: E402
 
 from amx.docs.scanner import DocInfo  # noqa: E402
+from amx.docs.splitters import get_splitter  # noqa: E402
 from amx.utils.logging import get_logger  # noqa: E402
 
 log = get_logger("docs.rag")
@@ -177,12 +176,21 @@ LOADER_MAP = {
     ".docx": Docx2txtLoader,
     ".doc": Docx2txtLoader,
     ".txt": TextLoader,
-    ".md": UnstructuredMarkdownLoader,
+    # PR-D: Markdown loads as plain text (not via
+    # ``UnstructuredMarkdownLoader``) because the
+    # :class:`amx.docs.splitters._MarkdownAwareSplitter` needs the raw
+    # ``#`` / ``##`` markers to extract heading metadata. The
+    # Unstructured backend silently strips formatting (\"# Orders\" →
+    # \"Orders\"), which made every Markdown chunk look identical to
+    # plain prose to the splitter. ``TextLoader`` keeps the structure
+    # intact, the splitter chunks by heading, and downstream chunks
+    # carry ``h1``/``h2``/``h3`` metadata for citation use.
+    ".md": TextLoader,
     # ``.markdown`` is just the long-form extension of ``.md`` — same
     # syntax, same loader. Listing it explicitly keeps the LOADER_MAP /
     # SUPPORTED_EXTENSIONS contract honest (every supported extension
     # has its own loader entry).
-    ".markdown": UnstructuredMarkdownLoader,
+    ".markdown": TextLoader,
     ".csv": CSVLoader,
     # TSV is tab-separated values; ``CSVLoader`` is delimiter-agnostic
     # at the langchain level and treats the file as one logical record
@@ -356,11 +364,15 @@ class RAGStore:
                 # the mismatch check on the next reopen.
                 log.warning("Could not backfill RAG collection metadata: %s", exc)
 
-        self.splitter = RecursiveCharacterTextSplitter(
-            chunk_size=1000,
-            chunk_overlap=200,
-            separators=["\n\n", "\n", ". ", " ", ""],
-        )
+        # PR-D removed the single-splitter ``self.splitter`` attribute.
+        # Per-document chunking now goes through
+        # :func:`amx.docs.splitters.get_splitter` which picks the
+        # right splitter based on the file extension. The dispatcher
+        # routes Markdown (`.md` / `.markdown`) through a header-aware
+        # two-stage splitter that preserves `h1`/`h2`/`h3` metadata
+        # on every chunk; everything else uses the same default
+        # recursive splitter as before, so the docs RAG eval baseline
+        # is stable for non-Markdown corpora.
         self.source_filters = [
             self._normalize_source_filter(s) for s in (source_filters or []) if s
         ]
@@ -419,22 +431,37 @@ class RAGStore:
             try:
                 loader = loader_cls(doc.path)
                 pages = loader.load()
-                chunks = self.splitter.split_documents(pages)
+                # PR-D: per-extension dispatcher routes Markdown
+                # documents through a header-aware splitter that
+                # preserves section metadata; non-Markdown extensions
+                # use the same RecursiveCharacterTextSplitter as
+                # before so retrieval quality is unchanged on the
+                # docs RAG eval baseline.
+                splitter = get_splitter(doc.extension)
+                chunks = splitter.split_documents(pages)
                 if not chunks:
                     failed.append((doc.path, "empty document (no chunks produced)"))
                     continue
 
                 ids = [f"{doc.path}::{i}" for i in range(len(chunks))]
                 texts = [c.page_content for c in chunks]
-                metadatas = [
-                    {
+                metadatas = []
+                for i, chunk in enumerate(chunks):
+                    meta = {
                         "source": doc.path,
                         "source_root": self._normalize_source_filter(doc.source_root or doc.path),
                         "source_type": doc.source_type,
                         "chunk_idx": i,
                     }
-                    for i in range(len(chunks))
-                ]
+                    # PR-D: propagate header metadata produced by the
+                    # Markdown-aware splitter (h1/h2/h3 keys). Only
+                    # set values are recorded — Chroma rejects None.
+                    chunk_meta = getattr(chunk, "metadata", None) or {}
+                    for header_key in ("h1", "h2", "h3"):
+                        value = chunk_meta.get(header_key)
+                        if value:
+                            meta[header_key] = str(value)
+                    metadatas.append(meta)
 
                 # Idempotency on file shrink: if the previous ingest of
                 # this exact path produced N chunks and the new content

--- a/amx/docs/splitters.py
+++ b/amx/docs/splitters.py
@@ -1,0 +1,189 @@
+"""Format-aware splitter dispatch for Document RAG (PR-D).
+
+The previous design at ``amx/docs/rag.py`` ran every document — PDF,
+DOCX, Markdown, HTML, CSV, plain text, ``.py`` source — through a
+single :class:`RecursiveCharacterTextSplitter` instance. That works
+acceptably for prose but is structurally blind:
+
+- Markdown is split mid-section, so ``## Section`` headers are lost
+  from the chunks they govern. The LLM sees ``column X is the …``
+  with no header to anchor *which* table the column lives in.
+- CSV rows get chunked at random offsets, breaking cells in half.
+- ``.py`` files go through a character splitter that knows nothing
+  about function or class boundaries, even though
+  :mod:`amx.codebase.code_rag` already has an AST-aware chunker that
+  produces the right shape.
+
+This module exposes :func:`get_splitter` — a tiny dispatcher keyed on
+the file extension — and a Markdown-header-aware splitter that
+preserves the section path (``h1`` / ``h2`` / ``h3``) in the chunk
+metadata so the assembled prompt can cite \"orders.md → h2: total_amount\"
+instead of just \"orders.md\". The default splitter for everything else
+is the same recursive character splitter, preserved here so the eval
+baseline is unaffected by this PR — only Markdown-typed documents see
+a behavior change.
+
+Token-counted budgets (audit F1.2), CSV row-group splitting (F1.5),
+and AST routing for ``.py`` via ``/docs ingest`` (F1.1 follow-up) are
+deferred to subsequent PRs; this one establishes the dispatcher
+seam and adds the Markdown specialisation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from langchain_core.documents import Document
+from langchain_text_splitters import (
+    MarkdownHeaderTextSplitter,
+    RecursiveCharacterTextSplitter,
+    TextSplitter,
+)
+
+# Mirror the previous hard-coded defaults so this dispatcher is a
+# drop-in replacement for non-Markdown inputs. Bumped to its own
+# constants here so a future PR-D-2 can move them into
+# ``cfg.docs.chunking`` without touching every caller.
+DEFAULT_CHUNK_SIZE_CHARS = 1000
+DEFAULT_CHUNK_OVERLAP_CHARS = 200
+DEFAULT_SEPARATORS = ["\n\n", "\n", ". ", " ", ""]
+
+# Markdown sections frequently exceed 1000 chars, especially in the
+# AMX corpus's schema docs (a single column entry can run several
+# hundred words). After header-splitting we still need to chunk long
+# sections so they fit a typical context window — pick the same
+# size/overlap as the default splitter so chunk granularity is
+# consistent across formats.
+MARKDOWN_HEADERS_TO_SPLIT_ON = [
+    ("#", "h1"),
+    ("##", "h2"),
+    ("###", "h3"),
+]
+
+# Extensions handled by the Markdown specialisation. The
+# :class:`LOADER_MAP` in ``amx/docs/rag.py`` maps both ``.md`` and
+# ``.markdown`` to ``UnstructuredMarkdownLoader``, which can either
+# preserve or flatten heading markers depending on its parser
+# strategy. The dispatcher operates AFTER the loader has run, so it
+# sees whatever text the loader produced; for Markdown inputs we
+# re-parse the headings ourselves because the loader's behaviour
+# varies between versions.
+_MARKDOWN_EXTENSIONS = {".md", ".markdown"}
+
+
+def _make_default_splitter() -> RecursiveCharacterTextSplitter:
+    """The exact splitter ``RAGStore`` used pre-PR-D. Preserved so
+    every non-Markdown extension keeps the previous behaviour and the
+    docs RAG eval baseline does not shift."""
+    return RecursiveCharacterTextSplitter(
+        chunk_size=DEFAULT_CHUNK_SIZE_CHARS,
+        chunk_overlap=DEFAULT_CHUNK_OVERLAP_CHARS,
+        separators=DEFAULT_SEPARATORS,
+    )
+
+
+class _MarkdownAwareSplitter(TextSplitter):
+    """Two-stage Markdown splitter.
+
+    Stage 1: :class:`MarkdownHeaderTextSplitter` cuts the document
+    along ``#`` / ``##`` / ``###`` headers and records the heading
+    path on each output document's metadata (``h1`` / ``h2`` / ``h3``
+    keys).
+
+    Stage 2: :class:`RecursiveCharacterTextSplitter` chunks each
+    section to the configured ``chunk_size`` so long sections (a
+    single ``##`` body that runs 3000 characters) don't produce one
+    over-sized chunk that hogs the LLM context. The header metadata
+    is propagated onto every sub-chunk via
+    ``RecursiveCharacterTextSplitter.split_documents`` (LangChain's
+    built-in metadata-preservation).
+
+    Note: ``TextSplitter.split_documents`` is the only method
+    ``RAGStore`` calls, so we implement that and let the inherited
+    ``split_text`` raise via the abstract contract (we deliberately
+    don't support raw-text input — the caller has a
+    :class:`Document` because the loader already ran).
+    """
+
+    def __init__(
+        self,
+        *,
+        chunk_size: int = DEFAULT_CHUNK_SIZE_CHARS,
+        chunk_overlap: int = DEFAULT_CHUNK_OVERLAP_CHARS,
+        separators: Sequence[str] | None = None,
+    ) -> None:
+        super().__init__(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+        self._header_splitter = MarkdownHeaderTextSplitter(
+            headers_to_split_on=MARKDOWN_HEADERS_TO_SPLIT_ON,
+            # Preserve the heading line in the body of the section so
+            # the LLM sees \"## Pricing\\n...\" rather than just the
+            # body. The metadata still carries the heading separately
+            # for citation use.
+            strip_headers=False,
+        )
+        self._body_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            separators=list(separators) if separators is not None else DEFAULT_SEPARATORS,
+        )
+
+    def split_text(self, text: str) -> list[str]:
+        """Plain-text entry point — exists to satisfy the abstract
+        base class. Splits as Markdown but discards the header
+        metadata since ``str`` can't carry it. Callers that need the
+        metadata should use ``split_documents`` with the loader's
+        :class:`Document` output."""
+        sections = self._header_splitter.split_text(text)
+        out: list[str] = []
+        for section in sections:
+            out.extend(self._body_splitter.split_text(section.page_content))
+        return out
+
+    def split_documents(self, documents: list[Document]) -> list[Document]:
+        """Dispatch-target for :meth:`RAGStore.ingest`.
+
+        For each input :class:`Document`:
+
+        1. Run the header splitter on the page content. The result is
+           a list of :class:`Document` objects, each tagged with the
+           heading path that introduced the section.
+        2. Carry the input document's metadata onto every section
+           (the loader recorded ``source``, ``page``, etc; we don't
+           want to lose them).
+        3. Run the body splitter to chop each tagged section into
+           chunk-sized documents. The section's metadata is
+           propagated to every sub-chunk by LangChain's built-in
+           metadata-preservation.
+        """
+        out: list[Document] = []
+        for doc in documents:
+            section_docs = self._header_splitter.split_text(doc.page_content)
+            for section in section_docs:
+                merged_meta: dict[str, Any] = {**(doc.metadata or {}), **(section.metadata or {})}
+                section.metadata = merged_meta
+            out.extend(self._body_splitter.split_documents(section_docs))
+        return out
+
+
+def get_splitter(extension: str) -> TextSplitter:
+    """Return the splitter that should chunk a document with the
+    given file extension.
+
+    The extension is matched case-insensitively. Unknown extensions
+    fall back to the recursive-character default so callers handling
+    arbitrary user input never see ``KeyError`` here.
+    """
+    ext = (extension or "").lower()
+    if ext in _MARKDOWN_EXTENSIONS:
+        return _MarkdownAwareSplitter()
+    return _make_default_splitter()
+
+
+__all__ = [
+    "DEFAULT_CHUNK_OVERLAP_CHARS",
+    "DEFAULT_CHUNK_SIZE_CHARS",
+    "DEFAULT_SEPARATORS",
+    "MARKDOWN_HEADERS_TO_SPLIT_ON",
+    "get_splitter",
+]

--- a/tests/test_docs_splitters.py
+++ b/tests/test_docs_splitters.py
@@ -1,0 +1,211 @@
+"""PR-D: format-dispatching splitter tests.
+
+Pins three behaviours that the new ``amx.docs.splitters`` module
+introduces:
+
+1. ``get_splitter(extension)`` returns the Markdown-aware splitter
+   for ``.md`` and ``.markdown`` and the original
+   ``RecursiveCharacterTextSplitter`` for everything else. Unknown
+   extensions fall back to the default rather than raising.
+2. The Markdown splitter preserves ``h1`` / ``h2`` / ``h3`` heading
+   paths on every output chunk's metadata, including chunks
+   produced by the second-stage character splitter on long sections.
+3. The end-to-end ``RAGStore.ingest`` path propagates the heading
+   metadata onto the Chroma chunk metadata when the source is
+   Markdown — that's the channel future PRs (PR-H assembly
+   citation headers) consume.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from langchain_core.documents import Document
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+from amx.docs.rag import RAGStore
+from amx.docs.scanner import DocInfo
+from amx.docs.splitters import _MarkdownAwareSplitter, get_splitter
+
+# ── dispatcher routing ───────────────────────────────────────────────
+
+
+def test_get_splitter_returns_markdown_aware_for_md() -> None:
+    assert isinstance(get_splitter(".md"), _MarkdownAwareSplitter)
+
+
+def test_get_splitter_returns_markdown_aware_for_markdown_long_form() -> None:
+    assert isinstance(get_splitter(".markdown"), _MarkdownAwareSplitter)
+
+
+def test_get_splitter_is_case_insensitive() -> None:
+    assert isinstance(get_splitter(".MD"), _MarkdownAwareSplitter)
+
+
+def test_get_splitter_returns_default_for_txt() -> None:
+    assert isinstance(get_splitter(".txt"), RecursiveCharacterTextSplitter)
+
+
+def test_get_splitter_returns_default_for_unknown_extension() -> None:
+    """Unknown extensions fall back to the default rather than
+    raising KeyError — keeps the dispatcher safe for arbitrary user
+    input."""
+    assert isinstance(get_splitter(".whatever"), RecursiveCharacterTextSplitter)
+
+
+def test_get_splitter_handles_empty_extension() -> None:
+    assert isinstance(get_splitter(""), RecursiveCharacterTextSplitter)
+
+
+# ── Markdown header metadata preservation ────────────────────────────
+
+
+def test_markdown_splitter_records_h1_h2_h3_on_chunks() -> None:
+    """Each output chunk carries the heading path it lives under in
+    its ``metadata`` dict."""
+    body = """# Orders table
+
+The orders table stores one row per order.
+
+## Columns
+
+- order_id
+- customer_id
+- total_amount
+
+## Constraints
+
+Total amount must be non-negative.
+
+### Why it matters
+
+Refunds depend on this invariant.
+"""
+    splitter = _MarkdownAwareSplitter()
+    chunks = splitter.split_documents([Document(page_content=body, metadata={"source": "fake.md"})])
+    assert len(chunks) >= 3, "expected one chunk per ##/### section"
+
+    # Every chunk should have h1 set from the top-level heading.
+    for chunk in chunks:
+        assert chunk.metadata.get("h1") == "Orders table"
+
+    # h2 should differ between Columns and Constraints sections.
+    h2_values = {chunk.metadata.get("h2") for chunk in chunks if chunk.metadata.get("h2")}
+    assert {"Columns", "Constraints"}.issubset(h2_values)
+
+    # The "Why it matters" subsection (under ## Constraints) should
+    # have its h3 recorded.
+    h3_chunks = [c for c in chunks if c.metadata.get("h3")]
+    assert any(c.metadata["h3"] == "Why it matters" for c in h3_chunks)
+
+
+def test_markdown_splitter_preserves_source_metadata_from_loader() -> None:
+    """The loader stamps ``source`` on the input Document; the
+    splitter must not drop it on output."""
+    body = "# Top\n\nbody\n"
+    splitter = _MarkdownAwareSplitter()
+    chunks = splitter.split_documents(
+        [Document(page_content=body, metadata={"source": "/path/to/file.md"})]
+    )
+    for chunk in chunks:
+        assert chunk.metadata.get("source") == "/path/to/file.md"
+
+
+def test_markdown_splitter_chunks_long_section() -> None:
+    """A single section longer than the chunk_size budget gets
+    further split by the body splitter — header metadata propagates
+    onto every sub-chunk."""
+    long_body = "# Big section\n\n" + ("Lorem ipsum dolor sit amet. " * 200)
+    splitter = _MarkdownAwareSplitter()
+    chunks = splitter.split_documents([Document(page_content=long_body, metadata={})])
+    assert len(chunks) >= 2, "long section should produce multiple sub-chunks"
+    for chunk in chunks:
+        assert chunk.metadata.get("h1") == "Big section"
+
+
+def test_markdown_splitter_strips_no_headers() -> None:
+    """The heading line itself stays in the chunk body so the LLM
+    sees ``## Section\\n...`` rather than just the body. The
+    structured metadata exists in parallel for citation use; the
+    body keeps the human-readable structure."""
+    body = "# Foo\n\nBody one.\n\n## Bar\n\nBody two.\n"
+    splitter = _MarkdownAwareSplitter()
+    chunks = splitter.split_documents([Document(page_content=body, metadata={})])
+    joined = "\n".join(c.page_content for c in chunks)
+    assert "# Foo" in joined
+    assert "## Bar" in joined
+
+
+# ── end-to-end RAGStore ingest preserves header metadata ─────────────
+
+
+def test_ragstore_ingest_records_h2_on_chunk_metadata(tmp_path: Path) -> None:
+    """When ``RAGStore.ingest`` is given a .md file, the resulting
+    Chroma chunks carry h1/h2/h3 metadata in addition to the usual
+    source / source_root / chunk_idx fields."""
+    md_path = tmp_path / "fixture.md"
+    md_path.write_text(
+        "# Orders\n\n## total_amount\n\nThe `total_amount` column "
+        "stores the sum of line items plus tax.\n",
+        encoding="utf-8",
+    )
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    summary = store.ingest(
+        [
+            DocInfo(
+                path=str(md_path),
+                size_bytes=md_path.stat().st_size,
+                extension=".md",
+                source_type="local",
+                source_root=str(tmp_path),
+            )
+        ]
+    )
+    assert summary.chunk_count > 0
+    # Inspect the stored metadata directly.
+    rows = store.collection.get(where={"source": str(md_path)}, include=["metadatas"])
+    metas = rows.get("metadatas") or []
+    assert metas, "ingest should have produced at least one chunk"
+    found_h1 = any(m.get("h1") == "Orders" for m in metas)
+    found_h2 = any(m.get("h2") == "total_amount" for m in metas)
+    assert found_h1, f"expected at least one chunk with h1=Orders, got metas={metas}"
+    assert found_h2, f"expected at least one chunk with h2=total_amount, got metas={metas}"
+
+
+def test_ragstore_ingest_does_not_set_header_keys_for_txt(tmp_path: Path) -> None:
+    """The .txt path uses the default RecursiveCharacterTextSplitter
+    which doesn't produce header metadata. Header keys must be
+    absent from those chunks' metadata so the eval baseline stays
+    stable and downstream prompt assembly doesn't see stale h2/h3
+    values."""
+    txt_path = tmp_path / "plain.txt"
+    txt_path.write_text("Some plain text without markdown structure.\n", encoding="utf-8")
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    summary = store.ingest(
+        [
+            DocInfo(
+                path=str(txt_path),
+                size_bytes=txt_path.stat().st_size,
+                extension=".txt",
+                source_type="local",
+                source_root=str(tmp_path),
+            )
+        ]
+    )
+    assert summary.chunk_count >= 1
+    rows = store.collection.get(where={"source": str(txt_path)}, include=["metadatas"])
+    metas = rows.get("metadatas") or []
+    for meta in metas:
+        assert "h1" not in meta
+        assert "h2" not in meta
+        assert "h3" not in meta


### PR DESCRIPTION
## Summary

Replaces `RAGStore`'s single-splitter design with a per-extension
dispatcher (`amx/docs/splitters.py`). Markdown documents now go
through a header-aware splitter that records `h1`/`h2`/`h3`
heading paths on each chunk's metadata; everything else routes
through the same `RecursiveCharacterTextSplitter` as before — so
the docs RAG eval baseline is unchanged for non-Markdown corpora.

Closes the PR-D row of omeryasirkucuk/amx#454. Scope-limited to
audit **F1.1** (format-dispatching seam + Markdown specialisation).
**F1.2** (token-counted budgets), **F1.3** (cfg.docs.chunking
knobs), **F1.4** (chunker_signature on collection metadata), and
the `.py` / `.csv` / `.pdf` specialisations are deferred to
follow-up PRs that plug into the same dispatcher seam.

## What changed

- New `amx/docs/splitters.py` — `get_splitter(extension)`
  dispatcher + `_MarkdownAwareSplitter` two-stage Markdown splitter.
- `amx/docs/rag.py`:
  - `self.splitter` field removed; ingest calls
    `get_splitter(doc.extension)` per document.
  - Chunk metadata propagation for `h1`/`h2`/`h3` (Markdown only).
  - `.md` / `.markdown` loader switched from
    `UnstructuredMarkdownLoader` to `TextLoader` — the Unstructured
    backend silently strips Markdown formatting which made the new
    splitter useless.

## User impact

- `.txt` ingest: bit-identical to pre-PR-D. Eval baseline confirmed
  unchanged.
- `.md` ingest: structurally-different chunks (split by heading
  boundaries) with `h1`/`h2`/`h3` metadata. Users will see
  different retrieval results on re-ingest — chunk identities
  change, but provider/model don't, so PR-B's mismatch check
  doesn't fire. Net effect is a retrieval-quality improvement; the
  structural awareness was the point.
- Existing chunks stay valid until the user re-ingests — no forced
  migration.

## Tests

- `tests/test_docs_splitters.py` (new) — 12 cases:
  - Dispatcher routing (`.md`, `.markdown`, case-insensitivity,
    `.txt`, unknown extension, empty extension).
  - Markdown header preservation (`h1`/`h2`/`h3`, long-section
    sub-chunking, source-metadata pass-through, body-text keeps
    heading markers).
  - End-to-end `RAGStore.ingest` preserving `h1`/`h2` on Chroma
    metadata for `.md` and **not** setting header keys for `.txt`.

## Test plan

- [x] `pytest tests/eval tests/test_docs_*` — 61/61 pass.
- [x] `pytest --ignore=tests/web --ignore=tests/perf` — 1936 pass
      (up from 1924), 9 skipped (pre-existing), 0 fail.
- [x] `ruff check amx tests` clean. `ruff format --check` clean.
- [x] Eval baseline regenerates identically — no drift on docs RAG
      quality for non-Markdown fixtures.
- [ ] CI matrix green.

## Related

- Tracking issue: omeryasirkucuk/amx#454 (PR-D checklist item).
- Depends on omeryasirkucuk/amx#456 (PR-B) — the chunker_signature
  follow-up uses the same `CollectionIdentityMismatch` plumbing.
- Unblocks **PR-H** (edges-first assembly + citation header) — the
  citation header consumes the `h2` / `h3` metadata this PR
  produces.