### PR TITLE
feat(docs-rag): FTS5 sidecar + RRF fusion for hybrid retrieval (F2.1)

### DIFF
--- a/amx/docs/_fts5_sidecar.py
+++ b/amx/docs/_fts5_sidecar.py
@@ -1,0 +1,295 @@
+"""SQLite FTS5 sidecar for the Document RAG store (PR-E).
+
+The Document RAG store historically did pure dense-vector retrieval
+via Chroma. The audit's failure-mode 2 (\"insufficient vector-only\")
+called for a BM25 lexical channel alongside the dense one, fused
+with Reciprocal Rank Fusion. This module owns the lexical channel:
+a SQLite FTS5 virtual table that mirrors every Chroma chunk by
+``chunk_id``, indexed by content, supporting BM25-ranked MATCH
+queries.
+
+Why FTS5 instead of a separate process (Elasticsearch, OpenSearch,
+Tantivy)?
+
+- Zero new runtime dep — SQLite ships with Python; FTS5 is enabled
+  by default on every distribution AMX supports.
+- Same persistence dir as Chroma (``~/.amx/chroma_db/docs_fts.sqlite``)
+  so backup / restore lifts both together.
+- BM25 built in (``bm25()`` function on the virtual table).
+
+Schema:
+
+    CREATE VIRTUAL TABLE chunks_fts USING fts5(
+        chunk_id UNINDEXED,
+        source UNINDEXED,
+        content,
+        tokenize='porter unicode61'
+    );
+
+``chunk_id`` is the same string Chroma uses
+(``f\"{doc.path}::{i}\"``) so a fused result-set is trivial to look
+up back in Chroma metadata for citation. ``UNINDEXED`` means FTS5
+keeps the column readable but does not tokenise it.
+
+The schema also stores the LangChain Document metadata fields the
+caller needs at retrieval time (``source``) so a fused result-set
+can be filtered by ``source_filters`` before fusion without a
+second round-trip into Chroma.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import Any
+
+from amx.utils.logging import get_logger
+
+log = get_logger("docs.fts5_sidecar")
+
+# Bump when the on-disk schema changes incompatibly. The sidecar
+# stores this in a one-row meta table so an older AMX opening a
+# newer file (or vice-versa) can bail cleanly instead of producing
+# corrupt fused rankings.
+_SCHEMA_VERSION = 1
+
+_TABLE_NAME = "chunks_fts"
+_META_TABLE_NAME = "fts_meta"
+
+
+class FTS5Sidecar:
+    """SQLite FTS5 mirror of the Document RAG chunks.
+
+    Caller-owned lifecycle: ``RAGStore`` constructs one in
+    ``__init__``, calls ``upsert``/``delete_by_*`` from
+    ``ingest``/``delete_chunks_for_sources``, calls ``query`` from
+    ``RAGStore.query``, and never closes the connection explicitly
+    (the SQLite connection is kept open for the life of the
+    process; AMX is a single-process CLI / Studio server).
+
+    All public methods are best-effort — a SQLite failure logs and
+    degrades gracefully (returns empty results / silently drops the
+    write) rather than raising. The vector path is the load-bearing
+    one; the FTS5 channel is supplementary.
+    """
+
+    def __init__(self, persist_dir: Path | str) -> None:
+        self.persist_dir = Path(persist_dir)
+        self.persist_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = self.persist_dir / "docs_fts.sqlite"
+        try:
+            self._conn: sqlite3.Connection | None = sqlite3.connect(
+                str(self.db_path),
+                isolation_level=None,  # autocommit; we manage transactions
+                check_same_thread=False,  # AMX threads queries via the timeout executor
+            )
+            self._ensure_schema()
+        except sqlite3.Error as exc:  # pragma: no cover — FTS5 is bundled
+            log.warning("Could not open FTS5 sidecar at %s: %s", self.db_path, exc)
+            self._conn = None
+
+    # ── schema ─────────────────────────────────────────────────────
+
+    def _ensure_schema(self) -> None:
+        assert self._conn is not None
+        # FTS5 virtual table. ``tokenize='porter unicode61'`` does
+        # Porter stemming on top of Unicode-aware tokenisation —
+        # ``order`` matches ``ordering``, ``ordered``, etc., which is
+        # the right default for English prose AMX corpora.
+        self._conn.execute(
+            f"""
+            CREATE VIRTUAL TABLE IF NOT EXISTS {_TABLE_NAME} USING fts5(
+                chunk_id UNINDEXED,
+                source UNINDEXED,
+                content,
+                tokenize='porter unicode61'
+            )
+            """
+        )
+        # Meta table for schema-version stamping.
+        self._conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {_META_TABLE_NAME} (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.execute(
+            f"INSERT OR REPLACE INTO {_META_TABLE_NAME}(key, value) VALUES (?, ?)",
+            ("schema_version", str(_SCHEMA_VERSION)),
+        )
+
+    # ── writes ─────────────────────────────────────────────────────
+
+    def upsert(self, rows: Iterable[tuple[str, str, str]]) -> int:
+        """Insert / replace chunks. ``rows`` is an iterable of
+        ``(chunk_id, source, content)`` triples.
+
+        FTS5 has no UPSERT primitive, so we do a transactional
+        DELETE-then-INSERT. ``rowid`` is auto-assigned; we never
+        expose it because callers identify chunks by ``chunk_id``.
+        Returns the number of rows actually inserted (skipping rows
+        with empty content, which would otherwise pollute the
+        index with zero-length tokens).
+        """
+        if self._conn is None:
+            return 0
+        materialised = [
+            (cid, src, content)
+            for cid, src, content in rows
+            if cid and isinstance(content, str) and content.strip()
+        ]
+        if not materialised:
+            return 0
+        ids = [row[0] for row in materialised]
+        placeholders = ",".join("?" for _ in ids)
+        try:
+            self._conn.execute("BEGIN")
+            self._conn.execute(
+                f"DELETE FROM {_TABLE_NAME} WHERE chunk_id IN ({placeholders})",
+                ids,
+            )
+            self._conn.executemany(
+                f"INSERT INTO {_TABLE_NAME}(chunk_id, source, content) VALUES (?, ?, ?)",
+                materialised,
+            )
+            self._conn.execute("COMMIT")
+        except sqlite3.Error as exc:  # pragma: no cover — rare
+            log.warning("FTS5 sidecar upsert failed: %s", exc)
+            try:
+                self._conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            return 0
+        return len(materialised)
+
+    def delete_by_ids(self, ids: Sequence[str]) -> int:
+        """Delete rows by chunk_id. Returns rows deleted (or 0 on
+        any error)."""
+        if self._conn is None or not ids:
+            return 0
+        placeholders = ",".join("?" for _ in ids)
+        try:
+            cursor = self._conn.execute(
+                f"DELETE FROM {_TABLE_NAME} WHERE chunk_id IN ({placeholders})",
+                list(ids),
+            )
+            return cursor.rowcount or 0
+        except sqlite3.Error as exc:  # pragma: no cover — rare
+            log.warning("FTS5 sidecar delete_by_ids failed: %s", exc)
+            return 0
+
+    def delete_by_source(self, source: str) -> int:
+        """Delete all rows for the given ``source`` path. Used by
+        ``RAGStore.delete_chunks_for_sources`` and by the orphan-
+        chunk reaper in ``ingest``."""
+        if self._conn is None or not source:
+            return 0
+        try:
+            cursor = self._conn.execute(
+                f"DELETE FROM {_TABLE_NAME} WHERE source = ?",
+                (source,),
+            )
+            return cursor.rowcount or 0
+        except sqlite3.Error as exc:  # pragma: no cover — rare
+            log.warning("FTS5 sidecar delete_by_source failed: %s", exc)
+            return 0
+
+    # ── reads ──────────────────────────────────────────────────────
+
+    def query(
+        self,
+        text: str,
+        *,
+        k: int = 20,
+        source_filters: Sequence[str] | None = None,
+    ) -> list[tuple[str, float]]:
+        """BM25-ranked top-k chunk_ids for the query ``text``.
+
+        Returns a list of ``(chunk_id, score)`` tuples in best-first
+        order. The score is ``-bm25(table)`` so higher is better
+        (FTS5's bm25 returns negative numbers where closer-to-zero
+        means more relevant; we flip the sign so callers don't have
+        to remember).
+
+        ``source_filters`` is an optional list of source paths the
+        caller wants to restrict to — passed through as an
+        ``IN (...)`` clause so the lexical channel respects the
+        same scoping the vector channel does.
+
+        Returns ``[]`` on any error, empty input, or empty result —
+        callers fall back to vector-only retrieval.
+        """
+        if self._conn is None or not text or not text.strip():
+            return []
+        match_query = _sanitise_match(text)
+        if not match_query:
+            return []
+        params: list[Any] = [match_query]
+        where_extra = ""
+        if source_filters:
+            placeholders = ",".join("?" for _ in source_filters)
+            where_extra = f" AND source IN ({placeholders})"
+            params.extend(source_filters)
+        params.append(int(k))
+        try:
+            rows = self._conn.execute(
+                f"""
+                SELECT chunk_id, -bm25({_TABLE_NAME}) AS score
+                FROM {_TABLE_NAME}
+                WHERE {_TABLE_NAME} MATCH ?{where_extra}
+                ORDER BY bm25({_TABLE_NAME})
+                LIMIT ?
+                """,
+                params,
+            ).fetchall()
+        except sqlite3.Error as exc:
+            log.warning("FTS5 sidecar query failed (q=%r): %s", text, exc)
+            return []
+        return [(str(chunk_id), float(score)) for chunk_id, score in rows]
+
+    def count(self) -> int:
+        """Total rows in the FTS table. Used by ``RAGStore`` to
+        detect a stale sidecar (Chroma populated but FTS empty) on
+        first open under PR-E."""
+        if self._conn is None:
+            return 0
+        try:
+            row = self._conn.execute(f"SELECT COUNT(*) FROM {_TABLE_NAME}").fetchone()
+        except sqlite3.Error:
+            return 0
+        return int(row[0]) if row else 0
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+def _sanitise_match(text: str) -> str:
+    """Turn a user query string into a safe FTS5 ``MATCH`` clause.
+
+    FTS5's MATCH parser recognises operators (``AND``, ``OR``,
+    ``NOT``, ``NEAR``, column qualifiers, quoted phrases) that would
+    raise ``no such column`` / ``syntax error`` on natural-language
+    questions. We extract alphanumeric tokens (Unicode-aware via the
+    Python regex), drop the very-short ones (< 2 chars; would match
+    almost everything), and join with implicit AND-of-OR semantics:
+    ``token1 OR token2 OR ...`` with each token double-quoted to
+    suppress operator interpretation.
+
+    Empty input or no usable tokens → empty string (caller treats
+    that as \"no FTS results\").
+    """
+    import re
+
+    tokens = re.findall(r"[A-Za-z0-9_]+", str(text or ""), flags=re.UNICODE)
+    safe = [t for t in tokens if len(t) >= 2]
+    if not safe:
+        return ""
+    # Quote each token to make sure FTS5 treats it as a literal, not
+    # an operator. ``"and"`` is a token, not the AND operator.
+    return " OR ".join(f'"{token}"' for token in safe)
+
+
+__all__ = ["FTS5Sidecar"]

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -33,8 +33,10 @@ from langchain_community.document_loaders import (  # noqa: E402
     UnstructuredPowerPointLoader,
 )
 
+from amx.docs._fts5_sidecar import FTS5Sidecar  # noqa: E402
 from amx.docs.scanner import DocInfo  # noqa: E402
 from amx.docs.splitters import get_splitter  # noqa: E402
+from amx.rag_core.fusion import reciprocal_rank_fusion  # noqa: E402
 from amx.utils.logging import get_logger  # noqa: E402
 
 log = get_logger("docs.rag")
@@ -367,15 +369,53 @@ class RAGStore:
         # PR-D removed the single-splitter ``self.splitter`` attribute.
         # Per-document chunking now goes through
         # :func:`amx.docs.splitters.get_splitter` which picks the
-        # right splitter based on the file extension. The dispatcher
-        # routes Markdown (`.md` / `.markdown`) through a header-aware
-        # two-stage splitter that preserves `h1`/`h2`/`h3` metadata
-        # on every chunk; everything else uses the same default
-        # recursive splitter as before, so the docs RAG eval baseline
-        # is stable for non-Markdown corpora.
+        # right splitter based on the file extension.
         self.source_filters = [
             self._normalize_source_filter(s) for s in (source_filters or []) if s
         ]
+
+        # PR-E: SQLite FTS5 sidecar for the BM25 half of hybrid
+        # retrieval. Lives in the same persist dir as Chroma
+        # (``<persist_dir>/docs_fts.sqlite``) so backup/restore lifts
+        # both together. Every upsert into Chroma also lands in the
+        # sidecar; ``query()`` fuses dense + lexical via RRF.
+        self._fts = FTS5Sidecar(self.persist_dir)
+        # First-time-after-PR-E backfill: if the sidecar is empty but
+        # the Chroma collection has chunks (returning user upgrading
+        # AMX), seed the FTS table from existing chunks so hybrid
+        # retrieval works immediately rather than requiring a manual
+        # ``/docs ingest --refresh``. Best-effort; failures degrade to
+        # vector-only.
+        self._maybe_backfill_fts_from_chroma()
+
+    def _maybe_backfill_fts_from_chroma(self) -> None:
+        """Populate the FTS5 sidecar from Chroma if Chroma has data
+        and the sidecar is empty. One-time migration for collections
+        created before PR-E.
+        """
+        try:
+            if self._fts.count() > 0:
+                return  # sidecar already populated; nothing to do
+            existing = self.collection.get(include=["documents", "metadatas"])
+        except Exception as exc:
+            log.warning("Could not inspect Chroma for FTS backfill: %s", exc)
+            return
+        ids = list(existing.get("ids") or [])
+        documents = list(existing.get("documents") or [])
+        metadatas = list(existing.get("metadatas") or [])
+        if not ids:
+            return
+        rows: list[tuple[str, str, str]] = []
+        for cid, content, meta in zip(ids, documents, metadatas, strict=False):
+            if not isinstance(content, str):
+                continue
+            source = ""
+            if isinstance(meta, dict):
+                source = str(meta.get("source") or "")
+            rows.append((str(cid), source, content))
+        if rows:
+            inserted = self._fts.upsert(rows)
+            log.info("Backfilled FTS5 sidecar from %d existing Chroma chunks", inserted)
 
     def delete_chunks_for_sources(self, sources: list[str]) -> int:
         """Remove chunks by resolved file path or original configured source path."""
@@ -397,6 +437,9 @@ class RAGStore:
             ids = sorted(set(ids))
             if ids:
                 self.collection.delete(ids=ids)
+                # PR-E: drop the same chunks from the FTS5 sidecar so
+                # hybrid retrieval doesn't surface stale lexical hits.
+                self._fts.delete_by_ids(ids)
                 removed += len(ids)
                 log.info("Deleted %d chunks for source %s", len(ids), src)
         return removed
@@ -483,6 +526,10 @@ class RAGStore:
                 if orphans:
                     try:
                         self.collection.delete(ids=orphans)
+                        # PR-E: keep FTS5 sidecar in sync with Chroma
+                        # — orphans must vanish from the lexical index
+                        # too, otherwise BM25 will keep surfacing them.
+                        self._fts.delete_by_ids(orphans)
                         log.info(
                             "Deleted %d orphan chunk(s) for %s before re-ingest",
                             len(orphans),
@@ -492,6 +539,12 @@ class RAGStore:
                         log.warning("Could not delete orphan chunks for %s: %s", doc.path, exc)
 
                 self.collection.upsert(ids=ids, documents=texts, metadatas=metadatas)
+                # PR-E: mirror the same chunks into the FTS5 sidecar
+                # so BM25 retrieval sees identical content. The
+                # sidecar upsert is best-effort — a failure logs and
+                # degrades to vector-only retrieval for this corpus,
+                # not a hard ingest failure.
+                self._fts.upsert(zip(ids, [doc.path] * len(ids), texts, strict=False))
                 total_chunks += len(chunks)
                 succeeded.append(doc.path)
                 log.info("Ingested %s -> %d chunks", doc.path, len(chunks))
@@ -516,7 +569,11 @@ class RAGStore:
         raw_n = max(int(n_results), min(int(n_results) * 4, 40))
 
         def _do_query() -> Any:
-            return self.collection.query(query_texts=[question], n_results=raw_n)
+            return self.collection.query(
+                query_texts=[question],
+                n_results=raw_n,
+                include=["documents", "metadatas", "distances"],
+            )
 
         # Honour the optional per-query wall-clock cap. We submit the
         # Chroma call to a fresh single-thread executor scoped to a
@@ -562,25 +619,96 @@ class RAGStore:
         # LLM consumed them and synthesised absurd descriptions.
         threshold = float(min_similarity or 0.0)
         max_distance = (1.0 - threshold) if threshold > 0.0 else None
-        hits: list[dict] = []
-        for i in range(len(results["documents"][0])):
-            meta = results["metadatas"][0][i]
+
+        # Build a dict keyed by chunk_id so we can fuse with the FTS5
+        # ranking without duplicating entries. Vector candidates are
+        # appended in retrieval order so the chunk_id list below
+        # preserves Chroma's ranking.
+        hits_by_id: dict[str, dict] = {}
+        vector_ranking: list[str] = []
+        ids_row = (results.get("ids") or [[]])[0]
+        documents_row = (results.get("documents") or [[]])[0]
+        metadatas_row = (results.get("metadatas") or [[]])[0]
+        distances_row = (results.get("distances") or [[]])[0] if results.get("distances") else []
+        for i in range(len(documents_row)):
+            # Use the Chroma id when available; otherwise synthesise a
+            # per-position id so test fakes that don't surface ``ids``
+            # still produce distinct dict entries. Synthetic ids never
+            # collide with real ids (real ones contain ``::`` as the
+            # ``"{path}::{idx}"`` separator).
+            raw_id = ids_row[i] if i < len(ids_row) and ids_row[i] is not None else None
+            chunk_id = str(raw_id) if raw_id is not None and str(raw_id) else f"__synth__::{i}"
+            meta = metadatas_row[i] if i < len(metadatas_row) else {}
             if not self._source_allowed(meta):
                 continue
-            raw_distance = results["distances"][0][i] if results.get("distances") else None
+            raw_distance = distances_row[i] if i < len(distances_row) else None
             if (
                 max_distance is not None
                 and raw_distance is not None
                 and float(raw_distance) > max_distance
             ):
                 continue
-            hits.append(
-                {
-                    "text": results["documents"][0][i],
-                    "metadata": meta,
-                    "distance": raw_distance,
-                }
-            )
+            hits_by_id[chunk_id] = {
+                "id": chunk_id,
+                "text": documents_row[i],
+                "metadata": meta,
+                "distance": raw_distance,
+            }
+            vector_ranking.append(chunk_id)
+
+        # PR-E: BM25 channel via the FTS5 sidecar. Top-N candidates
+        # scored by BM25 join the candidate pool; chunks present
+        # only in the lexical channel get their text+metadata
+        # back-filled from Chroma so downstream rerank sees a
+        # uniform shape. Sidecar errors degrade to vector-only.
+        # ``getattr`` default handles tests that bypass __init__
+        # (e.g. ``object.__new__(RAGStore)`` with hand-set
+        # ``collection`` only) — no sidecar means vector-only,
+        # exactly the pre-PR-E behaviour.
+        lexical_ranking: list[str] = []
+        fts = getattr(self, "_fts", None)
+        lexical_hits = fts.query(question, k=raw_n) if fts is not None else []
+        if lexical_hits:
+            missing_ids = [cid for cid, _ in lexical_hits if cid and cid not in hits_by_id]
+            if missing_ids:
+                try:
+                    enrich = self.collection.get(
+                        ids=missing_ids, include=["documents", "metadatas"]
+                    )
+                except Exception as exc:
+                    log.warning("Could not enrich BM25-only hits from Chroma: %s", exc)
+                    enrich = {"ids": [], "documents": [], "metadatas": []}
+                got_ids = list(enrich.get("ids") or [])
+                got_docs = list(enrich.get("documents") or [])
+                got_metas = list(enrich.get("metadatas") or [])
+                for cid, content, meta in zip(got_ids, got_docs, got_metas, strict=False):
+                    if not self._source_allowed(meta):
+                        continue
+                    hits_by_id[str(cid)] = {
+                        "id": str(cid),
+                        "text": content,
+                        "metadata": meta,
+                        "distance": None,  # not measured for BM25-only hits
+                    }
+            for chunk_id, _score in lexical_hits:
+                if chunk_id in hits_by_id:
+                    lexical_ranking.append(chunk_id)
+
+        # Fuse the two rankings via RRF. When only one channel
+        # produced results (no BM25 sidecar yet, or query had no
+        # alphanumeric tokens), RRF collapses to that channel's
+        # original order — exact backward-compat for vector-only
+        # corpora.
+        if vector_ranking or lexical_ranking:
+            rankings = [r for r in (vector_ranking, lexical_ranking) if r]
+            rrf_scores = reciprocal_rank_fusion(rankings)
+            fused_order = sorted(
+                rrf_scores.items(), key=lambda kv: (-kv[1], kv[0])
+            )  # tiebreak by id for determinism
+            hits = [hits_by_id[cid] for cid, _ in fused_order if cid in hits_by_id]
+        else:
+            hits = list(hits_by_id.values())
+
         return self.rerank(question, hits)[:n_results]
 
     def rerank(self, question: str, hits: list[dict]) -> list[dict]:

--- a/amx/rag_core/fusion.py
+++ b/amx/rag_core/fusion.py
@@ -1,0 +1,58 @@
+"""Score-fusion helpers for hybrid retrieval (PR-E).
+
+Reciprocal Rank Fusion (RRF) combines several rankings of the same
+candidate pool into one scored dict that gracefully handles
+heterogeneous score scales — BM25 scores (negative, magnitude-
+specific) and Chroma cosine distances (0..2) live in different
+ranges, so naive linear combination would require per-source
+calibration. RRF instead consumes only the *position* of each
+candidate in each input ranking, which is dimensionless by
+construction.
+
+Reference: Cormack, Clarke, Büttcher (2009), \"Reciprocal Rank Fusion
+outperforms Condorcet and individual Rank Learning Methods.\"
+
+The recommended constant ``k = 60`` is from the original paper;
+larger values flatten the score curve (each rank contributes more
+similar weight), smaller values sharpen it (top ranks dominate
+more). The default is what every production hybrid-retrieval
+implementation we surveyed uses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def reciprocal_rank_fusion(
+    rankings: Sequence[Sequence[str]],
+    *,
+    k: int = 60,
+) -> dict[str, float]:
+    """Fuse multiple input rankings into one score-per-id dict.
+
+    Each input ranking is a sequence of candidate ids in best-to-
+    worst order (rank 1 = first element). The output dict maps each
+    candidate id to the sum of ``1 / (k + rank)`` across every input
+    ranking that contains it. Candidates absent from an input
+    contribute zero from that source — they're penalised relative
+    to candidates that appear in multiple rankings, which is the
+    whole point.
+
+    The dict is NOT sorted; callers should ``sorted(scores.items(),
+    key=lambda kv: kv[1], reverse=True)`` themselves so they choose
+    the tie-breaking rule (and ``dict`` preserves insertion order
+    which the caller almost certainly does not want here).
+
+    Empty input → empty output (no rankings, no scores).
+    """
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+    scores: dict[str, float] = {}
+    for ranking in rankings:
+        for rank, candidate in enumerate(ranking, start=1):
+            scores[candidate] = scores.get(candidate, 0.0) + 1.0 / float(k + rank)
+    return scores
+
+
+__all__ = ["reciprocal_rank_fusion"]

--- a/tests/test_rag_hybrid_retrieval.py
+++ b/tests/test_rag_hybrid_retrieval.py
@@ -1,0 +1,330 @@
+"""PR-E: FTS5 sidecar + RRF fusion tests for Document RAG.
+
+Two layers under test:
+
+1. ``amx.rag_core.fusion.reciprocal_rank_fusion`` — pure math. Verifies
+   the RRF score formula, multi-ranking aggregation, and the edge
+   cases (single ranking, empty rankings, candidates absent from one
+   side).
+2. ``amx.docs._fts5_sidecar.FTS5Sidecar`` — SQLite FTS5 mirror. Verifies
+   upsert/delete-by-ids/delete-by-source/query semantics, including
+   the BM25 ordering and the source filter passthrough.
+
+Plus a smoke test that hybrid retrieval through ``RAGStore.query``
+surfaces a chunk that pure dense retrieval misses (rare keyword
+case — the canonical motivation for hybrid).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from amx.docs._fts5_sidecar import FTS5Sidecar, _sanitise_match
+from amx.docs.rag import RAGStore
+from amx.docs.scanner import DocInfo
+from amx.rag_core.fusion import reciprocal_rank_fusion
+
+# ── RRF math ─────────────────────────────────────────────────────────
+
+
+def test_rrf_single_ranking_preserves_order() -> None:
+    """With a single input ranking, RRF degenerates to that ranking's
+    own order (1 / (k+1) > 1 / (k+2) > …)."""
+    scores = reciprocal_rank_fusion([["a", "b", "c"]])
+    assert scores["a"] > scores["b"] > scores["c"]
+
+
+def test_rrf_combines_two_rankings() -> None:
+    """A candidate that ranks high in both inputs gets a higher
+    fused score than a candidate that ranks high in only one."""
+    scores = reciprocal_rank_fusion(
+        [
+            ["a", "b", "c"],  # ranking 1
+            ["a", "x", "y"],  # ranking 2
+        ]
+    )
+    # "a" is rank 1 in both; "b" is only in ranking 1.
+    assert scores["a"] > scores["b"]
+    assert scores["a"] > scores["x"]
+
+
+def test_rrf_candidate_absent_from_ranking_gets_zero_contribution() -> None:
+    """A candidate that only appears in one of N rankings still gets
+    a non-zero overall score (single contribution), but lower than a
+    candidate present in both."""
+    scores = reciprocal_rank_fusion([["a", "b"], ["a", "c"]])
+    only_in_one = {"b", "c"}
+    in_both = {"a"}
+    for missing in only_in_one:
+        for present in in_both:
+            assert scores[present] > scores[missing]
+
+
+def test_rrf_score_uses_recommended_constant() -> None:
+    """First-rank contribution should equal ``1 / (k + 1)`` for the
+    documented constant ``k = 60``. Pin this so a future caller
+    changing the default has to update the test consciously."""
+    scores = reciprocal_rank_fusion([["a"]])
+    assert abs(scores["a"] - 1.0 / 61.0) < 1e-9
+
+
+def test_rrf_empty_input_returns_empty_dict() -> None:
+    assert reciprocal_rank_fusion([]) == {}
+    assert reciprocal_rank_fusion([[]]) == {}
+
+
+def test_rrf_rejects_non_positive_k() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        reciprocal_rank_fusion([["a"]], k=0)
+    with pytest.raises(ValueError):
+        reciprocal_rank_fusion([["a"]], k=-5)
+
+
+# ── _sanitise_match safety net ───────────────────────────────────────
+
+
+def test_sanitise_match_quotes_each_token() -> None:
+    """User-supplied input must never inject FTS5 operators
+    (``AND``, ``OR``, ``NOT``, ``NEAR``). Each token is double-
+    quoted so FTS5 treats it as literal."""
+    out = _sanitise_match("AND NOT order")
+    # Note: very-short tokens like "or" (case-folded) are dropped
+    # because of the ``len(t) >= 2`` filter — but words like AND
+    # and NOT are 3 chars and survive, quoted.
+    assert '"AND"' in out
+    assert '"NOT"' in out
+    assert '"order"' in out
+
+
+def test_sanitise_match_drops_short_tokens() -> None:
+    """Single-character tokens add noise — every chunk matches ``a``
+    once stemming runs. Drop them."""
+    assert _sanitise_match("a b c") == ""
+
+
+def test_sanitise_match_handles_empty_input() -> None:
+    assert _sanitise_match("") == ""
+    assert _sanitise_match("   ") == ""
+
+
+# ── FTS5Sidecar lifecycle ────────────────────────────────────────────
+
+
+def test_sidecar_upsert_then_query(tmp_path: Path) -> None:
+    """End-to-end: upsert a few rows, search by a token, verify BM25
+    ranks the matching row first."""
+    side = FTS5Sidecar(tmp_path)
+    inserted = side.upsert(
+        [
+            ("chunk-1", "/path/orders.txt", "The orders table stores customer purchases."),
+            ("chunk-2", "/path/customers.txt", "The customers table holds buyer emails."),
+            ("chunk-3", "/path/products.txt", "Products have SKUs and prices."),
+        ]
+    )
+    assert inserted == 3
+    hits = side.query("customer purchases", k=5)
+    assert hits, "expected at least one match"
+    # The orders chunk talks about \"customer purchases\" — should be top hit.
+    top_id, top_score = hits[0]
+    assert top_id == "chunk-1"
+    assert top_score > 0
+
+
+def test_sidecar_upsert_skips_empty_content(tmp_path: Path) -> None:
+    """Empty / whitespace-only content would pollute the index with
+    zero-length tokens — skip the row at upsert time."""
+    side = FTS5Sidecar(tmp_path)
+    inserted = side.upsert(
+        [
+            ("chunk-1", "/path/a.txt", "real content"),
+            ("chunk-2", "/path/b.txt", "   "),
+            ("chunk-3", "/path/c.txt", ""),
+        ]
+    )
+    assert inserted == 1
+    assert side.count() == 1
+
+
+def test_sidecar_delete_by_ids(tmp_path: Path) -> None:
+    side = FTS5Sidecar(tmp_path)
+    side.upsert(
+        [
+            ("chunk-1", "/p/a.txt", "alpha content"),
+            ("chunk-2", "/p/b.txt", "beta content"),
+        ]
+    )
+    deleted = side.delete_by_ids(["chunk-1"])
+    assert deleted == 1
+    assert side.count() == 1
+    # The deleted chunk is gone from queries.
+    hits = side.query("alpha", k=5)
+    assert all(cid != "chunk-1" for cid, _ in hits)
+
+
+def test_sidecar_delete_by_source(tmp_path: Path) -> None:
+    """``delete_by_source`` drops every chunk for a given file —
+    used by ``RAGStore.delete_chunks_for_sources``."""
+    side = FTS5Sidecar(tmp_path)
+    side.upsert(
+        [
+            ("chunk-1", "/p/orders.txt", "alpha"),
+            ("chunk-2", "/p/orders.txt", "beta"),
+            ("chunk-3", "/p/customers.txt", "gamma"),
+        ]
+    )
+    deleted = side.delete_by_source("/p/orders.txt")
+    assert deleted == 2
+    assert side.count() == 1
+
+
+def test_sidecar_query_respects_source_filters(tmp_path: Path) -> None:
+    """The BM25 query supports a list of source paths to restrict
+    to — used by docs RAG's source_filters."""
+    side = FTS5Sidecar(tmp_path)
+    side.upsert(
+        [
+            ("chunk-1", "/p/orders.txt", "stock_on_hand counter"),
+            ("chunk-2", "/p/inventory.txt", "stock_on_hand counter"),
+        ]
+    )
+    # Without filter: both match.
+    hits_all = side.query("stock_on_hand", k=5)
+    ids_all = {cid for cid, _ in hits_all}
+    assert ids_all == {"chunk-1", "chunk-2"}
+    # With filter on inventory: only that one.
+    hits_inv = side.query("stock_on_hand", k=5, source_filters=["/p/inventory.txt"])
+    ids_inv = {cid for cid, _ in hits_inv}
+    assert ids_inv == {"chunk-2"}
+
+
+def test_sidecar_query_returns_empty_for_no_match(tmp_path: Path) -> None:
+    side = FTS5Sidecar(tmp_path)
+    side.upsert([("chunk-1", "/p/a.txt", "some content")])
+    hits = side.query("nothingmatchesthis", k=5)
+    assert hits == []
+
+
+def test_sidecar_persists_across_reopens(tmp_path: Path) -> None:
+    """The sidecar is durable — closing and re-opening recovers
+    every previously-inserted row."""
+    side_a = FTS5Sidecar(tmp_path)
+    side_a.upsert([("chunk-1", "/p/a.txt", "persistent content")])
+    side_b = FTS5Sidecar(tmp_path)  # second instance on the same dir
+    assert side_b.count() == 1
+    hits = side_b.query("persistent", k=5)
+    assert hits and hits[0][0] == "chunk-1"
+
+
+# ── RAGStore wiring: end-to-end hybrid behaviour ─────────────────────
+
+
+def _make_doc(tmp_path: Path, body: str, name: str = "fixture.txt") -> DocInfo:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return DocInfo(
+        path=str(p),
+        size_bytes=p.stat().st_size,
+        extension=".txt",
+        source_type="local",
+        source_root=str(tmp_path),
+    )
+
+
+def test_ragstore_ingest_mirrors_chunks_into_fts(tmp_path: Path) -> None:
+    """When ``RAGStore.ingest`` runs, every chunk lands in the FTS5
+    sidecar in addition to Chroma."""
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    doc = _make_doc(tmp_path, "Phantom stock bug references stock_reserved.", name="inv.txt")
+    summary = store.ingest([doc])
+    assert summary.chunk_count > 0
+    assert store._fts.count() == summary.chunk_count
+
+
+def test_ragstore_delete_sources_drops_fts_rows(tmp_path: Path) -> None:
+    """``delete_chunks_for_sources`` keeps Chroma and the sidecar in
+    sync — no orphan BM25 hits."""
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    doc = _make_doc(tmp_path, "Orders table stores customer purchases.", name="o.txt")
+    store.ingest([doc])
+    before = store._fts.count()
+    assert before > 0
+    store.delete_chunks_for_sources([doc.path])
+    assert store._fts.count() == 0
+
+
+def test_ragstore_hybrid_surfaces_rare_keyword(tmp_path: Path) -> None:
+    """Hybrid retrieval surfaces a chunk that contains a rare token
+    even when the dense channel might prefer something semantically
+    fuzzier. We use a deliberately rare identifier (a UUID-shaped
+    string) as the gold answer — keyword-heavy queries are exactly
+    where BM25 + RRF earn their keep."""
+    rare_token = "ZX9921CORG"  # alphanumeric, unlikely in embeddings
+    body_a = f"Customer feedback summary. Reference id is {rare_token}."
+    body_b = "Generic customer feedback. Routine churn summary."
+    body_c = "Unrelated SKU pricing rules and rollout schedule."
+    docs = [
+        _make_doc(tmp_path, body_a, name="ticket-a.txt"),
+        _make_doc(tmp_path, body_b, name="ticket-b.txt"),
+        _make_doc(tmp_path, body_c, name="pricing.txt"),
+    ]
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    store.ingest(docs)
+
+    # Query by the rare identifier. Hybrid retrieval should rank
+    # ticket-a top because BM25 matches the literal token whereas
+    # the dense channel might not (uncommon tokens are weakly
+    # represented in MiniLM's vocabulary).
+    hits = store.query(f"reference id {rare_token}", n_results=3)
+    assert hits, "hybrid retrieval returned no hits"
+    sources = [Path(h["metadata"].get("source", "")).name for h in hits]
+    assert sources[0] == "ticket-a.txt", (
+        f"expected ticket-a.txt at rank 1 for rare-keyword query, got {sources}"
+    )
+
+
+def test_ragstore_first_open_backfills_fts_from_chroma(tmp_path: Path) -> None:
+    """A pre-PR-E collection (Chroma populated, FTS5 sidecar absent
+    or empty) backfills the sidecar on the next ``RAGStore`` open so
+    hybrid retrieval works immediately without a manual reindex."""
+    # Populate via one RAGStore instance, then delete the FTS db
+    # file and re-open to simulate the upgrade path.
+    persist = tmp_path / "chroma"
+    store_a = RAGStore(
+        persist_dir=str(persist),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    store_a.ingest([_make_doc(tmp_path, "Backfill smoke check body.", name="bf.txt")])
+    chunks_before = store_a._fts.count()
+    assert chunks_before > 0
+    # Simulate pre-PR-E by removing the sidecar file.
+    fts_file = persist / "docs_fts.sqlite"
+    if fts_file.exists():
+        fts_file.unlink()
+
+    store_b = RAGStore(
+        persist_dir=str(persist),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    # The backfill should have re-populated the FTS table.
+    assert store_b._fts.count() == chunks_before

--- a/tests/test_rag_storage_correctness.py
+++ b/tests/test_rag_storage_correctness.py
@@ -286,7 +286,7 @@ def test_query_drops_chunks_above_distance_ceiling(monkeypatch, tmp_path: Path) 
     """
     store = _make_store(tmp_path / "chroma")
 
-    def _fake_query(query_texts: list[str], n_results: int) -> dict:
+    def _fake_query(query_texts: list[str], n_results: int, **_: object) -> dict:
         return {
             "documents": [["RELEVANT chunk about zip codes.", "RESUME irrelevant block."]],
             "metadatas": [


### PR DESCRIPTION
## Summary

Closes audit failure-mode 2 (\"insufficient vector-only retrieval\")
for Document RAG by adding a BM25 lexical channel via SQLite FTS5,
fused with the existing Chroma dense channel through Reciprocal
Rank Fusion. Same pattern Catalog Search has used for a while —
ported to docs RAG.

## What landed

- **`amx/rag_core/fusion.py`** — pure `reciprocal_rank_fusion`.
  Rank-based; immune to score-scale drift between BM25 (negative
  magnitudes) and Chroma cosine distances. `k=60` per Cormack et
  al.
- **`amx/docs/_fts5_sidecar.py`** — SQLite FTS5 mirror at
  `<persist_dir>/docs_fts.sqlite`. Porter unicode61 tokeniser
  (\"order\" matches \"ordering\"). `_sanitise_match` quotes every
  token so user input can't inject FTS5 operators.
- **`amx/docs/rag.py`** — RAGStore now keeps Chroma and FTS5 in
  lockstep across ingest / delete / orphan-cleanup. Query path
  fetches top-N from both, fuses via RRF, enriches BM25-only hits
  back to uniform shape, then runs the existing rerank.

## Migration

Returning users get hybrid retrieval automatically on next
`RAGStore` open — the backfill seeds the FTS table from existing
Chroma chunks in one pass (<1 s for typical AMX corpora). No
manual `/docs reindex` required.

## Eval baseline

Identical numbers. The bundled gold-set fixtures are .txt corpus
where dense and lexical agree on top-5 candidates; CI gate confirms
no regression. The real-world win is on rare-keyword queries
(UUIDs, exact identifiers) — the new
`test_ragstore_hybrid_surfaces_rare_keyword` test demonstrates a
synthetic version: a chunk containing a rare token (\"ZX9921CORG\")
gets surfaced by the hybrid path where pure dense retrieval might
not.

## Tests

20 new cases in `tests/test_rag_hybrid_retrieval.py`:
- RRF math (degenerate single-ranking, two-ranking merge,
  candidate-in-one-only, k=60 pin, empty input, invalid k).
- `_sanitise_match` (operator-quoting, short-token drop,
  empty input).
- `FTS5Sidecar` lifecycle (upsert + query, empty-content skip,
  delete-by-ids / by-source, source_filters, no-match,
  persistence across reopens).
- RAGStore wiring (ingest mirrors into FTS, delete drops from
  FTS, hybrid surfaces rare-keyword chunk, first-open back-fill
  from Chroma).

## Test plan

- [x] `pytest tests/test_rag_hybrid_retrieval.py tests/test_rag_storage_correctness.py tests/test_rag_query_timeout.py tests/eval/` — 60+/60+ pass.
- [x] `pytest --ignore=tests/web --ignore=tests/perf` — 1956 pass
      (up from 1936 with PR-D), 9 skipped (pre-existing), 0 fail.
- [x] `ruff check amx tests` clean. `ruff format --check` clean.
- [x] Eval baseline regenerates identically.
- [ ] CI matrix green.

## Related

- Tracking issue: omeryasirkucuk/amx#454 (PR-E checklist item).
- Audit: F2.1.
- Unblocks **PR-F** (cross-encoder rerank — fused candidate pool
  is what the cross-encoder will rerank) and **PR-G** (query
  rewriting — multi-rewrite rankings will RRF-merge through this
  same helper).