### PR TITLE
feat(rag-agent): edges-first assembly + citation header + model-aware budget (F3.1-F3.3)

### DIFF
--- a/amx/agents/rag_agent.py
+++ b/amx/agents/rag_agent.py
@@ -26,6 +26,11 @@ from amx.llm.style.guard import scrub_placeholders
 from amx.llm.style.injector import render_style_section
 from amx.llm.style.loader import load_active_style_profile
 from amx.llm.style.profile import StyleProfile
+from amx.rag_core.assembly import (
+    assemble_chunks,
+    compute_input_budget,
+    format_chunk_header,
+)
 from amx.utils.console import step_spinner
 from amx.utils.logging import get_logger
 from amx.utils.token_tracker import estimate_tokens, tracker
@@ -320,18 +325,32 @@ class RAGAgent(BaseAgent):
         if not unique_hits:
             return None
 
-        prompt_hits = list(unique_hits[: pd.rag_max_chunks])
+        # PR-H: edges-first reorder over the top-k chunks. ``chunks``
+        # arrives in descending rerank score; ``assemble_chunks``
+        # anchors the highest scorers at both prompt edges and pushes
+        # the mid-scorers into the attention-dead middle (Liu et al.
+        # 2023, "Lost in the Middle"). The function also implements
+        # the truncation, replacing the previous ``[:rag_max_chunks]``
+        # slice — single seam, no double-pass.
+        prompt_hits = list(assemble_chunks(unique_hits, pd.rag_max_chunks))
         # Stash for downstream snapshot writers; keyed by (schema,
         # table) since the agent is reused across many tables in one
         # run.
         self.last_prompt_hits[(ctx.schema, ctx.table)] = list(prompt_hits)
-        doc_chunks = [
-            f"[{h['metadata'].get('source', 'unknown')}]\n{h['text']}" for h in prompt_hits
-        ]
+        # PR-H: per-chunk citation header carries source basename +
+        # Markdown section (from PR-D's h2/h3 metadata) + relevance.
+        # Replaces the bare ``[source]`` prefix so the LLM has a
+        # scannable summary at every chunk boundary even when
+        # attention is weak in the middle of the prompt.
+        doc_chunks = [f"{format_chunk_header(h)}\n{h['text']}" for h in prompt_hits]
+        # PR-H: per-model input budget via LiteLLM lookup. Falls back
+        # to the legacy ``max_tokens * 3`` heuristic when the model id
+        # is unknown — same numeric floor, just more honest about big-
+        # context models.
+        model_name = str(getattr(self.llm.cfg, "model", "") or "")
+        max_output_tokens = int(getattr(self.llm.cfg, "max_tokens", 4096) or 4096)
         validator = MaxTokenValidator(
-            comfortable_input_tokens=max(
-                1_000, int(getattr(self.llm.cfg, "max_tokens", 4096) or 4096) * 3
-            )
+            comfortable_input_tokens=compute_input_budget(model_name, max_output_tokens)
         )
         doc_chunks = validator.compact_chunks(doc_chunks)
         doc_text = "\n\n---\n\n".join(doc_chunks)

--- a/amx/rag_core/assembly.py
+++ b/amx/rag_core/assembly.py
@@ -1,0 +1,169 @@
+"""Prompt-assembly helpers for the RAG Agent (PR-H).
+
+Three concerns live here:
+
+1. **Edges-first chunk reorder** — combats the "Lost in the Middle"
+   attention failure documented in Liu et al. (2023). LLMs pay
+   strong attention to the beginning and end of the prompt and
+   weak attention to the middle; placing the highest-scoring
+   chunks at *both* edges and the lower-scoring chunks in the
+   middle reduces the rate at which the model overlooks important
+   evidence buried in mid-prompt context.
+
+   The algorithm: take the top-k chunks (already in
+   descending-relevance order from rerank), then split into
+   odd-indexed and even-indexed positions, and concatenate
+   ``odd + reversed(even)``. The top-scorers anchor both ends;
+   mid-scorers settle into the attention-dead zone.
+
+2. **Per-chunk citation header** — every chunk's body gets a
+   short prefix line that names the source file, the Markdown
+   section heading (if known — produced by PR-D's Markdown-aware
+   splitter), and the chunk's relevance score. This gives the LLM
+   a scannable summary it can latch onto even when attention is
+   weakest in the middle of the prompt, and gives downstream
+   citation extraction a stable channel to mine.
+
+3. **Per-model input budget** — replaces the previous
+   ``max_tokens * 3`` heuristic with a real per-model lookup via
+   LiteLLM. Stops AMX from over-stuffing a small-context Mistral
+   or under-using a 200k-token Claude.
+
+All three are exposed as small pure-ish functions so PR-J can
+extract them into the shared retrieval core without touching the
+RAG agent's call sites again.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from amx.utils.logging import get_logger
+
+log = get_logger("rag_core.assembly")
+
+
+def assemble_chunks(chunks: Sequence[Mapping[str, Any]], k: int) -> list[Mapping[str, Any]]:
+    """Take the top-``k`` chunks from ``chunks`` and reorder them so
+    the highest-relevance chunks anchor both ends of the prompt.
+
+    ``chunks`` is expected in descending-relevance order (the
+    rerank output). The reorder works on the truncated top-``k`` —
+    chunks beyond index ``k`` are dropped, which is **by construction**
+    the "drop from middle" behaviour the old budget-compactor
+    used to perform with a second pass: after edges-first reorder,
+    the middle of the list is the lowest-relevance band.
+
+    Algorithm:
+        Given ``[c1, c2, c3, c4, c5, c6]`` (descending score)
+        Top-k slice (k=6) → ``[c1, c2, c3, c4, c5, c6]``
+        Odd positions (0, 2, 4) → ``[c1, c3, c5]``
+        Even positions (1, 3, 5) → ``[c2, c4, c6]`` → reversed → ``[c6, c4, c2]``
+        Result → ``[c1, c3, c5, c6, c4, c2]``
+
+    Top scorers anchor both ends; mid-scorers sit in the middle
+    where attention is weakest.
+
+    The same operation as LangChain's ``LongContextReorder`` — no
+    dependency on it here so PR-J can reuse this from outside the
+    rag_agent without dragging in LangChain.
+
+    Edge cases:
+    - ``k <= 0`` → return ``[]``.
+    - ``len(chunks) <= 1`` → return chunks unchanged.
+    """
+    if k <= 0:
+        return []
+    top = list(chunks[:k])
+    if len(top) <= 1:
+        return top
+    odd = top[0::2]
+    even = top[1::2]
+    return odd + list(reversed(even))
+
+
+def format_chunk_header(hit: Mapping[str, Any]) -> str:
+    """One-line citation header rendered above each chunk body.
+
+    Reads ``metadata.source``, ``metadata.h2`` / ``metadata.h3``
+    (produced by PR-D's Markdown-aware splitter), and ``score``
+    (from the rerank step). Falls back to a minimal header when
+    fields are missing — the prompt never breaks on incomplete
+    metadata, it just degrades from
+    "orders.md | section=total_amount (rel=0.84)" to "orders.md".
+
+    Examples:
+        >>> format_chunk_header({
+        ...     "metadata": {"source": "/path/orders.md",
+        ...                  "h2": "total_amount"},
+        ...     "score": 1.34})
+        '[orders.md | section=total_amount] (rel=1.34)'
+
+        >>> format_chunk_header({"metadata": {"source": "/x/y.txt"}})
+        '[y.txt]'
+    """
+    meta = hit.get("metadata") or {}
+    raw_source = meta.get("source") or "unknown"
+    # Project to file basename so the header stays readable when
+    # the absolute path is deep. Citation lookup still happens on
+    # the full path via ``hit['metadata']['source']``.
+    source = Path(str(raw_source)).name or str(raw_source)
+
+    # Pick the most specific heading available. h3 is more specific
+    # than h2; h2 than h1. None of them is fine.
+    section = meta.get("h3") or meta.get("h2") or meta.get("h1") or ""
+
+    score = hit.get("score")
+
+    parts = [source]
+    if section:
+        parts.append(f"section={section}")
+    header = "[" + " | ".join(parts) + "]"
+    if isinstance(score, (int, float)):
+        header = f"{header} (rel={float(score):.2f})"
+    return header
+
+
+def compute_input_budget(model_name: str, max_output_tokens: int) -> int:
+    """Return the input-token budget for ``model_name``.
+
+    Looks up the model's input window via LiteLLM
+    (``litellm.get_model_info``) and subtracts the planned output
+    budget plus a 256-token safety margin (for the system prompt,
+    tool calls, etc.). Falls back to the previous ``max_tokens * 3``
+    heuristic when the lookup fails (custom models, proxy
+    deployments, LiteLLM stale on the resolver side), with a floor
+    of 1000 tokens so the prompt is never starved.
+
+    The lookup is cached by LiteLLM internally, so this is cheap to
+    call on every retrieval.
+    """
+    floor = max(1_000, int(max_output_tokens) * 3)
+    if not model_name:
+        return floor
+    try:
+        import litellm  # noqa: E402
+
+        info = litellm.get_model_info(model_name)
+    except Exception as exc:  # noqa: BLE001 — broad on purpose
+        # Custom model id LiteLLM doesn't know about → keep the
+        # legacy heuristic. Log once-per-process via the logger's
+        # built-in dedup (no extra book-keeping needed; AMX runs
+        # exactly one _build_messages per table).
+        log.debug("litellm.get_model_info(%r) failed: %s; using heuristic", model_name, exc)
+        return floor
+    max_input = int(info.get("max_input_tokens") or 0)
+    if max_input <= 0:
+        return floor
+    safety_margin = 256
+    usable = max(floor, max_input - int(max_output_tokens) - safety_margin)
+    return usable
+
+
+__all__ = [
+    "assemble_chunks",
+    "compute_input_budget",
+    "format_chunk_header",
+]

--- a/tests/test_rag_assembly.py
+++ b/tests/test_rag_assembly.py
@@ -1,0 +1,261 @@
+"""PR-H: edges-first assembly + citation header + model-aware budget.
+
+Pure-ish unit tests for ``amx.rag_core.assembly``. The end-to-end
+flow through ``RAGAgent._build_messages`` is covered by the agent's
+own existing tests; here we pin the algorithmic contract of each
+function so a future refactor (PR-J shared-core extraction) can't
+silently drift the semantics.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from amx.rag_core.assembly import (
+    assemble_chunks,
+    compute_input_budget,
+    format_chunk_header,
+)
+
+# ── assemble_chunks: edges-first reorder ─────────────────────────────
+
+
+def test_assemble_six_chunks_anchors_top_scorers_at_both_ends() -> None:
+    """Canonical example from Liu et al. 2023: [c1..c6] (descending
+    score) should reorder to [c1, c3, c5, c6, c4, c2] — top scorers
+    at the edges, mid-scorers in the attention-dead middle."""
+    chunks = [{"id": i} for i in range(1, 7)]
+    result = assemble_chunks(chunks, k=6)
+    ids = [c["id"] for c in result]
+    assert ids == [1, 3, 5, 6, 4, 2]
+
+
+def test_assemble_truncates_to_k_before_reordering() -> None:
+    """``k`` is a hard cap. Chunks beyond index k are dropped by
+    construction — the old "drop from middle" budget operation
+    is implicit in the slice + reorder."""
+    chunks = [{"id": i} for i in range(1, 11)]  # 10 chunks
+    result = assemble_chunks(chunks, k=4)
+    ids = [c["id"] for c in result]
+    # Top 4 → [1, 2, 3, 4]; odd → [1, 3], even reversed → [4, 2].
+    assert ids == [1, 3, 4, 2]
+
+
+def test_assemble_k_larger_than_input_is_safe() -> None:
+    """``k`` greater than the candidate pool size reorders the whole
+    pool without raising."""
+    chunks = [{"id": i} for i in range(1, 4)]  # only 3 chunks
+    result = assemble_chunks(chunks, k=10)
+    ids = [c["id"] for c in result]
+    # Top 3 → [1, 2, 3]; odd → [1, 3], even reversed → [2].
+    assert ids == [1, 3, 2]
+
+
+def test_assemble_single_chunk_passes_through() -> None:
+    """Edge case: a single chunk has no middle to bury — return it
+    unchanged."""
+    result = assemble_chunks([{"id": 42}], k=5)
+    assert result == [{"id": 42}]
+
+
+def test_assemble_empty_input_returns_empty_list() -> None:
+    assert assemble_chunks([], k=5) == []
+
+
+def test_assemble_k_zero_returns_empty_list() -> None:
+    """``k <= 0`` short-circuits to empty rather than ValueError —
+    callers (config presets) may legitimately set rag_max_chunks=0
+    to disable RAG context for a profile."""
+    assert assemble_chunks([{"id": 1}, {"id": 2}], k=0) == []
+    assert assemble_chunks([{"id": 1}, {"id": 2}], k=-3) == []
+
+
+def test_assemble_preserves_chunk_objects_by_reference() -> None:
+    """The reorder is a list shuffle — the chunk dicts themselves
+    must NOT be copied/mutated, so downstream code reading
+    ``hit['metadata']`` sees the same objects retrieval produced."""
+    chunks = [{"id": i, "text": f"body {i}"} for i in range(4)]
+    result = assemble_chunks(chunks, k=4)
+    for r in result:
+        assert any(r is c for c in chunks)
+
+
+# ── format_chunk_header: citation header rendering ───────────────────
+
+
+def test_format_header_with_full_metadata() -> None:
+    hit = {
+        "metadata": {"source": "/path/to/orders.md", "h2": "total_amount"},
+        "score": 1.25,
+    }
+    assert format_chunk_header(hit) == "[orders.md | section=total_amount] (rel=1.25)"
+
+
+def test_format_header_falls_back_to_h1_when_h2_h3_absent() -> None:
+    """``h3`` > ``h2`` > ``h1`` in specificity. Pick the most
+    specific available; degrade gracefully."""
+    hit = {"metadata": {"source": "x.md", "h1": "Top section"}, "score": 0.5}
+    assert format_chunk_header(hit) == "[x.md | section=Top section] (rel=0.50)"
+
+
+def test_format_header_prefers_h3_over_h2() -> None:
+    hit = {
+        "metadata": {"source": "x.md", "h2": "Outer", "h3": "Inner"},
+        "score": 0.5,
+    }
+    header = format_chunk_header(hit)
+    assert "section=Inner" in header
+    assert "Outer" not in header
+
+
+def test_format_header_minimal_when_only_source_present() -> None:
+    """No heading metadata, no score → just the source basename in
+    brackets. Used for plain-text corpora (.txt) where PR-D's
+    Markdown-aware splitter doesn't fire."""
+    hit = {"metadata": {"source": "/p/plain.txt"}}
+    assert format_chunk_header(hit) == "[plain.txt]"
+
+
+def test_format_header_handles_missing_metadata_dict() -> None:
+    """Defensive against malformed hits — never raise from the
+    citation path; the prompt is more useful with a degraded
+    header than no header at all."""
+    assert format_chunk_header({}) == "[unknown]"
+    assert format_chunk_header({"metadata": None}) == "[unknown]"
+
+
+def test_format_header_skips_score_when_non_numeric() -> None:
+    """``score`` may be missing or a sentinel value; only render the
+    relevance suffix when it's a real number."""
+    hit_no_score = {"metadata": {"source": "x.md"}}
+    hit_string_score = {"metadata": {"source": "x.md"}, "score": "high"}
+    assert format_chunk_header(hit_no_score) == "[x.md]"
+    assert format_chunk_header(hit_string_score) == "[x.md]"
+
+
+# ── compute_input_budget: per-model context lookup ───────────────────
+
+
+def test_compute_budget_uses_litellm_max_input_tokens_when_available() -> None:
+    """LiteLLM's resolver returns a 200k-token window for Claude
+    Sonnet; ``compute_input_budget`` should land below it after
+    subtracting the planned output + safety margin."""
+    with patch("litellm.get_model_info", return_value={"max_input_tokens": 200_000}):
+        budget = compute_input_budget("claude-sonnet-4-6", max_output_tokens=16_384)
+    # 200k - 16k - 256 safety margin ≈ 183_360
+    assert 180_000 <= budget <= 200_000
+
+
+def test_compute_budget_falls_back_to_heuristic_when_litellm_fails() -> None:
+    """A custom / proxy model id LiteLLM doesn't recognise raises
+    inside ``get_model_info``; the legacy ``max_tokens * 3`` heuristic
+    kicks in (with a 1000-token floor)."""
+
+    def _raise(*_args, **_kwargs):
+        raise ValueError("LiteLLM: unknown model id 'proxy/custom-7b'")
+
+    with patch("litellm.get_model_info", side_effect=_raise):
+        budget = compute_input_budget("proxy/custom-7b", max_output_tokens=4096)
+    assert budget == 4096 * 3  # heuristic
+
+
+def test_compute_budget_honours_1000_token_floor() -> None:
+    """Very small ``max_output_tokens`` should not produce a tiny
+    input budget — the floor is 1000."""
+    with patch("litellm.get_model_info", side_effect=Exception("nope")):
+        budget = compute_input_budget("any", max_output_tokens=10)
+    assert budget == 1_000
+
+
+def test_compute_budget_with_empty_model_name_uses_heuristic() -> None:
+    """``model_name`` is empty string when the LLM config hasn't
+    been populated; treat as heuristic path. Don't even try to call
+    LiteLLM in this case."""
+    with patch("litellm.get_model_info", side_effect=AssertionError("should not be called")):
+        budget = compute_input_budget("", max_output_tokens=2048)
+    assert budget == max(1_000, 2048 * 3)
+
+
+def test_compute_budget_handles_zero_max_input_tokens() -> None:
+    """LiteLLM sometimes returns ``max_input_tokens=0`` for incomplete
+    model records — treat that as unknown, fall through to heuristic."""
+    with patch("litellm.get_model_info", return_value={"max_input_tokens": 0}):
+        budget = compute_input_budget("partial-model", max_output_tokens=4096)
+    assert budget == 4096 * 3
+
+
+def test_compute_budget_returns_at_least_floor_even_with_huge_output() -> None:
+    """If the planned output budget is so large it would consume the
+    entire window, fall back to the heuristic floor — never starve
+    the prompt to zero."""
+    with patch("litellm.get_model_info", return_value={"max_input_tokens": 8_192}):
+        budget = compute_input_budget("small", max_output_tokens=8_000)
+    # max(1000, 8000*3) = 24000; usable would be -64; the floor wins.
+    assert budget == max(1_000, 8_000 * 3)
+
+
+def test_compute_budget_with_pytest_raises_for_invalid() -> None:
+    """Smoke check that the function doesn't accidentally allow
+    negative max_output_tokens to produce nonsensical budgets."""
+    with patch("litellm.get_model_info", side_effect=Exception):
+        budget = compute_input_budget("x", max_output_tokens=0)
+    # 0 * 3 = 0; floor wins.
+    assert budget >= 1_000
+
+
+def test_compute_budget_litellm_missing_module_is_handled() -> None:
+    """The except clause is broad enough to swallow
+    ImportError too — defensive in environments where litellm
+    might be shimmed or unavailable."""
+    with patch("litellm.get_model_info", side_effect=ImportError("no litellm")):
+        budget = compute_input_budget("x", max_output_tokens=2_048)
+    assert budget == max(1_000, 2_048 * 3)
+
+
+def test_compute_budget_subtracts_safety_margin() -> None:
+    """Verify the 256-token safety margin is subtracted from the
+    raw input window. Pinning this so a future tweak (e.g. larger
+    margin for thinking-mode models) is conscious.
+
+    Picks a window/output combo where the model-aware path
+    dominates the ``max(floor, ...)`` selection (input 200k vs
+    floor 24k for output=8k) so the safety-margin arithmetic is
+    actually exercised.
+    """
+    with patch("litellm.get_model_info", return_value={"max_input_tokens": 200_000}):
+        budget = compute_input_budget("gpt-x", max_output_tokens=8_000)
+    # 200k - 8k - 256 = 191_744; the floor (24k) loses to this.
+    assert budget == 200_000 - 8_000 - 256
+
+
+# ── pytest smoke marker ──────────────────────────────────────────────
+
+
+def test_assembly_module_exports() -> None:
+    """Pin the public surface so PR-J's shared-core extraction
+    catches accidental renames."""
+    from amx.rag_core import assembly
+
+    assert "assemble_chunks" in assembly.__all__
+    assert "format_chunk_header" in assembly.__all__
+    assert "compute_input_budget" in assembly.__all__
+
+
+@pytest.mark.parametrize(
+    "k,expected",
+    [
+        (1, [1]),
+        (2, [1, 2]),
+        (3, [1, 3, 2]),
+        (4, [1, 3, 4, 2]),
+        (5, [1, 3, 5, 4, 2]),
+    ],
+)
+def test_assemble_chunks_parametric(k: int, expected: list[int]) -> None:
+    """Parameter sweep on the reorder algorithm — pin the result
+    for k=1..5 so the canonical pattern is uniquely defined."""
+    chunks = [{"id": i} for i in range(1, 11)]
+    result = assemble_chunks(chunks, k=k)
+    assert [c["id"] for c in result] == expected


### PR DESCRIPTION
## Summary

Addresses the audit's failure-mode 3 (\"Lost in the Middle\") for
Document RAG prompt construction. Three concerns ship together
because they all touch the same `_build_messages` seam:

1. **Edges-first reorder.** `assemble_chunks(chunks, k)` takes the
   top-k and reorders so the highest-relevance chunks anchor both
   ends and the mid-scorers sit in the attention-dead middle.
2. **Citation header per chunk.** Reads `source.basename` +
   `h2`/`h3`/`h1` (from PR-D's Markdown-aware splitter) + relevance
   score. Replaces the bare `[source]` prefix.
3. **Per-model input budget.** Queries
   `litellm.get_model_info()` for `max_input_tokens` minus
   output + safety margin. Falls back to the legacy
   `max(1000, max_tokens * 3)` heuristic for unknown models.

## Why ship them together

All three are tiny algorithmic changes touching adjacent lines of
`RAGAgent._build_messages`. Splitting them into three PRs would
multiply review overhead without adding test isolation — the
test file is already split into three sections.

## Eval baseline

Unchanged. The gate measures retrieval, not the prompt assembly
this PR changes. Generation-quality measurement belongs to the
LLM-judge tier of the eval harness (gated by `AMX_EVAL_JUDGE=1`),
follow-up.

## Tests

28 new cases in `tests/test_rag_assembly.py`:

- **`assemble_chunks`**: canonical `[c1..c6]→[1,3,5,6,4,2]` reorder,
  truncate-then-reorder for `k<len`, `k>len` safety, single/empty,
  `k<=0` short-circuit, by-reference preservation.
- **`format_chunk_header`**: full / partial / empty metadata, h3>h2>h1
  specificity, plain-text minimal, defensive None handling,
  non-numeric score skip.
- **`compute_input_budget`**: LiteLLM happy path, exception fallback,
  zero/missing input window, empty model name, 1000-token floor,
  huge-output protection, safety-margin arithmetic pin.
- Plus a parametric sweep on `k=1..5` and an `__all__` pin so
  PR-J catches accidental renames.

## Test plan

- [x] `pytest tests/test_rag_assembly.py tests/eval tests/agents` —
      all green.
- [x] `pytest --ignore=tests/web --ignore=tests/perf` — 1984 pass
      (up from 1956), 9 skipped (pre-existing), 0 fail.
- [x] `ruff check amx tests` clean. `ruff format --check` clean.
- [x] Eval baseline regenerates identically — retrieval untouched.
- [ ] CI matrix green.

## Related

- Tracking issue: omeryasirkucuk/amx#454 (PR-H checklist item).
- Audit: F3.1, F3.2, F3.3.
- Depends on omeryasirkucuk/amx#458 (PR-D) for the h2/h3 metadata
  the citation header consumes.
- Unblocks **PR-I** (MMR for diversity — slots between rerank and
  `assemble_chunks` in the seam structure this PR establishes).