### PR TITLE
feat(docs-rag): MMR diversity reorder after rerank (F2.5)

### DIFF
--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -36,7 +36,10 @@ from langchain_community.document_loaders import (  # noqa: E402
 from amx.docs._fts5_sidecar import FTS5Sidecar  # noqa: E402
 from amx.docs.scanner import DocInfo  # noqa: E402
 from amx.docs.splitters import get_splitter  # noqa: E402
-from amx.rag_core.fusion import reciprocal_rank_fusion  # noqa: E402
+from amx.rag_core.fusion import (  # noqa: E402
+    maximal_marginal_relevance,
+    reciprocal_rank_fusion,
+)
 from amx.utils.logging import get_logger  # noqa: E402
 
 log = get_logger("docs.rag")
@@ -565,6 +568,8 @@ class RAGStore:
         *,
         timeout: float | None = None,
         min_similarity: float = 0.0,
+        use_mmr: bool = True,
+        mmr_lambda: float = 0.7,
     ) -> list[dict]:
         raw_n = max(int(n_results), min(int(n_results) * 4, 40))
 
@@ -709,7 +714,86 @@ class RAGStore:
         else:
             hits = list(hits_by_id.values())
 
-        return self.rerank(question, hits)[:n_results]
+        reranked = self.rerank(question, hits)
+
+        # PR-I: MMR for diversity. After rerank we have a relevance
+        # ordering; MMR re-orders it to demote near-duplicate
+        # chunks (e.g. three consecutive paragraphs of the same
+        # section that all match the query). ``mmr_lambda=0.7``
+        # leans toward relevance but actively avoids duplicates.
+        # MMR runs over the full reranked pool then we take the
+        # first ``n_results`` — that way the diversity-aware
+        # selection has the most material to work with rather than
+        # being asked to diversify an already-tiny list.
+        if use_mmr and len(reranked) > 1:
+            mmr_candidates = self._build_mmr_candidates(reranked)
+            if mmr_candidates:
+                picked_ids = maximal_marginal_relevance(
+                    candidates=mmr_candidates,
+                    k=len(reranked),
+                    lambda_=mmr_lambda,
+                )
+                by_id = {h.get("id"): h for h in reranked if h.get("id")}
+                # Append in MMR order, then any hits without an id (in
+                # case of legacy sidecar-only entries) at the end so
+                # callers don't lose hits.
+                ordered = [by_id[cid] for cid in picked_ids if cid in by_id]
+                seen_ids = {cid for cid in picked_ids if cid in by_id}
+                for h in reranked:
+                    if h.get("id") not in seen_ids:
+                        ordered.append(h)
+                reranked = ordered
+        return reranked[:n_results]
+
+    def _build_mmr_candidates(self, hits: list[dict]) -> list[tuple[str, float, list[float]]]:
+        """Fetch embeddings for the reranked hits and build the MMR
+        candidate triples ``(chunk_id, relevance, embedding)``.
+
+        Uses the rerank ``score`` as the relevance signal (already
+        computed; no query re-embedding needed). Embeddings come
+        from Chroma's per-chunk store in one batched call. Hits
+        without an embedding (e.g. BM25-only enrichment edges, or
+        chunks the embedding fetch couldn't find) are dropped from
+        the MMR set — the caller falls back to the rerank order
+        for those.
+        """
+        ids = [str(h.get("id") or "") for h in hits if h.get("id")]
+        if not ids:
+            return []
+        try:
+            fetched = self.collection.get(ids=ids, include=["embeddings"])
+        except Exception as exc:
+            log.warning("MMR: could not fetch embeddings: %s; falling back to rerank order", exc)
+            return []
+        # Chroma may return numpy arrays here, not lists — ``or []``
+        # raises \"truth value of an empty array is ambiguous\" on
+        # those. Pull the fields with explicit None-check and let
+        # zip terminate naturally when either side runs out.
+        fetched_ids = fetched.get("ids")
+        fetched_embeddings = fetched.get("embeddings")
+        if fetched_ids is None or fetched_embeddings is None:
+            return []
+        emb_by_id: dict[str, list[float]] = {}
+        for cid, emb in zip(fetched_ids, fetched_embeddings, strict=False):
+            if emb is None:
+                continue
+            try:
+                emb_by_id[str(cid)] = [float(x) for x in emb]
+            except (TypeError, ValueError):
+                continue
+        if not emb_by_id:
+            return []
+        triples: list[tuple[str, float, list[float]]] = []
+        for h in hits:
+            cid = str(h.get("id") or "")
+            if not cid or cid not in emb_by_id:
+                continue
+            try:
+                rel = float(h.get("score") or 0.0)
+            except (TypeError, ValueError):
+                rel = 0.0
+            triples.append((cid, rel, emb_by_id[cid]))
+        return triples
 
     def rerank(self, question: str, hits: list[dict]) -> list[dict]:
         """Prioritize explanatory chunks over repetitive technical headers."""

--- a/amx/rag_core/fusion.py
+++ b/amx/rag_core/fusion.py
@@ -1,26 +1,26 @@
-"""Score-fusion helpers for hybrid retrieval (PR-E).
+"""Score-fusion and diversity helpers for hybrid retrieval.
 
-Reciprocal Rank Fusion (RRF) combines several rankings of the same
-candidate pool into one scored dict that gracefully handles
-heterogeneous score scales — BM25 scores (negative, magnitude-
-specific) and Chroma cosine distances (0..2) live in different
-ranges, so naive linear combination would require per-source
-calibration. RRF instead consumes only the *position* of each
-candidate in each input ranking, which is dimensionless by
-construction.
+Two reranking strategies live here:
 
-Reference: Cormack, Clarke, Büttcher (2009), \"Reciprocal Rank Fusion
-outperforms Condorcet and individual Rank Learning Methods.\"
+1. :func:`reciprocal_rank_fusion` (PR-E) — fuses several ranked
+   candidate lists into one score-per-id dict. Rank-based;
+   immune to score-scale drift between BM25 (negative magnitudes)
+   and Chroma cosine distances (0..2). Reference: Cormack, Clarke,
+   Büttcher (2009).
 
-The recommended constant ``k = 60`` is from the original paper;
-larger values flatten the score curve (each rank contributes more
-similar weight), smaller values sharpen it (top ranks dominate
-more). The default is what every production hybrid-retrieval
-implementation we surveyed uses.
+2. :func:`maximal_marginal_relevance` (PR-I) — picks a diverse
+   top-k from a candidate pool by trading off relevance to the
+   query against similarity to already-picked candidates. Reduces
+   the rate at which the LLM sees three near-duplicate chunks
+   from the same paragraph of one document instead of three
+   chunks from three different documents.
+
+Both functions are pure: no IO, no globals, deterministic.
 """
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 
 
@@ -55,4 +55,107 @@ def reciprocal_rank_fusion(
     return scores
 
 
-__all__ = ["reciprocal_rank_fusion"]
+def _cosine_similarity(vec_a: Sequence[float], vec_b: Sequence[float]) -> float:
+    """Plain cosine similarity, ``-1 <= result <= 1``.
+
+    Returns ``0.0`` when either vector is empty or has zero norm —
+    treats degenerate inputs as \"neutral, neither similar nor
+    dissimilar\" rather than raising. The MMR caller treats higher
+    as more similar; returning ``0`` for a degenerate vector keeps
+    it from being spuriously promoted or demoted.
+    """
+    if not vec_a or not vec_b:
+        return 0.0
+    n = min(len(vec_a), len(vec_b))
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for i in range(n):
+        a = float(vec_a[i])
+        b = float(vec_b[i])
+        dot += a * b
+        norm_a += a * a
+        norm_b += b * b
+    if norm_a <= 0.0 or norm_b <= 0.0:
+        return 0.0
+    return dot / (math.sqrt(norm_a) * math.sqrt(norm_b))
+
+
+def maximal_marginal_relevance(
+    *,
+    candidates: Sequence[tuple[str, float, Sequence[float]]],
+    k: int,
+    lambda_: float = 0.7,
+) -> list[str]:
+    """Pick a diverse top-``k`` from ``candidates`` via MMR.
+
+    Decouples *relevance* (already computed upstream, e.g. by the
+    rerank step) from *similarity-to-selected* (cosine on cached
+    chunk embeddings). MMR scores each unpicked candidate ``c``
+    against the running selection ``S`` as:
+
+        score(c) = lambda * relevance(c)
+                 - (1 - lambda) * max_{s in S} sim(c, s)
+
+    and greedily picks the highest-scoring candidate until ``k``
+    are chosen or candidates run out.
+
+    Parameters:
+        candidates — list of ``(id, relevance, embedding)`` tuples
+            in descending relevance order. The relevance score is
+            whatever upstream signal you want to preserve: rerank
+            heuristic, RRF fusion total, or raw cosine to the query.
+            The embedding is the dense vector for diversity math.
+            Decoupling relevance from the embedding lets MMR sit
+            cleanly after any reranker without re-embedding the
+            query.
+        k — how many to pick.
+        lambda_ — trade-off between relevance (``1.0`` → \"pure
+            relevance, no diversity\") and diversity (``0.0`` →
+            \"max-different, ignore relevance\"). ``0.7`` is a
+            reasonable default — relevance-leaning but actively
+            avoids near-duplicates.
+
+    Returns a list of selected ids in pick order. Always a subset
+    of (and order-preserving within) the input ids.
+
+    Edge cases:
+    - ``k <= 0`` → ``[]``.
+    - empty ``candidates`` → ``[]``.
+    - missing / empty embedding on a candidate → that candidate
+      gets a similarity of ``0`` against everything; effectively
+      treated as \"never near a duplicate\" and ranked by
+      relevance only.
+    - ``len(candidates) <= k`` → return every candidate (still in
+      MMR-pick order).
+    """
+    if k <= 0 or not candidates:
+        return []
+    if not 0.0 <= lambda_ <= 1.0:
+        raise ValueError(f"lambda_ must be in [0, 1], got {lambda_}")
+    relevance: dict[str, float] = {cid: float(rel) for cid, rel, _emb in candidates}
+    embeddings: dict[str, Sequence[float]] = {cid: emb for cid, _rel, emb in candidates}
+    remaining_order: list[str] = [cid for cid, _, _ in candidates]
+
+    selected: list[str] = []
+    while remaining_order and len(selected) < k:
+        if not selected:
+            # First pick: pure relevance, since there's nothing to
+            # diversify away from yet.
+            best_id = max(remaining_order, key=lambda cid: relevance.get(cid, 0.0))
+        else:
+            best_id = None
+            best_score = -math.inf
+            for cid in remaining_order:
+                rel = relevance.get(cid, 0.0)
+                max_sim = max(_cosine_similarity(embeddings[cid], embeddings[s]) for s in selected)
+                score = lambda_ * rel - (1.0 - lambda_) * max_sim
+                if score > best_score:
+                    best_score = score
+                    best_id = cid
+        selected.append(best_id)
+        remaining_order.remove(best_id)
+    return selected
+
+
+__all__ = ["maximal_marginal_relevance", "reciprocal_rank_fusion"]

--- a/tests/eval/baselines/docs_baseline.json
+++ b/tests/eval/baselines/docs_baseline.json
@@ -13,7 +13,7 @@
     "mrr": 0.775,
     "n_queries": 20,
     "ndcg_at_5": 0.8112,
-    "precision_at_5": 0.2842
+    "precision_at_5": 0.2775
   },
   "pipeline": "docs",
   "schema_version": 1

--- a/tests/test_rag_mmr_diversity.py
+++ b/tests/test_rag_mmr_diversity.py
@@ -1,0 +1,255 @@
+"""PR-I: Maximal Marginal Relevance (diversity) tests.
+
+Pure-math tests for the new ``maximal_marginal_relevance`` helper in
+``amx.rag_core.fusion``, plus a smoke test verifying that
+``RAGStore.query`` honours its ``use_mmr=True`` default by fetching
+embeddings and applying MMR after rerank.
+
+The end-to-end retrieval-quality impact is captured by the
+docs-RAG eval baseline (``tests/eval/baselines/docs_baseline.json``);
+this file pins the algorithmic contract so a future refactor (PR-J
+shared-core extraction) catches accidental drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amx.docs.rag import RAGStore
+from amx.docs.scanner import DocInfo
+from amx.rag_core.fusion import maximal_marginal_relevance
+
+# ── pure MMR math ────────────────────────────────────────────────────
+
+
+def test_mmr_first_pick_is_pure_relevance() -> None:
+    """With no prior selection there's nothing to diversify
+    against, so MMR's first pick is the highest-relevance
+    candidate regardless of lambda."""
+    cands = [
+        ("low", 0.1, [1.0, 0.0]),
+        ("high", 0.9, [0.0, 1.0]),
+        ("mid", 0.5, [0.5, 0.5]),
+    ]
+    picked = maximal_marginal_relevance(candidates=cands, k=1, lambda_=0.5)
+    assert picked == ["high"]
+
+
+def test_mmr_demotes_near_duplicates() -> None:
+    """When λ=0.7 (default), MMR should pick two diverse vectors
+    over two similar high-relevance vectors."""
+    cands = [
+        ("c1", 0.9, [1.0, 0.0]),
+        ("c2", 0.85, [0.99, 0.05]),  # near-dup of c1
+        ("c3", 0.7, [0.0, 1.0]),  # orthogonal — diverse
+    ]
+    picked = maximal_marginal_relevance(candidates=cands, k=2, lambda_=0.7)
+    assert picked == ["c1", "c3"]
+
+
+def test_mmr_lambda_one_is_pure_relevance() -> None:
+    """``lambda_=1.0`` weights diversity at zero — MMR degenerates
+    to the relevance ordering."""
+    cands = [
+        ("c1", 0.9, [1.0, 0.0]),
+        ("c2", 0.85, [0.99, 0.05]),  # near-dup but high relevance
+        ("c3", 0.7, [0.0, 1.0]),
+    ]
+    picked = maximal_marginal_relevance(candidates=cands, k=2, lambda_=1.0)
+    assert picked == ["c1", "c2"]
+
+
+def test_mmr_lambda_zero_is_pure_diversity_after_first_pick() -> None:
+    """``lambda_=0.0`` weights relevance at zero. First pick is
+    still the most relevant (by tie-break), but subsequent picks
+    maximise distance from already-picked candidates."""
+    cands = [
+        ("c1", 0.9, [1.0, 0.0]),
+        ("c2", 0.85, [0.99, 0.05]),  # near-dup of c1
+        ("c3", 0.1, [0.0, 1.0]),  # orthogonal, low relevance
+    ]
+    picked = maximal_marginal_relevance(candidates=cands, k=2, lambda_=0.0)
+    # First pick = c1 (highest relevance). Second pick should be
+    # the most distant from c1 — that's c3 (orthogonal), not c2
+    # (near-duplicate of c1).
+    assert picked == ["c1", "c3"]
+
+
+def test_mmr_empty_input_returns_empty_list() -> None:
+    assert maximal_marginal_relevance(candidates=[], k=5) == []
+
+
+def test_mmr_k_zero_returns_empty_list() -> None:
+    cands = [("c1", 0.9, [1.0, 0.0])]
+    assert maximal_marginal_relevance(candidates=cands, k=0) == []
+
+
+def test_mmr_k_larger_than_pool_returns_full_pool() -> None:
+    """``k`` greater than the candidate pool size reorders the
+    whole pool in MMR-pick order without raising."""
+    cands = [
+        ("c1", 0.9, [1.0, 0.0]),
+        ("c2", 0.5, [0.0, 1.0]),
+    ]
+    picked = maximal_marginal_relevance(candidates=cands, k=10, lambda_=0.7)
+    assert set(picked) == {"c1", "c2"}
+    assert len(picked) == 2
+
+
+def test_mmr_rejects_lambda_outside_zero_one() -> None:
+    cands = [("c1", 0.9, [1.0, 0.0])]
+    with pytest.raises(ValueError):
+        maximal_marginal_relevance(candidates=cands, k=1, lambda_=-0.1)
+    with pytest.raises(ValueError):
+        maximal_marginal_relevance(candidates=cands, k=1, lambda_=1.5)
+
+
+def test_mmr_handles_zero_vectors() -> None:
+    """Degenerate embeddings (all zeros) get a similarity of 0 against
+    everything — they don't crash MMR. Relevance still drives the
+    ordering."""
+    cands = [
+        ("zero_a", 0.5, [0.0, 0.0, 0.0]),
+        ("zero_b", 0.9, [0.0, 0.0, 0.0]),
+        ("normal", 0.3, [1.0, 0.0, 0.0]),
+    ]
+    picked = maximal_marginal_relevance(candidates=cands, k=2, lambda_=0.7)
+    # First pick: zero_b (highest relevance).
+    # Second pick: zero_a vs normal. Zero similarity to zero_b
+    # for both, so relevance wins → zero_a (0.5) > normal (0.3).
+    assert picked[0] == "zero_b"
+    assert picked[1] == "zero_a"
+
+
+def test_mmr_preserves_ids_as_strings() -> None:
+    """Output ids are the same string identity as input. No
+    canonicalisation, no surprise type coercion."""
+    cands = [
+        ("path/with/slash::5", 0.9, [1.0, 0.0]),
+        ("path/with/slash::6", 0.5, [0.0, 1.0]),
+    ]
+    picked = maximal_marginal_relevance(candidates=cands, k=2)
+    assert picked == ["path/with/slash::5", "path/with/slash::6"]
+
+
+# ── end-to-end RAGStore wire-up ──────────────────────────────────────
+
+
+def _make_doc(tmp_path: Path, body: str, name: str = "fixture.txt") -> DocInfo:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return DocInfo(
+        path=str(p),
+        size_bytes=p.stat().st_size,
+        extension=".txt",
+        source_type="local",
+        source_root=str(tmp_path),
+    )
+
+
+def test_ragstore_query_default_uses_mmr(tmp_path: Path) -> None:
+    """Default ``use_mmr=True`` runs MMR over the reranked hits;
+    setting ``use_mmr=False`` skips it. Smoke check that both
+    paths return a non-empty result on a real ingest."""
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    docs = [
+        _make_doc(tmp_path, "Orders table holds customer purchases.", name="o.txt"),
+        _make_doc(tmp_path, "Customers table holds buyer details.", name="c.txt"),
+        _make_doc(tmp_path, "Products table holds catalogue entries.", name="p.txt"),
+    ]
+    store.ingest(docs)
+    hits_mmr = store.query("customer purchases", n_results=3)
+    hits_no_mmr = store.query("customer purchases", n_results=3, use_mmr=False)
+    assert hits_mmr, "MMR-on path should return hits"
+    assert hits_no_mmr, "MMR-off path should return hits"
+    # Both paths should surface at least the orders chunk.
+    src_mmr = {Path(h["metadata"].get("source", "")).name for h in hits_mmr}
+    src_no_mmr = {Path(h["metadata"].get("source", "")).name for h in hits_no_mmr}
+    assert "o.txt" in src_mmr
+    assert "o.txt" in src_no_mmr
+
+
+def test_ragstore_mmr_diversifies_near_duplicate_chunks(tmp_path: Path) -> None:
+    """When several chunks of the SAME document semantically match
+    the query, MMR should pick at most one of them and prefer a
+    chunk from a different document when one's available with
+    comparable relevance.
+
+    The fixture: orders.txt has two paragraphs about customer
+    purchases; customers.txt has one paragraph mentioning
+    customer purchases too. With three documents producing four
+    candidate chunks total (orders has two chunks, the other two
+    one each), MMR should surface orders.txt AND customers.txt at
+    the top — not two orders chunks in a row.
+    """
+    paragraph_a = (
+        "Customer purchases are recorded as orders. Each order links a customer "
+        "to one or more product variants and computes a total amount. " * 4
+    )
+    paragraph_b = (
+        "Order totals include line items, tax, and adjustments. Refunds are "
+        "tracked separately and never mutate the original order row. " * 4
+    )
+    orders_body = paragraph_a + "\n\n---\n\n" + paragraph_b
+    customers_body = (
+        "Customer profiles capture identity for purchase orders. Buyers "
+        "with consistent purchase patterns receive loyalty perks. " * 4
+    )
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    docs = [
+        _make_doc(tmp_path, orders_body, name="orders.txt"),
+        _make_doc(tmp_path, customers_body, name="customers.txt"),
+    ]
+    store.ingest(docs)
+
+    hits_no_mmr = store.query("customer purchases", n_results=3, use_mmr=False)
+    hits_mmr = store.query("customer purchases", n_results=3, use_mmr=True)
+
+    sources_no_mmr = [Path(h["metadata"].get("source", "")).name for h in hits_no_mmr]
+    sources_mmr = [Path(h["metadata"].get("source", "")).name for h in hits_mmr]
+
+    # The without-MMR path may concentrate on orders.txt because
+    # both its chunks score highly. The with-MMR path must
+    # surface customers.txt as well — verifying diversity has the
+    # intended effect on at least one of the top-3.
+    assert "customers.txt" in sources_mmr, (
+        f"MMR should surface customers.txt; got sources_mmr={sources_mmr}, "
+        f"sources_no_mmr={sources_no_mmr}"
+    )
+
+
+def test_ragstore_mmr_handles_empty_embedding_fetch(tmp_path: Path, monkeypatch) -> None:
+    """When Chroma's ``get(ids=..., include=['embeddings'])`` returns
+    no usable rows (mismatched ids, indexing race), MMR degrades
+    gracefully to the rerank order rather than dropping hits."""
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    store.ingest([_make_doc(tmp_path, "Some content.", name="a.txt")])
+
+    original_get = store.collection.get
+
+    def _broken_get(*args, **kwargs):
+        # Simulate Chroma returning nothing for the embedding fetch.
+        if kwargs.get("include") == ["embeddings"]:
+            return {"ids": [], "embeddings": []}
+        return original_get(*args, **kwargs)
+
+    monkeypatch.setattr(store.collection, "get", _broken_get)
+    hits = store.query("some content", n_results=3)
+    assert hits, "fallback to rerank order should preserve hits"


### PR DESCRIPTION
## Summary

Adds Maximal Marginal Relevance to ``RAGStore.query``: after rerank,
fetch candidate embeddings and reorder so the top-k surfaces
diverse documents rather than near-duplicate chunks of the same one.

- New ``maximal_marginal_relevance`` in ``amx/rag_core/fusion.py``.
  Decoupled API takes ``(id, relevance, embedding)`` triples so it
  sits cleanly after any reranker.
- ``RAGStore.query`` accepts ``use_mmr=True`` (default) and
  ``mmr_lambda=0.7``. Fetches embeddings in one batched
  ``collection.get(include=['embeddings'])`` call. Falls back to
  rerank order on any embedding fetch failure.
- ``lambda_=0.7`` balances relevance and diversity; ``1.0`` collapses
  to pure rerank order; ``0.0`` is diversity-only after the first
  pick.

## Eval baseline

Shifts ``precision_at_5``: ``0.2842 → 0.2775`` (-0.7pp). Inside the
2pp CI tolerance. ``hit_at_3``, ``hit_at_5``, ``MRR``, ``nDCG@5``,
``keyword_recall`` all unchanged — diversity reordering moves
which chunks land in the window without dropping gold-set hits.

## Tests

13 new cases in ``tests/test_rag_mmr_diversity.py``:

- Pure math: first pick = pure relevance, near-dup demotion at
  ``λ=0.7``, ``λ=1.0`` collapses to relevance, ``λ=0.0`` maximises
  distance after first pick, empty / k=0 / k>len edges, lambda
  range validation, zero-vector handling, id preservation.
- End-to-end: default ``use_mmr=True`` returns non-empty hits,
  near-duplicate scenario surfaces a second document via MMR
  that the no-MMR path stacks with same-doc chunks, empty
  embedding fetch degrades to rerank order.

## Test plan

- [x] ``pytest tests/test_rag_mmr_diversity.py tests/eval/`` — green.
- [x] ``pytest --ignore=tests/web --ignore=tests/perf`` — 1997 pass
      (up from 1984 with PR-H), 9 skipped (pre-existing), 0 fail.
- [x] ``ruff check amx tests`` clean. ``ruff format --check`` clean.
- [x] Eval baseline regenerated; precision_at_5 -0.7pp documented.
- [ ] CI matrix green.

## Related

- Tracking issue: omeryasirkucuk/amx#454 (PR-I checklist item).
- Audit: F2.5.
- Builds on omeryasirkucuk/amx#459 (PR-E) — reuses ``amx/rag_core/fusion.py``.
- Only PR-G (query rewriting) and PR-J (shared retrieval core)
  remain on the rollout.