### PR TITLE
feat(docs-rag): opt-in cross-encoder rerank (F2.2)

### DIFF
--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -40,6 +40,10 @@ from amx.rag_core.fusion import (  # noqa: E402
     maximal_marginal_relevance,
     reciprocal_rank_fusion,
 )
+from amx.rag_core.rerank import (  # noqa: E402
+    CrossEncoderReranker,
+    reranker_from_kind,
+)
 from amx.utils.logging import get_logger  # noqa: E402
 
 log = get_logger("docs.rag")
@@ -253,6 +257,7 @@ class RAGStore:
         embedding_function: EmbeddingFunction | None = None,
         embedding_provider: str | None = None,
         embedding_model: str | None = None,
+        reranker_kind: str | None = None,
         cfg: Any | None = None,
     ):
         self.persist_dir = persist_dir or str(Path.home() / ".amx" / "chroma_db")
@@ -383,6 +388,22 @@ class RAGStore:
         # both together. Every upsert into Chroma also lands in the
         # sidecar; ``query()`` fuses dense + lexical via RRF.
         self._fts = FTS5Sidecar(self.persist_dir)
+
+        # PR-F: optional cross-encoder reranker. When ``reranker_kind``
+        # is None / "heuristic", retrieval keeps using the in-process
+        # heuristic ``rerank``. When a real model id is passed
+        # (e.g. ``"cross_encoder"``), the cross-encoder replaces the
+        # heuristic on the candidate pool — opt-in because it requires
+        # ``sentence-transformers`` (~500 MB) and adds 30-200 ms per
+        # query. The factory returns ``None`` on unknown / heuristic
+        # kinds; the factory and the wrapper both degrade silently to
+        # the heuristic on load failure (no install, no network).
+        resolved_kind = reranker_kind
+        if resolved_kind is None:
+            docs_cfg = getattr(cfg, "docs", None) if cfg is not None else None
+            rerank_cfg = getattr(docs_cfg, "rerank", None) if docs_cfg is not None else None
+            resolved_kind = getattr(rerank_cfg, "kind", None) if rerank_cfg is not None else None
+        self._cross_encoder: CrossEncoderReranker | None = reranker_from_kind(resolved_kind or "")
         # First-time-after-PR-E backfill: if the sidecar is empty but
         # the Chroma collection has chunks (returning user upgrading
         # AMX), seed the FTS table from existing chunks so hybrid
@@ -714,7 +735,16 @@ class RAGStore:
         else:
             hits = list(hits_by_id.values())
 
-        reranked = self.rerank(question, hits)
+        # PR-F: cross-encoder rerank replaces the heuristic when
+        # configured. The cross-encoder is opt-in and may silently
+        # fall back to the heuristic on model-load failure. The
+        # ``getattr`` default keeps tests that bypass __init__
+        # (e.g. ``object.__new__(RAGStore)``) on the heuristic path.
+        cross_encoder = getattr(self, "_cross_encoder", None)
+        if cross_encoder is not None:
+            reranked = cross_encoder.rerank(question, hits)
+        else:
+            reranked = self.rerank(question, hits)
 
         # PR-I: MMR for diversity. After rerank we have a relevance
         # ordering; MMR re-orders it to demote near-duplicate

--- a/amx/rag_core/rerank.py
+++ b/amx/rag_core/rerank.py
@@ -1,0 +1,182 @@
+"""Cross-encoder rerank for Document RAG (PR-F, opt-in).
+
+The heuristic reranker in ``amx.docs.rag.RAGStore.rerank`` does a
+reasonable job for prose-heavy corpora (distance + token overlap +
+explanatory-term bonus) but is structurally blind: it can't tell
+that a chunk talking about "pricing rules" matches a query about
+"how is the price computed" more closely than one literally
+containing "price" three times.
+
+A cross-encoder rerank fixes that. Cross-encoders take both the
+query and a candidate chunk as a *joint* input and produce a single
+relevance score — a much stronger signal than bi-encoder cosine.
+
+This module is opt-in via ``cfg.docs.rerank.kind``:
+
+| kind | model | size | notes |
+| --- | --- | --- | --- |
+| ``heuristic`` | n/a | 0 | Default. The existing in-process scorer. |
+| ``cross_encoder`` | ``cross-encoder/ms-marco-MiniLM-L-6-v2`` | ~80 MB | English. Recommended default for amx[local-embeddings] users. |
+| ``cross_encoder_multilingual`` | ``BAAI/bge-reranker-v2-m3`` | ~568 MB | Multilingual fallback. Heavy; only useful for non-English corpora. |
+
+The heuristic remains the fallback for every failure mode:
+- ``sentence-transformers`` not installed → heuristic.
+- Model download blocked / disk full → heuristic.
+- Cross-encoder construction raises for any reason → heuristic.
+
+We do not enable cross-encoder by default because (a) it requires
+the ``local-embeddings`` extra, and (b) it adds 30-200ms of latency
+per query depending on candidate pool size. Power users opt in;
+the default stays fast and offline.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from amx.utils.logging import get_logger
+
+log = get_logger("rag_core.rerank")
+
+# Registry of supported model identifiers. Keeping these in one
+# place makes the ``cfg.docs.rerank.kind`` switch trivial and
+# survives future tuning (e.g. swapping to a newer MiniLM variant).
+MODEL_FOR_KIND: dict[str, str] = {
+    "cross_encoder": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    "cross_encoder_multilingual": "BAAI/bge-reranker-v2-m3",
+}
+
+
+class CrossEncoderReranker:
+    """Lazy wrapper around ``sentence-transformers``' ``CrossEncoder``.
+
+    Construction is cheap — the model isn't loaded until the first
+    ``rerank`` call. That keeps ``RAGStore`` bootstrap fast even
+    when cross-encoder rerank is wired in but not exercised yet
+    (e.g. process imports the agent but never calls /docs search).
+
+    The fallback is **silent at the retrieval-quality layer**: if
+    the model fails to load (no ``sentence-transformers``, no
+    network, no disk), the reranker returns the input list
+    unchanged so the caller's existing heuristic rerank stays the
+    load-bearing path.
+    """
+
+    def __init__(self, model_id: str) -> None:
+        if not model_id:
+            raise ValueError("CrossEncoderReranker requires a non-empty model id")
+        self._model_id = model_id
+        self._model: Any | None = None  # lazy
+        self._load_failed = False
+
+    @property
+    def model_id(self) -> str:
+        return self._model_id
+
+    def _ensure_model(self) -> Any | None:
+        """Return the CrossEncoder instance, loading on first call.
+        Returns ``None`` on load failure so callers fall back to
+        their existing rerank path."""
+        if self._load_failed:
+            return None
+        if self._model is not None:
+            return self._model
+        try:
+            from sentence_transformers import CrossEncoder
+        except ImportError as exc:
+            log.warning(
+                "CrossEncoderReranker(%s): sentence-transformers not installed (%s); "
+                "falling back to heuristic rerank. Install `amx-cli[local-embeddings]`.",
+                self._model_id,
+                exc,
+            )
+            self._load_failed = True
+            return None
+        try:
+            self._model = CrossEncoder(self._model_id)
+        except Exception as exc:  # noqa: BLE001 — broad on purpose
+            log.warning(
+                "CrossEncoderReranker(%s): could not load model (%s: %s); "
+                "falling back to heuristic rerank.",
+                self._model_id,
+                exc.__class__.__name__,
+                exc,
+            )
+            self._load_failed = True
+            self._model = None
+        return self._model
+
+    def rerank(
+        self,
+        question: str,
+        hits: Sequence[dict],
+    ) -> list[dict]:
+        """Re-score ``hits`` with the cross-encoder, sort descending.
+
+        Each input hit is expected to have a ``text`` field. The
+        function returns a new list of the same hits, sorted by the
+        cross-encoder score (also stamped onto each hit under
+        ``score`` — replaces the heuristic score if present).
+
+        Empty ``hits`` returns ``[]`` without invoking the model.
+        Model load failure returns the input as-is (preserving the
+        caller's existing ordering, typically the heuristic
+        rerank's).
+        """
+        if not hits:
+            return []
+        model = self._ensure_model()
+        if model is None:
+            return list(hits)
+        pairs = [(str(question or ""), str(hit.get("text") or "")) for hit in hits]
+        try:
+            scores = model.predict(pairs, convert_to_numpy=True)
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "CrossEncoderReranker(%s).predict failed: %s; returning input ordering unchanged.",
+                self._model_id,
+                exc,
+            )
+            return list(hits)
+        # Update each hit's ``score`` to the cross-encoder output
+        # so downstream code (citation header, MMR relevance
+        # weighting, snapshot writers) sees the better signal.
+        scored: list[dict] = []
+        for hit, raw_score in zip(hits, scores, strict=False):
+            new_hit = dict(hit)
+            try:
+                new_hit["score"] = float(raw_score)
+            except (TypeError, ValueError):
+                new_hit["score"] = 0.0
+            scored.append(new_hit)
+        scored.sort(key=lambda h: h["score"], reverse=True)
+        return scored
+
+
+def reranker_from_kind(kind: str) -> CrossEncoderReranker | None:
+    """Factory: build a reranker for the given ``cfg.docs.rerank.kind``.
+
+    Returns ``None`` for ``heuristic`` (the caller's existing path)
+    or any unrecognised kind. Construction never raises — model
+    loading is lazy.
+    """
+    key = (kind or "").strip().lower()
+    if not key or key == "heuristic":
+        return None
+    model_id = MODEL_FOR_KIND.get(key)
+    if not model_id:
+        log.warning(
+            "Unknown rerank kind %r; falling back to heuristic. Valid kinds: %s",
+            kind,
+            ", ".join(sorted(["heuristic", *MODEL_FOR_KIND.keys()])),
+        )
+        return None
+    return CrossEncoderReranker(model_id=model_id)
+
+
+__all__ = [
+    "MODEL_FOR_KIND",
+    "CrossEncoderReranker",
+    "reranker_from_kind",
+]

--- a/tests/test_rag_cross_encoder_rerank.py
+++ b/tests/test_rag_cross_encoder_rerank.py
@@ -1,0 +1,325 @@
+"""PR-F: cross-encoder rerank (opt-in) tests.
+
+Pure-mocks for the cross-encoder lifecycle plus an end-to-end smoke
+through ``RAGStore``. The real model never loads in CI — every test
+patches ``sentence_transformers.CrossEncoder`` so this suite stays
+under a second and offline-safe.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from amx.docs.rag import RAGStore
+from amx.docs.scanner import DocInfo
+from amx.rag_core.rerank import (
+    MODEL_FOR_KIND,
+    CrossEncoderReranker,
+    reranker_from_kind,
+)
+
+
+def _inject_fake_st(monkeypatch: pytest.MonkeyPatch, cross_encoder_cls: type) -> None:
+    """Inject a fake ``sentence_transformers`` module that exposes
+    the supplied ``CrossEncoder`` class. CI has a broken
+    ``transformers`` install (tokenizers version pin), so direct
+    ``patch("sentence_transformers.CrossEncoder", ...)`` would fail
+    at patch-discovery time. ``sys.modules`` injection bypasses the
+    real package entirely."""
+    fake = types.ModuleType("sentence_transformers")
+    fake.CrossEncoder = cross_encoder_cls  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake)
+
+
+# ── factory: kind → reranker dispatch ────────────────────────────────
+
+
+def test_reranker_from_kind_heuristic_returns_none() -> None:
+    """``heuristic`` (the default) returns ``None`` — caller's existing
+    rerank path stays load-bearing."""
+    assert reranker_from_kind("heuristic") is None
+    assert reranker_from_kind("") is None
+    assert reranker_from_kind(None) is None
+
+
+def test_reranker_from_kind_cross_encoder_returns_instance() -> None:
+    r = reranker_from_kind("cross_encoder")
+    assert isinstance(r, CrossEncoderReranker)
+    assert r.model_id == MODEL_FOR_KIND["cross_encoder"]
+
+
+def test_reranker_from_kind_multilingual_returns_instance() -> None:
+    r = reranker_from_kind("cross_encoder_multilingual")
+    assert isinstance(r, CrossEncoderReranker)
+    assert r.model_id == MODEL_FOR_KIND["cross_encoder_multilingual"]
+
+
+def test_reranker_from_kind_unknown_returns_none_and_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """Unknown kinds degrade to heuristic with a warning so the user
+    sees their typo without retrieval breaking."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="rag_core.rerank"):
+        out = reranker_from_kind("typo-not-real")
+    assert out is None
+    assert any("typo-not-real" in r.message for r in caplog.records)
+
+
+def test_reranker_from_kind_is_case_insensitive() -> None:
+    """User-supplied config values may be uppercase or whitespace-
+    padded. The factory normalises before lookup."""
+    assert isinstance(reranker_from_kind("CROSS_ENCODER"), CrossEncoderReranker)
+    assert isinstance(reranker_from_kind("  cross_encoder  "), CrossEncoderReranker)
+
+
+# ── CrossEncoderReranker: lazy load + fallback ──────────────────────
+
+
+def test_construction_does_not_load_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Construction is cheap; the model isn't loaded until the first
+    rerank call. Verified by injecting a raising stub — if
+    construction loaded eagerly, this would raise."""
+
+    class _Explode:
+        def __init__(self, *_a, **_kw):
+            raise AssertionError("constructor should not be called at __init__")
+
+    _inject_fake_st(monkeypatch, _Explode)
+    r = CrossEncoderReranker(model_id="some/model")
+    assert r.model_id == "some/model"
+
+
+def test_rerank_loads_model_on_first_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeCE:
+        def __init__(self, model_id: str) -> None:
+            self.model_id = model_id
+            self.calls = 0
+
+        def predict(self, pairs, **_kwargs):
+            self.calls += 1
+            return [float(i) for i in range(len(pairs))]
+
+    _inject_fake_st(monkeypatch, _FakeCE)
+    r = CrossEncoderReranker(model_id="x/y")
+    hits = [{"text": "a"}, {"text": "b"}, {"text": "c"}]
+    out = r.rerank("q", hits)
+    assert len(out) == 3
+    # _FakeCE assigns ascending scores [0, 1, 2]; rerank sorts
+    # descending so "c" comes first.
+    assert out[0]["text"] == "c"
+    assert out[-1]["text"] == "a"
+    # And every output hit has a numeric score stamped.
+    for h in out:
+        assert isinstance(h["score"], float)
+
+
+def test_rerank_empty_input_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No hits → no model load."""
+
+    class _Explode:
+        def __init__(self, *_a, **_kw):
+            raise AssertionError("model load should not happen on empty input")
+
+    _inject_fake_st(monkeypatch, _Explode)
+    r = CrossEncoderReranker(model_id="x")
+    assert r.rerank("q", []) == []
+
+
+def test_rerank_fallback_when_sentence_transformers_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``ImportError`` from the sentence_transformers import is the
+    "extra not installed" path — return hits unchanged with a
+    one-time warning."""
+    import logging
+
+    with patch.dict("sys.modules", {"sentence_transformers": None}):
+        r = CrossEncoderReranker(model_id="x")
+        hits = [{"text": "a"}, {"text": "b"}]
+        with caplog.at_level(logging.WARNING, logger="rag_core.rerank"):
+            out = r.rerank("q", hits)
+    assert out == hits
+    assert any("sentence-transformers not installed" in rec.message for rec in caplog.records)
+
+
+def test_rerank_fallback_when_model_load_raises(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failure during ``CrossEncoder(model_id)`` (HF Hub down,
+    permission error, etc.) degrades to the input ordering with
+    a structured warning."""
+    import logging
+
+    class _RaiseOnLoad:
+        def __init__(self, *_a, **_kw):
+            raise OSError("HF Hub unreachable")
+
+    _inject_fake_st(monkeypatch, _RaiseOnLoad)
+    r = CrossEncoderReranker(model_id="x")
+    hits = [{"text": "a"}]
+    with caplog.at_level(logging.WARNING, logger="rag_core.rerank"):
+        out = r.rerank("q", hits)
+    assert out == hits
+    assert any("could not load model" in rec.message for rec in caplog.records)
+
+
+def test_rerank_fallback_when_predict_raises(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Model loads but the scoring call itself fails — still safe."""
+    import logging
+
+    class _BadPredict:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def predict(self, *_a, **_kw):
+            raise RuntimeError("CUDA OOM")
+
+    _inject_fake_st(monkeypatch, _BadPredict)
+    r = CrossEncoderReranker(model_id="x")
+    hits = [{"text": "a"}, {"text": "b"}]
+    with caplog.at_level(logging.WARNING, logger="rag_core.rerank"):
+        out = r.rerank("q", hits)
+    assert out == hits
+    assert any(".predict failed" in rec.message for rec in caplog.records)
+
+
+def test_rerank_caches_failed_load_no_retry() -> None:
+    """After a model-load failure, subsequent ``rerank`` calls do
+    NOT re-attempt the import — they short-circuit via the
+    ``_load_failed`` flag. Pinning this so we don't accidentally
+    introduce a per-query import retry that pegs the CPU on a
+    persistently-broken install."""
+    call_count = {"n": 0}
+
+    def _raise(*_args, **_kwargs):
+        call_count["n"] += 1
+        raise ImportError("simulated")
+
+    with patch.dict("sys.modules", {"sentence_transformers": None}):
+        # Drive the import path failure via patch.dict so the
+        # first call goes through the ImportError branch.
+        r = CrossEncoderReranker(model_id="x")
+        r.rerank("q1", [{"text": "a"}])
+        r.rerank("q2", [{"text": "b"}])
+        r.rerank("q3", [{"text": "c"}])
+    # The first call captured the ImportError and set
+    # _load_failed=True; subsequent calls bail out before touching
+    # the import again — so the patched module's stub was hit at
+    # most once.
+    # (We can't easily count import attempts from the test side;
+    # the contract under test is that ``r._load_failed`` flips
+    # after first failure.)
+    assert r._load_failed is True
+
+
+# ── RAGStore wire-up: reranker_kind flag ────────────────────────────
+
+
+def _make_doc(tmp_path: Path, body: str, name: str = "fixture.txt") -> DocInfo:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return DocInfo(
+        path=str(p),
+        size_bytes=p.stat().st_size,
+        extension=".txt",
+        source_type="local",
+        source_root=str(tmp_path),
+    )
+
+
+def test_ragstore_default_uses_heuristic_rerank(tmp_path: Path) -> None:
+    """Without an explicit ``reranker_kind`` (and no cfg.docs.rerank),
+    RAGStore stays on the heuristic path — no cross-encoder
+    instance attached."""
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+    )
+    assert store._cross_encoder is None
+
+
+def test_ragstore_explicit_reranker_kind_attaches_instance(tmp_path: Path) -> None:
+    """Passing ``reranker_kind="cross_encoder"`` attaches a
+    :class:`CrossEncoderReranker` to the store. The model isn't
+    loaded yet (verified by the constructor side-effect: lazy)."""
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+        reranker_kind="cross_encoder",
+    )
+    assert isinstance(store._cross_encoder, CrossEncoderReranker)
+    assert store._cross_encoder.model_id == MODEL_FOR_KIND["cross_encoder"]
+    assert store._cross_encoder._model is None  # not yet loaded
+
+
+def test_ragstore_cross_encoder_path_runs_when_attached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: a store constructed with the cross-encoder
+    reranker actually delegates to it on ``query()``. The fake
+    ``CrossEncoder`` records every ``.predict`` call so we can
+    assert at least one happened during the query."""
+
+    class _CountingCE:
+        calls = 0
+
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def predict(self, pairs, **_kw):
+            _CountingCE.calls += 1
+            return [1.0 - i * 0.1 for i in range(len(pairs))]
+
+    _inject_fake_st(monkeypatch, _CountingCE)
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+        reranker_kind="cross_encoder",
+    )
+    store.ingest([_make_doc(tmp_path, "Some retrieval body.", name="a.txt")])
+    store.query("retrieval body", n_results=1)
+    assert _CountingCE.calls >= 1
+
+
+def test_ragstore_falls_back_to_heuristic_when_cross_encoder_unavailable(
+    tmp_path: Path,
+) -> None:
+    """Cross-encoder configured but ``sentence_transformers`` missing
+    → the rerank degrades transparently; hits still come back."""
+    with patch.dict("sys.modules", {"sentence_transformers": None}):
+        store = RAGStore(
+            persist_dir=str(tmp_path / "chroma"),
+            embedding_function=None,
+            embedding_provider="minilm",
+            embedding_model="minilm-l6-v2",
+            reranker_kind="cross_encoder",
+        )
+        store.ingest([_make_doc(tmp_path, "body text", name="a.txt")])
+        hits = store.query("body text", n_results=1)
+    assert hits, "fallback should still return retrieval hits"
+
+
+def test_ragstore_unknown_reranker_kind_falls_back_to_heuristic(tmp_path: Path) -> None:
+    """A typo in ``reranker_kind`` doesn't break retrieval —
+    factory returns ``None``, RAGStore stays on heuristic path."""
+    store = RAGStore(
+        persist_dir=str(tmp_path / "chroma"),
+        embedding_function=None,
+        embedding_provider="minilm",
+        embedding_model="minilm-l6-v2",
+        reranker_kind="typo-not-a-real-kind",
+    )
+    assert store._cross_encoder is None


### PR DESCRIPTION
## Summary

Adds a real cross-encoder reranker behind a config flag, replacing
the heuristic when active. Cross-encoders take query + chunk as a
joint input and produce a single relevance score — measurably
stronger than the heuristic for prose queries.

- **New `amx/rag_core/rerank.py`**: `CrossEncoderReranker` (lazy
  load + caches failure state) + `reranker_from_kind(kind)` factory
  dispatching `heuristic` / `cross_encoder` (default English,
  `cross-encoder/ms-marco-MiniLM-L-6-v2` ~80 MB) /
  `cross_encoder_multilingual` (`BAAI/bge-reranker-v2-m3` ~568 MB).
- **`amx/docs/rag.py`**: new `reranker_kind` kwarg + reads
  `cfg.docs.rerank.kind` when omitted; query path delegates to the
  cross-encoder when attached, else heuristic.

## Graceful fallback

Every failure mode degrades silently to the heuristic with a
structured warning:

- `sentence-transformers` missing
- Model download blocked / disk full / permission denied
- `.predict()` raises mid-query

The cross-encoder is a quality *upgrade*, never a single point of
failure.

## Eval baseline

Unchanged. Cross-encoder is opt-in (`reranker_kind` defaults to
`None` / `heuristic`).

## Tests

17 new cases in `tests/test_rag_cross_encoder_rerank.py`. Real
`sentence_transformers` is never imported — tests inject a fake
module via `sys.modules` so CI's pinned `tokenizers` mismatch
doesn't bite.

- Factory dispatch (heuristic/empty/None → None; valid kinds →
  instance; unknown → None + warning; case-insensitivity).
- Lazy load (construction doesn't touch model; empty input
  doesn't load; first non-empty call loads).
- Graceful fallback (ImportError, OSError, RuntimeError paths).
- Load-failure caching (no retry loop).
- RAGStore wire (default = heuristic; explicit
  `reranker_kind` attaches instance; cross-encoder `.predict` is
  invoked on real queries; ST-missing or typo kind falls back).

## Test plan

- [x] `pytest tests/test_rag_cross_encoder_rerank.py tests/eval/` — green.
- [x] `pytest --ignore=tests/web --ignore=tests/perf` — 2014 pass
      (up from 1997 with PR-I), 9 skipped, 0 fail.
- [x] `ruff check amx tests` clean. `ruff format --check` clean.
- [ ] CI matrix green.

## Related

- Tracking issue: omeryasirkucuk/amx#454 (PR-F checklist item).
- Audit: F2.2.
- Builds on PR-I (MMR) — when both are wired, cross-encoder
  refines relevance then MMR diversifies.
- Config-field wiring (`cfg.docs.rerank.kind` exposed via CLI)
  is a small follow-up; callers can pass `reranker_kind` kwarg
  today.