### PR TITLE
fix(studio): defer RAG dep installs out of module import path

### DIFF
--- a/amx/codebase/code_rag.py
+++ b/amx/codebase/code_rag.py
@@ -13,19 +13,35 @@ from typing import TYPE_CHECKING, Any
 from amx.utils.optional_deps import ensure as _ensure
 
 if TYPE_CHECKING:
+    import chromadb
     from chromadb.api.types import EmbeddingFunction
 
 # Codebase RAG shares the ``rag`` bundle (chromadb + splitter +
-# tiktoken) with /docs and /search; whichever feature the user
-# touches first pays the install once.
-_ensure("rag")
+# tiktoken) with /docs and /search. The bundle is fetched on first
+# Chroma client construction, NOT at module import — keeping import
+# lightweight matters for Studio cold start (Studio's import chain
+# does not transitively pull this module today, but the same lazy-
+# install policy now applies uniformly across all four RAG modules).
 
-import chromadb  # noqa: E402
-from langchain_text_splitters import RecursiveCharacterTextSplitter  # noqa: E402
+from amx.codebase.analyzer import CODE_EXTENSIONS, CodebaseReport
+from amx.codebase.walker import walk_code_files
+from amx.utils.logging import get_logger
 
-from amx.codebase.analyzer import CODE_EXTENSIONS, CodebaseReport  # noqa: E402
-from amx.codebase.walker import walk_code_files  # noqa: E402
-from amx.utils.logging import get_logger  # noqa: E402
+
+def _get_chroma():
+    """Ensure the ``rag`` bundle is installed and return the
+    :mod:`chromadb` module.
+
+    Centralising the lazy import here means every Chroma entry point
+    in this module can write ``client = _get_chroma().PersistentClient
+    (path=...)`` without repeating the install + import boilerplate.
+    The :func:`amx.utils.optional_deps.ensure` call is idempotent.
+    """
+    _ensure("rag")
+    import chromadb
+
+    return chromadb
+
 
 log = get_logger("codebase.code_rag")
 
@@ -292,6 +308,9 @@ def _iter_ipynb_chunks(rel_path: str, content: str) -> list[tuple[str, str, str,
 
 
 def _split_fallback(text: str, max_chars: int = 4000) -> list[str]:
+    _ensure("rag")
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+
     sp = RecursiveCharacterTextSplitter(chunk_size=max_chars, chunk_overlap=200)
     return sp.split_text(text)
 
@@ -460,7 +479,7 @@ def index_codebase_tree(
     """Chunk Python (AST) and other code files; upsert into ``amx_code`` collection."""
     persist = persist_dir or str(Path.home() / ".amx" / "chroma_db")
     Path(persist).mkdir(parents=True, exist_ok=True)
-    client = chromadb.PersistentClient(path=persist)
+    client = _get_chroma().PersistentClient(path=persist)
 
     provider, model, ef = _resolve_active_embedding(cfg)
     coll = _open_collection(
@@ -674,7 +693,7 @@ def query_code_snippets(
     diagnostic instead of returning an ambiguous empty hit list.
     """
     persist = persist_dir or str(Path.home() / ".amx" / "chroma_db")
-    client = chromadb.PersistentClient(path=persist)
+    client = _get_chroma().PersistentClient(path=persist)
     try:
         # Honour cfg.embedding here too so a query running with a
         # custom provider can hit the collection it indexed earlier.
@@ -776,7 +795,7 @@ def code_collection_count(
     """
     persist = persist_dir or str(Path.home() / ".amx" / "chroma_db")
     try:
-        client = chromadb.PersistentClient(path=persist)
+        client = _get_chroma().PersistentClient(path=persist)
         coll = client.get_collection(COLLECTION)
         filters = [_normalize_source_filter(s) for s in (source_filters or []) if s]
         if not filters:
@@ -830,7 +849,7 @@ def code_collection_metadata(persist_dir: str | None = None) -> dict[str, Any]:
     """
     persist = persist_dir or str(Path.home() / ".amx" / "chroma_db")
     try:
-        client = chromadb.PersistentClient(path=persist)
+        client = _get_chroma().PersistentClient(path=persist)
         coll = client.get_collection(COLLECTION)
         return dict(coll.metadata or {})
     except Exception:
@@ -847,7 +866,7 @@ def delete_code_collection(
     """
     persist = persist_dir or str(Path.home() / ".amx" / "chroma_db")
     try:
-        client = chromadb.PersistentClient(path=persist)
+        client = _get_chroma().PersistentClient(path=persist)
         if not source_filters:
             client.delete_collection(COLLECTION)
             log.info("Deleted Chroma collection %s", COLLECTION)

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -13,38 +13,27 @@ from amx.utils.optional_deps import ensure as _ensure
 if TYPE_CHECKING:
     from chromadb.api.types import EmbeddingFunction
 
-# Document-RAG is a heavy cluster (~150 MB across chromadb + the
-# langchain ecosystem + unstructured's parser fleet). It only loads
-# on first ``/docs ingest`` / ``/run`` with docs / RAG-backed answer
-# — not on every CLI launch — so the install cost is amortised across
-# the whole tool's lifetime, incurred once, by the user who actually
-# uses the feature. The bundle name is shared with /search and /code
-# so a user who has already touched any RAG path skips the install.
-_ensure("docs-extended")
+# Document-RAG pulls a heavy cluster (~150 MB across chromadb + the
+# langchain ecosystem + unstructured's parser fleet). The cluster is
+# fetched on first :class:`RAGStore` construction, NOT at module
+# import — Studio's transitive import path runs through this module
+# unconditionally (web.routers.ask -> agents.orchestrator ->
+# agents.rag_agent -> here), and a module-level install call would
+# block every Studio cold start on a fresh ``pip install amx-cli``.
+# The bundle name is shared with /search and /code, so a user who
+# has already touched any RAG path skips the install.
 
-import chromadb  # noqa: E402
-from langchain_community.document_loaders import (  # noqa: E402
-    CSVLoader,
-    Docx2txtLoader,
-    PyPDFLoader,
-    TextLoader,
-    UnstructuredExcelLoader,
-    UnstructuredHTMLLoader,
-    UnstructuredPowerPointLoader,
-)
-
-from amx.docs._fts5_sidecar import FTS5Sidecar  # noqa: E402
-from amx.docs.scanner import DocInfo  # noqa: E402
-from amx.docs.splitters import get_splitter  # noqa: E402
-from amx.rag_core.fusion import (  # noqa: E402
+from amx.docs._fts5_sidecar import FTS5Sidecar
+from amx.docs.scanner import DocInfo
+from amx.rag_core.fusion import (
     maximal_marginal_relevance,
     reciprocal_rank_fusion,
 )
-from amx.rag_core.rerank import (  # noqa: E402
+from amx.rag_core.rerank import (
     CrossEncoderReranker,
     reranker_from_kind,
 )
-from amx.utils.logging import get_logger  # noqa: E402
+from amx.utils.logging import get_logger
 
 log = get_logger("docs.rag")
 
@@ -180,45 +169,56 @@ EXPLANATORY_TERMS = frozenset(
     }
 )
 
-LOADER_MAP = {
-    ".pdf": PyPDFLoader,
-    ".docx": Docx2txtLoader,
-    ".doc": Docx2txtLoader,
-    ".txt": TextLoader,
-    # PR-D: Markdown loads as plain text (not via
-    # ``UnstructuredMarkdownLoader``) because the
-    # :class:`amx.docs.splitters._MarkdownAwareSplitter` needs the raw
-    # ``#`` / ``##`` markers to extract heading metadata. The
-    # Unstructured backend silently strips formatting (\"# Orders\" →
-    # \"Orders\"), which made every Markdown chunk look identical to
-    # plain prose to the splitter. ``TextLoader`` keeps the structure
-    # intact, the splitter chunks by heading, and downstream chunks
-    # carry ``h1``/``h2``/``h3`` metadata for citation use.
-    ".md": TextLoader,
-    # ``.markdown`` is just the long-form extension of ``.md`` — same
-    # syntax, same loader. Listing it explicitly keeps the LOADER_MAP /
-    # SUPPORTED_EXTENSIONS contract honest (every supported extension
-    # has its own loader entry).
-    ".markdown": TextLoader,
-    ".csv": CSVLoader,
-    # TSV is tab-separated values; ``CSVLoader`` is delimiter-agnostic
-    # at the langchain level and treats the file as one logical record
-    # per row, which is all the RAG pipeline needs (the splitter then
-    # decides chunking).
-    ".tsv": CSVLoader,
-    ".xlsx": UnstructuredExcelLoader,
-    ".xls": UnstructuredExcelLoader,
-    ".html": UnstructuredHTMLLoader,
-    ".htm": UnstructuredHTMLLoader,
-    ".pptx": UnstructuredPowerPointLoader,
-    ".json": TextLoader,
-    ".yaml": TextLoader,
-    ".yml": TextLoader,
-    ".rst": TextLoader,
-    # Python source files: index as plain text so the chunker can pull
-    # out docstrings / comments alongside code identifiers.
-    ".py": TextLoader,
-}
+
+def _build_loader_map() -> dict[str, Any]:
+    """Build the extension -> langchain loader class map on first use.
+
+    The langchain document loaders ship in the ``docs-extended``
+    bundle, which is fetched lazily. Building the map at runtime
+    keeps :mod:`amx.docs.rag`'s import cost limited to the standard
+    library (Studio's cold-start path imports this module without
+    needing the loaders).
+    """
+    _ensure("docs-extended")
+    from langchain_community.document_loaders import (
+        CSVLoader,
+        Docx2txtLoader,
+        PyPDFLoader,
+        TextLoader,
+        UnstructuredExcelLoader,
+        UnstructuredHTMLLoader,
+        UnstructuredPowerPointLoader,
+    )
+
+    return {
+        ".pdf": PyPDFLoader,
+        ".docx": Docx2txtLoader,
+        ".doc": Docx2txtLoader,
+        ".txt": TextLoader,
+        # PR-D: Markdown loads as plain text (not via
+        # ``UnstructuredMarkdownLoader``) because the Markdown-aware
+        # splitter in ``amx.docs.splitters`` needs the raw ``#`` /
+        # ``##`` markers to extract heading metadata. The Unstructured
+        # backend silently strips formatting, making every Markdown
+        # chunk look identical to plain prose to the splitter.
+        ".md": TextLoader,
+        ".markdown": TextLoader,
+        ".csv": CSVLoader,
+        # TSV is tab-separated values; ``CSVLoader`` is delimiter-
+        # agnostic at the langchain level and treats the file as one
+        # logical record per row.
+        ".tsv": CSVLoader,
+        ".xlsx": UnstructuredExcelLoader,
+        ".xls": UnstructuredExcelLoader,
+        ".html": UnstructuredHTMLLoader,
+        ".htm": UnstructuredHTMLLoader,
+        ".pptx": UnstructuredPowerPointLoader,
+        ".json": TextLoader,
+        ".yaml": TextLoader,
+        ".yml": TextLoader,
+        ".rst": TextLoader,
+        ".py": TextLoader,
+    }
 
 
 @dataclass(frozen=True)
@@ -260,6 +260,13 @@ class RAGStore:
         reranker_kind: str | None = None,
         cfg: Any | None = None,
     ):
+        # First runtime touchpoint for the heavy RAG cluster — install
+        # the bundle and bind chromadb locally. Module-level imports
+        # are intentionally absent so Studio cold start can import
+        # this module without paying the ~150 MB install cost.
+        _ensure("docs-extended")
+        import chromadb
+
         self.persist_dir = persist_dir or str(Path.home() / ".amx" / "chroma_db")
         Path(self.persist_dir).mkdir(parents=True, exist_ok=True)
         self.client = chromadb.PersistentClient(path=self.persist_dir)
@@ -485,11 +492,18 @@ class RAGStore:
         """
         if refresh and docs:
             self.delete_chunks_for_sources([x for d in docs for x in (d.path, d.source_root) if x])
+        # Lazy imports: splitters and the loader-class map both rely
+        # on the ``docs-extended`` bundle. Building them here (not at
+        # module top) keeps :mod:`amx.docs.rag` import light enough
+        # for Studio's transitive cold-start path.
+        from amx.docs.splitters import get_splitter
+
+        loader_map = _build_loader_map()
         succeeded: list[str] = []
         failed: list[tuple[str, str]] = []
         total_chunks = 0
         for doc in docs:
-            loader_cls = LOADER_MAP.get(doc.extension)
+            loader_cls = loader_map.get(doc.extension)
             if loader_cls is None:
                 reason = f"no loader for extension {doc.extension!r}"
                 log.warning("No loader for %s, skipping %s", doc.extension, doc.path)

--- a/amx/search/index.py
+++ b/amx/search/index.py
@@ -15,25 +15,26 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from amx.utils.optional_deps import ensure as _ensure
 
-# Shares the ``rag`` bundle (chromadb + splitter + tiktoken) with
-# /docs and /code. Idempotent after the first feature touches it —
-# the bundle registry in ``optional_deps`` is the single source of
-# truth, so /search no longer has to know which packages chromadb
-# brings along.
-_ensure("rag")
+if TYPE_CHECKING:
+    from chromadb.api.types import EmbeddingFunction
 
-import chromadb  # noqa: E402
-from chromadb.api.types import EmbeddingFunction  # noqa: E402
+# Catalog Search shares the ``rag`` bundle (chromadb + splitter +
+# tiktoken) with /docs and /code. The bundle is fetched on first
+# :class:`SearchIndex` construction, NOT at module import — Studio's
+# transitive cold-start path runs through this module
+# (web.routers.ask -> search.catalog -> search.index), so a module-
+# level install call would block every Studio first launch on a
+# fresh wheel.
 
-from amx.rag_core.collection_identity import (  # noqa: E402
+from amx.rag_core.collection_identity import (
     CollectionIdentity,
     reconcile_identity,
 )
-from amx.utils.logging import get_logger  # noqa: E402
+from amx.utils.logging import get_logger
 
 log = get_logger("search.index")
 
@@ -113,6 +114,13 @@ class SearchIndex:
         embedding_function: EmbeddingFunction | None = None,
         cfg: Any | None = None,
     ) -> None:
+        # First runtime touchpoint for the search RAG cluster — install
+        # the ``rag`` bundle (~80 MB) and bind chromadb locally. Module
+        # top is intentionally clean so Studio cold start can import
+        # this module without paying the install cost.
+        _ensure("rag")
+        import chromadb
+
         self.persist_dir = persist_dir or str(Path.home() / ".amx" / "chroma_db")
         Path(self.persist_dir).mkdir(parents=True, exist_ok=True)
         self.client = chromadb.PersistentClient(path=self.persist_dir)

--- a/tests/test_code_query_timeout.py
+++ b/tests/test_code_query_timeout.py
@@ -38,8 +38,10 @@ def test_query_code_snippets_respects_timeout(monkeypatch, caplog):
         "_open_collection",
         lambda *_a, **_kw: fake_coll,
     )
+    import chromadb
+
     monkeypatch.setattr(
-        cr.chromadb,
+        chromadb,
         "PersistentClient",
         lambda **_kw: SimpleNamespace(),
     )
@@ -95,7 +97,9 @@ def test_query_code_snippets_hybrid_rerank_promotes_literal_match(monkeypatch):
 
     fake_coll = SimpleNamespace(query=_fake_query)
     monkeypatch.setattr(cr, "_open_collection", lambda *_a, **_kw: fake_coll)
-    monkeypatch.setattr(cr.chromadb, "PersistentClient", lambda **_kw: SimpleNamespace())
+    import chromadb
+
+    monkeypatch.setattr(chromadb, "PersistentClient", lambda **_kw: SimpleNamespace())
 
     hits = cr.query_code_snippets("sap", n_results=3, timeout=None)
     # The literal-match chunk must come first.
@@ -122,7 +126,9 @@ def test_query_code_snippets_no_timeout_runs_synchronously(monkeypatch):
 
     fake_coll = SimpleNamespace(query=_fast_query)
     monkeypatch.setattr(cr, "_open_collection", lambda *_a, **_kw: fake_coll)
-    monkeypatch.setattr(cr.chromadb, "PersistentClient", lambda **_kw: SimpleNamespace())
+    import chromadb
+
+    monkeypatch.setattr(chromadb, "PersistentClient", lambda **_kw: SimpleNamespace())
 
     hits = cr.query_code_snippets("q", n_results=1, timeout=None)
     assert len(hits) == 1

--- a/tests/test_docs_extensions.py
+++ b/tests/test_docs_extensions.py
@@ -49,7 +49,8 @@ def test_every_supported_extension_has_a_loader() -> None:
     """If scan accepts a file, ingest must be able to parse it. This
     guard previously broke for ``.tsv`` and ``.markdown``."""
     from amx.docs.extensions import SUPPORTED_EXTENSIONS
-    from amx.docs.rag import LOADER_MAP
+    from amx.docs.rag import _build_loader_map
 
-    missing = sorted(ext for ext in SUPPORTED_EXTENSIONS if ext not in LOADER_MAP)
+    loader_map = _build_loader_map()
+    missing = sorted(ext for ext in SUPPORTED_EXTENSIONS if ext not in loader_map)
     assert missing == [], f"loaders missing for: {missing}"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -4329,7 +4329,7 @@ class PerProfileCollectionTests(unittest.TestCase):
                 return col
 
         with tempfile.TemporaryDirectory() as td:
-            with patch.object(index_module.chromadb, "PersistentClient", FakeClient):
+            with patch("chromadb.PersistentClient", FakeClient):
                 idx = index_module.SearchIndex(persist_dir=td)
                 idx.upsert_entities(
                     [
@@ -4399,7 +4399,7 @@ class PerProfileCollectionTests(unittest.TestCase):
                 return FakeCollection()
 
         with tempfile.TemporaryDirectory() as td:
-            with patch.object(index_module.chromadb, "PersistentClient", FakeClient):
+            with patch("chromadb.PersistentClient", FakeClient):
                 idx = index_module.SearchIndex(persist_dir=td)
                 idx.query("what is X?", db_profile="prod", n_results=5)
 
@@ -4431,7 +4431,7 @@ class SearchIndexEmbeddingTests(unittest.TestCase):
                 captured.update(kwargs)
                 return FakeCollection()
 
-        with patch.object(index_module.chromadb, "PersistentClient", FakeClient):
+        with patch("chromadb.PersistentClient", FakeClient):
             index_module.SearchIndex(persist_dir=self._tempdir.name)
 
         # Default behaviour: no embedding_function → Chroma uses MiniLM.
@@ -4456,7 +4456,7 @@ class SearchIndexEmbeddingTests(unittest.TestCase):
                 return FakeCollection()
 
         sentinel_ef = object()
-        with patch.object(index_module.chromadb, "PersistentClient", FakeClient):
+        with patch("chromadb.PersistentClient", FakeClient):
             idx = index_module.SearchIndex(
                 persist_dir=self._tempdir.name,
                 embedding_function=sentinel_ef,  # type: ignore[arg-type]
@@ -4998,7 +4998,7 @@ class EmbeddingDefaultFactoryTests(unittest.TestCase):
 
         self.embeddings_module.set_default_embedding_function(lambda: sentinel)
         with tempfile.TemporaryDirectory() as td:
-            with patch.object(index_module.chromadb, "PersistentClient", FakeClient):
+            with patch("chromadb.PersistentClient", FakeClient):
                 index_module.SearchIndex(persist_dir=td)
 
         # Default factory's sentinel was wired into the Chroma collection.
@@ -5022,7 +5022,7 @@ class EmbeddingDefaultFactoryTests(unittest.TestCase):
         # must win over it so callers retain control.
         self.embeddings_module.set_default_embedding_function(lambda: object())
         with tempfile.TemporaryDirectory() as td:
-            with patch.object(index_module.chromadb, "PersistentClient", FakeClient):
+            with patch("chromadb.PersistentClient", FakeClient):
                 index_module.SearchIndex(
                     persist_dir=td,
                     embedding_function=explicit,  # type: ignore[arg-type]

--- a/tests/test_studio_cold_start_no_pip.py
+++ b/tests/test_studio_cold_start_no_pip.py
@@ -1,0 +1,76 @@
+"""Regression test for the Studio cold-start pip-install hang.
+
+v0.15.0 shipped with module-level ``_ensure(...)`` calls in four RAG
+modules (``amx/docs/rag.py``, ``amx/search/index.py``,
+``amx/search/embeddings.py``, ``amx/codebase/code_rag.py``). The
+Studio launcher's child process imports ``amx.web.server``, whose
+transitive import graph passes through ``docs.rag`` and ``search.
+index``. On a fresh ``pip install amx-cli`` (no extras) that import
+chain triggered a ~150 MB pip subprocess at module load time and
+blocked uvicorn from binding the port — Studio appeared dead until
+the install finished.
+
+This test pins the import-light contract for the modules in
+Studio's cold-start path: importing them must not spawn any pip
+subprocess. New ``_ensure(...)`` calls belong inside class
+constructors, factory functions, or runtime entry points — never
+at module top level in this import chain.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+
+@pytest.fixture
+def trap_pip_subprocess(monkeypatch):
+    """Replace :class:`subprocess.Popen` so any pip invocation
+    raises immediately with the offending argv. Tests that hit a
+    real subprocess for unrelated reasons (none in this file)
+    would need to scope the trap more tightly.
+    """
+    real_popen = subprocess.Popen
+    pip_invocations: list[list[str]] = []
+
+    def _trap(args, *rest, **kwargs):
+        # Cover both list-form (sys.executable, -m, pip, ...) and
+        # string-form invocations. The ``optional_deps`` module uses
+        # list-form, but the trap is permissive on purpose.
+        if isinstance(args, (list, tuple)):
+            argv = [str(x) for x in args]
+        else:
+            argv = [str(args)]
+        if any("pip" in tok for tok in argv):
+            pip_invocations.append(argv)
+            raise AssertionError(f"Module-level _ensure leaked into Studio cold start: pip {argv}")
+        return real_popen(args, *rest, **kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", _trap)
+    return pip_invocations
+
+
+COLD_START_MODULES = (
+    # Direct fixes in this PR.
+    "amx.docs.rag",
+    "amx.search.index",
+    "amx.codebase.code_rag",
+    # The end-to-end target. Importing this is what the Studio
+    # launcher's child process does at startup; if any transitive
+    # module reintroduces a module-level _ensure, the assertion
+    # below fires before uvicorn is even reached.
+    "amx.web.server",
+)
+
+
+@pytest.mark.parametrize("module_name", COLD_START_MODULES)
+def test_import_does_not_spawn_pip(module_name: str, trap_pip_subprocess) -> None:
+    """Importing each Studio cold-start module must not invoke pip."""
+    import importlib
+
+    importlib.import_module(module_name)
+    assert trap_pip_subprocess == [], (
+        f"{module_name} import triggered a pip subprocess; module-level "
+        "_ensure() must be moved into a runtime entry point"
+    )


### PR DESCRIPTION
## Summary

Studio cold-start regression in v0.15.0: `amx/docs/rag.py` and `amx/search/index.py` both called `ensure(...)` at module top level, so the Studio child process's import chain (`web.routers.ask` → `agents.orchestrator` → `agents.rag_agent` → `docs.rag` and `search.catalog` → `search.index`) ran a ~150 MB `pip install` for chromadb + langchain + unstructured before uvicorn could bind `127.0.0.1:47821`. The launcher's 5-second health-check timeout fired well before the install finished, the unconditional `AMX Studio running →` line masked the failure, and a `Ctrl-C` in that window left no Studio at all.

This PR moves the install + chromadb / langchain imports into the runtime entry points that actually need the cluster:

- **`amx/docs/rag.py`** — `chromadb` import is now local to `RAGStore.__init__`; the langchain document-loader map becomes a lazy `_build_loader_map()` helper called from `ingest()`. The splitter import also moved into `ingest()` to keep the module import light.
- **`amx/search/index.py`** — `ensure("rag")` + `chromadb` import move into `SearchIndex.__init__`. `EmbeddingFunction` is annotation-only so it moves to `TYPE_CHECKING`.
- **`amx/codebase/code_rag.py`** — a `_get_chroma()` helper centralises the lazy install + import for every `PersistentClient` site, and the splitter import moves into `_split_fallback()`. Not in Studio's cold-start path, but the pattern was the same and worth fixing for consistency.

A new test (`tests/test_studio_cold_start_no_pip.py`) pins the contract: importing the three fixed modules and `amx.web.server` must not spawn any pip subprocess. The test wraps `subprocess.Popen` and fails loudly with the leaked argv if a future PR reintroduces a module-level `ensure(...)`.

Existing tests that monkey-patched chromadb via the module attribute (`tests/test_regressions.py`, `tests/test_code_query_timeout.py`) are updated to patch the chromadb library directly. The docs-extensions guard (`tests/test_docs_extensions.py`) now calls the new `_build_loader_map()` helper instead of the removed `LOADER_MAP` constant.

## Out of scope (follow-up for v0.15.2)

`amx/search/embeddings.py` also has a module-level `ensure("rag")` call, but it uses `chromadb.api.types.EmbeddingFunction` as a real superclass at class-definition time. Restructuring it requires a factory-based class build that is too invasive for a patch release. It is NOT in Studio's cold-start transitive import path (callers all import it lazily from inside function bodies), so the user-facing regression in this PR is fully resolved without touching it.

## Test plan

- [x] `pytest tests/test_studio_cold_start_no_pip.py -v` → 4 passed (new regression test)
- [x] `pytest tests/ --ignore=tests/perf` → 2399 passed, 9 skipped (sentence-transformers env mismatch unrelated to this PR)
- [x] `ruff check amx/ tests/` → clean
- [x] `ruff format --check amx/ tests/` → clean
- [x] `mypy amx/docs/rag.py amx/search/index.py amx/codebase/code_rag.py` → 8 errors, all pre-existing on `main` (13 → 8; the move to TYPE_CHECKING / local imports happens to silence 5 derived inference errors)
- [x] Manual: `import amx.web.server` with `subprocess.Popen` trapped → no pip invocation