### PR TITLE
fix(tests): de-flake advisory_lock parallel test

### DIFF
--- a/tests/runtime/test_advisory_lock.py
+++ b/tests/runtime/test_advisory_lock.py
@@ -46,14 +46,16 @@ def test_lock_serialises_two_holders(tmp_path: Path) -> None:
 
 def test_lock_distinct_keys_run_in_parallel(tmp_path: Path) -> None:
     store = AdvisoryLockStore(str(tmp_path / "locks.sqlite3"))
-    starts: list[float] = []
-    starts_lock = threading.Lock()
+    intervals: list[tuple[float, float]] = []
+    intervals_lock = threading.Lock()
 
     def hold(key: tuple[str, str, str]) -> None:
         with store.acquire(key, timeout_sec=5.0):
-            with starts_lock:
-                starts.append(time.monotonic())
+            entered = time.monotonic()
             time.sleep(0.2)
+            exited = time.monotonic()
+        with intervals_lock:
+            intervals.append((entered, exited))
 
     t1 = threading.Thread(target=hold, args=(("prod_sf", "public", "a"),))
     t2 = threading.Thread(target=hold, args=(("prod_sf", "public", "b"),))
@@ -62,11 +64,19 @@ def test_lock_distinct_keys_run_in_parallel(tmp_path: Path) -> None:
     t1.join()
     t2.join()
 
-    # Distinct keys must not serialise; both starts within 150ms is
-    # generous slack for thread scheduling on a busy CI runner.
-    assert len(starts) == 2
-    assert abs(starts[0] - starts[1]) < 0.15, (
-        f"distinct keys should run in parallel; gap was {abs(starts[0] - starts[1]):.3f}s"
+    # Distinct keys must NOT serialise. The previous start-gap assertion
+    # was flaky on loaded CI runners (a slow thread schedule could
+    # measure ~250 ms between starts even though both locks were
+    # actually held concurrently). The overlap check is robust: serial
+    # execution leaves entered_b > exited_a (zero overlap), while
+    # parallel execution gives ~0.2 s of overlap matching the in-lock
+    # sleep, with broad tolerance for CI jitter.
+    assert len(intervals) == 2
+    (entered_a, exited_a), (entered_b, exited_b) = intervals
+    overlap = max(0.0, min(exited_a, exited_b) - max(entered_a, entered_b))
+    assert overlap > 0.05, (
+        f"distinct keys should run concurrently; overlap was {overlap:.3f}s "
+        f"(entered {entered_a:.3f}/{entered_b:.3f}, exited {exited_a:.3f}/{exited_b:.3f})"
     )
 
 


### PR DESCRIPTION
## Summary
- The `tests/runtime/test_advisory_lock.py::test_lock_distinct_keys_run_in_parallel` start-time-gap assertion (`abs(starts[0] - starts[1]) < 0.15`) was flaky on loaded CI runners — thread scheduling jitter could measure 250+ ms between the two starts even though both locks were actually held concurrently. PRs #470 (py3.11 at 156 ms) and #475 (py3.12 at 257 ms) both tripped on this in the last hour.
- Switch to an overlap-based assertion: each thread records its `entered` + `exited` timestamps, and the test asserts the two intervals overlap by at least 50 ms. Serial execution would leave zero overlap (`entered_b > exited_a`); parallel execution gives ~200 ms of overlap matching the in-lock sleep, with broad tolerance for CI jitter.
- The assertion still catches gross regressions (a serial implementation would have zero overlap), without false-positiving on slow scheduling.

## Test plan
- [x] `pytest tests/runtime/test_advisory_lock.py` — all 4 tests pass
- [x] Ran the rewritten parallel test 5x in a row locally — all 5 pass
- [x] `make test` — 2415 passed, 9 skipped (env-related), zero new failures
- [x] `make lint` — clean
- [x] No Studio surface touched (`web/routers/*` unchanged) — `deploy.sh` not required