### PR TITLE
refactor(cli): extract analyze_flow bounded-input prompts

### DIFF
--- a/amx/cli_support/_analyze_flow_prompts.py
+++ b/amx/cli_support/_analyze_flow_prompts.py
@@ -1,0 +1,81 @@
+"""Small bounded-input prompt helpers used by ``amx analyze``.
+
+Extracted from :mod:`amx.cli_support.commands.analyze_flow` so the
+three ``_ask_optional_*`` helpers and their input-validation rules
+live in one focused module — they were originally the only piece of
+``analyze_flow`` with no dependency on the run lifecycle and are a
+natural home for any future shared CLI prompt helper.
+
+``analyze_flow.py`` re-exports each name so any internal call site
+that imported the underscore form continues to work unchanged.
+"""
+
+from __future__ import annotations
+
+from amx.utils.console import ask, ask_choice, warn
+
+
+def _ask_optional_float(
+    prompt: str,
+    *,
+    current: float | None,
+    lo: float,
+    hi: float,
+) -> tuple[bool, float | None]:
+    """Prompt for a bounded float, returning ``(changed, value)``.
+
+    ``current`` shows up as the default in the prompt. The user can:
+    * press Enter to keep the current value (changed=False)
+    * type ``-`` (a single dash) to clear the field (changed=True, value=None)
+    * type a number in [lo, hi] (changed=True, value=number)
+
+    Out-of-range or unparseable input is treated as "keep current"
+    with a warning so a typo never silently lands a bad override.
+    """
+    raw = ask(prompt, default="" if current is None else str(current)).strip()
+    if not raw:
+        return False, current
+    if raw == "-":
+        return current is not None, None
+    try:
+        value = float(raw)
+    except ValueError:
+        warn(f"Could not parse {raw!r} as a number; keeping {current}.")
+        return False, current
+    if value < lo or value > hi:
+        warn(f"Value {value} out of range [{lo}, {hi}]; keeping {current}.")
+        return False, current
+    return value != current, value
+
+
+def _ask_optional_int(
+    prompt: str,
+    *,
+    current: int,
+    lo: int,
+    hi: int,
+) -> tuple[bool, int]:
+    """Bounded integer prompt; same conventions as ``_ask_optional_float``."""
+    raw = ask(prompt, default=str(current)).strip()
+    if not raw:
+        return False, current
+    try:
+        value = int(raw)
+    except ValueError:
+        warn(f"Could not parse {raw!r} as an integer; keeping {current}.")
+        return False, current
+    if value < lo or value > hi:
+        warn(f"Value {value} out of range [{lo}, {hi}]; keeping {current}.")
+        return False, current
+    return value != current, value
+
+
+def _ask_optional_choice(
+    prompt: str,
+    *,
+    current: str,
+    choices: list[str],
+) -> tuple[bool, str]:
+    """Pick-from-list prompt with ``current`` as the default."""
+    selected = ask_choice(prompt, choices, default=current if current in choices else choices[0])
+    return selected != current, selected

--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -10,6 +10,15 @@ from typing import Any
 
 import click
 
+from amx.cli_support._analyze_flow_prompts import (  # noqa: PLC0414
+    _ask_optional_choice as _ask_optional_choice,
+)
+from amx.cli_support._analyze_flow_prompts import (
+    _ask_optional_float as _ask_optional_float,
+)
+from amx.cli_support._analyze_flow_prompts import (
+    _ask_optional_int as _ask_optional_int,
+)
 from amx.config import (
     ALTERNATIVES_MODE_CHOICES,
     CONFIDENCE_SIGNAL_CHOICES,
@@ -18,7 +27,6 @@ from amx.config import (
 )
 from amx.storage.sqlite_store import history_store
 from amx.utils.console import (
-    ask,
     ask_choice,
     confirm,
     console,
@@ -54,72 +62,6 @@ ResolveCodebaseForRun = Callable[
     [AMXConfig, object, dict[str, list[str]], str | None, bool], object | None
 ]
 LogEvent = Callable[..., None]
-
-
-def _ask_optional_float(
-    prompt: str,
-    *,
-    current: float | None,
-    lo: float,
-    hi: float,
-) -> tuple[bool, float | None]:
-    """Prompt for a bounded float, returning ``(changed, value)``.
-
-    ``current`` shows up as the default in the prompt. The user can:
-    * press Enter to keep the current value (changed=False)
-    * type ``-`` (a single dash) to clear the field (changed=True, value=None)
-    * type a number in [lo, hi] (changed=True, value=number)
-
-    Out-of-range or unparseable input is treated as "keep current"
-    with a warning so a typo never silently lands a bad override.
-    """
-    raw = ask(prompt, default="" if current is None else str(current)).strip()
-    if not raw:
-        return False, current
-    if raw == "-":
-        return current is not None, None
-    try:
-        value = float(raw)
-    except ValueError:
-        warn(f"Could not parse {raw!r} as a number; keeping {current}.")
-        return False, current
-    if value < lo or value > hi:
-        warn(f"Value {value} out of range [{lo}, {hi}]; keeping {current}.")
-        return False, current
-    return value != current, value
-
-
-def _ask_optional_int(
-    prompt: str,
-    *,
-    current: int,
-    lo: int,
-    hi: int,
-) -> tuple[bool, int]:
-    """Bounded integer prompt; same conventions as ``_ask_optional_float``."""
-    raw = ask(prompt, default=str(current)).strip()
-    if not raw:
-        return False, current
-    try:
-        value = int(raw)
-    except ValueError:
-        warn(f"Could not parse {raw!r} as an integer; keeping {current}.")
-        return False, current
-    if value < lo or value > hi:
-        warn(f"Value {value} out of range [{lo}, {hi}]; keeping {current}.")
-        return False, current
-    return value != current, value
-
-
-def _ask_optional_choice(
-    prompt: str,
-    *,
-    current: str,
-    choices: list[str],
-) -> tuple[bool, str]:
-    """Pick-from-list prompt with ``current`` as the default."""
-    selected = ask_choice(prompt, choices, default=current if current in choices else choices[0])
-    return selected != current, selected
 
 
 def _maybe_apply_llm_overrides_interactively(

--- a/tests/test_analyze_llm_overrides.py
+++ b/tests/test_analyze_llm_overrides.py
@@ -60,8 +60,7 @@ def test_override_gate_noop_when_user_declines(cfg_with_profile, monkeypatch) ->
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(analyze_flow, "confirm", lambda *_a, **_k: False)
     monkeypatch.setattr(
-        analyze_flow,
-        "ask",
+        "amx.cli_support._analyze_flow_prompts.ask",
         lambda *_a, **_k: pytest.fail("ask must not be called when user declines"),
     )
     saved_llm = cfg_with_profile.llm
@@ -108,8 +107,8 @@ def test_override_gate_applies_only_changed_fields(cfg_with_profile, monkeypatch
     def fake_ask_choice(_q: str, choices: list[str], *, default: str = "", **_k):
         return default  # accept current
 
-    monkeypatch.setattr(analyze_flow, "ask", fake_ask)
-    monkeypatch.setattr(analyze_flow, "ask_choice", fake_ask_choice)
+    monkeypatch.setattr("amx.cli_support._analyze_flow_prompts.ask", fake_ask)
+    monkeypatch.setattr("amx.cli_support._analyze_flow_prompts.ask_choice", fake_ask_choice)
 
     saved_llm = cfg_with_profile.llm
     restore, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
@@ -148,13 +147,10 @@ def test_override_gate_out_of_range_keeps_profile_value(cfg_with_profile, monkey
         ]
     )
     monkeypatch.setattr(
-        analyze_flow,
-        "ask",
-        lambda *_a, **_k: next(answers, ""),
+        "amx.cli_support._analyze_flow_prompts.ask", lambda *_a, **_k: next(answers, "")
     )
     monkeypatch.setattr(
-        analyze_flow,
-        "ask_choice",
+        "amx.cli_support._analyze_flow_prompts.ask_choice",
         lambda _q, _c, *, default="", **_k: default,
     )
 
@@ -171,8 +167,7 @@ def test_override_gate_walks_choice_fields(cfg_with_profile, monkeypatch) -> Non
     monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(analyze_flow, "confirm", lambda *_a, **_k: True)
     monkeypatch.setattr(
-        analyze_flow,
-        "ask",
+        "amx.cli_support._analyze_flow_prompts.ask",
         lambda *_a, **_k: "",  # accept every numeric default
     )
 
@@ -187,7 +182,7 @@ def test_override_gate_walks_choice_fields(cfg_with_profile, monkeypatch) -> Non
                 return value
         return default
 
-    monkeypatch.setattr(analyze_flow, "ask_choice", fake_choice)
+    monkeypatch.setattr("amx.cli_support._analyze_flow_prompts.ask_choice", fake_choice)
 
     _, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
     assert applied == {
@@ -212,7 +207,7 @@ def test_override_gate_walks_choice_fields(cfg_with_profile, monkeypatch) -> Non
 def _all_numeric_blank(monkeypatch) -> None:
     """Helper: monkeypatch ``ask`` to return blank (= accept default)
     for every numeric prompt the picker walks."""
-    monkeypatch.setattr(analyze_flow, "ask", lambda *_a, **_k: "")
+    monkeypatch.setattr("amx.cli_support._analyze_flow_prompts.ask", lambda *_a, **_k: "")
 
 
 def test_override_gate_walks_alternatives_mode_when_n_gt_1(cfg_with_profile, monkeypatch) -> None:
@@ -235,7 +230,7 @@ def test_override_gate_walks_alternatives_mode_when_n_gt_1(cfg_with_profile, mon
             return "lexical"
         return default
 
-    monkeypatch.setattr(analyze_flow, "ask_choice", fake_choice)
+    monkeypatch.setattr("amx.cli_support._analyze_flow_prompts.ask_choice", fake_choice)
 
     saved_llm = cfg_with_profile.llm
     restore, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
@@ -272,7 +267,9 @@ def test_override_gate_skips_alternatives_mode_when_n_is_1(cfg_with_profile, mon
             "",  # custom_output
         ]
     )
-    monkeypatch.setattr(analyze_flow, "ask", lambda *_a, **_k: next(answers, ""))
+    monkeypatch.setattr(
+        "amx.cli_support._analyze_flow_prompts.ask", lambda *_a, **_k: next(answers, "")
+    )
 
     asked_alt_mode = False
 
@@ -282,7 +279,7 @@ def test_override_gate_skips_alternatives_mode_when_n_is_1(cfg_with_profile, mon
             asked_alt_mode = True
         return default
 
-    monkeypatch.setattr(analyze_flow, "ask_choice", fake_choice)
+    monkeypatch.setattr("amx.cli_support._analyze_flow_prompts.ask_choice", fake_choice)
 
     _, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
 
@@ -310,7 +307,7 @@ def test_override_gate_walks_confidence_signal(cfg_with_profile, monkeypatch) ->
             return "judge"
         return default
 
-    monkeypatch.setattr(analyze_flow, "ask_choice", fake_choice)
+    monkeypatch.setattr("amx.cli_support._analyze_flow_prompts.ask_choice", fake_choice)
 
     saved_llm = cfg_with_profile.llm
     _, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
@@ -331,8 +328,7 @@ def test_override_gate_keep_default_for_new_fields(cfg_with_profile, monkeypatch
     _all_numeric_blank(monkeypatch)
 
     monkeypatch.setattr(
-        analyze_flow,
-        "ask_choice",
+        "amx.cli_support._analyze_flow_prompts.ask_choice",
         lambda _q, _choices, *, default="", **_k: default,
     )
 
@@ -364,7 +360,7 @@ def test_override_summary_line_includes_new_overrides(
             return "judge"
         return default
 
-    monkeypatch.setattr(analyze_flow, "ask_choice", fake_choice)
+    monkeypatch.setattr("amx.cli_support._analyze_flow_prompts.ask_choice", fake_choice)
 
     _, applied = analyze_flow._maybe_apply_llm_overrides_interactively(cfg_with_profile)
     assert applied == {
@@ -388,13 +384,11 @@ def test_override_gate_non_interactive_does_not_prompt_for_new_fields(
     non-interactive run produces deterministic output."""
     monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
     monkeypatch.setattr(
-        analyze_flow,
-        "ask_choice",
+        "amx.cli_support._analyze_flow_prompts.ask_choice",
         lambda *_a, **_k: pytest.fail("ask_choice must not run in non-TTY mode"),
     )
     monkeypatch.setattr(
-        analyze_flow,
-        "ask",
+        "amx.cli_support._analyze_flow_prompts.ask",
         lambda *_a, **_k: pytest.fail("ask must not run in non-TTY mode"),
     )
 


### PR DESCRIPTION
## Summary
- A1 of the analyze_flow split: moves the three bounded-input prompt helpers (`_ask_optional_float`, `_ask_optional_int`, `_ask_optional_choice`) out of `amx/cli_support/commands/analyze_flow.py` into a focused `amx/cli_support/_analyze_flow_prompts.py`.
- `analyze_flow.py` re-exports the three names so any internal call site that imported the underscore form keeps working unchanged.
- Tests in `test_analyze_llm_overrides.py` `monkeypatch.setattr(analyze_flow, "ask", ...)` were updated to target `amx.cli_support._analyze_flow_prompts.ask` / `.ask_choice` — that's where the calls now happen.
- `analyze_flow.py`: 2152 -> 2094 LOC (-58, -3%). First cut; the run-finalization + scope-mutation pieces remain for follow-up extractions.

## Test plan
- [x] `make test` — 2415 passed, 9 skipped (env-related), zero new failures
- [x] `make lint` — clean
- [x] Public API: `from amx.cli_support.commands.analyze_flow import _ask_optional_float, _ask_optional_int, _ask_optional_choice` still works
- [x] All `test_analyze_llm_overrides` tests still pass after patch-path rewrite
- [x] No Studio surface touched — `deploy.sh` not required