### PR TITLE
refactor(cli): extract db.py environment-diagnostic helpers

### DIFF
--- a/amx/cli_support/_db_diagnostics.py
+++ b/amx/cli_support/_db_diagnostics.py
@@ -1,0 +1,129 @@
+"""Diagnostic helpers for the ``amx db`` wizard.
+
+Extracted from :mod:`amx.cli_support.commands.db`. The four functions
+share the role of giving the user actionable hints when their
+environment is the obstacle rather than the wizard input.
+
+``db.py`` re-exports each name so call sites and existing test
+imports (``tests/test_mssql_system_prereq_hint.py``) keep working.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from amx.utils.console import error, info
+
+_BACKEND_DRIVER_PROBES: dict[str, tuple[str, str]] = {
+    "postgresql": ("postgresql", "psycopg2"),
+    "snowflake": ("snowflake", "snowflake.connector"),
+    "databricks": ("databricks", "databricks.sql"),
+    "bigquery": ("bigquery", "google.cloud.bigquery"),
+    "mysql": ("mysql", "pymysql"),
+    "oracle": ("oracle", "oracledb"),
+    "mssql": ("mssql", "pyodbc"),
+    "redshift": ("redshift", "redshift_connector"),
+    "clickhouse": ("clickhouse", "clickhouse_connect"),
+    "duckdb": ("duckdb", "duckdb"),
+}
+
+
+def _print_system_prereq_hint(backend: str) -> None:
+    """Surface platform-specific system-package install instructions.
+
+    Pure-Python drivers (psycopg2-binary, snowflake-sqlalchemy, …)
+    pip-install fine on every supported platform. ODBC-based drivers
+    (MSSQL via pyodbc) require a separate system package — without it
+    the connection fails with ``Can't open lib 'ODBC Driver 18 for SQL
+    Server'`` even after ``pip install amx-cli[mssql]`` succeeds.
+    Print the right command for the user's OS so they don't have to
+    google the error.
+    """
+    import platform
+
+    if backend != "mssql":
+        return
+
+    system = platform.system()
+    if system == "Darwin":
+        info(
+            "Note: macOS also needs the Microsoft ODBC system driver. "
+            "If the connection fails with 'Can't open lib', run:\n"
+            "    brew tap microsoft/mssql-release "
+            "https://github.com/Microsoft/homebrew-mssql-release\n"
+            "    brew install msodbcsql18 mssql-tools18"
+        )
+    elif system == "Linux":
+        info(
+            "Note: Linux also needs the Microsoft ODBC system driver. "
+            "See https://learn.microsoft.com/sql/connect/odbc/linux-mac/"
+            "installing-the-microsoft-odbc-driver-for-sql-server for "
+            "your distro's package (``msodbcsql18`` on Debian / RHEL)."
+        )
+    elif system == "Windows":
+        info(
+            "Note: Windows installers for the Microsoft ODBC driver "
+            "are bundled with SSMS or downloadable from "
+            "https://learn.microsoft.com/sql/connect/odbc/."
+        )
+
+
+def _offer_to_install_backend_driver(backend: str) -> None:
+    """Auto-install *backend*'s driver during the ``/add-db-profile`` wizard.
+
+    Pre-0.12.9 this asked a Y/n prompt and ran ``pip install
+    'amx-cli[<extra>]'``. The Y/n was friction (the user had just
+    picked the backend; "do you want it to work?" is not a useful
+    question), and the wizard's pre-install was duplicated by
+    ``DatabaseConnector.__init__`` which would have triggered the
+    same install on first use anyway. Calling
+    ``ensure_backend_driver`` here pre-warms the same path so the
+    wizard's "test connection" step at the end of the flow finds the
+    driver already loaded.
+    """
+    probe = _BACKEND_DRIVER_PROBES.get(backend)
+    if not probe:
+        return
+    from amx.db.drivers import ensure_backend_driver
+
+    _print_system_prereq_hint(backend)
+
+    try:
+        ensure_backend_driver(backend)
+    except RuntimeError as exc:
+        # Surface the failure but don't abort the wizard — the user
+        # can still finish entering connection details and AMX will
+        # re-attempt the install (or report the same hint) on first
+        # connect.
+        error(str(exc))
+
+
+def _is_databricks_tls_failure(message: str) -> bool:
+    msg = (message or "").lower()
+    return any(
+        token in msg
+        for token in (
+            "tls",
+            "certificate",
+            "ssl",
+            "trusted ca bundle",
+            "self-signed",
+        )
+    )
+
+
+def _env_trusted_ca_candidate() -> tuple[str, str] | None:
+    for env_name in (
+        "AMX_DATABRICKS_TRUSTED_CA_FILE",
+        "DATABRICKS_TRUSTED_CA_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+    ):
+        raw = os.environ.get(env_name, "").strip()
+        if not raw:
+            continue
+        resolved = Path(os.path.expandvars(os.path.expanduser(raw)))
+        if resolved.is_file():
+            return env_name, str(resolved)
+    return None

--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable
 from dataclasses import dataclass, replace
-from pathlib import Path
 from typing import Any
 
+from amx.cli_support._db_diagnostics import (  # noqa: PLC0414
+    _BACKEND_DRIVER_PROBES as _BACKEND_DRIVER_PROBES,
+)
+from amx.cli_support._db_diagnostics import (
+    _env_trusted_ca_candidate as _env_trusted_ca_candidate,
+)
+from amx.cli_support._db_diagnostics import (
+    _is_databricks_tls_failure as _is_databricks_tls_failure,
+)
+from amx.cli_support._db_diagnostics import (
+    _offer_to_install_backend_driver as _offer_to_install_backend_driver,
+)
+from amx.cli_support._db_diagnostics import (
+    _print_system_prereq_hint as _print_system_prereq_hint,
+)
 from amx.config import (
     PROFILING_MODES,
     SUPPORTED_BACKENDS,
@@ -38,93 +51,6 @@ class DBConnectAttempt:
     label: str
     ok: bool
     detail: str = ""
-
-
-# (label, importable module) — extras whose presence we probe up front
-# in the wizard. Keep in sync with ``[project.optional-dependencies]``
-# entries in ``pyproject.toml``.
-_BACKEND_DRIVER_PROBES: dict[str, tuple[str, str]] = {
-    "postgresql": ("postgresql", "psycopg2"),
-    "snowflake": ("snowflake", "snowflake.connector"),
-    "databricks": ("databricks", "databricks.sql"),
-    "bigquery": ("bigquery", "google.cloud.bigquery"),
-    "mysql": ("mysql", "pymysql"),
-    "oracle": ("oracle", "oracledb"),
-    "mssql": ("mssql", "pyodbc"),
-    "redshift": ("redshift", "redshift_connector"),
-    "clickhouse": ("clickhouse", "clickhouse_connect"),
-    "duckdb": ("duckdb", "duckdb"),
-}
-
-
-def _print_system_prereq_hint(backend: str) -> None:
-    """Surface platform-specific system-package install instructions.
-
-    Pure-Python drivers (psycopg2-binary, snowflake-sqlalchemy, …)
-    pip-install fine on every supported platform. ODBC-based drivers
-    (MSSQL via pyodbc) require a separate system package — without it
-    the connection fails with ``Can't open lib 'ODBC Driver 18 for SQL
-    Server'`` even after ``pip install amx-cli[mssql]`` succeeds.
-    Print the right command for the user's OS so they don't have to
-    google the error.
-    """
-    import platform
-
-    if backend != "mssql":
-        return
-
-    system = platform.system()
-    if system == "Darwin":
-        info(
-            "Note: macOS also needs the Microsoft ODBC system driver. "
-            "If the connection fails with 'Can't open lib', run:\n"
-            "    brew tap microsoft/mssql-release "
-            "https://github.com/Microsoft/homebrew-mssql-release\n"
-            "    brew install msodbcsql18 mssql-tools18"
-        )
-    elif system == "Linux":
-        info(
-            "Note: Linux also needs the Microsoft ODBC system driver. "
-            "See https://learn.microsoft.com/sql/connect/odbc/linux-mac/"
-            "installing-the-microsoft-odbc-driver-for-sql-server for "
-            "your distro's package (``msodbcsql18`` on Debian / RHEL)."
-        )
-    elif system == "Windows":
-        info(
-            "Note: Windows installers for the Microsoft ODBC driver "
-            "are bundled with SSMS or downloadable from "
-            "https://learn.microsoft.com/sql/connect/odbc/."
-        )
-
-
-def _offer_to_install_backend_driver(backend: str) -> None:
-    """Auto-install *backend*'s driver during the ``/add-db-profile`` wizard.
-
-    Pre-0.12.9 this asked a Y/n prompt and ran ``pip install
-    'amx-cli[<extra>]'``. The Y/n was friction (the user had just
-    picked the backend; "do you want it to work?" is not a useful
-    question), and the wizard's pre-install was duplicated by
-    ``DatabaseConnector.__init__`` which would have triggered the
-    same install on first use anyway. Calling
-    ``ensure_backend_driver`` here pre-warms the same path so the
-    wizard's "test connection" step at the end of the flow finds the
-    driver already loaded.
-    """
-    probe = _BACKEND_DRIVER_PROBES.get(backend)
-    if not probe:
-        return
-    from amx.db.drivers import ensure_backend_driver
-
-    _print_system_prereq_hint(backend)
-
-    try:
-        ensure_backend_driver(backend)
-    except RuntimeError as exc:
-        # Surface the failure but don't abort the wizard — the user
-        # can still finish entering connection details and AMX will
-        # re-attempt the install (or report the same hint) on first
-        # connect.
-        error(str(exc))
 
 
 def _ask_update_text(
@@ -204,36 +130,6 @@ def _save_active_db_profile(cfg: AMXConfig, db: DBConfig) -> None:
     if cfg.active_db_profile and cfg.active_db_profile in cfg.db_profiles:
         cfg.db_profiles[cfg.active_db_profile] = db
     cfg.save()
-
-
-def _is_databricks_tls_failure(message: str) -> bool:
-    msg = (message or "").lower()
-    return any(
-        token in msg
-        for token in (
-            "tls",
-            "certificate",
-            "ssl",
-            "trusted ca bundle",
-            "self-signed",
-        )
-    )
-
-
-def _env_trusted_ca_candidate() -> tuple[str, str] | None:
-    for env_name in (
-        "AMX_DATABRICKS_TRUSTED_CA_FILE",
-        "DATABRICKS_TRUSTED_CA_FILE",
-        "REQUESTS_CA_BUNDLE",
-        "SSL_CERT_FILE",
-    ):
-        raw = os.environ.get(env_name, "").strip()
-        if not raw:
-            continue
-        resolved = Path(os.path.expandvars(os.path.expanduser(raw)))
-        if resolved.is_file():
-            return env_name, str(resolved)
-    return None
 
 
 def databricks_connect_with_recovery(

--- a/tests/test_mssql_system_prereq_hint.py
+++ b/tests/test_mssql_system_prereq_hint.py
@@ -22,7 +22,7 @@ class MssqlSystemPrereqHintTests(unittest.TestCase):
         with (
             patch("platform.system", return_value="Darwin"),
             patch(
-                "amx.cli_support.commands.db.info",
+                "amx.cli_support._db_diagnostics.info",
                 side_effect=lambda msg, *a, **kw: infos.append(str(msg)),
             ),
         ):
@@ -34,7 +34,7 @@ class MssqlSystemPrereqHintTests(unittest.TestCase):
         with (
             patch("platform.system", return_value="Linux"),
             patch(
-                "amx.cli_support.commands.db.info",
+                "amx.cli_support._db_diagnostics.info",
                 side_effect=lambda msg, *a, **kw: infos.append(str(msg)),
             ),
         ):
@@ -44,7 +44,7 @@ class MssqlSystemPrereqHintTests(unittest.TestCase):
     def test_other_backends_print_nothing(self) -> None:
         infos: list[str] = []
         with patch(
-            "amx.cli_support.commands.db.info",
+            "amx.cli_support._db_diagnostics.info",
             side_effect=lambda msg, *a, **kw: infos.append(str(msg)),
         ):
             _print_system_prereq_hint("postgresql")


### PR DESCRIPTION
## Summary
- A2 of the db.py wizard split: moves the four environment-diagnostic helpers + their probe table out of `amx/cli_support/commands/db.py` into a focused `amx/cli_support/_db_diagnostics.py`.
- Extracted: `_BACKEND_DRIVER_PROBES` (per-backend probe table), `_print_system_prereq_hint` (OS-level package hints), `_offer_to_install_backend_driver` (Python driver install offer), `_is_databricks_tls_failure` (TLS-error pattern match), `_env_trusted_ca_candidate` (CA-bundle env-var pickup).
- `db.py` re-exports every name so existing imports and `tests/test_mssql_system_prereq_hint.py` keep working. That test's `amx.cli_support.commands.db.info` patch was rewritten to target `amx.cli_support._db_diagnostics.info` since the `info()` call now lives in the diagnostics module.
- `db.py`: 1911 -> 1807 LOC (-104, -5%).

## Test plan
- [x] `make test` — 2415 passed, 9 skipped (env-related), zero new failures
- [x] `make lint` — clean
- [x] Public API: `from amx.cli_support.commands.db import _print_system_prereq_hint, _offer_to_install_backend_driver, _is_databricks_tls_failure, _env_trusted_ca_candidate, _BACKEND_DRIVER_PROBES` still works
- [x] All three `MssqlSystemPrereqHintTests` tests pass after patch path update
- [x] No Studio surface touched — `deploy.sh` not required