### PR TITLE
refactor(storage): extract sqlite_store event log + session state

### DIFF
--- a/amx/storage/_history_event_log.py
+++ b/amx/storage/_history_event_log.py
@@ -1,0 +1,40 @@
+"""``app_events`` audit logging extracted from :mod:`amx.storage.sqlite_store`.
+
+A single one-shot ``INSERT INTO app_events`` row per CLI command keeps
+the lightweight telemetry trail the ``/history events`` view reads. The
+function takes the store as ``hs`` and uses its ``_lock`` +
+``_connect()`` plumbing — no DDL touched.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def log_event(
+    hs: SQLiteHistoryStore,
+    *,
+    event_type: str,
+    status: str,
+    command: str,
+    details: dict[str, Any] | None = None,
+) -> None:
+    with hs._lock, hs._connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO app_events (created_at, event_type, status, command, details_json)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                time.time(),
+                event_type,
+                status,
+                command,
+                json.dumps(details or {}, ensure_ascii=True),
+            ),
+        )

--- a/amx/storage/_history_session_state.py
+++ b/amx/storage/_history_session_state.py
@@ -1,0 +1,48 @@
+"""Session/agent state KV storage extracted from :mod:`amx.storage.sqlite_store`.
+
+The two helpers read/write the ``session_state`` table that AMX uses
+as a tiny namespaced key-value bucket for transient agent state
+(active scope, recent picks, etc.). Values are JSON-serialised.
+
+The functions take the store as ``hs`` and use its ``_lock`` +
+``_connect()`` plumbing — no DDL touched.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def set_session_state(hs: SQLiteHistoryStore, namespace: str, key: str, value: Any) -> None:
+    """Write-through session/agent state storage."""
+    payload = json.dumps(value, ensure_ascii=True)
+    with hs._lock, hs._connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO session_state (namespace, key_name, value_json, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(namespace, key_name) DO UPDATE SET
+                value_json = excluded.value_json,
+                updated_at = excluded.updated_at
+            """,
+            (namespace, key, payload, time.time()),
+        )
+
+
+def get_session_state(hs: SQLiteHistoryStore, namespace: str, key: str, default: Any = None) -> Any:
+    with hs._connect() as conn:
+        row = conn.execute(
+            "SELECT value_json FROM session_state WHERE namespace = ? AND key_name = ?",
+            (namespace, key),
+        ).fetchone()
+    if not row:
+        return default
+    try:
+        return json.loads(str(row["value_json"] or ""))
+    except Exception:
+        return default

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -1381,32 +1381,32 @@ class SQLiteHistoryStore:
         return ids
 
     def set_session_state(self, namespace: str, key: str, value: Any) -> None:
-        """Write-through session/agent state storage."""
-        payload = json.dumps(value, ensure_ascii=True)
-        with self._lock, self._connect() as conn:
-            conn.execute(
-                """
-                INSERT INTO session_state (namespace, key_name, value_json, updated_at)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT(namespace, key_name) DO UPDATE SET
-                    value_json = excluded.value_json,
-                    updated_at = excluded.updated_at
-                """,
-                (namespace, key, payload, time.time()),
-            )
+        from amx.storage._history_session_state import set_session_state
+
+        set_session_state(self, namespace, key, value)
 
     def get_session_state(self, namespace: str, key: str, default: Any = None) -> Any:
-        with self._connect() as conn:
-            row = conn.execute(
-                "SELECT value_json FROM session_state WHERE namespace = ? AND key_name = ?",
-                (namespace, key),
-            ).fetchone()
-        if not row:
-            return default
-        try:
-            return json.loads(str(row["value_json"] or ""))
-        except Exception:
-            return default
+        from amx.storage._history_session_state import get_session_state
+
+        return get_session_state(self, namespace, key, default)
+
+    def log_event(
+        self,
+        *,
+        event_type: str,
+        status: str,
+        command: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        from amx.storage._history_event_log import log_event
+
+        log_event(
+            self,
+            event_type=event_type,
+            status=status,
+            command=command,
+            details=details,
+        )
 
     def record_evaluation(
         self,
@@ -2665,29 +2665,6 @@ class SQLiteHistoryStore:
         conn.execute("PRAGMA synchronous=NORMAL")
         conn.execute("PRAGMA busy_timeout=30000")
         return conn
-
-    def log_event(
-        self,
-        *,
-        event_type: str,
-        status: str,
-        command: str,
-        details: dict[str, Any] | None = None,
-    ) -> None:
-        with self._lock, self._connect() as conn:
-            conn.execute(
-                """
-                INSERT INTO app_events (created_at, event_type, status, command, details_json)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                (
-                    time.time(),
-                    event_type,
-                    status,
-                    command,
-                    json.dumps(details or {}, ensure_ascii=True),
-                ),
-            )
 
     def list_recent_runs(
         self,


### PR DESCRIPTION
## Summary
- **A1 of the sqlite_store decomposition** (Round 2 plan): moves the two fully-isolated helper methods out of the 3535-LOC `SQLiteHistoryStore` into focused sibling modules — warm-up for the larger A2-A5 phases.
- Extracted: `log_event` (the app_events audit insert) → `amx/storage/_history_event_log.py`; `set_session_state` + `get_session_state` → `amx/storage/_history_session_state.py`.
- Both extracts take the store as `hs` and reuse its `_lock` + `_connect()` plumbing. **No DDL touched** — all `CREATE TABLE` / `ALTER TABLE` / `CREATE INDEX` statements in `init()` stay byte-identical. The user's local `~/.amx/history.db` is unaffected.
- `SQLiteHistoryStore` keeps thin delegating wrappers on each name so the ~30+ external call sites (CLI telemetry via `history_store()`, orchestrator `app_events`) stay untouched.
- `sqlite_store.py`: 3535 -> 3512 LOC (-23).

## Test plan
- [x] `make test` — 2415 passed, 9 skipped (env-related), zero new failures
- [x] `make lint` — clean
- [x] Public API: `SQLiteHistoryStore.log_event`, `.set_session_state`, `.get_session_state` still callable
- [x] No DDL changes — `grep -nE "CREATE TABLE|ALTER TABLE|CREATE INDEX" amx/storage/sqlite_store.py` returns the same lines as on `main`
- [x] No Studio surface touched — `deploy.sh` not required