### PR TITLE
refactor(cli): extract analyze_flow bulk review actions

### DIFF
--- a/amx/cli_support/_analyze_bulk_actions.py
+++ b/amx/cli_support/_analyze_bulk_actions.py
@@ -1,0 +1,128 @@
+"""Bulk review-action helpers for ``amx analyze review``.
+
+Extracted from :mod:`amx.cli_support.commands.analyze_flow` so the
+three filter-driven bulk action functions (accept / skip / apply on a
+filtered subset of pending review rows) live in their own focused
+module. Each function operates on the pending-review queue + history
+store; none requires per-row UI interaction.
+
+``analyze_flow.py`` re-exports the three names so any caller importing
+the underscore form keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+from typing import Any
+
+from amx.agents.orchestrator import apply_review_results_to_db
+from amx.config import AMXConfig
+from amx.db.connector import DatabaseConnector
+from amx.pending_review import load_pending, save_pending
+from amx.utils.console import error, info
+
+LogEvent = Callable[..., None]
+
+
+def _bulk_accept_rows(
+    rows: list[Any],
+    *,
+    log_event: LogEvent,
+    run_id: int,
+) -> None:
+    """Queue every row for apply by re-saving the pending review file.
+
+    Mirrors what the standard /review flow does on an Accept: stamp
+    ``applied=True`` so :func:`save_pending` picks it up, then write the file.
+    Idempotent — calling twice with the same rows produces the same queue.
+    """
+
+    by_rid: dict[int, Any] = {}
+    for entry in load_pending():
+        rid = getattr(entry, "result_id", None)
+        if rid is not None:
+            by_rid[int(rid)] = entry
+    queued = 0
+    for r in rows:
+        # Skip rows without a description (nothing to accept) and rows
+        # that are already applied to the live DB.
+        if not (r.final_description or "").strip() or getattr(r, "applied", False):
+            continue
+        accepted = dataclasses.replace(r, applied=True)
+        rid = getattr(r, "result_id", None)
+        if rid is not None:
+            by_rid[int(rid)] = accepted
+        else:
+            by_rid[id(r)] = accepted  # synthetic key for ID-less rows
+        queued += 1
+    save_pending(list(by_rid.values()))
+    info(f"Queued {queued} row(s) for apply — see /apply to write them to the DB.")
+    log_event(
+        "analyze_review_bulk_accept",
+        run_id=run_id,
+        accepted_count=queued,
+    )
+
+
+def _bulk_skip_rows(
+    rows: list[Any],
+    *,
+    log_event: LogEvent,
+    run_id: int,
+) -> None:
+    """Drop every row from the pending queue (the CLI's analogue of Skip)."""
+
+    drop_ids: set[int] = set()
+    for r in rows:
+        rid = getattr(r, "result_id", None)
+        if rid is not None:
+            drop_ids.add(int(rid))
+    if not drop_ids:
+        info("No rows had a stored result_id — nothing to skip.")
+        log_event("analyze_review_bulk_skip", run_id=run_id, skipped_count=0)
+        return
+    survivors = [
+        entry
+        for entry in load_pending()
+        if getattr(entry, "result_id", None) is None or int(entry.result_id) not in drop_ids
+    ]
+    save_pending(survivors)
+    info(f"Skipped {len(drop_ids)} row(s) from the pending queue.")
+    log_event(
+        "analyze_review_bulk_skip",
+        run_id=run_id,
+        skipped_count=len(drop_ids),
+    )
+
+
+def _bulk_apply_rows(
+    cfg: AMXConfig,
+    rows: list[Any],
+    *,
+    log_event: LogEvent,
+    run_id: int,
+) -> None:
+    """Accept rows into pending, then immediately apply to the live database."""
+
+    if not cfg.db.backend:
+        error("No database configured. Cannot apply.")
+        return
+    db = DatabaseConnector(cfg.db)
+    if not db.test_connection():
+        error("Cannot connect to database.")
+        return
+
+    accepted = [
+        dataclasses.replace(r, applied=True) for r in rows if (r.final_description or "").strip()
+    ]
+    if not accepted:
+        info("No rows with a non-empty description — nothing to apply.")
+        return
+    applied = apply_review_results_to_db(db, accepted)
+    info(f"Applied {applied} metadata comment(s) to the database.")
+    log_event(
+        "analyze_review_bulk_apply",
+        run_id=run_id,
+        applied_count=applied,
+    )

--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -10,6 +10,15 @@ from typing import Any
 
 import click
 
+from amx.cli_support._analyze_bulk_actions import (  # noqa: PLC0414
+    _bulk_accept_rows as _bulk_accept_rows,
+)
+from amx.cli_support._analyze_bulk_actions import (
+    _bulk_apply_rows as _bulk_apply_rows,
+)
+from amx.cli_support._analyze_bulk_actions import (
+    _bulk_skip_rows as _bulk_skip_rows,
+)
 from amx.cli_support._analyze_flow_prompts import (  # noqa: PLC0414
     _ask_optional_choice as _ask_optional_choice,
 )
@@ -1615,113 +1624,6 @@ def register_analyze_run_command(
             # PR δ: same rollback contract for the code-profile override.
             if code_override_saved is not None:
                 object.__setattr__(cfg, "run_code_profiles", code_override_saved)
-
-
-def _bulk_accept_rows(
-    rows: list[Any],
-    *,
-    log_event: LogEvent,
-    run_id: int,
-) -> None:
-    """Queue every row for apply by re-saving the pending review file.
-
-    Mirrors what the standard /review flow does on an Accept: stamp
-    ``applied=True`` so :func:`save_pending` picks it up, then write the file.
-    Idempotent — calling twice with the same rows produces the same queue.
-    """
-    from amx.pending_review import load_pending, save_pending
-
-    by_rid: dict[int, Any] = {}
-    for entry in load_pending():
-        rid = getattr(entry, "result_id", None)
-        if rid is not None:
-            by_rid[int(rid)] = entry
-    queued = 0
-    for r in rows:
-        # Skip rows without a description (nothing to accept) and rows
-        # that are already applied to the live DB.
-        if not (r.final_description or "").strip() or getattr(r, "applied", False):
-            continue
-        accepted = dataclasses.replace(r, applied=True)
-        rid = getattr(r, "result_id", None)
-        if rid is not None:
-            by_rid[int(rid)] = accepted
-        else:
-            by_rid[id(r)] = accepted  # synthetic key for ID-less rows
-        queued += 1
-    save_pending(list(by_rid.values()))
-    info(f"Queued {queued} row(s) for apply — see /apply to write them to the DB.")
-    log_event(
-        "analyze_review_bulk_accept",
-        run_id=run_id,
-        accepted_count=queued,
-    )
-
-
-def _bulk_skip_rows(
-    rows: list[Any],
-    *,
-    log_event: LogEvent,
-    run_id: int,
-) -> None:
-    """Drop every row from the pending queue (the CLI's analogue of Skip)."""
-    from amx.pending_review import load_pending, save_pending
-
-    drop_ids: set[int] = set()
-    for r in rows:
-        rid = getattr(r, "result_id", None)
-        if rid is not None:
-            drop_ids.add(int(rid))
-    if not drop_ids:
-        info("No rows had a stored result_id — nothing to skip.")
-        log_event("analyze_review_bulk_skip", run_id=run_id, skipped_count=0)
-        return
-    survivors = [
-        entry
-        for entry in load_pending()
-        if getattr(entry, "result_id", None) is None or int(entry.result_id) not in drop_ids
-    ]
-    save_pending(survivors)
-    info(f"Skipped {len(drop_ids)} row(s) from the pending queue.")
-    log_event(
-        "analyze_review_bulk_skip",
-        run_id=run_id,
-        skipped_count=len(drop_ids),
-    )
-
-
-def _bulk_apply_rows(
-    cfg: AMXConfig,
-    rows: list[Any],
-    *,
-    log_event: LogEvent,
-    run_id: int,
-) -> None:
-    """Accept rows into pending, then immediately apply to the live database."""
-    from amx.agents.orchestrator import apply_review_results_to_db
-    from amx.db.connector import DatabaseConnector
-
-    if not cfg.db.backend:
-        error("No database configured. Cannot apply.")
-        return
-    db = DatabaseConnector(cfg.db)
-    if not db.test_connection():
-        error("Cannot connect to database.")
-        return
-
-    accepted = [
-        dataclasses.replace(r, applied=True) for r in rows if (r.final_description or "").strip()
-    ]
-    if not accepted:
-        info("No rows with a non-empty description — nothing to apply.")
-        return
-    applied = apply_review_results_to_db(db, accepted)
-    info(f"Applied {applied} metadata comment(s) to the database.")
-    log_event(
-        "analyze_review_bulk_apply",
-        run_id=run_id,
-        applied_count=applied,
-    )
 
 
 def register_analyze_review_command(


### PR DESCRIPTION
## Summary
- B6 of the Round 2 plan: moves the three bulk review-action functions (`_bulk_accept_rows`, `_bulk_skip_rows`, `_bulk_apply_rows`) out of `amx/cli_support/commands/analyze_flow.py` into a focused `amx/cli_support/_analyze_bulk_actions.py`.
- Each function operates on the pending-review queue + history store; no per-row UI interaction. `analyze_flow.py` re-exports the three names so any caller importing the underscore form keeps working.
- `analyze_flow.py`: 2094 -> 1996 LOC (-98).

## Test plan
- [x] `make test` — 2415 passed, 9 skipped (env-related), zero new failures
- [x] `make lint` — clean
- [x] Public API: `from amx.cli_support.commands.analyze_flow import _bulk_accept_rows, _bulk_apply_rows, _bulk_skip_rows` still works
- [x] No Studio surface touched — `deploy.sh` not required