### PR TITLE
refactor(cli): extract manual.py DB error classifier

### DIFF
--- a/amx/cli_support/_manual_errors.py
+++ b/amx/cli_support/_manual_errors.py
@@ -1,0 +1,36 @@
+"""DB error summarization for ``amx metadata`` CLI commands.
+
+Extracted from :mod:`amx.cli_support.commands.manual`. The two
+helpers convert raw DB driver exceptions into a short user-friendly
+sentence plus an actionable error line — the manual edit wizards
+catch every DB write failure and pipe them through here so the user
+sees ``Permission denied (HTTP 403)`` instead of an SQL stack trace.
+
+``manual.py`` re-exports both names so any caller importing the
+underscore form keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+from amx.utils.console import error, warn
+
+
+def _summarize_db_exception(exc: Exception) -> str:
+    detail = str(exc).strip()
+    lower = detail.lower()
+    if "connection refused" in lower:
+        return "Database connection refused."
+    if "timeout" in lower or "timed out" in lower:
+        return "Database connection timed out."
+    if "authentication" in lower or "password" in lower or "permission denied" in lower:
+        return "Database authentication failed."
+    first_line = next((line.strip() for line in detail.splitlines() if line.strip()), "")
+    return first_line[:220]
+
+
+def _report_manual_db_error(action: str, exc: Exception) -> None:
+    error(f"Could not {action} because AMX cannot reach the active database.")
+    warn("Check the active DB profile and run /db then /connect.")
+    summary = _summarize_db_exception(exc)
+    if summary:
+        warn(f"Cause: {summary}")

--- a/amx/cli_support/commands/manual.py
+++ b/amx/cli_support/commands/manual.py
@@ -8,6 +8,12 @@ from typing import Any
 
 import click
 
+from amx.cli_support._manual_errors import (  # noqa: PLC0414
+    _report_manual_db_error as _report_manual_db_error,
+)
+from amx.cli_support._manual_errors import (
+    _summarize_db_exception as _summarize_db_exception,
+)
 from amx.config import AMXConfig, DBConfig
 from amx.db.connector import AssetKind
 from amx.services.manual_metadata import (
@@ -24,27 +30,6 @@ from amx.services.manual_metadata import (
 from amx.utils.console import ask, confirm, console, error, info, render_table, success, warn
 
 LogEvent = Callable[..., None]
-
-
-def _summarize_db_exception(exc: Exception) -> str:
-    detail = str(exc).strip()
-    lower = detail.lower()
-    if "connection refused" in lower:
-        return "Database connection refused."
-    if "timeout" in lower or "timed out" in lower:
-        return "Database connection timed out."
-    if "authentication" in lower or "password" in lower or "permission denied" in lower:
-        return "Database authentication failed."
-    first_line = next((line.strip() for line in detail.splitlines() if line.strip()), "")
-    return first_line[:220]
-
-
-def _report_manual_db_error(action: str, exc: Exception) -> None:
-    error(f"Could not {action} because AMX cannot reach the active database.")
-    warn("Check the active DB profile and run /db then /connect.")
-    summary = _summarize_db_exception(exc)
-    if summary:
-        warn(f"Cause: {summary}")
 
 
 def _is_cancel(value: str | None) -> bool:


### PR DESCRIPTION
## Summary
- B7 of the Round 2 plan: moves the two DB error helpers (`_summarize_db_exception` and `_report_manual_db_error`) out of `amx/cli_support/commands/manual.py` into a focused `amx/cli_support/_manual_errors.py`.
- The helpers turn raw DB driver exceptions into a short user-friendly sentence + an actionable error line; the manual edit wizards pipe every DB write failure through here.
- `manual.py` re-exports both names so any caller importing the underscore form keeps working unchanged.
- `manual.py`: 1239 -> 1224 LOC (-15).

## Test plan
- [x] `make test` — 2415 passed, 9 skipped (env-related), zero new failures
- [x] `make lint` — clean
- [x] Public API: `from amx.cli_support.commands.manual import _summarize_db_exception, _report_manual_db_error` still works
- [x] No Studio surface touched — `deploy.sh` not required