### PR TITLE
refactor(storage): extract apply audit + scheduled runs from sqlite_store

### DIFF
--- a/amx/storage/_history_apply_audit.py
+++ b/amx/storage/_history_apply_audit.py
@@ -1,0 +1,303 @@
+"""Apply-event audit trail extracted from :mod:`amx.storage.sqlite_store`.
+
+Six methods that drive the run_results write + apply_events audit log:
+- save_run_results (batch INSERT into run_results)
+- record_evaluation (UPDATE run_results after the user reviews)
+- record_applied / record_db_apply_failure (DB writeback signals)
+- record_apply_event / list_apply_events (apply_events audit table)
+
+Each function takes the store as ``hs`` and reuses its ``_lock`` +
+``_connect()`` plumbing. No DDL touched.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+from amx.storage.sqlite_store import build_alternatives_json
+
+if TYPE_CHECKING:
+    from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def save_run_results(
+    hs: SQLiteHistoryStore,
+    run_id: int,
+    suggestions: list[dict[str, Any]],
+) -> list[int]:
+    """Persist all LLM alternatives produced for a run before human review.
+
+    Each *suggestion* dict should contain:
+      schema, table, column (or None), asset_kind, source, confidence,
+      reasoning, alternatives (list[str])
+
+    Optional re-run fields:
+      parent_result_id (int | None) — original run_results.id this row
+        re-runs; ``rerun_seq`` (int, default 0) — versioned position in
+        the chain (0 = original, 1+ = ordered re-runs);
+      ``user_instructions`` (str | None) — free-text addendum the user
+        typed in the re-run modal.
+
+    Returns the inserted row IDs.
+    """
+    now = time.time()
+    ids: list[int] = []
+    with hs._lock, hs._connect() as conn:
+        for s in suggestions:
+            cur = conn.execute(
+                """
+                INSERT INTO run_results (
+                    run_id, saved_at, schema_name, table_name, column_name,
+                    asset_kind, source, confidence, logprob_score, raw_logprob,
+                    token_count, model_version, reasoning, alternatives_json,
+                    parent_result_id, rerun_seq, user_instructions, citations_json,
+                    alternatives_mode, seed_alternative_id, seed_alternative_text,
+                    parent_run_id, model, provider, production_warning
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    now,
+                    s.get("schema", ""),
+                    s.get("table", ""),
+                    s.get("column"),
+                    s.get("asset_kind", "table"),
+                    s.get("source", "unknown"),
+                    s.get("confidence", "medium"),
+                    s.get("logprob_score"),
+                    s.get("raw_logprob", s.get("logprob_score")),
+                    s.get("token_count"),
+                    s.get("model_version", ""),
+                    s.get("reasoning", ""),
+                    build_alternatives_json(s),
+                    s.get("parent_result_id"),
+                    int(s.get("rerun_seq", 0) or 0),
+                    s.get("user_instructions"),
+                    # ``citations`` is a list of plain dicts at
+                    # this layer; the orchestrator serializer
+                    # converted dataclasses upstream so SQLite
+                    # only sees JSON-safe values. ``None`` on
+                    # non-RAG suggestions keeps the column space
+                    # cheap for legacy rows.
+                    (
+                        json.dumps(s.get("citations") or [], ensure_ascii=True)
+                        if s.get("citations")
+                        else None
+                    ),
+                    # ``alternatives_mode`` captures the diversity mode
+                    # active when this row's alternatives were generated,
+                    # per Definition 1: ``semantic`` ⇒ paraphrases of
+                    # DESCRIPTION_1; ``lexical`` ⇒ shared vocabulary with
+                    # DESCRIPTION_1, meaning may drift. ``None`` on
+                    # legacy / non-LLM rows is treated as "not recorded"
+                    # by the review UI.
+                    s.get("alternatives_mode"),
+                    # Variations audit (NULL on non-variations rows).
+                    s.get("seed_alternative_id"),
+                    s.get("seed_alternative_text"),
+                    s.get("parent_run_id"),
+                    # Per-row LLM identity — captures the effective model /
+                    # provider in use when the alternatives were generated.
+                    # Needed when a per-run profile override was applied,
+                    # since analysis_runs.llm_model / llm_provider would
+                    # still report the base profile's values.
+                    s.get("model"),
+                    s.get("provider"),
+                    # Under-production audit (NULL on success path).
+                    s.get("production_warning"),
+                ),
+            )
+            ids.append(int(cur.lastrowid))
+    return ids
+
+
+def record_evaluation(
+    hs: SQLiteHistoryStore,
+    result_id: int,
+    *,
+    chosen_description: str,
+    evaluation: str,  # 'accepted' | 'skipped' | 'custom'
+) -> None:
+    """Record the user's evaluation decision for one run_result row."""
+    now = time.time()
+    with hs._lock, hs._connect() as conn:
+        conn.execute(
+            """
+            UPDATE run_results
+            SET evaluated_at = ?,
+                chosen_description = ?,
+                evaluation = ?
+            WHERE id = ?
+            """,
+            (now, chosen_description, evaluation, result_id),
+        )
+
+
+def record_applied(
+    hs: SQLiteHistoryStore,
+    result_id: int,
+    *,
+    chosen_description: str | None = None,
+) -> None:
+    """Record when a reviewed description was successfully applied to DB.
+
+    When ``chosen_description`` is provided it backfills
+    ``run_results.chosen_description`` *only* if the column is still empty.
+    The interactive review path (``record_evaluation``) wins when both ran,
+    but non-interactive apply paths (Studio "Apply pending", CLI
+    ``/history apply``) finally persist the text actually written to the
+    live DB, so ``describe_run`` / chat answers can quote it later.
+    """
+    now = time.time()
+    with hs._lock, hs._connect() as conn:
+        if chosen_description:
+            conn.execute(
+                """
+                UPDATE run_results
+                SET applied_at = ?,
+                    db_applied_status = 'applied',
+                    rejection_reason = '',
+                    chosen_description = COALESCE(NULLIF(chosen_description, ''), ?)
+                WHERE id = ?
+                """,
+                (now, chosen_description, result_id),
+            )
+        else:
+            conn.execute(
+                """
+                UPDATE run_results
+                SET applied_at = ?,
+                    db_applied_status = 'applied',
+                    rejection_reason = ''
+                WHERE id = ?
+                """,
+                (now, result_id),
+            )
+
+
+def record_db_apply_failure(hs: SQLiteHistoryStore, result_id: int, error_text: str = "") -> None:
+    """Record when a reviewed description failed during DB write-back."""
+    with hs._lock, hs._connect() as conn:
+        conn.execute(
+            """
+            UPDATE run_results
+            SET db_applied_status = 'failed',
+                rejection_reason = CASE
+                    WHEN ? != '' THEN ?
+                    ELSE rejection_reason
+                END
+            WHERE id = ?
+            """,
+            (error_text, error_text, result_id),
+        )
+
+
+def record_apply_event(
+    hs: SQLiteHistoryStore,
+    *,
+    schema_name: str,
+    new_comment: str,
+    run_id: int | None = None,
+    result_id: int | None = None,
+    profile_name: str = "",
+    table_name: str = "",
+    column_name: str | None = None,
+    asset_kind: str = "table",
+    old_comment: str | None = None,
+    applied_by: str = "",
+    hostname: str = "",
+    sql_template: str = "",
+) -> int:
+    """Append one ``apply_events`` row for a successful COMMENT write.
+
+    ``new_comment`` is the comment text actually written to the
+    database. ``old_comment`` (when supplied) lets a future
+    rollback step restore the prior state byte-for-byte. Every
+    other field is optional so callers that don't yet propagate
+    full attribution can still record a basic audit trail.
+
+    Returns the inserted row id so callers (e.g. Studio SSE) can
+    link a UI event back to the audit row.
+    """
+    now = time.time()
+    with hs._lock, hs._connect() as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO apply_events (
+                applied_at, run_id, result_id, profile_name,
+                schema_name, table_name, column_name, asset_kind,
+                old_comment, new_comment, applied_by, hostname,
+                sql_template
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                now,
+                run_id,
+                result_id,
+                profile_name,
+                schema_name,
+                table_name,
+                column_name,
+                asset_kind,
+                old_comment,
+                new_comment,
+                applied_by,
+                hostname,
+                sql_template,
+            ),
+        )
+        return int(cursor.lastrowid or 0)
+
+
+def list_apply_events(
+    hs: SQLiteHistoryStore,
+    *,
+    run_id: int | None = None,
+    profile_name: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return apply events newest-first, optionally filtered by run / profile.
+
+    Used by ``/history rollback`` (PR-12b) to find the events to
+    replay in reverse, and by Studio's Recent Applies panel
+    (PR-12c) to render the timeline.
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+    if run_id is not None:
+        clauses.append("run_id = ?")
+        params.append(run_id)
+    if profile_name is not None:
+        clauses.append("profile_name = ?")
+        params.append(profile_name)
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    sql = (
+        "SELECT id, applied_at, run_id, result_id, profile_name, "
+        "schema_name, table_name, column_name, asset_kind, "
+        "old_comment, new_comment, applied_by, hostname, sql_template "
+        "FROM apply_events" + where + " ORDER BY applied_at DESC LIMIT ?"
+    )
+    params.append(int(limit))
+    with hs._lock, hs._connect() as conn:
+        rows = conn.execute(sql, tuple(params)).fetchall()
+    return [
+        {
+            "id": int(r[0]),
+            "applied_at": float(r[1]),
+            "run_id": r[2],
+            "result_id": r[3],
+            "profile_name": str(r[4]),
+            "schema_name": str(r[5]),
+            "table_name": str(r[6]),
+            "column_name": r[7],
+            "asset_kind": str(r[8]),
+            "old_comment": r[9],
+            "new_comment": str(r[10]),
+            "applied_by": str(r[11]),
+            "hostname": str(r[12]),
+            "sql_template": str(r[13]),
+        }
+        for r in rows
+    ]

--- a/amx/storage/_history_scheduled.py
+++ b/amx/storage/_history_scheduled.py
@@ -1,0 +1,380 @@
+"""Scheduled-runs state machine extracted from :mod:`amx.storage.sqlite_store`.
+
+Eleven methods that drive the scheduled_runs table and the
+tick-engine's claim_due_schedule / arm_next_fire transitions. Each
+function takes the store as ``hs`` and reuses its ``_lock`` +
+``_connect()`` plumbing. No DDL touched.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from typing import TYPE_CHECKING, Any
+
+from amx.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from amx.storage.sqlite_store import SQLiteHistoryStore
+
+log = get_logger("storage.sqlite.scheduled")
+
+
+def create_scheduled_run(
+    hs: SQLiteHistoryStore,
+    *,
+    name: str,
+    fire_at_utc: float,
+    fire_at_tz: str,
+    db_profile: str,
+    scope_json: str,
+    llm_profile: str,
+    review_strategy: str,
+    database: str | None = None,
+    catalog: str | None = None,
+    extra_args_json: str | None = None,
+    kind: str = "analyze",
+    cron_expr: str | None = None,
+) -> int:
+    """Insert a new scheduled_runs row in status='pending'.
+
+    ``database`` and ``catalog`` carry the picker's overlay so the
+    scheduler can rebuild the same connection at fire time (mirrors
+    the ``/api/live/schemas`` picker that ScopeTree drives). Both
+    are nullable: legacy rows + backends that don't expose a
+    database/catalog axis (e.g. SQLite single-file profiles) keep
+    the profile default.
+
+    ``kind`` discriminates between the legacy analyze-run schedule
+    ('analyze') and the Catalog-Freshness cache refresh
+    ('cache_refresh'). ``cron_expr`` is NULL for one-shot fires and
+    a valid croniter expression for recurring schedules — the tick
+    engine re-arms the row from the cron after each fire.
+    """
+    now = time.time()
+    with hs._lock, hs._connect() as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO scheduled_runs (
+                name, fire_at_utc, fire_at_tz, status,
+                db_profile, database, catalog,
+                scope_json, llm_profile, review_strategy,
+                extra_args_json, kind, cron_expr,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                name,
+                fire_at_utc,
+                fire_at_tz,
+                db_profile,
+                database,
+                catalog,
+                scope_json,
+                llm_profile,
+                review_strategy,
+                extra_args_json,
+                str(kind or "analyze"),
+                cron_expr,
+                now,
+                now,
+            ),
+        )
+        return int(cur.lastrowid or 0)
+
+
+def get_scheduled_run(hs: SQLiteHistoryStore, schedule_id: int) -> dict[str, Any] | None:
+    """Return the full row as a dict, or None if missing."""
+    with hs._connect() as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM scheduled_runs WHERE id=?", (schedule_id,)).fetchone()
+    return dict(row) if row else None
+
+
+def list_scheduled_runs(
+    hs: SQLiteHistoryStore,
+    *,
+    statuses: list[str] | None = None,
+    db_profile: str | None = None,
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    """List rows sorted by fire_at_utc ASC with optional filters."""
+    clauses: list[str] = []
+    params: list[Any] = []
+    if statuses:
+        placeholders = ",".join("?" for _ in statuses)
+        clauses.append(f"status IN ({placeholders})")
+        params.extend(statuses)
+    if db_profile is not None:
+        clauses.append("db_profile = ?")
+        params.append(db_profile)
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    params.append(int(limit))
+    sql = "SELECT * FROM scheduled_runs" + where + " ORDER BY fire_at_utc ASC LIMIT ?"
+    with hs._connect() as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(sql, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+def list_due_pending_schedules(
+    hs: SQLiteHistoryStore,
+    *,
+    now_utc: float,
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    """Return rows that are pending and whose fire time has elapsed.
+
+    Read-only: does not transition status. Used by the bootstrap
+    tick path to surface "missed while AMX was closed" entries.
+    """
+    with hs._connect() as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT * FROM scheduled_runs
+            WHERE status = 'pending'
+              AND fire_at_utc <= ?
+            ORDER BY fire_at_utc ASC
+            LIMIT ?
+            """,
+            (now_utc, int(limit)),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def update_scheduled_run(
+    hs: SQLiteHistoryStore,
+    schedule_id: int,
+    *,
+    patch: dict[str, Any],
+) -> None:
+    """Apply a whitelisted patch to a scheduled_runs row.
+
+    Only the fields in ``_SCHEDULE_UPDATABLE_FIELDS`` can be
+    modified through this path -- status changes go through
+    :meth:`set_scheduled_run_status`, and id/created_at/fired_at/
+    triggered_run_id/last_error are owned by the engine.
+    """
+    if not patch:
+        return
+    unknown = (
+        set(patch)
+        - hs._SCHEDULE_UPDATABLE_FIELDS
+        - {
+            "status",
+            "id",
+            "created_at",
+            "updated_at",
+            "fired_at",
+            "triggered_run_id",
+            "last_error",
+        }
+    )
+    if unknown:
+        raise ValueError(f"unknown patch field(s): {sorted(unknown)}")
+    forbidden = set(patch) - hs._SCHEDULE_UPDATABLE_FIELDS
+    if forbidden:
+        raise ValueError(
+            f"forbidden patch field(s) for update_scheduled_run: "
+            f"{sorted(forbidden)} -- use a dedicated method"
+        )
+    cols = sorted(patch)
+    set_clause = ", ".join(f"{c} = ?" for c in cols)
+    params: list[Any] = [patch[c] for c in cols]
+    params.append(time.time())
+    params.append(schedule_id)
+    with hs._lock, hs._connect() as conn:
+        conn.execute(
+            f"UPDATE scheduled_runs SET {set_clause}, updated_at = ? WHERE id = ?",
+            params,
+        )
+
+
+def set_scheduled_run_status(
+    hs: SQLiteHistoryStore,
+    schedule_id: int,
+    status: str,
+    *,
+    last_error: str | None = None,
+    fired_at: float | None = None,
+    triggered_run_id: int | None = None,
+) -> None:
+    """Transition a schedule to *status*, enforcing the state machine."""
+    if status not in hs._SCHEDULE_TRANSITIONS:
+        raise ValueError(f"unknown status: {status!r}")
+    now = time.time()
+    with hs._lock, hs._connect() as conn:
+        row = conn.execute(
+            "SELECT status FROM scheduled_runs WHERE id = ?",
+            (schedule_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"no scheduled_runs row with id={schedule_id}")
+        current = str(row[0])
+        allowed = hs._SCHEDULE_TRANSITIONS.get(current, set())
+        if status not in allowed and status != current:
+            raise ValueError(f"illegal transition: {current!r} -> {status!r}")
+        sets = ["status = ?", "updated_at = ?"]
+        params: list[Any] = [status, now]
+        if last_error is not None:
+            sets.append("last_error = ?")
+            params.append(last_error)
+        if fired_at is not None:
+            sets.append("fired_at = ?")
+            params.append(fired_at)
+        if triggered_run_id is not None:
+            sets.append("triggered_run_id = ?")
+            params.append(triggered_run_id)
+        params.append(schedule_id)
+        conn.execute(
+            f"UPDATE scheduled_runs SET {', '.join(sets)} WHERE id = ?",
+            params,
+        )
+
+
+def delete_scheduled_run(hs: SQLiteHistoryStore, schedule_id: int) -> None:
+    """Hard-delete a scheduled_runs row; write an audit event.
+
+    Idempotent: deleting a non-existent id is a no-op (no error,
+    no audit row).
+    """
+    with hs._lock, hs._connect() as conn:
+        row = conn.execute(
+            "SELECT name FROM scheduled_runs WHERE id = ?",
+            (schedule_id,),
+        ).fetchone()
+        if row is None:
+            return
+        name = str(row[0])
+        conn.execute("DELETE FROM scheduled_runs WHERE id = ?", (schedule_id,))
+        conn.execute(
+            """
+            INSERT INTO app_events (
+                created_at, event_type, status, command, details_json
+            ) VALUES (?, 'schedule.deleted', 'ok', 'schedule.rm', ?)
+            """,
+            (
+                time.time(),
+                json.dumps({"schedule_id": schedule_id, "name": name}),
+            ),
+        )
+
+
+def claim_due_schedule(hs: SQLiteHistoryStore, *, now_utc: float) -> int | None:
+    """Atomically transition the oldest due pending schedule to running.
+
+    Returns the claimed schedule id, or None if none are due. Safe
+    under concurrent calls from multiple threads -- the
+    ``WHERE status='pending'`` predicate on the UPDATE turns a lost
+    race into a return of None for the loser.
+    """
+    now = time.time()
+    with hs._lock, hs._connect() as conn:
+        row = conn.execute(
+            """
+            SELECT id FROM scheduled_runs
+            WHERE status = 'pending' AND fire_at_utc <= ?
+            ORDER BY fire_at_utc ASC
+            LIMIT 1
+            """,
+            (now_utc,),
+        ).fetchone()
+        if row is None:
+            return None
+        sid = int(row[0])
+        cur = conn.execute(
+            """
+            UPDATE scheduled_runs
+            SET status = 'running', fired_at = ?, updated_at = ?
+            WHERE id = ? AND status = 'pending'
+            """,
+            (now, now, sid),
+        )
+        if cur.rowcount == 1:
+            return sid
+        return None
+
+
+def arm_next_fire(hs: SQLiteHistoryStore, schedule_id: int) -> float | None:
+    """Re-arm a recurring schedule to its next ``fire_at_utc``.
+
+    Reads ``cron_expr`` from the row; if NULL or invalid, leaves
+    the row alone (one-shot schedules complete after a single fire
+    — they should be left at ``status='completed'`` by the tick
+    path). Otherwise computes the next fire timestamp via
+    ``croniter.get_next(float)`` and flips ``status`` back to
+    ``'pending'`` so the tick loop picks it up next cycle.
+
+    Returns the new ``fire_at_utc`` on success, or None when the
+    row had no usable cron expression (caller treats that as
+    one-shot done).
+    """
+    try:
+        from croniter import croniter
+    except Exception as exc:
+        log.warning("croniter unavailable; cannot re-arm schedule %s: %s", schedule_id, exc)
+        return None
+    with hs._lock, hs._connect() as conn:
+        row = conn.execute(
+            "SELECT cron_expr FROM scheduled_runs WHERE id = ?",
+            (schedule_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        expr = row[0]
+        if not expr:
+            return None
+        try:
+            next_at = float(croniter(str(expr), time.time()).get_next(float))
+        except Exception as exc:
+            log.warning(
+                "Invalid cron_expr %r on schedule %s, leaving completed: %s",
+                expr,
+                schedule_id,
+                exc,
+            )
+            return None
+        conn.execute(
+            """
+            UPDATE scheduled_runs
+            SET status = 'pending', fire_at_utc = ?, updated_at = ?, last_error = NULL
+            WHERE id = ?
+            """,
+            (next_at, time.time(), schedule_id),
+        )
+        return next_at
+
+
+def profile_has_active_cache_refresh_schedule(hs: SQLiteHistoryStore, db_profile: str) -> bool:
+    """``True`` when the profile has any non-terminal cache-refresh
+    schedule. The 1-week auto-refresh sweeper uses this to skip
+    profiles that already have user-managed schedules — the user's
+    schedule is authoritative."""
+    with hs._connect() as conn:
+        row = conn.execute(
+            """
+            SELECT 1 FROM scheduled_runs
+            WHERE db_profile = ?
+              AND kind = 'cache_refresh'
+              AND status IN ('pending', 'running')
+            LIMIT 1
+            """,
+            (str(db_profile or ""),),
+        ).fetchone()
+    return row is not None
+
+
+def set_run_schedule_link(hs: SQLiteHistoryStore, run_id: int, schedule_id: int) -> None:
+    """Attach a scheduled_runs id to an existing analysis_runs row.
+
+    Idempotent: writing the same link twice has no effect, and a
+    missing run_id is a no-op (callers can be defensive without a
+    preflight check).
+    """
+    with hs._lock, hs._connect() as conn:
+        conn.execute(
+            "UPDATE analysis_runs SET triggered_by_schedule_id = ? WHERE id = ?",
+            (schedule_id, run_id),
+        )

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -1288,97 +1288,91 @@ class SQLiteHistoryStore:
                 ),
             )
 
-    # ── run_results helpers ────────────────────────────────────────────────
+    # ── Audit + scheduled delegators (extracted to amx.storage._history_apply_audit / _history_scheduled) ──
+    def save_run_results(self, *args, **kwargs):
+        from amx.storage._history_apply_audit import save_run_results
 
-    def save_run_results(
-        self,
-        run_id: int,
-        suggestions: list[dict[str, Any]],
-    ) -> list[int]:
-        """Persist all LLM alternatives produced for a run before human review.
+        return save_run_results(self, *args, **kwargs)
 
-        Each *suggestion* dict should contain:
-          schema, table, column (or None), asset_kind, source, confidence,
-          reasoning, alternatives (list[str])
+    def record_evaluation(self, *args, **kwargs):
+        from amx.storage._history_apply_audit import record_evaluation
 
-        Optional re-run fields:
-          parent_result_id (int | None) — original run_results.id this row
-            re-runs; ``rerun_seq`` (int, default 0) — versioned position in
-            the chain (0 = original, 1+ = ordered re-runs);
-          ``user_instructions`` (str | None) — free-text addendum the user
-            typed in the re-run modal.
+        return record_evaluation(self, *args, **kwargs)
 
-        Returns the inserted row IDs.
-        """
-        now = time.time()
-        ids: list[int] = []
-        with self._lock, self._connect() as conn:
-            for s in suggestions:
-                cur = conn.execute(
-                    """
-                    INSERT INTO run_results (
-                        run_id, saved_at, schema_name, table_name, column_name,
-                        asset_kind, source, confidence, logprob_score, raw_logprob,
-                        token_count, model_version, reasoning, alternatives_json,
-                        parent_result_id, rerun_seq, user_instructions, citations_json,
-                        alternatives_mode, seed_alternative_id, seed_alternative_text,
-                        parent_run_id, model, provider, production_warning
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        run_id,
-                        now,
-                        s.get("schema", ""),
-                        s.get("table", ""),
-                        s.get("column"),
-                        s.get("asset_kind", "table"),
-                        s.get("source", "unknown"),
-                        s.get("confidence", "medium"),
-                        s.get("logprob_score"),
-                        s.get("raw_logprob", s.get("logprob_score")),
-                        s.get("token_count"),
-                        s.get("model_version", ""),
-                        s.get("reasoning", ""),
-                        build_alternatives_json(s),
-                        s.get("parent_result_id"),
-                        int(s.get("rerun_seq", 0) or 0),
-                        s.get("user_instructions"),
-                        # ``citations`` is a list of plain dicts at
-                        # this layer; the orchestrator serializer
-                        # converted dataclasses upstream so SQLite
-                        # only sees JSON-safe values. ``None`` on
-                        # non-RAG suggestions keeps the column space
-                        # cheap for legacy rows.
-                        (
-                            json.dumps(s.get("citations") or [], ensure_ascii=True)
-                            if s.get("citations")
-                            else None
-                        ),
-                        # ``alternatives_mode`` captures the diversity mode
-                        # active when this row's alternatives were generated,
-                        # per Definition 1: ``semantic`` ⇒ paraphrases of
-                        # DESCRIPTION_1; ``lexical`` ⇒ shared vocabulary with
-                        # DESCRIPTION_1, meaning may drift. ``None`` on
-                        # legacy / non-LLM rows is treated as "not recorded"
-                        # by the review UI.
-                        s.get("alternatives_mode"),
-                        # Variations audit (NULL on non-variations rows).
-                        s.get("seed_alternative_id"),
-                        s.get("seed_alternative_text"),
-                        s.get("parent_run_id"),
-                        # Per-row LLM identity — captures the effective model /
-                        # provider in use when the alternatives were generated.
-                        # Needed when a per-run profile override was applied,
-                        # since analysis_runs.llm_model / llm_provider would
-                        # still report the base profile's values.
-                        s.get("model"),
-                        s.get("provider"),
-                        # Under-production audit (NULL on success path).
-                        s.get("production_warning"),
-                    ),
-                )
-                ids.append(int(cur.lastrowid))
-        return ids
+    def record_applied(self, *args, **kwargs):
+        from amx.storage._history_apply_audit import record_applied
+
+        return record_applied(self, *args, **kwargs)
+
+    def record_db_apply_failure(self, *args, **kwargs):
+        from amx.storage._history_apply_audit import record_db_apply_failure
+
+        return record_db_apply_failure(self, *args, **kwargs)
+
+    def record_apply_event(self, *args, **kwargs):
+        from amx.storage._history_apply_audit import record_apply_event
+
+        return record_apply_event(self, *args, **kwargs)
+
+    def list_apply_events(self, *args, **kwargs):
+        from amx.storage._history_apply_audit import list_apply_events
+
+        return list_apply_events(self, *args, **kwargs)
+
+    def create_scheduled_run(self, *args, **kwargs):
+        from amx.storage._history_scheduled import create_scheduled_run
+
+        return create_scheduled_run(self, *args, **kwargs)
+
+    def get_scheduled_run(self, *args, **kwargs):
+        from amx.storage._history_scheduled import get_scheduled_run
+
+        return get_scheduled_run(self, *args, **kwargs)
+
+    def list_scheduled_runs(self, *args, **kwargs):
+        from amx.storage._history_scheduled import list_scheduled_runs
+
+        return list_scheduled_runs(self, *args, **kwargs)
+
+    def list_due_pending_schedules(self, *args, **kwargs):
+        from amx.storage._history_scheduled import list_due_pending_schedules
+
+        return list_due_pending_schedules(self, *args, **kwargs)
+
+    def update_scheduled_run(self, *args, **kwargs):
+        from amx.storage._history_scheduled import update_scheduled_run
+
+        return update_scheduled_run(self, *args, **kwargs)
+
+    def set_scheduled_run_status(self, *args, **kwargs):
+        from amx.storage._history_scheduled import set_scheduled_run_status
+
+        return set_scheduled_run_status(self, *args, **kwargs)
+
+    def delete_scheduled_run(self, *args, **kwargs):
+        from amx.storage._history_scheduled import delete_scheduled_run
+
+        return delete_scheduled_run(self, *args, **kwargs)
+
+    def claim_due_schedule(self, *args, **kwargs):
+        from amx.storage._history_scheduled import claim_due_schedule
+
+        return claim_due_schedule(self, *args, **kwargs)
+
+    def arm_next_fire(self, *args, **kwargs):
+        from amx.storage._history_scheduled import arm_next_fire
+
+        return arm_next_fire(self, *args, **kwargs)
+
+    def profile_has_active_cache_refresh_schedule(self, *args, **kwargs):
+        from amx.storage._history_scheduled import profile_has_active_cache_refresh_schedule
+
+        return profile_has_active_cache_refresh_schedule(self, *args, **kwargs)
+
+    def set_run_schedule_link(self, *args, **kwargs):
+        from amx.storage._history_scheduled import set_run_schedule_link
+
+        return set_run_schedule_link(self, *args, **kwargs)
 
     def set_session_state(self, namespace: str, key: str, value: Any) -> None:
         from amx.storage._history_session_state import set_session_state
@@ -1407,191 +1401,6 @@ class SQLiteHistoryStore:
             command=command,
             details=details,
         )
-
-    def record_evaluation(
-        self,
-        result_id: int,
-        *,
-        chosen_description: str,
-        evaluation: str,  # 'accepted' | 'skipped' | 'custom'
-    ) -> None:
-        """Record the user's evaluation decision for one run_result row."""
-        now = time.time()
-        with self._lock, self._connect() as conn:
-            conn.execute(
-                """
-                UPDATE run_results
-                SET evaluated_at = ?,
-                    chosen_description = ?,
-                    evaluation = ?
-                WHERE id = ?
-                """,
-                (now, chosen_description, evaluation, result_id),
-            )
-
-    def record_applied(
-        self,
-        result_id: int,
-        *,
-        chosen_description: str | None = None,
-    ) -> None:
-        """Record when a reviewed description was successfully applied to DB.
-
-        When ``chosen_description`` is provided it backfills
-        ``run_results.chosen_description`` *only* if the column is still empty.
-        The interactive review path (``record_evaluation``) wins when both ran,
-        but non-interactive apply paths (Studio "Apply pending", CLI
-        ``/history apply``) finally persist the text actually written to the
-        live DB, so ``describe_run`` / chat answers can quote it later.
-        """
-        now = time.time()
-        with self._lock, self._connect() as conn:
-            if chosen_description:
-                conn.execute(
-                    """
-                    UPDATE run_results
-                    SET applied_at = ?,
-                        db_applied_status = 'applied',
-                        rejection_reason = '',
-                        chosen_description = COALESCE(NULLIF(chosen_description, ''), ?)
-                    WHERE id = ?
-                    """,
-                    (now, chosen_description, result_id),
-                )
-            else:
-                conn.execute(
-                    """
-                    UPDATE run_results
-                    SET applied_at = ?,
-                        db_applied_status = 'applied',
-                        rejection_reason = ''
-                    WHERE id = ?
-                    """,
-                    (now, result_id),
-                )
-
-    def record_db_apply_failure(self, result_id: int, error_text: str = "") -> None:
-        """Record when a reviewed description failed during DB write-back."""
-        with self._lock, self._connect() as conn:
-            conn.execute(
-                """
-                UPDATE run_results
-                SET db_applied_status = 'failed',
-                    rejection_reason = CASE
-                        WHEN ? != '' THEN ?
-                        ELSE rejection_reason
-                    END
-                WHERE id = ?
-                """,
-                (error_text, error_text, result_id),
-            )
-
-    def record_apply_event(
-        self,
-        *,
-        schema_name: str,
-        new_comment: str,
-        run_id: int | None = None,
-        result_id: int | None = None,
-        profile_name: str = "",
-        table_name: str = "",
-        column_name: str | None = None,
-        asset_kind: str = "table",
-        old_comment: str | None = None,
-        applied_by: str = "",
-        hostname: str = "",
-        sql_template: str = "",
-    ) -> int:
-        """Append one ``apply_events`` row for a successful COMMENT write.
-
-        ``new_comment`` is the comment text actually written to the
-        database. ``old_comment`` (when supplied) lets a future
-        rollback step restore the prior state byte-for-byte. Every
-        other field is optional so callers that don't yet propagate
-        full attribution can still record a basic audit trail.
-
-        Returns the inserted row id so callers (e.g. Studio SSE) can
-        link a UI event back to the audit row.
-        """
-        now = time.time()
-        with self._lock, self._connect() as conn:
-            cursor = conn.execute(
-                """
-                INSERT INTO apply_events (
-                    applied_at, run_id, result_id, profile_name,
-                    schema_name, table_name, column_name, asset_kind,
-                    old_comment, new_comment, applied_by, hostname,
-                    sql_template
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    now,
-                    run_id,
-                    result_id,
-                    profile_name,
-                    schema_name,
-                    table_name,
-                    column_name,
-                    asset_kind,
-                    old_comment,
-                    new_comment,
-                    applied_by,
-                    hostname,
-                    sql_template,
-                ),
-            )
-            return int(cursor.lastrowid or 0)
-
-    def list_apply_events(
-        self,
-        *,
-        run_id: int | None = None,
-        profile_name: str | None = None,
-        limit: int = 100,
-    ) -> list[dict[str, Any]]:
-        """Return apply events newest-first, optionally filtered by run / profile.
-
-        Used by ``/history rollback`` (PR-12b) to find the events to
-        replay in reverse, and by Studio's Recent Applies panel
-        (PR-12c) to render the timeline.
-        """
-        clauses: list[str] = []
-        params: list[Any] = []
-        if run_id is not None:
-            clauses.append("run_id = ?")
-            params.append(run_id)
-        if profile_name is not None:
-            clauses.append("profile_name = ?")
-            params.append(profile_name)
-        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-        sql = (
-            "SELECT id, applied_at, run_id, result_id, profile_name, "
-            "schema_name, table_name, column_name, asset_kind, "
-            "old_comment, new_comment, applied_by, hostname, sql_template "
-            "FROM apply_events" + where + " ORDER BY applied_at DESC LIMIT ?"
-        )
-        params.append(int(limit))
-        with self._lock, self._connect() as conn:
-            rows = conn.execute(sql, tuple(params)).fetchall()
-        return [
-            {
-                "id": int(r[0]),
-                "applied_at": float(r[1]),
-                "run_id": r[2],
-                "result_id": r[3],
-                "profile_name": str(r[4]),
-                "schema_name": str(r[5]),
-                "table_name": str(r[6]),
-                "column_name": r[7],
-                "asset_kind": str(r[8]),
-                "old_comment": r[9],
-                "new_comment": str(r[10]),
-                "applied_by": str(r[11]),
-                "hostname": str(r[12]),
-                "sql_template": str(r[13]),
-            }
-            for r in rows
-        ]
 
     def update_run_status(self, run_id: int, status: str, error_text: str = "") -> None:
         """Update run status without overwriting metrics/tokens/results payloads."""
@@ -2535,354 +2344,6 @@ class SQLiteHistoryStore:
             "cron_expr",
         }
     )
-
-    def create_scheduled_run(
-        self,
-        *,
-        name: str,
-        fire_at_utc: float,
-        fire_at_tz: str,
-        db_profile: str,
-        scope_json: str,
-        llm_profile: str,
-        review_strategy: str,
-        database: str | None = None,
-        catalog: str | None = None,
-        extra_args_json: str | None = None,
-        kind: str = "analyze",
-        cron_expr: str | None = None,
-    ) -> int:
-        """Insert a new scheduled_runs row in status='pending'.
-
-        ``database`` and ``catalog`` carry the picker's overlay so the
-        scheduler can rebuild the same connection at fire time (mirrors
-        the ``/api/live/schemas`` picker that ScopeTree drives). Both
-        are nullable: legacy rows + backends that don't expose a
-        database/catalog axis (e.g. SQLite single-file profiles) keep
-        the profile default.
-
-        ``kind`` discriminates between the legacy analyze-run schedule
-        ('analyze') and the Catalog-Freshness cache refresh
-        ('cache_refresh'). ``cron_expr`` is NULL for one-shot fires and
-        a valid croniter expression for recurring schedules — the tick
-        engine re-arms the row from the cron after each fire.
-        """
-        now = time.time()
-        with self._lock, self._connect() as conn:
-            cur = conn.execute(
-                """
-                INSERT INTO scheduled_runs (
-                    name, fire_at_utc, fire_at_tz, status,
-                    db_profile, database, catalog,
-                    scope_json, llm_profile, review_strategy,
-                    extra_args_json, kind, cron_expr,
-                    created_at, updated_at
-                ) VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    name,
-                    fire_at_utc,
-                    fire_at_tz,
-                    db_profile,
-                    database,
-                    catalog,
-                    scope_json,
-                    llm_profile,
-                    review_strategy,
-                    extra_args_json,
-                    str(kind or "analyze"),
-                    cron_expr,
-                    now,
-                    now,
-                ),
-            )
-            return int(cur.lastrowid or 0)
-
-    def get_scheduled_run(self, schedule_id: int) -> dict[str, Any] | None:
-        """Return the full row as a dict, or None if missing."""
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
-            row = conn.execute("SELECT * FROM scheduled_runs WHERE id=?", (schedule_id,)).fetchone()
-        return dict(row) if row else None
-
-    def list_scheduled_runs(
-        self,
-        *,
-        statuses: list[str] | None = None,
-        db_profile: str | None = None,
-        limit: int = 200,
-    ) -> list[dict[str, Any]]:
-        """List rows sorted by fire_at_utc ASC with optional filters."""
-        clauses: list[str] = []
-        params: list[Any] = []
-        if statuses:
-            placeholders = ",".join("?" for _ in statuses)
-            clauses.append(f"status IN ({placeholders})")
-            params.extend(statuses)
-        if db_profile is not None:
-            clauses.append("db_profile = ?")
-            params.append(db_profile)
-        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-        params.append(int(limit))
-        sql = "SELECT * FROM scheduled_runs" + where + " ORDER BY fire_at_utc ASC LIMIT ?"
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
-            rows = conn.execute(sql, params).fetchall()
-        return [dict(r) for r in rows]
-
-    def list_due_pending_schedules(
-        self,
-        *,
-        now_utc: float,
-        limit: int = 200,
-    ) -> list[dict[str, Any]]:
-        """Return rows that are pending and whose fire time has elapsed.
-
-        Read-only: does not transition status. Used by the bootstrap
-        tick path to surface "missed while AMX was closed" entries.
-        """
-        with self._connect() as conn:
-            conn.row_factory = sqlite3.Row
-            rows = conn.execute(
-                """
-                SELECT * FROM scheduled_runs
-                WHERE status = 'pending'
-                  AND fire_at_utc <= ?
-                ORDER BY fire_at_utc ASC
-                LIMIT ?
-                """,
-                (now_utc, int(limit)),
-            ).fetchall()
-        return [dict(r) for r in rows]
-
-    def update_scheduled_run(
-        self,
-        schedule_id: int,
-        *,
-        patch: dict[str, Any],
-    ) -> None:
-        """Apply a whitelisted patch to a scheduled_runs row.
-
-        Only the fields in ``_SCHEDULE_UPDATABLE_FIELDS`` can be
-        modified through this path -- status changes go through
-        :meth:`set_scheduled_run_status`, and id/created_at/fired_at/
-        triggered_run_id/last_error are owned by the engine.
-        """
-        if not patch:
-            return
-        unknown = (
-            set(patch)
-            - self._SCHEDULE_UPDATABLE_FIELDS
-            - {
-                "status",
-                "id",
-                "created_at",
-                "updated_at",
-                "fired_at",
-                "triggered_run_id",
-                "last_error",
-            }
-        )
-        if unknown:
-            raise ValueError(f"unknown patch field(s): {sorted(unknown)}")
-        forbidden = set(patch) - self._SCHEDULE_UPDATABLE_FIELDS
-        if forbidden:
-            raise ValueError(
-                f"forbidden patch field(s) for update_scheduled_run: "
-                f"{sorted(forbidden)} -- use a dedicated method"
-            )
-        cols = sorted(patch)
-        set_clause = ", ".join(f"{c} = ?" for c in cols)
-        params: list[Any] = [patch[c] for c in cols]
-        params.append(time.time())
-        params.append(schedule_id)
-        with self._lock, self._connect() as conn:
-            conn.execute(
-                f"UPDATE scheduled_runs SET {set_clause}, updated_at = ? WHERE id = ?",
-                params,
-            )
-
-    def set_scheduled_run_status(
-        self,
-        schedule_id: int,
-        status: str,
-        *,
-        last_error: str | None = None,
-        fired_at: float | None = None,
-        triggered_run_id: int | None = None,
-    ) -> None:
-        """Transition a schedule to *status*, enforcing the state machine."""
-        if status not in self._SCHEDULE_TRANSITIONS:
-            raise ValueError(f"unknown status: {status!r}")
-        now = time.time()
-        with self._lock, self._connect() as conn:
-            row = conn.execute(
-                "SELECT status FROM scheduled_runs WHERE id = ?",
-                (schedule_id,),
-            ).fetchone()
-            if row is None:
-                raise ValueError(f"no scheduled_runs row with id={schedule_id}")
-            current = str(row[0])
-            allowed = self._SCHEDULE_TRANSITIONS.get(current, set())
-            if status not in allowed and status != current:
-                raise ValueError(f"illegal transition: {current!r} -> {status!r}")
-            sets = ["status = ?", "updated_at = ?"]
-            params: list[Any] = [status, now]
-            if last_error is not None:
-                sets.append("last_error = ?")
-                params.append(last_error)
-            if fired_at is not None:
-                sets.append("fired_at = ?")
-                params.append(fired_at)
-            if triggered_run_id is not None:
-                sets.append("triggered_run_id = ?")
-                params.append(triggered_run_id)
-            params.append(schedule_id)
-            conn.execute(
-                f"UPDATE scheduled_runs SET {', '.join(sets)} WHERE id = ?",
-                params,
-            )
-
-    def delete_scheduled_run(self, schedule_id: int) -> None:
-        """Hard-delete a scheduled_runs row; write an audit event.
-
-        Idempotent: deleting a non-existent id is a no-op (no error,
-        no audit row).
-        """
-        with self._lock, self._connect() as conn:
-            row = conn.execute(
-                "SELECT name FROM scheduled_runs WHERE id = ?",
-                (schedule_id,),
-            ).fetchone()
-            if row is None:
-                return
-            name = str(row[0])
-            conn.execute("DELETE FROM scheduled_runs WHERE id = ?", (schedule_id,))
-            conn.execute(
-                """
-                INSERT INTO app_events (
-                    created_at, event_type, status, command, details_json
-                ) VALUES (?, 'schedule.deleted', 'ok', 'schedule.rm', ?)
-                """,
-                (
-                    time.time(),
-                    json.dumps({"schedule_id": schedule_id, "name": name}),
-                ),
-            )
-
-    def claim_due_schedule(self, *, now_utc: float) -> int | None:
-        """Atomically transition the oldest due pending schedule to running.
-
-        Returns the claimed schedule id, or None if none are due. Safe
-        under concurrent calls from multiple threads -- the
-        ``WHERE status='pending'`` predicate on the UPDATE turns a lost
-        race into a return of None for the loser.
-        """
-        now = time.time()
-        with self._lock, self._connect() as conn:
-            row = conn.execute(
-                """
-                SELECT id FROM scheduled_runs
-                WHERE status = 'pending' AND fire_at_utc <= ?
-                ORDER BY fire_at_utc ASC
-                LIMIT 1
-                """,
-                (now_utc,),
-            ).fetchone()
-            if row is None:
-                return None
-            sid = int(row[0])
-            cur = conn.execute(
-                """
-                UPDATE scheduled_runs
-                SET status = 'running', fired_at = ?, updated_at = ?
-                WHERE id = ? AND status = 'pending'
-                """,
-                (now, now, sid),
-            )
-            if cur.rowcount == 1:
-                return sid
-            return None
-
-    def arm_next_fire(self, schedule_id: int) -> float | None:
-        """Re-arm a recurring schedule to its next ``fire_at_utc``.
-
-        Reads ``cron_expr`` from the row; if NULL or invalid, leaves
-        the row alone (one-shot schedules complete after a single fire
-        — they should be left at ``status='completed'`` by the tick
-        path). Otherwise computes the next fire timestamp via
-        ``croniter.get_next(float)`` and flips ``status`` back to
-        ``'pending'`` so the tick loop picks it up next cycle.
-
-        Returns the new ``fire_at_utc`` on success, or None when the
-        row had no usable cron expression (caller treats that as
-        one-shot done).
-        """
-        try:
-            from croniter import croniter
-        except Exception as exc:
-            log.warning("croniter unavailable; cannot re-arm schedule %s: %s", schedule_id, exc)
-            return None
-        with self._lock, self._connect() as conn:
-            row = conn.execute(
-                "SELECT cron_expr FROM scheduled_runs WHERE id = ?",
-                (schedule_id,),
-            ).fetchone()
-            if row is None:
-                return None
-            expr = row[0]
-            if not expr:
-                return None
-            try:
-                next_at = float(croniter(str(expr), time.time()).get_next(float))
-            except Exception as exc:
-                log.warning(
-                    "Invalid cron_expr %r on schedule %s, leaving completed: %s",
-                    expr,
-                    schedule_id,
-                    exc,
-                )
-                return None
-            conn.execute(
-                """
-                UPDATE scheduled_runs
-                SET status = 'pending', fire_at_utc = ?, updated_at = ?, last_error = NULL
-                WHERE id = ?
-                """,
-                (next_at, time.time(), schedule_id),
-            )
-            return next_at
-
-    def profile_has_active_cache_refresh_schedule(self, db_profile: str) -> bool:
-        """``True`` when the profile has any non-terminal cache-refresh
-        schedule. The 1-week auto-refresh sweeper uses this to skip
-        profiles that already have user-managed schedules — the user's
-        schedule is authoritative."""
-        with self._connect() as conn:
-            row = conn.execute(
-                """
-                SELECT 1 FROM scheduled_runs
-                WHERE db_profile = ?
-                  AND kind = 'cache_refresh'
-                  AND status IN ('pending', 'running')
-                LIMIT 1
-                """,
-                (str(db_profile or ""),),
-            ).fetchone()
-        return row is not None
-
-    def set_run_schedule_link(self, run_id: int, schedule_id: int) -> None:
-        """Attach a scheduled_runs id to an existing analysis_runs row.
-
-        Idempotent: writing the same link twice has no effect, and a
-        missing run_id is a no-op (callers can be defensive without a
-        preflight check).
-        """
-        with self._lock, self._connect() as conn:
-            conn.execute(
-                "UPDATE analysis_runs SET triggered_by_schedule_id = ? WHERE id = ?",
-                (schedule_id, run_id),
-            )
 
     def recover_stale_runs(
         self,


### PR DESCRIPTION
## Summary
- **A3 of the sqlite_store decomposition** (Round 2 plan): two independent extracts in one PR.
- **`amx/storage/_history_apply_audit.py`** (6 methods): `save_run_results`, `record_evaluation`, `record_applied`, `record_db_apply_failure`, `record_apply_event`, `list_apply_events`. Drives the `run_results` write path + the `apply_events` audit log.
- **`amx/storage/_history_scheduled.py`** (11 methods): `create_scheduled_run`, `get_scheduled_run`, `list_scheduled_runs`, `list_due_pending_schedules`, `update_scheduled_run`, `set_scheduled_run_status`, `delete_scheduled_run`, `claim_due_schedule`, `arm_next_fire`, `profile_has_active_cache_refresh_schedule`, `set_run_schedule_link`. Drives the `scheduled_runs` state machine consumed by the tick engine + CLI schedule commands.
- Each function takes the store as `hs` and reuses `_lock` + `_connect()` plumbing. **No DDL touched** — `init()`'s `CREATE TABLE` / `ALTER TABLE` statements stay byte-identical.
- `SQLiteHistoryStore` keeps thin delegating wrappers on every name so the dozens of callers stay byte-compatible.
- `sqlite_store.py`: 3019 -> 2480 LOC (-539, -18%). Combined with #482 (A1) + #486 (A2), `sqlite_store.py` is now **3535 -> 2480 LOC (-30 %)** over three PRs.

## Test plan
- [x] `make test` — 2415 passed, 9 skipped (env-related), zero new failures
- [x] `make lint` — clean
- [x] Public API: every method still callable on `SQLiteHistoryStore`
- [x] No DDL changes — `grep -nE "CREATE TABLE|ALTER TABLE|CREATE INDEX" amx/storage/sqlite_store.py` returns the same lines as on `main`
- [x] `tests/storage/test_scheduled_runs_sqlite.py` (scheduled CRUD + state machine + claim_due_schedule + list filters) — green
- [x] `tests/test_apply_audit_*` (audit insert, savepoint isolation, dry-run, llm-overrides, old-comment) — green
- [x] No Studio surface touched — `deploy.sh` not required