### PR TITLE
fix(web/ask): guarantee terminal SSE event when worker fails

### DIFF
--- a/amx/web/routers/ask.py
+++ b/amx/web/routers/ask.py
@@ -536,6 +536,20 @@ def _event_generator(job: Job):
                 yield {"event": "ping", "data": json.dumps({"t": now})}
                 last_keepalive = now
             if job.status not in ("queued", "running"):
+                # Diagnostic: the generator is about to close the SSE
+                # stream because the worker flipped status. If the
+                # worker has not yet enqueued the terminal event (or
+                # enqueued one we still need to drain), the SPA will
+                # see "Connection lost" instead of a clean job.done /
+                # job.failed / job.cancelled. ``queue_size`` is the
+                # smoking gun: a value > 0 means the terminal event
+                # was waiting on the queue when we exited.
+                log.warning(
+                    "ask SSE generator exiting early: job_id=%s status=%s queue_size=%s",
+                    job.id,
+                    job.status,
+                    job.queue.qsize(),
+                )
                 break
             continue
         kind = str(event.get("type", ""))
@@ -631,6 +645,80 @@ def _ask_worker(
     doc_profiles_override: list[str] | None = None,
     code_profiles_override: list[str] | None = None,
 ) -> None:
+    """Run the tool-calling agent and guarantee a terminal SSE event.
+
+    Wraps :func:`_ask_worker_impl` in a try/finally so that any
+    unhandled exception on a path that does not already emit a
+    terminal still produces a ``job.failed`` SSE frame. Without this
+    belt-and-suspenders, a regression like the historical
+    ``_load_catalog`` raise inside ``CollectionIdentityMismatch``
+    silently killed the worker thread and the SPA hung on
+    "Reasoning…" until the browser eventually reported
+    "Connection lost. Reconnecting (attempt 1/5)…".
+    """
+    try:
+        _ask_worker_impl(
+            cfg,
+            job,
+            question,
+            session_id,
+            db_profile,
+            scope_profiles,
+            doc_profiles_override,
+            code_profiles_override,
+        )
+    except Exception:
+        # Last-resort safety net. The two real paths
+        # (``_ask_worker_impl`` happy + named-exception branches)
+        # already emit clean terminal frames; this only fires when
+        # something escapes them.
+        log.exception(
+            "ask worker crashed without emitting a terminal event: job_id=%s",
+            job.id,
+        )
+    finally:
+        if job.status in ("queued", "running"):
+            # No terminal event was emitted — the thread died on a path
+            # the explicit handlers did not cover. Synthesize a
+            # ``job.failed`` so the SPA renders an actionable error
+            # state instead of hanging until the browser SSE proxy
+            # gives up.
+            job.status = "failed"
+            job.error = job.error or (
+                "Internal error: the ask worker exited without "
+                "emitting a terminal event. See ~/.amx/logs/amx.log."
+            )
+            job.ended_at = time.time()
+            try:
+                emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
+            except Exception:
+                pass
+            log.warning(
+                "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=synth-fallback",
+                job.id,
+                job.status,
+                time.time() - job.started_at,
+            )
+            try:
+                emit_terminal(
+                    job.queue,
+                    "job.failed",
+                    {"error": job.error, "hint": "internal-error"},
+                )
+            except Exception:
+                pass
+
+
+def _ask_worker_impl(
+    cfg: AMXConfig,
+    job: Job,
+    question: str,
+    session_id: int | None,
+    db_profile: str,
+    scope_profiles: list[str],
+    doc_profiles_override: list[str] | None = None,
+    code_profiles_override: list[str] | None = None,
+) -> None:
     """Run the tool-calling agent + stream every reasoning chunk and
     tool result back to the SSE consumer. Persists the assistant
     turn to chat_sessions on success.
@@ -639,6 +727,11 @@ def _ask_worker(
     (per-question body override > session sticky > config default).
     Passed through to ``run_tool_agent`` which threads it into every
     catalog tool call.
+
+    Wrapped by :func:`_ask_worker` so an unhandled exception on a code
+    path that does not already emit a terminal still produces a
+    ``job.failed`` SSE event instead of silently killing the worker
+    thread and stranding the SPA on a hung stream.
     """
     job.status = "running"
     emit(job.queue, "activity.added", {"idx": 0, "label": "Thinking"})
@@ -711,13 +804,52 @@ def _ask_worker(
         except Exception as exc:  # pragma: no cover - best-effort
             log.warning("Could not finalise tokens_json for ask run %s: %s", run_id, exc)
 
-    catalog = _load_catalog()
+    # ``_load_catalog`` can raise when the user's chromadb collection was
+    # indexed under one embedding identity and the active embedding
+    # profile points at a different one (the canonical signal is
+    # ``"Vector collection was indexed with a different embedding
+    # identity"``). Without this try/except the exception bubbled out
+    # of the worker thread before any terminal event was emitted, so
+    # the SSE consumer hung indefinitely and the browser eventually
+    # reported "Connection lost. Reconnecting (attempt 1/5)..." with
+    # no recovery path. Surface the failure as a clean ``job.failed``
+    # event with the original message so the SPA can render the
+    # actionable hint ("run /search rebuild").
+    try:
+        catalog = _load_catalog()
+    except Exception as exc:
+        message = str(exc) or exc.__class__.__name__
+        job.status = "failed"
+        job.error = f"Search catalog could not be opened: {message}"
+        job.ended_at = time.time()
+        emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
+        _finish(status_value="failed", error_text=job.error)
+        hint = "rebuild-catalog" if "embedding identity" in message.lower() else "sync-catalog"
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=catalog-load-failed hint=%s",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+            hint,
+        )
+        emit_terminal(
+            job.queue,
+            "job.failed",
+            {"error": job.error, "hint": hint},
+        )
+        return
     if catalog is None:
         job.status = "failed"
         job.error = "Search catalog isn't initialised yet — run /search sync first."
         job.ended_at = time.time()
         emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
         _finish(status_value="failed", error_text=job.error)
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=catalog-not-initialised",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+        )
         emit_terminal(
             job.queue,
             "job.failed",
@@ -743,6 +875,12 @@ def _ask_worker(
         job.ended_at = time.time()
         emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
         _finish(status_value="failed", error_text=job.error)
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=llm-init-failed",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+        )
         emit_terminal(
             job.queue,
             "job.failed",
@@ -833,6 +971,12 @@ def _ask_worker(
                         session_id,
                         exc,
                     )
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=cancelled",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+        )
         emit_terminal(job.queue, "job.cancelled", {})
         return
     except Exception as exc:
@@ -877,6 +1021,12 @@ def _ask_worker(
         payload: dict[str, Any] = {"error": job.error}
         if hint:
             payload["hint"] = hint
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=run_tool_agent-exception",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+        )
         emit_terminal(job.queue, "job.failed", payload)
         return
 
@@ -976,6 +1126,12 @@ def _ask_worker(
             "scope_profiles": list(result.scope_profiles or []),
             "focus_profile": result.focus_profile,
         },
+    )
+    log.info(
+        "ask worker terminal: job_id=%s status=%s elapsed=%.2fs",
+        job.id,
+        job.status,
+        time.time() - job.started_at,
     )
     emit_terminal(job.queue, "job.done", {"summary": job.summary})
 

--- a/tests/web/test_ask_sse_terminal_drain.py
+++ b/tests/web/test_ask_sse_terminal_drain.py
@@ -1,0 +1,137 @@
+"""Terminal-event guarantees for /api/ask SSE streams.
+
+Historically, when ``_load_catalog()`` raised (e.g. the on-disk
+chromadb collection's embedding identity diverged from the active
+profile after a model swap), the worker thread died silently. The
+job status stayed ``"running"``, no ``job.failed`` ever reached the
+queue, the SSE generator kept emitting pings, and the SPA eventually
+gave up with "Connection lost. Reconnecting (attempt 1/5)..." — a
+useless error state.
+
+Two complementary safeguards now protect the SSE contract:
+
+1. **Targeted handler** around ``_load_catalog()`` emits a clean
+   ``job.failed`` with ``hint=rebuild-catalog`` so the SPA can render
+   an actionable "Run /search rebuild" toast.
+2. **Wrapper-level synth fallback** in ``_ask_worker``: a try/finally
+   that synthesizes ``job.failed`` with ``hint=internal-error`` if
+   any future code path escapes the explicit handlers. Belt and
+   suspenders for the silent-thread-death failure mode.
+
+Both safeguards are covered below.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+
+from amx.web.routers import ask as ask_router
+
+
+def _drain_sse(client, path: str, headers: dict[str, str]) -> list[dict]:
+    events: list[dict] = []
+    t0 = time.monotonic()
+    with client.stream("GET", path, headers=headers) as response:
+        assert response.status_code == 200
+        current_event = None
+        for line in response.iter_lines():
+            if not line:
+                continue
+            if isinstance(line, bytes):
+                line = line.decode("utf-8")
+            if line.startswith("event:"):
+                current_event = line.split(":", 1)[1].strip()
+            elif line.startswith("data:"):
+                payload = line.split(":", 1)[1].strip()
+                try:
+                    parsed = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                parsed["type"] = current_event or parsed.get("type", "")
+                events.append(parsed)
+                if (current_event or "") in {
+                    "job.done",
+                    "job.cancelled",
+                    "job.failed",
+                }:
+                    return events
+            if time.monotonic() - t0 > 5:
+                break
+    return events
+
+
+def test_load_catalog_failure_emits_clean_terminal_with_rebuild_hint(
+    client, auth_headers, monkeypatch
+) -> None:
+    """``_load_catalog()`` raising bubbles up as a clean ``job.failed``
+    SSE event with ``hint=rebuild-catalog`` — the SPA receives a
+    terminal frame and renders an actionable error instead of hanging
+    until the browser drops the stream as "Connection lost"."""
+
+    def _boom() -> None:
+        raise RuntimeError(
+            "Vector collection was indexed with a different embedding "
+            "identity. Run /search rebuild to refresh."
+        )
+
+    monkeypatch.setattr(ask_router, "_load_catalog", _boom)
+    monkeypatch.setattr(ask_router, "LLMProvider", lambda _cfg: MagicMock())
+
+    response = client.post(
+        "/api/ask",
+        headers=auth_headers,
+        json={"question": "are my syncs up to date"},
+    )
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+
+    events = _drain_sse(client, f"/api/ask/{job_id}/events", auth_headers)
+    failed = [e for e in events if e["type"] == "job.failed"]
+    assert len(failed) == 1, f"Expected one job.failed event, got: {events}"
+    payload = failed[0]
+    assert payload.get("hint") == "rebuild-catalog"
+    assert "catalog" in payload.get("error", "").lower()
+
+
+def test_ask_worker_synthesizes_terminal_on_silent_death(monkeypatch) -> None:
+    """If any path inside ``_ask_worker_impl`` raises without first
+    emitting a terminal event, the wrapper's try/finally MUST
+    synthesize a ``job.failed`` with ``hint=internal-error`` so the
+    SSE consumer is never left hanging."""
+
+    from amx.config import AMXConfig
+    from amx.web.jobs import Job
+
+    def _impl_dies(*_args, **_kwargs) -> None:
+        raise RuntimeError("simulated silent worker crash")
+
+    monkeypatch.setattr(ask_router, "_ask_worker_impl", _impl_dies)
+
+    job = Job(id="ask-test", kind="ask")
+    job.status = "running"
+    job.started_at = time.time()
+
+    ask_router._ask_worker(
+        AMXConfig(),
+        job,
+        question="anything",
+        session_id=None,
+        db_profile="default",
+        scope_profiles=["default"],
+    )
+
+    assert job.status == "failed"
+
+    drained: list[dict] = []
+    while True:
+        try:
+            drained.append(job.queue.get_nowait())
+        except Exception:
+            break
+
+    terminal = [e for e in drained if e.get("type") == "job.failed"]
+    assert len(terminal) == 1, f"No synth terminal emitted: {drained}"
+    assert terminal[0].get("hint") == "internal-error"
+    assert "log" in (terminal[0].get("error") or "").lower()


### PR DESCRIPTION
## Summary

- Targeted handler around `_load_catalog()` emits `job.failed` with `hint=rebuild-catalog` instead of letting `CollectionIdentityMismatch` (or any other catalog-open exception) kill the worker thread silently.
- Belt-and-suspenders try/finally in `_ask_worker` synthesizes `job.failed` with `hint=internal-error` if any future code path escapes the explicit handlers, so the SPA can never hang on "Reasoning…" waiting for a terminal SSE frame that never arrives.
- New regression tests cover both paths.

The symptom this fixes: Studio's `/ask` view showing "Cancelling..." then "Connection lost. Reconnecting (attempt 1/5)..." when the active chromadb collection's embedding identity drifts from the live LLM profile. The worker died silently mid-init, the SSE generator pinged forever, the browser eventually dropped the stream.

## Test plan

- [x] `pytest tests/web/test_ask_sse_terminal_drain.py -q` — 2 new tests pass
- [x] `pytest tests/web/ -q -k ask` — 48 tests pass (46 existing + 2 new)
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [x] Studio deployed via `~/amx-remote/scripts/deploy.sh`; ready to reproduce the failure scenario in `/ask`