### PR TITLE
fix(search/docs/code): unblock RAG rebuild + lazy catalog open

### DIFF
--- a/amx/cli_support/commands/code.py
+++ b/amx/cli_support/commands/code.py
@@ -352,7 +352,12 @@ def register_code_commands(
     def code_refresh_cmd(cfg: AMXConfig, code_profile: str | None) -> None:
         """Clear persisted codebase scan cache and the semantic ``amx_code`` Chroma index."""
         from amx.codebase.cache import invalidate_cache
-        from amx.codebase.code_rag import delete_code_collection
+        from amx.codebase.code_rag import (
+            CodeEmbeddingMismatch,
+            _open_collection,
+            _resolve_code_embedding,
+            delete_code_collection,
+        )
 
         try:
             code_path = cfg.resolve_code_path((code_profile or "").strip() or None, None)
@@ -365,10 +370,53 @@ def register_code_commands(
         profile_nm = (
             (code_profile or "").strip() or cfg.active_code_profile or "default"
         ).strip() or "default"
+
+        # Probe the on-disk collection's identity against the active
+        # config — but only if a collection already exists. ``/embeddings``
+        # swapping the code embedding model leaves the stamped identity
+        # in place, and partial deletes never refresh it, so the next
+        # ``/ask`` keeps hitting :class:`CodeEmbeddingMismatch`. Detect
+        # that here and drop the whole collection so the next scan
+        # re-stamps cleanly. The probe must be side-effect free: if no
+        # collection exists yet (fresh install, no scan yet) we skip
+        # the probe entirely rather than risk creating one as a side
+        # effect of detection.
+        identity_mismatch = False
+        try:
+            chromadb_mod = __import__("chromadb")
+            persist_dir = str(Path.home() / ".amx" / "chroma_db")
+            client = chromadb_mod.PersistentClient(path=persist_dir)
+            existing_names = {getattr(c, "name", str(c)) for c in client.list_collections()}
+            from amx.codebase.code_rag import COLLECTION as _CODE_COLL
+
+            if _CODE_COLL in existing_names:
+                provider, model, ef = _resolve_code_embedding(cfg)
+                _open_collection(
+                    client,
+                    embedding_provider=provider,
+                    embedding_model=model,
+                    embedding_function=ef,
+                )
+        except CodeEmbeddingMismatch:
+            identity_mismatch = True
+        except Exception:
+            # Anything else (chromadb not installed, fresh install, etc.)
+            # falls back to the same per-path delete behaviour we had
+            # before; mismatch recovery is the only special case.
+            pass
+
         with command_display(mode="code-refresh", provider=cfg.llm.provider, model=cfg.llm.model):
             with step_spinner("Clearing cached code scan"):
                 invalidate_cache(profile_nm, code_path)
-                delete_code_collection(source_filters=[code_path])
+                if identity_mismatch:
+                    # Force a full drop. The stamped identity on the
+                    # existing collection no longer matches the active
+                    # embedding profile; per-source deletes would leave
+                    # the mismatch in place and ``/ask`` would keep
+                    # failing.
+                    delete_code_collection(source_filters=None)
+                else:
+                    delete_code_collection(source_filters=[code_path])
         try:
             from amx.search.catalog import SearchCatalog
 

--- a/amx/cli_support/commands/docs.py
+++ b/amx/cli_support/commands/docs.py
@@ -306,6 +306,92 @@ def register_docs_commands(
         finally:
             cleanup_scan_artifacts(documents)
 
+    @docs.command("reindex")
+    @click.option(
+        "--doc-profile",
+        "doc_profile",
+        default=None,
+        help="Use paths from this named document profile when no paths are given.",
+    )
+    @click.argument("paths", nargs=-1)
+    @click.pass_obj
+    def docs_reindex(
+        cfg: AMXConfig,
+        paths: tuple[str, ...],
+        doc_profile: str | None,
+    ) -> None:
+        """Drop the docs vector store and re-ingest with the active
+        embedding profile.
+
+        Use this after ``/embeddings`` swaps the docs embedding model
+        — ``/docs ingest --refresh`` only deletes documents and
+        leaves the recorded identity intact, so the next open raises
+        ``EmbeddingProviderMismatch`` and blocks ``/ask`` retrieval.
+        Reindex drops the Chroma collection outright (and the FTS5
+        sidecar), then re-runs the full ingest so the rebuilt
+        collection is stamped with the active provider/model/dim.
+        """
+        from amx.docs.rag import EmbeddingProviderMismatch, RAGStore
+        from amx.docs.scanner import (
+            cleanup_scan_artifacts,
+            scan_all_sources,
+            total_size_mb,
+        )
+
+        try:
+            all_paths = list(paths) if paths else cfg.resolve_doc_paths(doc_profile, [])
+        except KeyError as exc:
+            error(str(exc))
+            return
+        if not all_paths:
+            warn_no_doc_paths_for_scan_or_ingest(cfg, cmd="reindex")
+            return
+
+        documents = []
+        try:
+            with command_display(
+                mode="docs-ingest", provider=cfg.llm.provider, model=cfg.llm.model
+            ):
+                with step_spinner("Scanning document sources"):
+                    documents = scan_all_sources(all_paths)
+                _render_scan_failures(documents)
+                size = total_size_mb(documents)
+                info(f"Found {len(documents)} documents ({size:.1f} MB)")
+                if size > 100:
+                    warn(f"Large document set ({size:.1f} MB). This will take some time.")
+                    if not confirm("Continue?"):
+                        return
+
+                # If the on-disk collection already has a mismatched
+                # identity stamp, ``RAGStore()`` raises on construction.
+                # In that case force-drop the collection by hand and
+                # then construct a fresh store that re-stamps with
+                # the active identity.
+                try:
+                    store = RAGStore()
+                except EmbeddingProviderMismatch:
+                    import chromadb
+
+                    persist = str(Path.home() / ".amx" / "chroma_db")
+                    client = chromadb.PersistentClient(path=persist)
+                    try:
+                        client.delete_collection(name="amx_docs")
+                    except Exception:
+                        pass
+                    store = RAGStore()
+
+                store.reset_collection()
+                with step_spinner("Re-ingesting documents into RAG store"):
+                    summary = store.ingest(documents, refresh=False)
+                _render_ingest_summary(summary, total_files=len(documents))
+                success(
+                    f"Reindexed: {summary.chunk_count} chunks rebuilt under "
+                    f"{store.embedding_provider}/{store.embedding_model} "
+                    f"({store.doc_count} total chunks)"
+                )
+        finally:
+            cleanup_scan_artifacts(documents)
+
     @docs.command("search-docs")
     @click.argument("question")
     @click.option("-n", "--results", default=5, help="Number of results.")

--- a/amx/docs/_fts5_sidecar.py
+++ b/amx/docs/_fts5_sidecar.py
@@ -181,6 +181,24 @@ class FTS5Sidecar:
             log.warning("FTS5 sidecar delete_by_ids failed: %s", exc)
             return 0
 
+    def clear(self) -> int:
+        """Remove every row from the FTS5 table.
+
+        Used by ``RAGStore.reset_collection`` so that after a docs
+        embedding-model swap the BM25 channel cannot resurface chunks
+        from the dropped Chroma collection. Returns the row count
+        before the wipe (best-effort, 0 on any error).
+        """
+        if self._conn is None:
+            return 0
+        try:
+            before = self._conn.execute(f"SELECT COUNT(*) FROM {_TABLE_NAME}").fetchone()
+            self._conn.execute(f"DELETE FROM {_TABLE_NAME}")
+            return int(before[0]) if before else 0
+        except sqlite3.Error as exc:  # pragma: no cover — rare
+            log.warning("FTS5 sidecar clear failed: %s", exc)
+            return 0
+
     def delete_by_source(self, source: str) -> int:
         """Delete all rows for the given ``source`` path. Used by
         ``RAGStore.delete_chunks_for_sources`` and by the orphan-

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -476,6 +476,49 @@ class RAGStore:
                 log.info("Deleted %d chunks for source %s", len(ids), src)
         return removed
 
+    def reset_collection(self) -> None:
+        """Drop the docs vector store and rebuild it with the active
+        identity.
+
+        ``ingest(refresh=True)`` removes documents one source at a
+        time but leaves the Chroma collection's identity metadata
+        (``embedding_provider`` / ``embedding_model`` /
+        ``embedding_dim``) intact. After an ``/embeddings`` swap that
+        leaves the user stuck — the next ``RAGStore()`` open reads
+        the stale identity and raises
+        :class:`EmbeddingProviderMismatch`. ``reset_collection``
+        drops the Chroma collection outright AND clears the FTS5
+        sidecar so the next ingest stamps fresh identity metadata
+        and the BM25 channel cannot resurface chunks from the dropped
+        collection.
+
+        The instance keeps working after the reset: ``self.collection``
+        is rebound to a freshly opened Chroma collection with the
+        active triple.
+        """
+        name = self.collection.name if hasattr(self.collection, "name") else "amx_docs"
+        try:
+            self.client.delete_collection(name=name)
+        except Exception as exc:
+            log.debug("reset_collection: delete_collection(%s) skipped: %s", name, exc)
+        try:
+            self._fts.clear()
+        except Exception as exc:
+            log.debug("reset_collection: fts clear failed: %s", exc)
+        kwargs: dict[str, Any] = {
+            "name": name,
+            "metadata": {
+                "hnsw:space": "cosine",
+                "embedding_provider": self.embedding_provider,
+                "embedding_model": self.embedding_model,
+                "embedding_dim": int(self.embedding_dim),
+                "amx_schema_version": _AMX_RAG_SCHEMA_VERSION,
+            },
+        }
+        if self.embedding_function is not None:
+            kwargs["embedding_function"] = self.embedding_function
+        self.collection = self.client.get_or_create_collection(**kwargs)
+
     def ingest(
         self,
         docs: list[DocInfo],

--- a/amx/search/index.py
+++ b/amx/search/index.py
@@ -144,10 +144,21 @@ class SearchIndex:
         # RAG's /code-refresh in semantics.
         self._identity = _resolve_search_identity(embedding_function, cfg=cfg)
         self._collections: dict[str, Any] = {}
-        # Eagerly construct the legacy collection (empty profile key) so the
-        # historical ``self.collection`` attribute keeps working for callers
-        # and tests that have not adopted the per-profile API.
-        self.collection = self._collection_for("")
+
+    @property
+    def collection(self) -> Any:
+        """Legacy (empty-profile) collection, opened lazily.
+
+        Earlier versions opened this in ``__init__``. The eager open
+        meant every ``/ask`` request absorbed the chroma init cost and
+        — worse — surfaced a ``CollectionIdentityMismatch`` at worker
+        startup even when the user had explicitly turned both Docs
+        and Code RAG off and the legacy collection was never going to
+        be queried. Opening lazily defers ``reconcile_identity`` to
+        the first call site that actually needs the collection, so
+        non-RAG questions never touch the on-disk vector store.
+        """
+        return self._collection_for("")
 
     def _collection_for(self, db_profile: str) -> Any:
         """Get or create the Chroma collection for *db_profile*.
@@ -251,11 +262,34 @@ class SearchIndex:
                 continue
 
     def reset_profile(self, db_profile: str) -> None:
-        col = self._collection_for(db_profile)
-        rows = col.get(include=[])
-        ids = rows.get("ids") or []
-        if ids:
-            col.delete(ids=ids)
+        """Drop the per-profile collection so the next open reseeds
+        the identity metadata.
+
+        The previous body deleted documents one id at a time but left
+        the collection's identity metadata (``embedding_provider`` /
+        ``embedding_model`` / ``embedding_dim``) in place. After an
+        ``/embeddings`` swap that meant the user could run
+        ``/search rebuild`` and STILL hit
+        :class:`CollectionIdentityMismatch` on the next ``/ask`` — the
+        rebuild deleted vectors but did not invalidate the stamped
+        identity, so the new MiniLM/MiniLM-L6-v2 active config kept
+        clashing with the old (e.g. ``sentence_transformers`` /
+        ``gte-small``) recorded triple. Dropping the collection
+        outright forces the next ``_collection_for`` call to
+        ``get_or_create_collection`` with the active identity.
+        """
+        name = _collection_name_for(db_profile)
+        # Drop the in-process cache first so the next access creates
+        # a fresh collection handle bound to the new on-disk state.
+        self._collections.pop(db_profile or "", None)
+        try:
+            self.client.delete_collection(name=name)
+        except Exception as exc:
+            # The collection may not exist yet (first ``rebuild`` on a
+            # fresh install) — that is fine. We log at debug instead
+            # of swallowing silently so a genuine Chroma error during
+            # rebuild is still investigable from the log.
+            log.debug("reset_profile: delete_collection(%s) skipped: %s", name, exc)
 
     def query(
         self,

--- a/amx/web/routers/ask.py
+++ b/amx/web/routers/ask.py
@@ -536,6 +536,20 @@ def _event_generator(job: Job):
                 yield {"event": "ping", "data": json.dumps({"t": now})}
                 last_keepalive = now
             if job.status not in ("queued", "running"):
+                # Diagnostic: the generator is about to close the SSE
+                # stream because the worker flipped status. If the
+                # worker has not yet enqueued the terminal event (or
+                # enqueued one we still need to drain), the SPA will
+                # see "Connection lost" instead of a clean job.done /
+                # job.failed / job.cancelled. ``queue_size`` is the
+                # smoking gun: a value > 0 means the terminal event
+                # was waiting on the queue when we exited.
+                log.warning(
+                    "ask SSE generator exiting early: job_id=%s status=%s queue_size=%s",
+                    job.id,
+                    job.status,
+                    job.queue.qsize(),
+                )
                 break
             continue
         kind = str(event.get("type", ""))
@@ -631,6 +645,80 @@ def _ask_worker(
     doc_profiles_override: list[str] | None = None,
     code_profiles_override: list[str] | None = None,
 ) -> None:
+    """Run the tool-calling agent and guarantee a terminal SSE event.
+
+    Wraps :func:`_ask_worker_impl` in a try/finally so that any
+    unhandled exception on a path that does not already emit a
+    terminal still produces a ``job.failed`` SSE frame. Without this
+    belt-and-suspenders, a regression like the historical
+    ``_load_catalog`` raise inside ``CollectionIdentityMismatch``
+    silently killed the worker thread and the SPA hung on
+    "Reasoning…" until the browser eventually reported
+    "Connection lost. Reconnecting (attempt 1/5)…".
+    """
+    try:
+        _ask_worker_impl(
+            cfg,
+            job,
+            question,
+            session_id,
+            db_profile,
+            scope_profiles,
+            doc_profiles_override,
+            code_profiles_override,
+        )
+    except Exception:
+        # Last-resort safety net. The two real paths
+        # (``_ask_worker_impl`` happy + named-exception branches)
+        # already emit clean terminal frames; this only fires when
+        # something escapes them.
+        log.exception(
+            "ask worker crashed without emitting a terminal event: job_id=%s",
+            job.id,
+        )
+    finally:
+        if job.status in ("queued", "running"):
+            # No terminal event was emitted — the thread died on a path
+            # the explicit handlers did not cover. Synthesize a
+            # ``job.failed`` so the SPA renders an actionable error
+            # state instead of hanging until the browser SSE proxy
+            # gives up.
+            job.status = "failed"
+            job.error = job.error or (
+                "Internal error: the ask worker exited without "
+                "emitting a terminal event. See ~/.amx/logs/amx.log."
+            )
+            job.ended_at = time.time()
+            try:
+                emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
+            except Exception:
+                pass
+            log.warning(
+                "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=synth-fallback",
+                job.id,
+                job.status,
+                time.time() - job.started_at,
+            )
+            try:
+                emit_terminal(
+                    job.queue,
+                    "job.failed",
+                    {"error": job.error, "hint": "internal-error"},
+                )
+            except Exception:
+                pass
+
+
+def _ask_worker_impl(
+    cfg: AMXConfig,
+    job: Job,
+    question: str,
+    session_id: int | None,
+    db_profile: str,
+    scope_profiles: list[str],
+    doc_profiles_override: list[str] | None = None,
+    code_profiles_override: list[str] | None = None,
+) -> None:
     """Run the tool-calling agent + stream every reasoning chunk and
     tool result back to the SSE consumer. Persists the assistant
     turn to chat_sessions on success.
@@ -639,6 +727,11 @@ def _ask_worker(
     (per-question body override > session sticky > config default).
     Passed through to ``run_tool_agent`` which threads it into every
     catalog tool call.
+
+    Wrapped by :func:`_ask_worker` so an unhandled exception on a code
+    path that does not already emit a terminal still produces a
+    ``job.failed`` SSE event instead of silently killing the worker
+    thread and stranding the SPA on a hung stream.
     """
     job.status = "running"
     emit(job.queue, "activity.added", {"idx": 0, "label": "Thinking"})
@@ -711,13 +804,52 @@ def _ask_worker(
         except Exception as exc:  # pragma: no cover - best-effort
             log.warning("Could not finalise tokens_json for ask run %s: %s", run_id, exc)
 
-    catalog = _load_catalog()
+    # ``_load_catalog`` can raise when the user's chromadb collection was
+    # indexed under one embedding identity and the active embedding
+    # profile points at a different one (the canonical signal is
+    # ``"Vector collection was indexed with a different embedding
+    # identity"``). Without this try/except the exception bubbled out
+    # of the worker thread before any terminal event was emitted, so
+    # the SSE consumer hung indefinitely and the browser eventually
+    # reported "Connection lost. Reconnecting (attempt 1/5)..." with
+    # no recovery path. Surface the failure as a clean ``job.failed``
+    # event with the original message so the SPA can render the
+    # actionable hint ("run /search rebuild").
+    try:
+        catalog = _load_catalog()
+    except Exception as exc:
+        message = str(exc) or exc.__class__.__name__
+        job.status = "failed"
+        job.error = f"Search catalog could not be opened: {message}"
+        job.ended_at = time.time()
+        emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
+        _finish(status_value="failed", error_text=job.error)
+        hint = "rebuild-catalog" if "embedding identity" in message.lower() else "sync-catalog"
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=catalog-load-failed hint=%s",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+            hint,
+        )
+        emit_terminal(
+            job.queue,
+            "job.failed",
+            {"error": job.error, "hint": hint},
+        )
+        return
     if catalog is None:
         job.status = "failed"
         job.error = "Search catalog isn't initialised yet — run /search sync first."
         job.ended_at = time.time()
         emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
         _finish(status_value="failed", error_text=job.error)
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=catalog-not-initialised",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+        )
         emit_terminal(
             job.queue,
             "job.failed",
@@ -743,6 +875,12 @@ def _ask_worker(
         job.ended_at = time.time()
         emit(job.queue, "activity.fail", {"idx": 0, "detail": job.error})
         _finish(status_value="failed", error_text=job.error)
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=llm-init-failed",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+        )
         emit_terminal(
             job.queue,
             "job.failed",
@@ -833,6 +971,12 @@ def _ask_worker(
                         session_id,
                         exc,
                     )
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=cancelled",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+        )
         emit_terminal(job.queue, "job.cancelled", {})
         return
     except Exception as exc:
@@ -877,6 +1021,12 @@ def _ask_worker(
         payload: dict[str, Any] = {"error": job.error}
         if hint:
             payload["hint"] = hint
+        log.info(
+            "ask worker terminal: job_id=%s status=%s elapsed=%.2fs reason=run_tool_agent-exception",
+            job.id,
+            job.status,
+            time.time() - job.started_at,
+        )
         emit_terminal(job.queue, "job.failed", payload)
         return
 
@@ -976,6 +1126,12 @@ def _ask_worker(
             "scope_profiles": list(result.scope_profiles or []),
             "focus_profile": result.focus_profile,
         },
+    )
+    log.info(
+        "ask worker terminal: job_id=%s status=%s elapsed=%.2fs",
+        job.id,
+        job.status,
+        time.time() - job.started_at,
     )
     emit_terminal(job.queue, "job.done", {"summary": job.summary})
 

--- a/tests/test_code_refresh_mismatch_recovery.py
+++ b/tests/test_code_refresh_mismatch_recovery.py
@@ -1,0 +1,80 @@
+"""``/code-refresh`` mismatch recovery.
+
+When the user swaps the code embedding model via ``/embeddings``, the
+on-disk ``amx_code`` Chroma collection's stamped identity stops
+matching the active config. The pre-fix ``/code-refresh`` invoked
+``delete_code_collection(source_filters=[code_path])``, which only
+deleted documents whose ``source_root`` matched the active code path
+and left the recorded identity triple alone — so the very next
+``/ask`` opened the unchanged collection and raised
+:class:`CodeEmbeddingMismatch` again. Users had no path out.
+
+This regression pins the new behaviour: when the probe detects a
+mismatch, ``/code-refresh`` calls ``delete_code_collection`` with
+``source_filters=None`` so Chroma drops the whole collection and the
+next scan recreates it with the active identity.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from amx.cli import main
+from amx.codebase.code_rag import CodeEmbeddingMismatch
+
+
+class FakeChromaCollection:
+    name = "amx_code"
+
+
+class FakeChromaClient:
+    def __init__(self, *, path: str) -> None:
+        self._path = path
+
+    def list_collections(self):
+        return [FakeChromaCollection()]
+
+
+class CodeRefreshMismatchRecoveryTests(unittest.TestCase):
+    def test_mismatch_probe_routes_through_full_collection_drop(self) -> None:
+        runner = CliRunner()
+
+        def _raise_mismatch(*_a, **_k):
+            raise CodeEmbeddingMismatch(
+                recorded_provider="minilm",
+                recorded_model="minilm-l6-v2",
+                active_provider="sentence_transformers",
+                active_model="thenlper/gte-small",
+            )
+
+        with (
+            patch("amx.config.AMXConfig.resolve_code_path", return_value="."),
+            patch("amx.codebase.cache.invalidate_cache"),
+            patch("amx.codebase.code_rag.delete_code_collection") as delete_code_collection,
+            patch("chromadb.PersistentClient", FakeChromaClient),
+            patch(
+                "amx.codebase.code_rag._resolve_code_embedding",
+                return_value=("sentence_transformers", "thenlper/gte-small", None),
+            ),
+            patch(
+                "amx.codebase.code_rag._open_collection",
+                side_effect=_raise_mismatch,
+            ),
+        ):
+            result = runner.invoke(
+                main,
+                ["--config", "test-config.yml", "code", "refresh"],
+                env={"AMX_SESSION_CHILD": "1"},
+                catch_exceptions=False,
+            )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        # Mismatch detected → full collection drop, not per-path delete.
+        delete_code_collection.assert_called_once_with(source_filters=None)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_docs_rag_reset_collection.py
+++ b/tests/test_docs_rag_reset_collection.py
@@ -1,0 +1,89 @@
+"""``RAGStore.reset_collection`` regression.
+
+After an ``/embeddings`` swap the docs Chroma collection's stamped
+identity (``embedding_provider`` / ``embedding_model`` /
+``embedding_dim``) no longer matches the active config, and every
+subsequent ``RAGStore()`` open raises
+:class:`EmbeddingProviderMismatch`. ``ingest(refresh=True)`` did not
+help — it only deleted documents for the same source path and left
+the identity stamp alone.
+
+This test pins the new contract: ``reset_collection()`` drops the
+Chroma collection outright AND clears the FTS5 sidecar, then
+re-opens with the current identity so the next ingest is consistent.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+
+from amx.docs import rag as docs_rag
+
+
+def test_reset_collection_drops_chroma_and_clears_fts() -> None:
+    deleted: list[str] = []
+    creates: list[dict[str, object]] = []
+
+    class FakeCollection:
+        def __init__(self, name: str = "amx_docs") -> None:
+            self.name = name
+            self.metadata: dict[str, object] = {}
+
+        # Surface enough no-ops for the constructor's backfill /
+        # FTS-bootstrap path to complete.
+        def modify(self, *, metadata: dict[str, object]) -> None:
+            self.metadata = dict(metadata)
+
+        def get(self, **_: object) -> dict[str, list]:
+            return {"ids": [], "documents": [], "metadatas": []}
+
+    class FakeClient:
+        def __init__(self, *, path: str) -> None:
+            self._path = path
+            self._collections: dict[str, FakeCollection] = {}
+
+        def get_or_create_collection(self, **kwargs: object) -> FakeCollection:
+            creates.append(kwargs)
+            name = str(kwargs.get("name") or "amx_docs")
+            col = self._collections.get(name) or FakeCollection(name)
+            self._collections[name] = col
+            return col
+
+        def delete_collection(self, *, name: str) -> None:
+            deleted.append(name)
+            self._collections.pop(name, None)
+
+    with tempfile.TemporaryDirectory() as td:
+        # Use the real RAGStore against a fake Chroma client. The
+        # FTS5 sidecar is real (SQLite); we will inspect it directly.
+        import chromadb
+
+        original_pc = chromadb.PersistentClient
+        chromadb.PersistentClient = FakeClient  # type: ignore[assignment]
+        try:
+            store = docs_rag.RAGStore(persist_dir=td)
+            # Seed the FTS sidecar with a row so we can prove ``clear``
+            # actually runs.
+            assert store._fts.upsert([("chunk_x", "doc.md", "hello world")]) == 1
+            assert store._fts.count() == 1
+
+            store.reset_collection()
+        finally:
+            chromadb.PersistentClient = original_pc  # type: ignore[assignment]
+
+        # Chroma collection was dropped (not just emptied).
+        assert "amx_docs" in deleted, f"expected amx_docs drop, got {deleted}"
+
+        # And re-opened with active identity metadata.
+        assert len(creates) >= 2, "reset_collection should re-open the collection"
+        reopen_kwargs = creates[-1]
+        metadata = dict(reopen_kwargs.get("metadata") or {})
+        assert metadata.get("embedding_provider") == store.embedding_provider
+        assert metadata.get("embedding_model") == store.embedding_model
+
+        # FTS sidecar was cleared so BM25 cannot resurrect dropped chunks.
+        conn = sqlite3.connect(str(store._fts.db_path))
+        count = conn.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0]
+        conn.close()
+        assert count == 0, f"FTS sidecar should be empty after reset, got {count} rows"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -4433,7 +4433,13 @@ class SearchIndexEmbeddingTests(unittest.TestCase):
                 return FakeCollection()
 
         with patch("chromadb.PersistentClient", FakeClient):
-            index_module.SearchIndex(persist_dir=self._tempdir.name)
+            idx = index_module.SearchIndex(persist_dir=self._tempdir.name)
+            # ``SearchIndex`` opens the legacy collection lazily, so the
+            # ``get_or_create_collection`` call only fires when a caller
+            # actually reaches for ``.collection`` (or any per-profile
+            # collection). Triggering it here keeps the embedding-wiring
+            # contract under test.
+            _ = idx.collection
 
         # Default behaviour: no embedding_function → Chroma uses MiniLM.
         self.assertNotIn("embedding_function", captured)
@@ -4462,6 +4468,9 @@ class SearchIndexEmbeddingTests(unittest.TestCase):
                 persist_dir=self._tempdir.name,
                 embedding_function=sentinel_ef,  # type: ignore[arg-type]
             )
+            # Legacy collection now opens lazily; touch it so the
+            # ``get_or_create_collection`` kwargs are captured.
+            _ = idx.collection
 
         self.assertIs(captured.get("embedding_function"), sentinel_ef)
         self.assertIs(idx.embedding_function, sentinel_ef)
@@ -5036,7 +5045,10 @@ class EmbeddingFactoryRegistryTests(unittest.TestCase):
         self.embeddings_module.set_embedding_function("code", lambda: code_sentinel)
         with tempfile.TemporaryDirectory() as td:
             with patch("chromadb.PersistentClient", FakeClient):
-                index_module.SearchIndex(persist_dir=td)
+                idx = index_module.SearchIndex(persist_dir=td)
+                # Legacy collection opens lazily — touch it to trigger
+                # the ``get_or_create_collection`` we are asserting on.
+                _ = idx.collection
 
         # Docs sentinel got wired in, NOT the code sentinel.
         self.assertIs(captured.get("embedding_function"), docs_sentinel)
@@ -5060,10 +5072,11 @@ class EmbeddingFactoryRegistryTests(unittest.TestCase):
         self.embeddings_module.set_embedding_function("docs", lambda: object())
         with tempfile.TemporaryDirectory() as td:
             with patch("chromadb.PersistentClient", FakeClient):
-                index_module.SearchIndex(
+                idx = index_module.SearchIndex(
                     persist_dir=td,
                     embedding_function=explicit,  # type: ignore[arg-type]
                 )
+                _ = idx.collection  # legacy collection now opens lazily
 
         self.assertIs(captured.get("embedding_function"), explicit)
 

--- a/tests/test_search_index_identity.py
+++ b/tests/test_search_index_identity.py
@@ -81,7 +81,12 @@ def test_provider_swap_raises_collection_identity_mismatch(tmp_path: Path) -> No
     """A collection stamped with one provider, re-opened by an index
     configured for another, raises the structured mismatch with a
     ``/search rebuild`` recovery hint. This is the failure the previous
-    silent-re-embed behaviour hid."""
+    silent-re-embed behaviour hid.
+
+    ``SearchIndex`` opens the legacy collection lazily, so the mismatch
+    fires on first access to ``index.collection`` (or any tool path
+    that reaches ``_collection_for``), not at construction.
+    """
     persist = tmp_path / "chroma"
     persist.mkdir(parents=True, exist_ok=True)
     client = chromadb.PersistentClient(path=str(persist))
@@ -99,8 +104,9 @@ def test_provider_swap_raises_collection_identity_mismatch(tmp_path: Path) -> No
             "amx_schema_version": 1,
         },
     )
+    index = SearchIndex(persist_dir=str(persist))
     with pytest.raises(CollectionIdentityMismatch) as excinfo:
-        SearchIndex(persist_dir=str(persist))
+        _ = index.collection
     msg = str(excinfo.value)
     assert "/search rebuild" in msg
     # provider changed AND model changed AND dim changed.
@@ -128,8 +134,9 @@ def test_dim_mismatch_alone_raises(tmp_path: Path) -> None:
             "amx_schema_version": 1,
         },
     )
+    index = SearchIndex(persist_dir=str(persist))
     with pytest.raises(CollectionIdentityMismatch) as excinfo:
-        SearchIndex(persist_dir=str(persist))
+        _ = index.collection
     msg = str(excinfo.value)
     assert "dim: 768" in msg or "dim 768 -> 384" in msg
 

--- a/tests/test_search_index_lazy_open.py
+++ b/tests/test_search_index_lazy_open.py
@@ -1,0 +1,129 @@
+"""Lazy chroma open for :class:`amx.search.index.SearchIndex`.
+
+PR #498 surfaced ``CollectionIdentityMismatch`` cleanly when the
+``/ask`` worker opened the search catalog. The follow-up reproduction
+revealed that the legacy (empty-profile) Chroma collection was opened
+inside ``SearchIndex.__init__`` — so a ``/ask`` request that explicitly
+turned both Docs and Code RAG off STILL absorbed the chroma open + identity
+check, and the user could never get past the embedding-mismatch error
+without a manual rebuild that itself was broken (see
+``test_reset_profile_drops_collection``).
+
+This module pins the new contract:
+
+* ``SearchIndex()`` does not open the legacy collection at construction
+  time.
+* The legacy collection materialises on first attribute access (via the
+  ``.collection`` property or any per-profile ``_collection_for`` call).
+* After ``reset_profile`` the on-disk Chroma collection is removed
+  outright — not just emptied — so the next reopen registers the
+  active embedding identity from scratch.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from amx.search import index as index_module
+
+
+def test_construction_does_not_call_get_or_create_collection() -> None:
+    """``SearchIndex()`` must not touch any Chroma collection at
+    construction time. Without this, a docs/code-off ``/ask`` still
+    opens the legacy collection and re-runs ``reconcile_identity``."""
+    captured: list[dict[str, object]] = []
+
+    class FakeClient:
+        def __init__(self, *, path: str) -> None:
+            self._path = path
+
+        def get_or_create_collection(self, **kwargs: object) -> object:
+            captured.append(kwargs)
+            return object()
+
+    with tempfile.TemporaryDirectory() as td:
+        with patch("chromadb.PersistentClient", FakeClient):
+            _ = index_module.SearchIndex(persist_dir=td)
+
+    assert captured == [], f"SearchIndex opened a Chroma collection at construction: {captured}"
+
+
+def test_collection_property_triggers_lazy_open() -> None:
+    """Accessing ``index.collection`` materialises the legacy
+    collection on demand, so callers that depend on the historical
+    attribute keep working."""
+    captured: list[dict[str, object]] = []
+
+    class FakeCollection:
+        metadata: dict[str, object] = {}
+
+    class FakeClient:
+        def __init__(self, *, path: str) -> None:
+            self._path = path
+
+        def get_or_create_collection(self, **kwargs: object) -> FakeCollection:
+            captured.append(kwargs)
+            return FakeCollection()
+
+    with tempfile.TemporaryDirectory() as td:
+        with patch("chromadb.PersistentClient", FakeClient):
+            idx = index_module.SearchIndex(persist_dir=td)
+            assert captured == []
+            _ = idx.collection
+            assert len(captured) == 1
+            assert captured[0]["name"] == "amx_search"
+
+
+def test_reset_profile_drops_collection_so_identity_can_change(tmp_path: Path) -> None:
+    """``reset_profile`` must drop the chroma collection so the next
+    ``_collection_for`` re-runs ``get_or_create_collection`` with the
+    active identity metadata. The previous body deleted documents but
+    left the recorded provider/model/dim alone, so ``/search rebuild``
+    after an ``/embeddings`` swap could not unstick the user."""
+    deleted: list[str] = []
+    created: list[dict[str, object]] = []
+
+    class FakeCollection:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.metadata: dict[str, object] = {}
+
+        def get(self, **_: object) -> dict[str, list[str]]:
+            return {"ids": []}
+
+        def delete(self, **_: object) -> None:  # documents-only delete
+            raise AssertionError(
+                "reset_profile must drop the whole collection, not just delete documents"
+            )
+
+    class FakeClient:
+        def __init__(self, *, path: str) -> None:
+            self._path = path
+            self._collections: dict[str, FakeCollection] = {}
+
+        def get_or_create_collection(self, **kwargs: object) -> FakeCollection:
+            created.append(kwargs)
+            name = str(kwargs.get("name") or "")
+            col = self._collections.get(name) or FakeCollection(name)
+            self._collections[name] = col
+            return col
+
+        def delete_collection(self, *, name: str) -> None:
+            deleted.append(name)
+            self._collections.pop(name, None)
+
+    with patch("chromadb.PersistentClient", FakeClient):
+        idx = index_module.SearchIndex(persist_dir=str(tmp_path / "chroma"))
+        # Populate the in-process cache to mirror the real flow:
+        # something queried this profile before the swap.
+        _ = idx._collection_for("prod")
+        assert "prod" in {kw.get("metadata", {}).get("amx_db_profile") for kw in created}
+
+        idx.reset_profile("prod")
+
+    profile_collection_name = index_module._collection_name_for("prod")
+    assert profile_collection_name in deleted, (
+        f"reset_profile should have dropped {profile_collection_name}, got {deleted}"
+    )

--- a/tests/web/test_ask_sse_terminal_drain.py
+++ b/tests/web/test_ask_sse_terminal_drain.py
@@ -1,0 +1,137 @@
+"""Terminal-event guarantees for /api/ask SSE streams.
+
+Historically, when ``_load_catalog()`` raised (e.g. the on-disk
+chromadb collection's embedding identity diverged from the active
+profile after a model swap), the worker thread died silently. The
+job status stayed ``"running"``, no ``job.failed`` ever reached the
+queue, the SSE generator kept emitting pings, and the SPA eventually
+gave up with "Connection lost. Reconnecting (attempt 1/5)..." — a
+useless error state.
+
+Two complementary safeguards now protect the SSE contract:
+
+1. **Targeted handler** around ``_load_catalog()`` emits a clean
+   ``job.failed`` with ``hint=rebuild-catalog`` so the SPA can render
+   an actionable "Run /search rebuild" toast.
+2. **Wrapper-level synth fallback** in ``_ask_worker``: a try/finally
+   that synthesizes ``job.failed`` with ``hint=internal-error`` if
+   any future code path escapes the explicit handlers. Belt and
+   suspenders for the silent-thread-death failure mode.
+
+Both safeguards are covered below.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+
+from amx.web.routers import ask as ask_router
+
+
+def _drain_sse(client, path: str, headers: dict[str, str]) -> list[dict]:
+    events: list[dict] = []
+    t0 = time.monotonic()
+    with client.stream("GET", path, headers=headers) as response:
+        assert response.status_code == 200
+        current_event = None
+        for line in response.iter_lines():
+            if not line:
+                continue
+            if isinstance(line, bytes):
+                line = line.decode("utf-8")
+            if line.startswith("event:"):
+                current_event = line.split(":", 1)[1].strip()
+            elif line.startswith("data:"):
+                payload = line.split(":", 1)[1].strip()
+                try:
+                    parsed = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                parsed["type"] = current_event or parsed.get("type", "")
+                events.append(parsed)
+                if (current_event or "") in {
+                    "job.done",
+                    "job.cancelled",
+                    "job.failed",
+                }:
+                    return events
+            if time.monotonic() - t0 > 5:
+                break
+    return events
+
+
+def test_load_catalog_failure_emits_clean_terminal_with_rebuild_hint(
+    client, auth_headers, monkeypatch
+) -> None:
+    """``_load_catalog()`` raising bubbles up as a clean ``job.failed``
+    SSE event with ``hint=rebuild-catalog`` — the SPA receives a
+    terminal frame and renders an actionable error instead of hanging
+    until the browser drops the stream as "Connection lost"."""
+
+    def _boom() -> None:
+        raise RuntimeError(
+            "Vector collection was indexed with a different embedding "
+            "identity. Run /search rebuild to refresh."
+        )
+
+    monkeypatch.setattr(ask_router, "_load_catalog", _boom)
+    monkeypatch.setattr(ask_router, "LLMProvider", lambda _cfg: MagicMock())
+
+    response = client.post(
+        "/api/ask",
+        headers=auth_headers,
+        json={"question": "are my syncs up to date"},
+    )
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+
+    events = _drain_sse(client, f"/api/ask/{job_id}/events", auth_headers)
+    failed = [e for e in events if e["type"] == "job.failed"]
+    assert len(failed) == 1, f"Expected one job.failed event, got: {events}"
+    payload = failed[0]
+    assert payload.get("hint") == "rebuild-catalog"
+    assert "catalog" in payload.get("error", "").lower()
+
+
+def test_ask_worker_synthesizes_terminal_on_silent_death(monkeypatch) -> None:
+    """If any path inside ``_ask_worker_impl`` raises without first
+    emitting a terminal event, the wrapper's try/finally MUST
+    synthesize a ``job.failed`` with ``hint=internal-error`` so the
+    SSE consumer is never left hanging."""
+
+    from amx.config import AMXConfig
+    from amx.web.jobs import Job
+
+    def _impl_dies(*_args, **_kwargs) -> None:
+        raise RuntimeError("simulated silent worker crash")
+
+    monkeypatch.setattr(ask_router, "_ask_worker_impl", _impl_dies)
+
+    job = Job(id="ask-test", kind="ask")
+    job.status = "running"
+    job.started_at = time.time()
+
+    ask_router._ask_worker(
+        AMXConfig(),
+        job,
+        question="anything",
+        session_id=None,
+        db_profile="default",
+        scope_profiles=["default"],
+    )
+
+    assert job.status == "failed"
+
+    drained: list[dict] = []
+    while True:
+        try:
+            drained.append(job.queue.get_nowait())
+        except Exception:
+            break
+
+    terminal = [e for e in drained if e.get("type") == "job.failed"]
+    assert len(terminal) == 1, f"No synth terminal emitted: {drained}"
+    assert terminal[0].get("hint") == "internal-error"
+    assert "log" in (terminal[0].get("error") or "").lower()


### PR DESCRIPTION
## Summary

Two reproductions surfaced after PR #498's SSE cleanup:

- **Ask still tried RAG even when both Docs and Code were off.** The legacy chroma collection was opened inside `SearchIndex.__init__`, so a `/ask` request that explicitly set `Docs: off · Code: off` still absorbed the chroma open + identity check and surfaced `CollectionIdentityMismatch` for a trivial `hey`. The legacy collection now opens lazily through a `.collection` property; non-RAG questions never touch the on-disk vector store.
- **Rebuild commands could not recover from an embedding-model swap.** `/search rebuild`, `/docs reindex` (previously a phantom), and `/code-refresh` all deleted documents but left the collection's identity metadata in place, so the next `RAGStore()` / `SearchIndex()` open re-raised the mismatch indefinitely. Rebuild paths now drop the chroma collection outright (and the docs path clears the FTS5 sidecar) so the next open re-stamps the active provider/model/dim.

Also adds the `/docs reindex` CLI command the existing `EmbeddingProviderMismatch` error message has been pointing at all along.

## Test plan

- [x] `pytest tests/test_search_index_lazy_open.py tests/test_docs_rag_reset_collection.py tests/test_code_refresh_mismatch_recovery.py -q` — 5 new tests pass
- [x] `pytest tests/ -q --ignore=tests/perf --ignore=tests/storage -k "not slow"` — 2371 passed, 9 skipped (env), 0 new failures
- [x] `ruff check` + `ruff format --check` — clean
- [x] Studio deployed via `~/amx-remote/scripts/deploy.sh`; ready to reproduce
- [ ] Live smoke in Studio:
  - With `Docs: off · Code: off` and a deliberately-stale chroma identity on disk, ask `hey` — expect the LLM to answer instead of `Connection lost` / `Search catalog could not be opened`
  - Swap docs embedding model → run `/docs reindex` from CLI — expect the docs collection to rebuild cleanly
  - Swap code embedding model → run `/code-refresh` from CLI — expect the mismatch probe to route through the full collection drop