### PR TITLE
feat(lineage): /lineage slice 1 — cache-first column lineage

### DIFF
--- a/amx/cli.py
+++ b/amx/cli.py
@@ -27,6 +27,7 @@ from amx.cli_support.commands.doctor import register_doctor_command
 from amx.cli_support.commands.eval_confidence import register_eval_confidence_command
 from amx.cli_support.commands.history import register_history_commands
 from amx.cli_support.commands.history_store import register_history_store_commands
+from amx.cli_support.commands.lineage import register_lineage_commands
 from amx.cli_support.commands.manual import register_manual_commands
 from amx.cli_support.commands.profiles import (
     interactive_llm_block as _interactive_llm_block,
@@ -412,6 +413,7 @@ def main(ctx: click.Context, cfg_path: str | None, debug: bool) -> None:
 history_group = register_history_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_compare_command(history_group, pass_config=pass_config, log_event=_log_app_event)
 register_eval_confidence_command(history_group, pass_config=pass_config, log_event=_log_app_event)
+register_lineage_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_search_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_doctor_command(main, pass_config=pass_config, log_event=_log_app_event)
 register_chat_session_commands(main, pass_config=pass_config, log_event=_log_app_event)

--- a/amx/cli_support/_session_keybindings.py
+++ b/amx/cli_support/_session_keybindings.py
@@ -28,7 +28,18 @@ def _kb_escape_namespace() -> KeyBindings:
 
         return len(get_app().current_buffer.text) == 0
 
-    tabs = ["", "db", "metadata", "docs", "llm", "code", "analyze", "search", "history"]
+    tabs = [
+        "",
+        "db",
+        "metadata",
+        "docs",
+        "llm",
+        "code",
+        "analyze",
+        "search",
+        "history",
+        "lineage",
+    ]
 
     @kb.add("escape")
     def _(event) -> None:  # type: ignore[no-untyped-def]

--- a/amx/cli_support/_session_ui.py
+++ b/amx/cli_support/_session_ui.py
@@ -24,7 +24,18 @@ def _canonical_namespace(namespace: str) -> str:
     return "metadata" if namespace == "manual" else namespace
 
 
-_TAB_ORDER = ["root", "db", "metadata", "docs", "llm", "code", "analyze", "search", "history"]
+_TAB_ORDER = [
+    "root",
+    "db",
+    "metadata",
+    "docs",
+    "llm",
+    "code",
+    "analyze",
+    "search",
+    "history",
+    "lineage",
+]
 
 
 def _print_tab_bar(namespace: str) -> None:
@@ -74,6 +85,11 @@ def _print_namespace_hint(
         info("Search generated/manual metadata, join candidates, and code usage evidence.")
     elif namespace == "history":
         info("View past metadata extractions. Use /review to inspect results.")
+    elif namespace == "lineage":
+        info(
+            "Render column-level lineage diagrams from cached metadata. "
+            "Each subcommand walks a picker — /create starts a guided wizard."
+        )
 
 
 def _print_session_help(*, namespace: str, cfg: AMXConfig) -> None:
@@ -383,6 +399,36 @@ Commands:
 
 SQLite file:
   ~/.amx/history.db
+"""
+        )
+        return
+
+    if namespace == "lineage":
+        out.print(
+            """
+[heading]Help — /lineage namespace[/heading]
+Cache-first, wizard-driven column-level lineage diagrams. Every subcommand
+walks an ask_choice/ask picker chain when invoked bare — no flag is
+required. Power-user flags exist but are optional.
+
+Commands:
+  1) /back                       Return to root namespace
+  2) /create                     Wizard: profile → schema → table → (column)
+                                 → format → depth → cache strategy → render
+  3) /list                       Show all rendered artifacts in a table
+  4) /open                       Picker over existing artifacts; opens the file
+  5) /refresh                    Picker over artifacts; re-extracts + re-renders
+  6) /delete                     Picker over artifacts; removes row + file
+  7) /show                       Wizard for anchor; text-mode tree (no image)
+
+Cache strategies (asked at the end of /create and /refresh):
+  • cache-only           — never call the DB, use only what's cached (default)
+  • ask if needed        — mid-run prompt if a cache miss occurs
+  • fetch from DB        — auto-confirm cache fill before rendering
+  • force fresh          — invalidate view-DDL cache and re-pull from DB
+
+Artifacts:
+  ~/.amx/lineage/<slug>.<format>     (default output location)
 """
         )
         return

--- a/amx/cli_support/commands/lineage.py
+++ b/amx/cli_support/commands/lineage.py
@@ -1,0 +1,639 @@
+"""``/lineage`` namespace commands.
+
+Cache-first by construction: no command opens a live DB connection
+without the user explicitly answering ``y`` to the cost-confirm prompt
+(or passing ``--prefetch`` / ``--no-cache``).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import click
+
+from amx.config import AMXConfig, DBConfig
+from amx.lineage import service
+from amx.lineage import store as lineage_store
+from amx.lineage.extractors.view_ddl import ConnectorHandle
+from amx.lineage.render import (
+    SUPPORTED_FORMATS,
+    DotBinaryNotFound,
+    open_artifact,
+)
+from amx.lineage.service import CacheMissReport, FillDecision, LineageRunResult, ScaleVerdict
+from amx.lineage.types import ColumnRef, Scope
+from amx.storage.sqlite_store import history_store
+from amx.utils.console import (
+    ask,
+    ask_choice,
+    confirm,
+    error,
+    heading,
+    info,
+    render_table,
+    success,
+    warn,
+)
+
+LogEvent = Callable[..., None]
+
+_DEFAULT_FORMAT = "svg"
+_DEFAULT_DEPTH = 1
+
+
+def register_lineage_commands(
+    main: click.Group,
+    *,
+    pass_config: Callable[[Callable[..., Any]], Callable[..., Any]],
+    log_event: LogEvent,
+) -> click.Group:
+    """Attach ``/lineage`` namespace commands to the main Click group."""
+
+    @main.group()
+    def lineage() -> None:
+        """Render and manage column-level lineage diagrams (cache-first)."""
+
+    @lineage.command("create")
+    @click.argument("anchor", required=False)
+    @click.option("--column", "column", default=None, help="Restrict anchor to a specific column.")
+    @click.option(
+        "--out", "out", default=None, help="Output image path (defaults under ~/.amx/lineage)."
+    )
+    @click.option(
+        "--format",
+        "fmt",
+        type=click.Choice(SUPPORTED_FORMATS, case_sensitive=False),
+        default=None,
+        help="Image format. Default: svg.",
+    )
+    @click.option("--depth-up", "depth_up", type=int, default=None, help="Upstream hop limit.")
+    @click.option(
+        "--depth-down", "depth_down", type=int, default=None, help="Downstream hop limit."
+    )
+    @click.option(
+        "--name", "name", default=None, help="Artifact slug (default: derived from anchor)."
+    )
+    @click.option("--profile", "profile_flag", default=None, help="Override active DB profile.")
+    @click.option(
+        "--no-cache", is_flag=True, help="Force fresh DB fetch (refills cache afterwards)."
+    )
+    @click.option("--cache-only", is_flag=True, help="Refuse any DB hit. For scripted/CI use.")
+    @click.option("--prefetch", is_flag=True, help="Auto-confirm the cache-fill prompt.")
+    @click.option("--force", is_flag=True, help="Override scale guardrails.")
+    @pass_config
+    def lineage_create(
+        cfg: AMXConfig,
+        anchor: str | None,
+        column: str | None,
+        out: str | None,
+        fmt: str | None,
+        depth_up: int | None,
+        depth_down: int | None,
+        name: str | None,
+        profile_flag: str | None,
+        no_cache: bool,
+        cache_only: bool,
+        prefetch: bool,
+        force: bool,
+    ) -> None:
+        hs = history_store()
+        if hs is None:
+            error("History store not initialised — run /db first.")
+            return
+        if cache_only and (prefetch or no_cache):
+            error("--cache-only is mutually exclusive with --prefetch / --no-cache.")
+            return
+
+        profile_name, profile_cfg = _resolve_profile(cfg, profile_flag)
+        if profile_name is None:
+            error("No DB profile available. Run /db add-profile first.")
+            return
+
+        if not anchor:
+            anchor = ask("Anchor table (schema.table or schema.table.column)").strip()
+            if not anchor:
+                error("Anchor is required.")
+                return
+
+        parts = [p for p in re.split(r"[./]", anchor) if p]
+        if len(parts) == 1:
+            schema = ""
+            table = parts[0]
+        elif len(parts) == 2:
+            schema, table = parts
+        elif len(parts) >= 3:
+            schema = parts[-3]
+            table = parts[-2]
+            if not column:
+                column = parts[-1]
+        else:
+            error(f"Could not parse anchor {anchor!r}.")
+            return
+
+        database = _default_database(profile_cfg)
+        anchor_ref = ColumnRef(database=database, schema=schema, table=table, column=column or "")
+
+        fmt = (fmt or _DEFAULT_FORMAT).lower()
+        if fmt not in SUPPORTED_FORMATS:
+            error(f"Unsupported format {fmt!r}. Choose one of {SUPPORTED_FORMATS}.")
+            return
+
+        depth_up = depth_up if depth_up is not None else _DEFAULT_DEPTH
+        depth_down = depth_down if depth_down is not None else _DEFAULT_DEPTH
+        slug = name or _default_slug(anchor_ref)
+
+        output_path = _resolve_output_path(out, slug, fmt)
+        if output_path is None:
+            error("Output path is invalid or not writable.")
+            return
+
+        scope = Scope(
+            profile=profile_name,
+            anchor=anchor_ref,
+            depth_up=depth_up,
+            depth_down=depth_down,
+            database=database,
+            schema=schema,
+        )
+
+        fill_decision: FillDecision | None
+        if cache_only:
+            fill_decision = "skip"
+        elif prefetch or no_cache:
+            fill_decision = "fill"
+        else:
+            fill_decision = None  # interactive prompt below
+
+        connector_factory = _build_connector_factory(cfg)
+
+        try:
+            result = service.create_lineage(
+                hs=hs,
+                scope=scope,
+                name=slug,
+                output_path=output_path,
+                fmt=fmt,
+                fill_prompt=_make_fill_prompt(),
+                fill_decision=fill_decision,
+                force_scale=force,
+                soft_confirm=_make_soft_confirm(),
+                connector_factory=connector_factory,
+            )
+        except LookupError as exc:
+            error(str(exc))
+            return
+        except DotBinaryNotFound as exc:
+            error(str(exc))
+            return
+        except Exception as exc:
+            error(f"Lineage render failed: {exc}")
+            return
+
+        _print_run_result(result)
+        log_event(
+            event_type="lineage.create",
+            status="aborted" if result.aborted else "ok",
+            command="/lineage create",
+            details={
+                "profile": profile_name,
+                "anchor": _ref_to_str(anchor_ref),
+                "format": fmt,
+                "node_count": result.node_count,
+                "edge_count": result.edge_count,
+                "extractors": result.extractors_used,
+                "partial": result.extractors_partial,
+            },
+        )
+
+    @lineage.command("list")
+    @click.option("--profile", "profile_flag", default=None, help="Filter by DB profile.")
+    @pass_config
+    def lineage_list(cfg: AMXConfig, profile_flag: str | None) -> None:
+        hs = history_store()
+        if hs is None:
+            error("History store not initialised — run /db first.")
+            return
+        rows = lineage_store.list_lineage_artifacts(hs, db_profile=profile_flag or "")
+        if not rows:
+            info("No lineage artifacts yet. Try /lineage create <table>.")
+            return
+        render_table(
+            "Lineage artifacts",
+            [
+                "id",
+                "name",
+                "profile",
+                "anchor",
+                "fmt",
+                "nodes",
+                "edges",
+                "extractors",
+                "partial",
+                "generated_at",
+                "path",
+            ],
+            [
+                [
+                    str(r["id"]),
+                    r["name"],
+                    r["db_profile"],
+                    _anchor_display(hs, r["anchor_entity_id"]),
+                    r["format"],
+                    str(r["node_count"]),
+                    str(r["edge_count"]),
+                    ",".join(r["extractors_used"]) or "-",
+                    "yes" if r["extractors_partial"] else "no",
+                    _fmt_time(r["generated_at"]),
+                    r["output_path"],
+                ]
+                for r in rows
+            ],
+        )
+
+    @lineage.command("open")
+    @click.argument("name_or_id", required=True)
+    @pass_config
+    def lineage_open(cfg: AMXConfig, name_or_id: str) -> None:
+        hs = history_store()
+        if hs is None:
+            error("History store not initialised — run /db first.")
+            return
+        artifact = lineage_store.lookup_lineage_artifact(hs, name_or_id=name_or_id)
+        if artifact is None:
+            error(f"No artifact named {name_or_id!r}.")
+            return
+        path = Path(artifact["output_path"])
+        if not path.exists():
+            warn(f"File missing at {path} — run /lineage refresh {artifact['name']}.")
+            return
+        _warn_if_stale(hs, artifact)
+        info(f"Opening {path}")
+        if not open_artifact(path):
+            info(f"Path: {path}")
+
+    @lineage.command("refresh")
+    @click.argument("name_or_id", required=True)
+    @click.option(
+        "--no-cache", is_flag=True, help="Invalidate view-cache and force fresh DB fetch."
+    )
+    @click.option("--cache-only", is_flag=True, help="Refuse any DB hit.")
+    @click.option("--prefetch", is_flag=True, help="Auto-confirm the cache-fill prompt.")
+    @click.option("--force", is_flag=True, help="Override scale guardrails.")
+    @click.option("--yes", is_flag=True, help="Skip the overwrite confirmation.")
+    @pass_config
+    def lineage_refresh(
+        cfg: AMXConfig,
+        name_or_id: str,
+        no_cache: bool,
+        cache_only: bool,
+        prefetch: bool,
+        force: bool,
+        yes: bool,
+    ) -> None:
+        hs = history_store()
+        if hs is None:
+            error("History store not initialised — run /db first.")
+            return
+        if cache_only and (prefetch or no_cache):
+            error("--cache-only is mutually exclusive with --prefetch / --no-cache.")
+            return
+        artifact = lineage_store.lookup_lineage_artifact(hs, name_or_id=name_or_id)
+        if artifact is None:
+            error(f"No artifact named {name_or_id!r}.")
+            return
+        if not yes and not confirm(
+            f"This will overwrite {artifact['output_path']}. Continue?",
+            default=True,
+        ):
+            warn("Cancelled.")
+            return
+
+        fill_decision: FillDecision | None
+        if cache_only:
+            fill_decision = "skip"
+        elif prefetch:
+            fill_decision = "fill"
+        else:
+            fill_decision = None
+
+        connector_factory = _build_connector_factory(cfg)
+        try:
+            result = service.refresh_lineage(
+                hs=hs,
+                artifact=artifact,
+                fill_prompt=_make_fill_prompt(),
+                fill_decision=fill_decision,
+                no_cache=no_cache,
+                force_scale=force,
+                soft_confirm=_make_soft_confirm(),
+                connector_factory=connector_factory,
+            )
+        except DotBinaryNotFound as exc:
+            error(str(exc))
+            return
+        except Exception as exc:
+            error(f"Refresh failed: {exc}")
+            return
+        _print_run_result(result)
+        log_event(
+            event_type="lineage.refresh",
+            status="aborted" if result.aborted else "ok",
+            command="/lineage refresh",
+            details={
+                "id": artifact["id"],
+                "node_count": result.node_count,
+                "edge_count": result.edge_count,
+                "partial": result.extractors_partial,
+            },
+        )
+
+    @lineage.command("delete")
+    @click.argument("name_or_id", required=True)
+    @click.option("--yes", is_flag=True, help="Skip confirmation.")
+    @pass_config
+    def lineage_delete(cfg: AMXConfig, name_or_id: str, yes: bool) -> None:
+        hs = history_store()
+        if hs is None:
+            error("History store not initialised — run /db first.")
+            return
+        artifact = lineage_store.lookup_lineage_artifact(hs, name_or_id=name_or_id)
+        if artifact is None:
+            error(f"No artifact named {name_or_id!r}.")
+            return
+        path = Path(artifact["output_path"])
+        if not yes and not confirm(
+            f"Delete artifact {artifact['name']!r} and file {path}?",
+            default=False,
+        ):
+            warn("Cancelled.")
+            return
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        lineage_store.delete_lineage_artifact(hs, artifact_id=int(artifact["id"]))
+        success(f"Deleted artifact {artifact['name']!r}.")
+        log_event(
+            event_type="lineage.delete",
+            status="ok",
+            command="/lineage delete",
+            details={"id": artifact["id"]},
+        )
+
+    @lineage.command("show")
+    @click.argument("anchor", required=True)
+    @click.option("--column", "column", default=None, help="Restrict anchor to a specific column.")
+    @click.option(
+        "--depth-up", "depth_up", type=int, default=_DEFAULT_DEPTH, help="Upstream hop limit."
+    )
+    @click.option(
+        "--depth-down", "depth_down", type=int, default=_DEFAULT_DEPTH, help="Downstream hop limit."
+    )
+    @click.option("--profile", "profile_flag", default=None, help="Override active DB profile.")
+    @pass_config
+    def lineage_show(
+        cfg: AMXConfig,
+        anchor: str,
+        column: str | None,
+        depth_up: int,
+        depth_down: int,
+        profile_flag: str | None,
+    ) -> None:
+        hs = history_store()
+        if hs is None:
+            error("History store not initialised — run /db first.")
+            return
+        profile_name, profile_cfg = _resolve_profile(cfg, profile_flag)
+        if profile_name is None:
+            error("No DB profile available.")
+            return
+        parts = [p for p in re.split(r"[./]", anchor) if p]
+        if len(parts) == 1:
+            schema, table = "", parts[0]
+        elif len(parts) == 2:
+            schema, table = parts
+        else:
+            schema, table = parts[-3], parts[-2]
+            column = column or parts[-1]
+        anchor_ref = ColumnRef(
+            database=_default_database(profile_cfg),
+            schema=schema,
+            table=table,
+            column=column or "",
+        )
+        scope = Scope(
+            profile=profile_name,
+            anchor=anchor_ref,
+            depth_up=depth_up,
+            depth_down=depth_down,
+            database=anchor_ref.database,
+            schema=schema,
+        )
+        for line in service.text_tree(hs=hs, scope=scope):
+            click.echo(line)
+
+    return lineage
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+def _resolve_profile(cfg: AMXConfig, flag: str | None) -> tuple[str | None, DBConfig | None]:
+    """Return (profile_name, DBConfig) or (None, None) when no profile resolves."""
+    profiles = getattr(cfg, "db_profiles", {}) or {}
+    if flag:
+        if flag in profiles:
+            return flag, profiles[flag]
+        return None, None
+    active = getattr(cfg, "active_db_profile", "") or ""
+    if active and active in profiles:
+        return active, profiles[active]
+    # Fall back to the only-profile case (common on fresh installs).
+    if len(profiles) == 1:
+        only = next(iter(profiles.items()))
+        return only[0], only[1]
+    return None, None
+
+
+def _default_database(profile_cfg: DBConfig | None) -> str:
+    if profile_cfg is None:
+        return ""
+    return getattr(profile_cfg, "database", "") or ""
+
+
+def _build_connector_factory(cfg: AMXConfig):
+    """Return a ConnectorFactory closed over the live config.
+
+    The factory imports DatabaseConnector lazily so adapters that need
+    optional driver wheels are only pulled when the user actually opts
+    into a db_fill round-trip.
+    """
+
+    def factory(profile_name: str) -> ConnectorHandle | None:
+        profiles = getattr(cfg, "db_profiles", {}) or {}
+        profile_cfg = profiles.get(profile_name)
+        if profile_cfg is None:
+            return None
+        try:
+            from amx.db.connector import DatabaseConnector
+
+            connector = DatabaseConnector(profile_cfg, profile_name=profile_name)
+            return ConnectorHandle(
+                engine=connector.engine,
+                adapter=connector._adapter,
+                backend=connector.backend,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            warn(f"Could not open connector for profile {profile_name!r}: {exc}")
+            return None
+
+    return factory
+
+
+def _make_fill_prompt() -> Callable[[CacheMissReport], FillDecision]:
+    def prompter(report: CacheMissReport) -> FillDecision:
+        scopes = (
+            ", ".join(
+                f"{s.schema}" if not s.database else f"{s.database}.{s.schema}"
+                for s in report.missing_scopes
+            )
+            or "(unknown)"
+        )
+        heading("Lineage cache miss")
+        info(f"  Extractors needing fresh data: {', '.join(report.extractors_with_misses) or '-'}")
+        info(f"  Schemas without cached view DDL: {scopes}")
+        if report.estimated_views:
+            info(
+                f"  Estimated cost: ~{report.estimated_views} views, "
+                f"~{report.estimated_seconds:.1f}s DB time."
+            )
+        choice = ask_choice(
+            "Fetch from DB now?",
+            ["cache-only (skip DB)", "fetch from DB", "abort"],
+            default="cache-only (skip DB)",
+        )
+        if choice.startswith("fetch"):
+            return "fill"
+        if choice == "abort":
+            return "abort"
+        return "skip"
+
+    return prompter
+
+
+def _make_soft_confirm() -> Callable[[ScaleVerdict], bool]:
+    def confirmer(verdict: ScaleVerdict) -> bool:
+        return confirm(
+            f"Graph has {verdict.node_count} nodes and {verdict.edge_count} edges. "
+            "Rendering may be slow. Continue?",
+            default=False,
+        )
+
+    return confirmer
+
+
+def _resolve_output_path(out: str | None, slug: str, fmt: str) -> Path | None:
+    if out:
+        path = Path(out).expanduser()
+    else:
+        # Default under the AMX config dir so the file survives /clear.
+        from amx.config import resolve_config_dir
+
+        base = Path(resolve_config_dir()) / "lineage"
+        path = base / f"{slug}.{fmt}"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    return path.resolve()
+
+
+def _default_slug(ref: ColumnRef) -> str:
+    parts = [p for p in (ref.schema, ref.table, ref.column) if p]
+    base = "-".join(parts) or "lineage"
+    return re.sub(r"[^A-Za-z0-9_-]+", "_", base)
+
+
+def _anchor_display(hs: Any, anchor_entity_id: int) -> str:
+    with hs._connect() as conn:
+        row = conn.execute(
+            "SELECT database_name, schema_name, table_name, column_name "
+            "FROM catalog_entities WHERE id = ?",
+            (int(anchor_entity_id),),
+        ).fetchone()
+    if not row:
+        return f"#{anchor_entity_id} (missing)"
+    parts = [str(p) for p in row if p]
+    return ".".join(parts) if parts else f"#{anchor_entity_id}"
+
+
+def _fmt_time(ts: float) -> str:
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+    except Exception:
+        return "-"
+
+
+def _print_run_result(result: LineageRunResult) -> None:
+    if result.aborted:
+        warn(f"Aborted: {result.abort_reason}")
+        return
+    success(f"Lineage written to {result.output_path}")
+    info(
+        f"  Nodes: {result.node_count}  Edges: {result.edge_count}  "
+        f"Extractors: {', '.join(result.extractors_used) or '-'}"
+        + (" (partial)" if result.extractors_partial else "")
+    )
+
+
+def _warn_if_stale(hs: Any, artifact: dict[str, Any]) -> None:
+    """Best-effort hash comparison. A miss is just a warning, not a block."""
+    scope_anchor = _anchor_from_db(hs, int(artifact["anchor_entity_id"]))
+    if scope_anchor is None:
+        return
+    scope = Scope(
+        profile=str(artifact["db_profile"]),
+        anchor=scope_anchor,
+        depth_up=int(artifact["depth_up"]),
+        depth_down=int(artifact["depth_down"]),
+        database=scope_anchor.database,
+        schema=scope_anchor.schema,
+    )
+    extractors = service.build_default_extractors(connector_factory=None)
+    try:
+        edges, _, _ = service.gather_edges(hs, scope, extractors)
+    except Exception:
+        return
+    current_hash = lineage_store.compute_edge_set_hash(
+        service._edges_for_hash(hs, scope, edges)  # type: ignore[attr-defined]
+    )
+    if current_hash != artifact["edge_set_hash"]:
+        warn(
+            "The cached image may be stale — current edges differ from when it was rendered. "
+            f"Run /lineage refresh {artifact['name']} to update."
+        )
+
+
+def _anchor_from_db(hs: Any, anchor_entity_id: int) -> ColumnRef | None:
+    with hs._connect() as conn:
+        row = conn.execute(
+            "SELECT database_name, schema_name, table_name, column_name "
+            "FROM catalog_entities WHERE id = ?",
+            (int(anchor_entity_id),),
+        ).fetchone()
+    if not row:
+        return None
+    return ColumnRef(
+        database=str(row[0] or ""),
+        schema=str(row[1] or ""),
+        table=str(row[2] or ""),
+        column=str(row[3] or ""),
+    )
+
+
+def _ref_to_str(ref: ColumnRef) -> str:
+    return ".".join(p for p in (ref.database, ref.schema, ref.table, ref.column) if p)

--- a/amx/cli_support/commands/lineage.py
+++ b/amx/cli_support/commands/lineage.py
@@ -689,23 +689,26 @@ def _ask_output_path(out: str | None, slug: str, fmt: str) -> Path | None:
 
 
 def _list_cached_databases(hs: Any, profile: str) -> list[str]:
-    """Return distinct cached databases for the profile.
+    """Return distinct, non-empty cached databases for the profile.
 
-    Empty-string ``database_name`` rows (flat backends) are folded into
-    a single empty entry the caller can present as "(unspecified)" or
-    silently use as the scope key.
+    Empty-string ``database_name`` rows are filtered out — they get
+    written by upstream callers that don't carry a database scope
+    (connection probes, schema-level entities). Surfacing them would
+    show up as a confusing blank picker entry. When *every* cached
+    row is empty (flat backends like SQLite) the caller falls back to
+    the empty scope on its own.
     """
     with hs._connect() as conn:
         rows = conn.execute(
             """
             SELECT DISTINCT database_name
             FROM catalog_entities
-            WHERE db_profile = ?
+            WHERE db_profile = ? AND database_name IS NOT NULL AND database_name <> ''
             ORDER BY database_name
             """,
             (profile,),
         ).fetchall()
-    return [str(r[0] or "") for r in rows]
+    return [str(r[0]) for r in rows]
 
 
 def _list_cached_schemas(hs: Any, profile: str, database: str) -> list[str]:

--- a/amx/cli_support/commands/lineage.py
+++ b/amx/cli_support/commands/lineage.py
@@ -125,11 +125,10 @@ def register_lineage_commands(
         if profile_name is None:
             return
 
-        database = _default_database(profile_cfg)
-        schema, table, column = _pick_anchor_location(
+        database, schema, table, column = _pick_anchor_location(
             hs,
             profile=profile_name,
-            database=database,
+            profile_default_db=_default_database(profile_cfg),
             raw_anchor=anchor,
             preset_column=column,
             require_column=False,
@@ -429,11 +428,10 @@ def register_lineage_commands(
         profile_name, profile_cfg = _pick_profile(cfg, profile_flag)
         if profile_name is None:
             return
-        database = _default_database(profile_cfg)
-        schema, table, column = _pick_anchor_location(
+        database, schema, table, column = _pick_anchor_location(
             hs,
             profile=profile_name,
-            database=database,
+            profile_default_db=_default_database(profile_cfg),
             raw_anchor=anchor,
             preset_column=column,
             require_column=False,
@@ -493,14 +491,21 @@ def _pick_anchor_location(
     hs: Any,
     *,
     profile: str,
-    database: str,
+    profile_default_db: str,
     raw_anchor: str | None,
     preset_column: str | None,
     require_column: bool,
-) -> tuple[str | None, str | None, str | None]:
-    """Pick (schema, table, column). ``raw_anchor`` short-circuits the wizard
-    when it's a fully-qualified path.
+) -> tuple[str | None, str | None, str | None, str | None]:
+    """Pick (database, schema, table, column). ``raw_anchor`` short-circuits
+    the wizard when it's a fully-qualified path.
+
+    Path parsing convention:
+      * ``table``                          → table
+      * ``schema.table``                   → schema + table
+      * ``schema.table.column``            → schema + table + column
+      * ``database.schema.table.column``   → fully qualified
     """
+    database = ""
     schema = ""
     table = ""
     column = preset_column
@@ -511,24 +516,34 @@ def _pick_anchor_location(
             table = parts[0]
         elif len(parts) == 2:
             schema, table = parts
-        elif len(parts) >= 3:
+        elif len(parts) == 3:
+            schema, table = parts[0], parts[1]
+            if not column:
+                column = parts[2]
+        elif len(parts) >= 4:
+            database = parts[-4]
             schema = parts[-3]
             table = parts[-2]
             if not column:
                 column = parts[-1]
 
+    if not database:
+        database = _pick_database(hs, profile, profile_default_db)
+        if database is None:
+            return None, None, None, None
+
     if not schema:
         schemas = _list_cached_schemas(hs, profile, database)
         if not schemas:
             error(
-                "No cached schemas found for this profile. "
+                f"No cached schemas under database {database!r}. "
                 "Run /db inspect first to populate the catalog."
             )
-            return None, None, None
+            return None, None, None, None
         schema = ask_choice("Pick a schema", schemas, default=schemas[0])
         if not schema:
             error("No schema picked.")
-            return None, None, None
+            return None, None, None, None
 
     if not table:
         tables = _list_cached_tables(hs, profile, database, schema)
@@ -536,11 +551,11 @@ def _pick_anchor_location(
             error(
                 f"No cached tables under schema {schema!r}. Run /db inspect on this schema first."
             )
-            return None, None, None
+            return None, None, None, None
         table = ask_choice("Pick a table", tables, default=tables[0])
         if not table:
             error("No table picked.")
-            return None, None, None
+            return None, None, None, None
 
     if not column:
         # Offer column-level anchor as an optional refinement.
@@ -552,9 +567,37 @@ def _pick_anchor_location(
                 column = picked
         elif require_column:
             error(f"No columns cached for {schema}.{table}.")
-            return None, None, None
+            return None, None, None, None
 
-    return schema, table, column
+    return database, schema, table, column
+
+
+def _pick_database(hs: Any, profile: str, profile_default: str) -> str | None:
+    """Resolve a database via the profile pin, sole-cached fallback, or picker.
+
+    Returns ``None`` when the user explicitly aborts the picker. An empty
+    string return means "no database scope" — flat backends (SQLite,
+    DuckDB single-file) carry no database hierarchy, so the downstream
+    catalog query is keyed on ``database_name = ''`` and still works.
+    """
+    if profile_default:
+        return profile_default
+    cached = _list_cached_databases(hs, profile)
+    if not cached:
+        # Nothing in the catalog — fall back to the empty-database scope
+        # so flat profiles keep working. The schema picker below will
+        # complain if nothing is cached there either.
+        return ""
+    if len(cached) == 1:
+        only = cached[0]
+        label = only or "(unspecified)"
+        info(f"Using database [bold]{label}[/bold] (only cached database for this profile).")
+        return only
+    picked = ask_choice("Pick a database", cached, default=cached[0])
+    if not picked:
+        error("No database picked.")
+        return None
+    return picked
 
 
 def _pick_format() -> str:
@@ -643,6 +686,26 @@ def _ask_output_path(out: str | None, slug: str, fmt: str) -> Path | None:
 
 
 # ── catalog readers (cache-only) ─────────────────────────────────────────
+
+
+def _list_cached_databases(hs: Any, profile: str) -> list[str]:
+    """Return distinct cached databases for the profile.
+
+    Empty-string ``database_name`` rows (flat backends) are folded into
+    a single empty entry the caller can present as "(unspecified)" or
+    silently use as the scope key.
+    """
+    with hs._connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT database_name
+            FROM catalog_entities
+            WHERE db_profile = ?
+            ORDER BY database_name
+            """,
+            (profile,),
+        ).fetchall()
+    return [str(r[0] or "") for r in rows]
 
 
 def _list_cached_schemas(hs: Any, profile: str, database: str) -> list[str]:

--- a/amx/cli_support/commands/lineage.py
+++ b/amx/cli_support/commands/lineage.py
@@ -3,6 +3,11 @@
 Cache-first by construction: no command opens a live DB connection
 without the user explicitly answering ``y`` to the cost-confirm prompt
 (or passing ``--prefetch`` / ``--no-cache``).
+
+Wizard-first by construction: every subcommand, when invoked bare,
+walks through ``ask_choice`` / ``ask`` pickers for profile → database
+→ schema → table → column → format → cache strategy. Flags stay
+available for power users but are never required.
 """
 
 from __future__ import annotations
@@ -43,6 +48,13 @@ LogEvent = Callable[..., None]
 
 _DEFAULT_FORMAT = "svg"
 _DEFAULT_DEPTH = 1
+
+_CACHE_STRATEGY_LABELS = {
+    "cache-only": "use only cached data, never call the DB (safest, fastest)",
+    "ask if needed": "if a cache miss occurs, prompt for permission before any DB call",
+    "fetch from DB": "fill cache misses immediately (auto-confirm; pulls fresh DDL)",
+    "force fresh (no cache)": "invalidate cached view DDL and re-pull from DB",
+}
 
 
 def register_lineage_commands(
@@ -108,48 +120,52 @@ def register_lineage_commands(
             error("--cache-only is mutually exclusive with --prefetch / --no-cache.")
             return
 
-        profile_name, profile_cfg = _resolve_profile(cfg, profile_flag)
+        heading("Lineage · create")
+        profile_name, profile_cfg = _pick_profile(cfg, profile_flag)
         if profile_name is None:
-            error("No DB profile available. Run /db add-profile first.")
-            return
-
-        if not anchor:
-            anchor = ask("Anchor table (schema.table or schema.table.column)").strip()
-            if not anchor:
-                error("Anchor is required.")
-                return
-
-        parts = [p for p in re.split(r"[./]", anchor) if p]
-        if len(parts) == 1:
-            schema = ""
-            table = parts[0]
-        elif len(parts) == 2:
-            schema, table = parts
-        elif len(parts) >= 3:
-            schema = parts[-3]
-            table = parts[-2]
-            if not column:
-                column = parts[-1]
-        else:
-            error(f"Could not parse anchor {anchor!r}.")
             return
 
         database = _default_database(profile_cfg)
-        anchor_ref = ColumnRef(database=database, schema=schema, table=table, column=column or "")
+        schema, table, column = _pick_anchor_location(
+            hs,
+            profile=profile_name,
+            database=database,
+            raw_anchor=anchor,
+            preset_column=column,
+            require_column=False,
+        )
+        if schema is None or table is None:
+            return
 
-        fmt = (fmt or _DEFAULT_FORMAT).lower()
+        fmt = _pick_format() if fmt is None else fmt.lower()
         if fmt not in SUPPORTED_FORMATS:
             error(f"Unsupported format {fmt!r}. Choose one of {SUPPORTED_FORMATS}.")
             return
 
-        depth_up = depth_up if depth_up is not None else _DEFAULT_DEPTH
-        depth_down = depth_down if depth_down is not None else _DEFAULT_DEPTH
-        slug = name or _default_slug(anchor_ref)
+        if depth_up is None:
+            depth_up = _pick_depth("Upstream hop limit", default=_DEFAULT_DEPTH)
+        if depth_down is None:
+            depth_down = _pick_depth("Downstream hop limit", default=_DEFAULT_DEPTH)
 
-        output_path = _resolve_output_path(out, slug, fmt)
+        anchor_ref = ColumnRef(database=database, schema=schema, table=table, column=column or "")
+        slug = name or _ask_slug(anchor_ref)
+        output_path = _ask_output_path(out, slug, fmt)
         if output_path is None:
-            error("Output path is invalid or not writable.")
             return
+
+        strategy = _pick_cache_strategy(cache_only, no_cache, prefetch)
+        fill_decision: FillDecision | None
+        if strategy == "cache-only":
+            fill_decision = "skip"
+            no_cache = False
+        elif strategy == "fetch from DB":
+            fill_decision = "fill"
+            no_cache = False
+        elif strategy == "force fresh (no cache)":
+            fill_decision = "fill"
+            no_cache = True
+        else:
+            fill_decision = None  # 'ask if needed' → interactive prompt mid-run
 
         scope = Scope(
             profile=profile_name,
@@ -160,13 +176,11 @@ def register_lineage_commands(
             schema=schema,
         )
 
-        fill_decision: FillDecision | None
-        if cache_only:
-            fill_decision = "skip"
-        elif prefetch or no_cache:
-            fill_decision = "fill"
-        else:
-            fill_decision = None  # interactive prompt below
+        if no_cache:
+            # User chose force-fresh from the wizard; invalidate this scope.
+            lineage_store.invalidate_view_definitions(
+                hs, db_profile=profile_name, database=database, schema=schema
+            )
 
         connector_factory = _build_connector_factory(cfg)
 
@@ -219,7 +233,7 @@ def register_lineage_commands(
             return
         rows = lineage_store.list_lineage_artifacts(hs, db_profile=profile_flag or "")
         if not rows:
-            info("No lineage artifacts yet. Try /lineage create <table>.")
+            info("No lineage artifacts yet. Try /lineage create.")
             return
         render_table(
             "Lineage artifacts",
@@ -255,16 +269,15 @@ def register_lineage_commands(
         )
 
     @lineage.command("open")
-    @click.argument("name_or_id", required=True)
+    @click.argument("name_or_id", required=False)
     @pass_config
-    def lineage_open(cfg: AMXConfig, name_or_id: str) -> None:
+    def lineage_open(cfg: AMXConfig, name_or_id: str | None) -> None:
         hs = history_store()
         if hs is None:
             error("History store not initialised — run /db first.")
             return
-        artifact = lineage_store.lookup_lineage_artifact(hs, name_or_id=name_or_id)
+        artifact = _pick_artifact(hs, name_or_id, verb="open")
         if artifact is None:
-            error(f"No artifact named {name_or_id!r}.")
             return
         path = Path(artifact["output_path"])
         if not path.exists():
@@ -276,7 +289,7 @@ def register_lineage_commands(
             info(f"Path: {path}")
 
     @lineage.command("refresh")
-    @click.argument("name_or_id", required=True)
+    @click.argument("name_or_id", required=False)
     @click.option(
         "--no-cache", is_flag=True, help="Invalidate view-cache and force fresh DB fetch."
     )
@@ -287,7 +300,7 @@ def register_lineage_commands(
     @pass_config
     def lineage_refresh(
         cfg: AMXConfig,
-        name_or_id: str,
+        name_or_id: str | None,
         no_cache: bool,
         cache_only: bool,
         prefetch: bool,
@@ -301,9 +314,9 @@ def register_lineage_commands(
         if cache_only and (prefetch or no_cache):
             error("--cache-only is mutually exclusive with --prefetch / --no-cache.")
             return
-        artifact = lineage_store.lookup_lineage_artifact(hs, name_or_id=name_or_id)
+        heading("Lineage · refresh")
+        artifact = _pick_artifact(hs, name_or_id, verb="refresh")
         if artifact is None:
-            error(f"No artifact named {name_or_id!r}.")
             return
         if not yes and not confirm(
             f"This will overwrite {artifact['output_path']}. Continue?",
@@ -312,13 +325,20 @@ def register_lineage_commands(
             warn("Cancelled.")
             return
 
+        strategy = _pick_cache_strategy(cache_only, no_cache, prefetch)
         fill_decision: FillDecision | None
-        if cache_only:
+        if strategy == "cache-only":
             fill_decision = "skip"
-        elif prefetch:
+            no_cache_effective = False
+        elif strategy == "fetch from DB":
             fill_decision = "fill"
+            no_cache_effective = False
+        elif strategy == "force fresh (no cache)":
+            fill_decision = "fill"
+            no_cache_effective = True
         else:
             fill_decision = None
+            no_cache_effective = False
 
         connector_factory = _build_connector_factory(cfg)
         try:
@@ -327,7 +347,7 @@ def register_lineage_commands(
                 artifact=artifact,
                 fill_prompt=_make_fill_prompt(),
                 fill_decision=fill_decision,
-                no_cache=no_cache,
+                no_cache=no_cache_effective,
                 force_scale=force,
                 soft_confirm=_make_soft_confirm(),
                 connector_factory=connector_factory,
@@ -352,17 +372,17 @@ def register_lineage_commands(
         )
 
     @lineage.command("delete")
-    @click.argument("name_or_id", required=True)
+    @click.argument("name_or_id", required=False)
     @click.option("--yes", is_flag=True, help="Skip confirmation.")
     @pass_config
-    def lineage_delete(cfg: AMXConfig, name_or_id: str, yes: bool) -> None:
+    def lineage_delete(cfg: AMXConfig, name_or_id: str | None, yes: bool) -> None:
         hs = history_store()
         if hs is None:
             error("History store not initialised — run /db first.")
             return
-        artifact = lineage_store.lookup_lineage_artifact(hs, name_or_id=name_or_id)
+        heading("Lineage · delete")
+        artifact = _pick_artifact(hs, name_or_id, verb="delete")
         if artifact is None:
-            error(f"No artifact named {name_or_id!r}.")
             return
         path = Path(artifact["output_path"])
         if not yes and not confirm(
@@ -385,52 +405,54 @@ def register_lineage_commands(
         )
 
     @lineage.command("show")
-    @click.argument("anchor", required=True)
+    @click.argument("anchor", required=False)
     @click.option("--column", "column", default=None, help="Restrict anchor to a specific column.")
+    @click.option("--depth-up", "depth_up", type=int, default=None, help="Upstream hop limit.")
     @click.option(
-        "--depth-up", "depth_up", type=int, default=_DEFAULT_DEPTH, help="Upstream hop limit."
-    )
-    @click.option(
-        "--depth-down", "depth_down", type=int, default=_DEFAULT_DEPTH, help="Downstream hop limit."
+        "--depth-down", "depth_down", type=int, default=None, help="Downstream hop limit."
     )
     @click.option("--profile", "profile_flag", default=None, help="Override active DB profile.")
     @pass_config
     def lineage_show(
         cfg: AMXConfig,
-        anchor: str,
+        anchor: str | None,
         column: str | None,
-        depth_up: int,
-        depth_down: int,
+        depth_up: int | None,
+        depth_down: int | None,
         profile_flag: str | None,
     ) -> None:
         hs = history_store()
         if hs is None:
             error("History store not initialised — run /db first.")
             return
-        profile_name, profile_cfg = _resolve_profile(cfg, profile_flag)
+        heading("Lineage · show")
+        profile_name, profile_cfg = _pick_profile(cfg, profile_flag)
         if profile_name is None:
-            error("No DB profile available.")
             return
-        parts = [p for p in re.split(r"[./]", anchor) if p]
-        if len(parts) == 1:
-            schema, table = "", parts[0]
-        elif len(parts) == 2:
-            schema, table = parts
-        else:
-            schema, table = parts[-3], parts[-2]
-            column = column or parts[-1]
-        anchor_ref = ColumnRef(
-            database=_default_database(profile_cfg),
-            schema=schema,
-            table=table,
-            column=column or "",
+        database = _default_database(profile_cfg)
+        schema, table, column = _pick_anchor_location(
+            hs,
+            profile=profile_name,
+            database=database,
+            raw_anchor=anchor,
+            preset_column=column,
+            require_column=False,
         )
+        if schema is None or table is None:
+            return
+
+        if depth_up is None:
+            depth_up = _pick_depth("Upstream hop limit", default=_DEFAULT_DEPTH)
+        if depth_down is None:
+            depth_down = _pick_depth("Downstream hop limit", default=_DEFAULT_DEPTH)
+
+        anchor_ref = ColumnRef(database=database, schema=schema, table=table, column=column or "")
         scope = Scope(
             profile=profile_name,
             anchor=anchor_ref,
             depth_up=depth_up,
             depth_down=depth_down,
-            database=anchor_ref.database,
+            database=database,
             schema=schema,
         )
         for line in service.text_tree(hs=hs, scope=scope):
@@ -439,24 +461,240 @@ def register_lineage_commands(
     return lineage
 
 
-# ── helpers ─────────────────────────────────────────────────────────────
+# ── wizard pickers ───────────────────────────────────────────────────────
 
 
-def _resolve_profile(cfg: AMXConfig, flag: str | None) -> tuple[str | None, DBConfig | None]:
-    """Return (profile_name, DBConfig) or (None, None) when no profile resolves."""
+def _pick_profile(cfg: AMXConfig, flag: str | None) -> tuple[str | None, DBConfig | None]:
+    """Resolve a profile via flag, sole-profile fallback, active profile, or picker."""
     profiles = getattr(cfg, "db_profiles", {}) or {}
+    if not profiles:
+        error("No DB profile available. Run /db add-profile first.")
+        return None, None
     if flag:
         if flag in profiles:
             return flag, profiles[flag]
+        error(f"Unknown profile {flag!r}. Available: {', '.join(sorted(profiles))}.")
         return None, None
-    active = getattr(cfg, "active_db_profile", "") or ""
-    if active and active in profiles:
-        return active, profiles[active]
-    # Fall back to the only-profile case (common on fresh installs).
     if len(profiles) == 1:
-        only = next(iter(profiles.items()))
-        return only[0], only[1]
-    return None, None
+        name, cfg_obj = next(iter(profiles.items()))
+        info(f"Using DB profile [bold]{name}[/bold] (only profile configured).")
+        return name, cfg_obj
+    names = sorted(profiles)
+    active = (getattr(cfg, "active_db_profile", "") or "").strip()
+    default = active if active in names else names[0]
+    picked = ask_choice("Pick a DB profile", names, default=default)
+    if not picked:
+        error("No profile picked.")
+        return None, None
+    return picked, profiles[picked]
+
+
+def _pick_anchor_location(
+    hs: Any,
+    *,
+    profile: str,
+    database: str,
+    raw_anchor: str | None,
+    preset_column: str | None,
+    require_column: bool,
+) -> tuple[str | None, str | None, str | None]:
+    """Pick (schema, table, column). ``raw_anchor`` short-circuits the wizard
+    when it's a fully-qualified path.
+    """
+    schema = ""
+    table = ""
+    column = preset_column
+
+    if raw_anchor:
+        parts = [p for p in re.split(r"[./]", raw_anchor) if p]
+        if len(parts) == 1:
+            table = parts[0]
+        elif len(parts) == 2:
+            schema, table = parts
+        elif len(parts) >= 3:
+            schema = parts[-3]
+            table = parts[-2]
+            if not column:
+                column = parts[-1]
+
+    if not schema:
+        schemas = _list_cached_schemas(hs, profile, database)
+        if not schemas:
+            error(
+                "No cached schemas found for this profile. "
+                "Run /db inspect first to populate the catalog."
+            )
+            return None, None, None
+        schema = ask_choice("Pick a schema", schemas, default=schemas[0])
+        if not schema:
+            error("No schema picked.")
+            return None, None, None
+
+    if not table:
+        tables = _list_cached_tables(hs, profile, database, schema)
+        if not tables:
+            error(
+                f"No cached tables under schema {schema!r}. Run /db inspect on this schema first."
+            )
+            return None, None, None
+        table = ask_choice("Pick a table", tables, default=tables[0])
+        if not table:
+            error("No table picked.")
+            return None, None, None
+
+    if not column:
+        # Offer column-level anchor as an optional refinement.
+        columns = _list_cached_columns(hs, profile, database, schema, table)
+        if columns:
+            options = ["(whole table)", *columns]
+            picked = ask_choice("Anchor on a column? (optional)", options, default="(whole table)")
+            if picked and picked != "(whole table)":
+                column = picked
+        elif require_column:
+            error(f"No columns cached for {schema}.{table}.")
+            return None, None, None
+
+    return schema, table, column
+
+
+def _pick_format() -> str:
+    return ask_choice(
+        "Output format",
+        list(SUPPORTED_FORMATS),
+        default=_DEFAULT_FORMAT,
+        descriptions={
+            "svg": "scalable vector — best for browsers + design tools (default)",
+            "png": "raster bitmap — best for slide decks",
+            "jpg": "compressed raster — smaller file, lossy",
+        },
+    )
+
+
+def _pick_depth(label: str, *, default: int) -> int:
+    raw = ask(f"{label} (Enter for {default})", default=str(default)).strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+        return max(1, min(value, 5))
+    except ValueError:
+        warn(f"Could not parse {raw!r} as int — using default {default}.")
+        return default
+
+
+def _pick_cache_strategy(cache_only: bool, no_cache: bool, prefetch: bool) -> str:
+    """Pick a cache strategy. Flags short-circuit the wizard."""
+    if cache_only:
+        return "cache-only"
+    if no_cache:
+        return "force fresh (no cache)"
+    if prefetch:
+        return "fetch from DB"
+    options = list(_CACHE_STRATEGY_LABELS.keys())
+    return ask_choice(
+        "Cache strategy",
+        options,
+        default="cache-only",
+        descriptions=_CACHE_STRATEGY_LABELS,
+    )
+
+
+def _pick_artifact(hs: Any, name_or_id: str | None, *, verb: str) -> dict[str, Any] | None:
+    """Resolve an existing artifact via id/slug or interactive picker."""
+    if name_or_id:
+        artifact = lineage_store.lookup_lineage_artifact(hs, name_or_id=name_or_id)
+        if artifact is None:
+            error(f"No artifact named {name_or_id!r}.")
+        return artifact
+    rows = lineage_store.list_lineage_artifacts(hs)
+    if not rows:
+        info("No lineage artifacts to pick from. Run /lineage create first.")
+        return None
+    labels = [
+        f"{r['id']}: {r['name']}  ({_anchor_display(hs, r['anchor_entity_id'])}, "
+        f"{r['format']}, {_fmt_time(r['generated_at'])})"
+        for r in rows
+    ]
+    picked_label = ask_choice(f"Pick artifact to {verb}", labels, default=labels[0])
+    if not picked_label:
+        error("No artifact picked.")
+        return None
+    return rows[labels.index(picked_label)]
+
+
+def _ask_slug(ref: ColumnRef) -> str:
+    default = _default_slug(ref)
+    raw = ask(f"Artifact slug (Enter for {default!r})", default=default).strip()
+    return raw or default
+
+
+def _ask_output_path(out: str | None, slug: str, fmt: str) -> Path | None:
+    if out is None:
+        from amx.config import _resolve_config_dir as resolve_config_dir
+
+        base = Path(resolve_config_dir()) / "lineage"
+        suggested = base / f"{slug}.{fmt}"
+        raw = ask(
+            f"Output path (Enter for {suggested})",
+            default=str(suggested),
+        ).strip()
+        out = raw or str(suggested)
+    return _resolve_output_path(out, slug, fmt)
+
+
+# ── catalog readers (cache-only) ─────────────────────────────────────────
+
+
+def _list_cached_schemas(hs: Any, profile: str, database: str) -> list[str]:
+    with hs._connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT schema_name
+            FROM catalog_entities
+            WHERE db_profile = ? AND database_name = ?
+              AND schema_name <> ''
+            ORDER BY schema_name
+            """,
+            (profile, database),
+        ).fetchall()
+    return [str(r[0]) for r in rows]
+
+
+def _list_cached_tables(hs: Any, profile: str, database: str, schema: str) -> list[str]:
+    with hs._connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT table_name
+            FROM catalog_entities
+            WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+              AND table_name <> '' AND entity_kind = 'table'
+            ORDER BY table_name
+            """,
+            (profile, database, schema),
+        ).fetchall()
+    return [str(r[0]) for r in rows]
+
+
+def _list_cached_columns(
+    hs: Any, profile: str, database: str, schema: str, table: str
+) -> list[str]:
+    with hs._connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT column_name
+            FROM catalog_entities
+            WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+              AND table_name = ?
+              AND column_name IS NOT NULL AND column_name <> ''
+              AND entity_kind = 'column'
+            ORDER BY column_name
+            """,
+            (profile, database, schema, table),
+        ).fetchall()
+    return [str(r[0]) for r in rows]
+
+
+# ── shared helpers ───────────────────────────────────────────────────────
 
 
 def _default_database(profile_cfg: DBConfig | None) -> str:
@@ -540,14 +778,14 @@ def _resolve_output_path(out: str | None, slug: str, fmt: str) -> Path | None:
     if out:
         path = Path(out).expanduser()
     else:
-        # Default under the AMX config dir so the file survives /clear.
-        from amx.config import resolve_config_dir
+        from amx.config import _resolve_config_dir as resolve_config_dir
 
         base = Path(resolve_config_dir()) / "lineage"
         path = base / f"{slug}.{fmt}"
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
     except OSError:
+        error(f"Cannot create parent directory for {path}.")
         return None
     return path.resolve()
 

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -677,6 +677,7 @@ _CROSS_NAMESPACE_HEADS: frozenset[str] = frozenset(
         "setup",
         "config",
         "studio",
+        "lineage",
     }
 )
 
@@ -852,6 +853,7 @@ def run_interactive_session(
     analyze_cmd_heads = _registry_cmd_heads("analyze")
     search_cmd_heads = _registry_cmd_heads("search") | frozenset({"embeddings", "embedding"})
     history_cmd_heads = _registry_cmd_heads("history")
+    lineage_cmd_heads = _registry_cmd_heads("lineage")
 
     # SIGWINCH (terminal resize) is POSIX-only — Windows raises
     # AttributeError on signal.SIGWINCH. Guard so the interactive session
@@ -1029,6 +1031,7 @@ def run_interactive_session(
                 "analyze",
                 "search",
                 "history",
+                "lineage",
             }:
                 namespace = "metadata" if cmdline == "manual" else cmdline
                 console.clear()
@@ -1081,6 +1084,9 @@ def run_interactive_session(
                 elif head in history_cmd_heads:
                     namespace = "history"
                     info("Assumed /history namespace for this command.")
+                elif head in lineage_cmd_heads:
+                    namespace = "lineage"
+                    info("Assumed /lineage namespace for this command.")
 
             if namespace == "docs":
                 if parts[0] == "search-docs" and len(parts) == 1:

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -619,6 +619,8 @@ def commands_for_namespace(namespace: str) -> tuple[SlashCommand, ...]:
         return (*_ROOT_BUILTINS, *_SEARCH_COMMANDS)
     if ns == "history":
         return (*_ROOT_BUILTINS, *_HISTORY_COMMANDS)
+    if ns == "lineage":
+        return (*_ROOT_BUILTINS, *_LINEAGE_COMMANDS)
     return _ROOT_BUILTINS
 
 
@@ -639,6 +641,7 @@ def cmd_heads_for_namespace(namespace: str) -> frozenset[str]:
         "analyze": _ANALYZE_COMMANDS,
         "search": _SEARCH_COMMANDS,
         "history": _HISTORY_COMMANDS,
+        "lineage": _LINEAGE_COMMANDS,
     }
     if ns not in table:
         return frozenset()
@@ -669,7 +672,17 @@ def find_command(slash_or_head: str) -> SlashCommand | None:
 
 def all_namespaces() -> tuple[str, ...]:
     """Distinct namespaces that have at least one command."""
-    return ("db", "metadata", "docs", "llm", "code", "analyze", "search", "history")
+    return (
+        "db",
+        "metadata",
+        "docs",
+        "llm",
+        "code",
+        "analyze",
+        "search",
+        "history",
+        "lineage",
+    )
 
 
 __all__ = [

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -115,6 +115,18 @@ _ROOT_ENTRYPOINTS: tuple[SlashCommand, ...] = (
     SlashCommand("/search", "root", "Enter /search namespace"),
     SlashCommand("/history", "root", "Enter /history namespace"),
     SlashCommand(
+        "/lineage",
+        "root",
+        "Enter /lineage namespace",
+        long_desc=(
+            "Render and manage column-level lineage diagrams. AMX derives "
+            "edges from cached schema introspection (FK constraints), parsed "
+            "view DDL, and a name-match heuristic — no live DB call unless "
+            "you explicitly confirm. Subcommands: create, list, open, "
+            "refresh, delete, show."
+        ),
+    ),
+    SlashCommand(
         "/studio",
         "root",
         "Open AMX Studio in your browser",
@@ -492,6 +504,53 @@ _HISTORY_COMMANDS: tuple[SlashCommand, ...] = (
     ),
 )
 
+_LINEAGE_COMMANDS: tuple[SlashCommand, ...] = (
+    SlashCommand(
+        "/create",
+        "lineage",
+        "Render a lineage diagram (/create <table> [--out PATH --format svg|png|jpg])",
+        long_desc=(
+            "Run extractors in cache-only mode by default. If anything would "
+            "require a DB round-trip, AMX prints the cost and asks before "
+            "fetching. --no-cache forces fresh; --cache-only refuses any DB "
+            "hit; --prefetch auto-confirms the cache fill."
+        ),
+    ),
+    SlashCommand("/list", "lineage", "List rendered lineage artifacts"),
+    SlashCommand(
+        "/open",
+        "lineage",
+        "Open a saved lineage diagram (/open <name_or_id>)",
+        long_desc=(
+            "Reads the cached image file from disk and opens it in the "
+            "platform default viewer. No DB call. Warns when the edge-set "
+            "hash differs from the current catalog state."
+        ),
+    ),
+    SlashCommand(
+        "/refresh",
+        "lineage",
+        "Re-render an existing lineage artifact (/refresh <name_or_id>)",
+        long_desc=(
+            "Re-runs the extractors with the artifact's stored scope and "
+            "writes a new image at the same path. Cache-first by default; "
+            "--no-cache invalidates the view-cache for the anchor's schema "
+            "and forces a fresh DB fetch."
+        ),
+    ),
+    SlashCommand(
+        "/delete",
+        "lineage",
+        "Delete a lineage artifact row and its file (/delete <name_or_id>)",
+    ),
+    SlashCommand(
+        "/show",
+        "lineage",
+        "Text-mode upstream/downstream tree for a table or column",
+    ),
+)
+
+
 # Search-namespace cross-cuts: extra commands callable from /search even
 # though their handlers live elsewhere. Used by the dispatch chain to
 # accept these without bouncing the user back to root.
@@ -518,6 +577,7 @@ ALL_COMMANDS: tuple[SlashCommand, ...] = (
     *_ANALYZE_COMMANDS,
     *_SEARCH_COMMANDS,
     *_HISTORY_COMMANDS,
+    *_LINEAGE_COMMANDS,
 )
 
 

--- a/amx/db/adapters/base.py
+++ b/amx/db/adapters/base.py
@@ -450,6 +450,23 @@ class DatabaseAdapter(ABC):
         """Backend-specific view listing. ``None`` → SQLAlchemy fallback."""
         return None
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        """Views in ``schema`` paired with their DDL text.
+
+        Used by ``/lineage`` to populate ``view_definitions_cache``. Return
+        shape mirrors the "extended object types" convention: each entry is
+        ``{name, type='view', definition, comment, metadata}``. Adapters that
+        don't expose view definitions return ``[]``; the lineage extractor
+        treats that as "no view-level signal for this schema" rather than an
+        error. The call MUST be safe to make from a cache-fill path
+        triggered by user confirmation — no implicit writes.
+        """
+        return []
+
     # ── Extended object types ─────────────────────────────────────────────
     #
     # Each ``list_<object>()`` returns an empty list by default. Adapters

--- a/amx/db/adapters/bigquery.py
+++ b/amx/db/adapters/bigquery.py
@@ -336,6 +336,37 @@ class BigQueryAdapter(DatabaseAdapter):
             f"ORDER BY routine_name"
         )
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        # BigQuery views live in `<project>.<dataset>.INFORMATION_SCHEMA.VIEWS`.
+        # Project comes from the engine URL; SQLAlchemy puts it in the dialect
+        # at run time. The dataset is the AMX-level "schema". Fully qualifying
+        # avoids relying on a session-level default project.
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        f"SELECT table_name, view_definition "
+                        f"FROM `{schema}`.INFORMATION_SCHEMA.VIEWS "
+                        f"ORDER BY table_name"
+                    )
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         with engine.connect() as conn:
             try:

--- a/amx/db/adapters/clickhouse.py
+++ b/amx/db/adapters/clickhouse.py
@@ -154,6 +154,35 @@ class ClickHouseAdapter(DatabaseAdapter):
             ).fetchall()
         return [str(r[0]) for r in rows]
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT name, create_table_query, comment "
+                        "FROM system.tables "
+                        "WHERE database = :db AND engine = 'View' "
+                        "ORDER BY name"
+                    ),
+                    {"db": schema},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     # ── Column profiling ──────────────────────────────────────────────────
 
     def column_stats_sql(self, fqn: str, quoted_col: str) -> str:

--- a/amx/db/adapters/databricks.py
+++ b/amx/db/adapters/databricks.py
@@ -382,6 +382,40 @@ class DatabricksAdapter(DatabaseAdapter):
         except Exception:
             return None
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        # Unity Catalog: ``system.information_schema.views`` carries the
+        # view definition. Hive-metastore profiles return ``[]`` since the
+        # legacy metastore exposes only ``SHOW VIEWS`` (name list).
+        if not schema:
+            return []
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT table_name, view_definition "
+                        "FROM system.information_schema.views "
+                        "WHERE table_schema = :schema "
+                        "ORDER BY table_name"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     # ── Bulk catalog metadata ─────────────────────────────────────────────
 
     def bulk_catalog_metadata(

--- a/amx/db/adapters/duckdb.py
+++ b/amx/db/adapters/duckdb.py
@@ -285,6 +285,35 @@ class DuckDBAdapter(DatabaseAdapter):
             for r in rows
         ]
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT view_name, sql, comment "
+                        "FROM duckdb_views() "
+                        "WHERE schema_name = :schema AND NOT internal "
+                        "ORDER BY view_name"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     def list_functions(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         # DuckDB exposes ~1000 built-in functions; restrict to user-defined
         # ones (function_type = 'macro' is handled separately by

--- a/amx/db/adapters/mssql.py
+++ b/amx/db/adapters/mssql.py
@@ -412,6 +412,41 @@ class MSSQLAdapter(DatabaseAdapter):
 
     # ── Extended object types ─────────────────────────────────────────────
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT v.name, m.definition, "
+                        "       ep.value AS comment "
+                        "FROM sys.views v "
+                        "JOIN sys.sql_modules m ON m.object_id = v.object_id "
+                        "LEFT JOIN sys.extended_properties ep "
+                        "       ON ep.major_id = v.object_id "
+                        "       AND ep.minor_id = 0 "
+                        "       AND ep.name = 'MS_Description' "
+                        "WHERE SCHEMA_NAME(v.schema_id) = :schema "
+                        "ORDER BY v.name"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         with engine.connect() as conn:
             rows = conn.execute(

--- a/amx/db/adapters/mysql.py
+++ b/amx/db/adapters/mysql.py
@@ -213,6 +213,35 @@ class MySQLAdapter(DatabaseAdapter):
 
     # ── Extended object types ─────────────────────────────────────────────
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT TABLE_NAME, VIEW_DEFINITION "
+                        "FROM information_schema.views "
+                        "WHERE TABLE_SCHEMA = :schema "
+                        "ORDER BY TABLE_NAME"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         with engine.connect() as conn:
             rows = conn.execute(

--- a/amx/db/adapters/oracle.py
+++ b/amx/db/adapters/oracle.py
@@ -410,6 +410,39 @@ class OracleAdapter(DatabaseAdapter):
 
     # ── Extended object types ─────────────────────────────────────────────
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT v.view_name, v.text, c.comments "
+                        "FROM all_views v "
+                        "LEFT JOIN all_tab_comments c "
+                        "       ON c.owner = v.owner "
+                        "      AND c.table_name = v.view_name "
+                        "      AND c.table_type = 'VIEW' "
+                        "WHERE v.owner = :owner "
+                        "ORDER BY v.view_name"
+                    ),
+                    {"owner": (schema or "").upper()},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         # ALL_PROCEDURES rows are duplicated when a procedure lives
         # inside a package — restrict to standalone procedures

--- a/amx/db/adapters/postgresql.py
+++ b/amx/db/adapters/postgresql.py
@@ -401,6 +401,37 @@ class PostgreSQLAdapter(DatabaseAdapter):
 
     # ── Extended object types ─────────────────────────────────────────────
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT viewname, definition, "
+                        "obj_description(("
+                        "  quote_ident(schemaname) || '.' || quote_ident(viewname)"
+                        ")::regclass) "
+                        "FROM pg_views WHERE schemaname = :schema "
+                        "ORDER BY viewname"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         # PG 11+ distinguishes procedures (prokind='p') from functions
         # ('f') and aggregates ('a'). Older PG only has functions, so

--- a/amx/db/adapters/redshift.py
+++ b/amx/db/adapters/redshift.py
@@ -287,6 +287,34 @@ class RedshiftAdapter(DatabaseAdapter):
 
     # ── Extended object types ─────────────────────────────────────────────
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT viewname, definition "
+                        "FROM pg_views WHERE schemaname = :schema "
+                        "ORDER BY viewname"
+                    ),
+                    {"schema": schema},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         with engine.connect() as conn:
             rows = conn.execute(

--- a/amx/db/adapters/snowflake.py
+++ b/amx/db/adapters/snowflake.py
@@ -447,6 +447,37 @@ class SnowflakeAdapter(DatabaseAdapter):
             )
         return out
 
+    def list_views_with_definitions(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> list[dict[str, Any]]:
+        from sqlalchemy import text
+
+        with engine.connect() as conn:
+            try:
+                rows = conn.execute(
+                    text(
+                        "SELECT TABLE_NAME, VIEW_DEFINITION, COMMENT "
+                        "FROM INFORMATION_SCHEMA.VIEWS "
+                        "WHERE TABLE_SCHEMA = :schema "
+                        "ORDER BY TABLE_NAME"
+                    ),
+                    {"schema": schema.upper()},
+                ).fetchall()
+            except Exception:
+                return []
+        return [
+            {
+                "name": str(r[0]),
+                "type": "view",
+                "definition": str(r[1]) if r[1] else None,
+                "comment": str(r[2]) if r[2] else None,
+                "metadata": {},
+            }
+            for r in rows
+        ]
+
     def list_stored_procedures(self, engine: Engine, schema: str) -> list[dict[str, Any]]:
         sql = f"SHOW PROCEDURES IN SCHEMA {self.quote_identifier(schema)}"
         return self._show_to_dicts(engine, sql, "procedure", extra_keys=("arguments", "language"))

--- a/amx/lineage/__init__.py
+++ b/amx/lineage/__init__.py
@@ -1,0 +1,22 @@
+"""AMX `/lineage` — column-level lineage extraction, caching, and rendering.
+
+The package is intentionally split:
+
+* :mod:`amx.lineage.types` — value objects (``Edge``, ``Scope``, ``ExtractResult``)
+  and the ``LineageExtractor`` protocol. No I/O.
+* :mod:`amx.lineage.store` — SQLite reads/writes for ``view_definitions_cache``
+  and ``lineage_artifacts``. Pure cache layer; no DB or rendering.
+* :mod:`amx.lineage.extractors` — three pluggable extractors (FK, view-DDL,
+  name-match heuristic). Each is cache-first; live DB calls are opt-in.
+* :mod:`amx.lineage.render` — DOT generation + ``dot`` subprocess. Cross-platform.
+* :mod:`amx.lineage.service` — orchestration. Fans out extractors, prompts
+  before any DB round-trip, and gates render on scale guardrails.
+
+The CLI lives in :mod:`amx.cli_support.commands.lineage` and imports only
+:mod:`amx.lineage.service`. The Studio Lineage View (when added) will import
+the same service module.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/amx/lineage/extractors/__init__.py
+++ b/amx/lineage/extractors/__init__.py
@@ -1,0 +1,14 @@
+"""Pluggable lineage extractors.
+
+Each extractor returns an :class:`amx.lineage.types.ExtractResult` that
+reports edges plus cache status. The service layer fans them out and
+prompts the user before any DB round-trip.
+"""
+
+from __future__ import annotations
+
+from amx.lineage.extractors.fk import FKExtractor
+from amx.lineage.extractors.name_match import NameMatchExtractor
+from amx.lineage.extractors.view_ddl import ViewDDLExtractor
+
+__all__ = ["FKExtractor", "ViewDDLExtractor", "NameMatchExtractor"]

--- a/amx/lineage/extractors/fk.py
+++ b/amx/lineage/extractors/fk.py
@@ -1,0 +1,196 @@
+"""FK-derived lineage edges, read straight out of ``catalog_relationships``.
+
+This extractor never touches the wire — :class:`SQLiteHistoryStore` *is*
+the cache. Empty results when the target platform doesn't expose FK
+metadata are treated as normal, not as errors. Edges are emitted at table
+granularity; column refinements are added per-FK from ``details_json``
+when ``constrained_columns`` and ``referred_columns`` are present.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from amx.lineage.types import ColumnRef, Edge, ExtractMode, ExtractResult, Scope
+
+_RELATIONSHIP_TYPE = "lineage_fk"
+
+
+class FKExtractor:
+    name = "fk"
+
+    def extract(
+        self,
+        *,
+        hs: Any,
+        scope: Scope,
+        mode: ExtractMode = "cache_only",
+    ) -> ExtractResult:
+        anchor_table_id = _resolve_anchor_table_id(hs, scope)
+        if anchor_table_id is None:
+            return ExtractResult()
+
+        edges: list[Edge] = []
+        with hs._connect() as conn:
+            edges.extend(_outgoing_fk_edges(conn, anchor_table_id, scope))
+            edges.extend(_incoming_fk_edges(conn, anchor_table_id, scope))
+        return ExtractResult(edges=edges, cache_status="hit")
+
+
+def _resolve_anchor_table_id(hs: Any, scope: Scope) -> int | None:
+    """Return ``catalog_entities.id`` of the anchor's table row."""
+    with hs._connect() as conn:
+        row = conn.execute(
+            """
+            SELECT id FROM catalog_entities
+            WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+              AND table_name = ? AND entity_kind = 'table'
+            LIMIT 1
+            """,
+            (
+                scope.profile,
+                scope.anchor.database,
+                scope.anchor.schema,
+                scope.anchor.table,
+            ),
+        ).fetchone()
+    return int(row[0]) if row else None
+
+
+def _outgoing_fk_edges(conn: Any, anchor_table_id: int, scope: Scope) -> list[Edge]:
+    """anchor.fk_col -> referenced_table.referenced_col (anchor is upstream-consumer)."""
+    rows = conn.execute(
+        """
+        SELECT cr.details_json, ce.database_name, ce.schema_name, ce.table_name
+        FROM catalog_relationships cr
+        JOIN catalog_entities ce ON ce.id = cr.to_entity_id
+        WHERE cr.from_entity_id = ? AND cr.relationship_type = 'foreign_key'
+        """,
+        (anchor_table_id,),
+    ).fetchall()
+    edges: list[Edge] = []
+    for raw, db, sch, tbl in rows:
+        fk = _safe_json(raw)
+        constrained = list(fk.get("constrained_columns") or []) if isinstance(fk, dict) else []
+        referred = list(fk.get("referred_columns") or []) if isinstance(fk, dict) else []
+        if constrained and referred and len(constrained) == len(referred):
+            for src_col, anchor_col in zip(referred, constrained, strict=False):
+                edges.append(
+                    Edge(
+                        source=ColumnRef(
+                            database=str(db or ""),
+                            schema=str(sch or ""),
+                            table=str(tbl or ""),
+                            column=str(src_col),
+                        ),
+                        target=ColumnRef(
+                            database=scope.anchor.database,
+                            schema=scope.anchor.schema,
+                            table=scope.anchor.table,
+                            column=str(anchor_col),
+                        ),
+                        relationship_type=_RELATIONSHIP_TYPE,
+                        extractor="fk",
+                        confidence=1.0,
+                        evidence=f"FK {scope.anchor.table}.({','.join(constrained)}) -> {tbl}.({','.join(referred)})",
+                    )
+                )
+        else:
+            edges.append(
+                Edge(
+                    source=ColumnRef(
+                        database=str(db or ""),
+                        schema=str(sch or ""),
+                        table=str(tbl or ""),
+                        column="",
+                    ),
+                    target=ColumnRef(
+                        database=scope.anchor.database,
+                        schema=scope.anchor.schema,
+                        table=scope.anchor.table,
+                        column="",
+                    ),
+                    relationship_type=_RELATIONSHIP_TYPE,
+                    extractor="fk",
+                    confidence=1.0,
+                    evidence=f"FK to {tbl}",
+                )
+            )
+    return edges
+
+
+def _incoming_fk_edges(conn: Any, anchor_table_id: int, scope: Scope) -> list[Edge]:
+    """source_table.col -> anchor.col (other tables consume anchor's columns)."""
+    rows = conn.execute(
+        """
+        SELECT cr.details_json, ce.database_name, ce.schema_name, ce.table_name
+        FROM catalog_relationships cr
+        JOIN catalog_entities ce ON ce.id = cr.from_entity_id
+        WHERE cr.to_entity_id = ? AND cr.relationship_type = 'incoming_foreign_key'
+        """,
+        (anchor_table_id,),
+    ).fetchall()
+    edges: list[Edge] = []
+    for raw, db, sch, tbl in rows:
+        fk = _safe_json(raw)
+        if not isinstance(fk, dict):
+            fk = {}
+        # incoming FK payload uses 'source_columns' / 'target_columns' in some
+        # writers, 'constrained_columns' / 'referred_columns' in the standard
+        # SQLAlchemy shape. Accept either.
+        source_cols = list(fk.get("source_columns") or fk.get("constrained_columns") or [])
+        target_cols = list(fk.get("target_columns") or fk.get("referred_columns") or [])
+        if source_cols and target_cols and len(source_cols) == len(target_cols):
+            for src_col, anchor_col in zip(source_cols, target_cols, strict=False):
+                edges.append(
+                    Edge(
+                        source=ColumnRef(
+                            database=scope.anchor.database,
+                            schema=scope.anchor.schema,
+                            table=scope.anchor.table,
+                            column=str(anchor_col),
+                        ),
+                        target=ColumnRef(
+                            database=str(db or ""),
+                            schema=str(sch or ""),
+                            table=str(tbl or ""),
+                            column=str(src_col),
+                        ),
+                        relationship_type=_RELATIONSHIP_TYPE,
+                        extractor="fk",
+                        confidence=1.0,
+                        evidence=f"FK from {tbl}.({','.join(source_cols)})",
+                    )
+                )
+        else:
+            edges.append(
+                Edge(
+                    source=ColumnRef(
+                        database=scope.anchor.database,
+                        schema=scope.anchor.schema,
+                        table=scope.anchor.table,
+                        column="",
+                    ),
+                    target=ColumnRef(
+                        database=str(db or ""),
+                        schema=str(sch or ""),
+                        table=str(tbl or ""),
+                        column="",
+                    ),
+                    relationship_type=_RELATIONSHIP_TYPE,
+                    extractor="fk",
+                    confidence=1.0,
+                    evidence=f"FK from {tbl}",
+                )
+            )
+    return edges
+
+
+def _safe_json(raw: Any) -> Any:
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        return {}

--- a/amx/lineage/extractors/name_match.py
+++ b/amx/lineage/extractors/name_match.py
@@ -1,0 +1,174 @@
+"""Name + type heuristic fallback.
+
+100% cache-driven: reads ``column_comments_cache.columns_json`` for the
+anchor's database and proposes edges to columns elsewhere whose
+``(name, type)`` match. Edges are tagged as proposed (``confidence < 1``)
+and rendered with a distinct style so they never look authoritative.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from amx.lineage.types import (
+    ColumnRef,
+    Edge,
+    ExtractMode,
+    ExtractResult,
+    Scope,
+    ScopeFragment,
+)
+
+_MAX_PROPOSED_PER_ANCHOR = 10
+
+
+class NameMatchExtractor:
+    name = "name_match"
+
+    def extract(
+        self,
+        *,
+        hs: Any,
+        scope: Scope,
+        mode: ExtractMode = "cache_only",
+    ) -> ExtractResult:
+        anchor = scope.anchor
+        if not anchor.column:
+            return ExtractResult()  # heuristic only fires for column anchors
+
+        with hs._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT database_name, schema_name, table_name, columns_json
+                FROM column_comments_cache
+                WHERE db_profile = ?
+                  AND database_name = ?
+                """,
+                (scope.profile, anchor.database),
+            ).fetchall()
+
+        if not rows:
+            return ExtractResult(
+                edges=[],
+                cache_status="miss",
+                missing_scope=[ScopeFragment(database=anchor.database, schema=anchor.schema)],
+            )
+
+        anchor_type = _resolve_anchor_type(rows, anchor)
+        candidates: list[tuple[float, Edge]] = []
+        for db_name, sch_name, tbl_name, cols_json in rows:
+            if str(sch_name) == anchor.schema and str(tbl_name) == anchor.table:
+                continue
+            try:
+                cols = json.loads(cols_json) if cols_json else {}
+            except (TypeError, ValueError):
+                cols = {}
+            if not isinstance(cols, dict):
+                continue
+            for col_name, payload in cols.items():
+                col_type = _extract_type(payload)
+                conf = _score(anchor.column, col_name, anchor_type, col_type)
+                if conf == 0.0:
+                    continue
+                candidates.append(
+                    (
+                        conf,
+                        Edge(
+                            source=ColumnRef(
+                                database=str(db_name or ""),
+                                schema=str(sch_name or ""),
+                                table=str(tbl_name or ""),
+                                column=str(col_name),
+                            ),
+                            target=anchor,
+                            relationship_type="lineage_name_match",
+                            extractor="name_match",
+                            confidence=conf,
+                            evidence=f"name match {col_name} ({col_type or '?'})",
+                        ),
+                    )
+                )
+        candidates.sort(key=lambda t: t[0], reverse=True)
+        edges = [edge for _, edge in candidates[:_MAX_PROPOSED_PER_ANCHOR]]
+        return ExtractResult(edges=edges, cache_status="hit")
+
+
+def _resolve_anchor_type(rows: list[tuple], anchor: ColumnRef) -> str:
+    for _, sch, tbl, cols_json in rows:
+        if str(sch) != anchor.schema or str(tbl) != anchor.table:
+            continue
+        try:
+            cols = json.loads(cols_json) if cols_json else {}
+        except (TypeError, ValueError):
+            return ""
+        payload = cols.get(anchor.column) if isinstance(cols, dict) else None
+        return _extract_type(payload)
+    return ""
+
+
+def _extract_type(payload: Any) -> str:
+    """``columns_json`` stores either a string comment or a richer dict."""
+    if isinstance(payload, dict):
+        for key in ("type", "data_type", "dtype"):
+            value = payload.get(key)
+            if value:
+                return str(value).lower()
+    return ""
+
+
+def _score(
+    anchor_col: str,
+    other_col: str,
+    anchor_type: str,
+    other_type: str,
+) -> float:
+    """Heuristic: exact name+type > name+type-family > name only > nothing."""
+    if not anchor_col or not other_col:
+        return 0.0
+    a = anchor_col.lower()
+    o = other_col.lower()
+    types_match_exact = bool(anchor_type and other_type and anchor_type == other_type)
+    types_match_family = _types_family_match(anchor_type, other_type)
+    if a == o:
+        if types_match_exact:
+            return 0.6
+        if types_match_family:
+            return 0.5
+        return 0.3
+    # Suffix match: 'order_id' on `orders.id` is the canonical signal.
+    if _suffix_match(a, o, types_match_family):
+        if types_match_exact:
+            return 0.5
+        return 0.4 if types_match_family else 0.3
+    return 0.0
+
+
+def _suffix_match(a: str, o: str, type_family_match: bool) -> bool:
+    """``order_id`` ↔ ``id`` only when types agree. Avoid spurious unrelated joins."""
+    if not type_family_match:
+        return False
+    return a.endswith("_" + o) or o.endswith("_" + a)
+
+
+_INTEGER_TYPES = {"int", "integer", "bigint", "smallint", "tinyint", "long", "int4", "int8"}
+_TEXT_TYPES = {"text", "varchar", "char", "string", "nvarchar", "clob"}
+_FLOAT_TYPES = {"float", "double", "real", "numeric", "decimal"}
+_DATE_TYPES = {"date", "datetime", "timestamp", "timestamptz", "time"}
+_BOOL_TYPES = {"bool", "boolean", "bit"}
+
+
+def _types_family_match(a: str, b: str) -> bool:
+    if not a or not b:
+        return False
+    a = a.split("(")[0].strip()
+    b = b.split("(")[0].strip()
+    if a == b:
+        return True
+    for family in (_INTEGER_TYPES, _TEXT_TYPES, _FLOAT_TYPES, _DATE_TYPES, _BOOL_TYPES):
+        if a in family and b in family:
+            return True
+    return False
+
+
+__all__ = ["NameMatchExtractor"]

--- a/amx/lineage/extractors/view_ddl.py
+++ b/amx/lineage/extractors/view_ddl.py
@@ -1,0 +1,368 @@
+"""View-DDL lineage extraction.
+
+Primary signal — works without FK metadata. Cache-first by construction:
+the extractor never opens a wire connection in ``cache_only`` mode and
+only fetches/parses in ``db_fill`` mode after the service layer has
+confirmed with the user.
+
+Sqlglot column-lineage is computed once at cache-fill time and stored
+verbatim in ``view_definitions_cache.parsed_lineage_json``. Subsequent
+reads emit edges with zero parsing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from amx.lineage import store as lineage_store
+from amx.lineage.types import (
+    ColumnRef,
+    CostHint,
+    Edge,
+    ExtractMode,
+    ExtractResult,
+    Scope,
+    ScopeFragment,
+)
+
+# Adapter dialect → sqlglot dialect tag. Adapters that already match
+# sqlglot's name are absent from this map (sqlglot accepts the same
+# string).
+_DIALECT_MAP = {
+    "postgresql": "postgres",
+    "redshift": "redshift",
+    "mssql": "tsql",
+    "databricks": "databricks",
+    "mysql": "mysql",
+    "snowflake": "snowflake",
+    "bigquery": "bigquery",
+    "duckdb": "duckdb",
+    "clickhouse": "clickhouse",
+    "oracle": "oracle",
+    "trino": "trino",
+    "presto": "presto",
+}
+
+# Per-view fetch is conservatively budgeted at 0.04s. Real warehouses
+# vary; this is just a cost-hint shown to the user before they confirm.
+_PER_VIEW_SECONDS = 0.04
+
+# Adapter facade injected by the service layer. The factory returns a
+# small struct with everything the extractor needs to do one db_fill
+# round-trip: the engine, the adapter (for list_views_with_definitions),
+# and the backend dialect tag.
+ConnectorFactory = Callable[[str], "ConnectorHandle | None"]
+
+
+class ConnectorHandle:
+    """Minimal handle the extractor receives — see service layer."""
+
+    def __init__(self, engine: Any, adapter: Any, backend: str) -> None:
+        self.engine = engine
+        self.adapter = adapter
+        self.backend = backend
+
+
+class ViewDDLExtractor:
+    name = "view_ddl"
+
+    def __init__(
+        self,
+        *,
+        connector_factory: ConnectorFactory | None = None,
+        ttl_seconds: float = lineage_store.DEFAULT_VIEW_CACHE_TTL_SECONDS,
+    ) -> None:
+        self._connector_factory = connector_factory
+        self._ttl_seconds = ttl_seconds
+
+    def extract(
+        self,
+        *,
+        hs: Any,
+        scope: Scope,
+        mode: ExtractMode = "cache_only",
+    ) -> ExtractResult:
+        database = scope.anchor.database
+        schema = scope.anchor.schema
+        if not schema:
+            return ExtractResult()
+
+        cached = lineage_store.lookup_view_definitions(
+            hs,
+            db_profile=scope.profile,
+            database=database,
+            schema=schema,
+        )
+        if cached:
+            return ExtractResult(
+                edges=list(_edges_from_cached(cached, scope, database, schema)),
+                cache_status="hit",
+            )
+
+        # Cache empty/stale for this scope.
+        if mode == "cache_only":
+            return ExtractResult(
+                edges=[],
+                cache_status="miss",
+                missing_scope=[ScopeFragment(database=database, schema=schema)],
+                estimated_db_cost=CostHint(),  # unknown until we hit the DB
+            )
+
+        # db_fill: open a connection, list views, parse, persist, emit.
+        if self._connector_factory is None:
+            return ExtractResult(
+                edges=[],
+                cache_status="miss",
+                missing_scope=[ScopeFragment(database=database, schema=schema)],
+            )
+        handle = self._connector_factory(scope.profile)
+        if handle is None:
+            return ExtractResult(
+                edges=[],
+                cache_status="miss",
+                missing_scope=[ScopeFragment(database=database, schema=schema)],
+            )
+
+        view_payloads = _fetch_view_definitions(handle, schema)
+        dialect = _DIALECT_MAP.get(handle.backend, handle.backend)
+        entries = list(_build_cache_entries(view_payloads, dialect))
+        lineage_store.upsert_view_definitions(
+            hs,
+            db_profile=scope.profile,
+            database=database,
+            schema=schema,
+            entries=entries,
+            ttl_seconds=self._ttl_seconds,
+        )
+        return ExtractResult(
+            edges=list(
+                _edges_from_cached(
+                    lineage_store.lookup_view_definitions(
+                        hs,
+                        db_profile=scope.profile,
+                        database=database,
+                        schema=schema,
+                    ),
+                    scope,
+                    database,
+                    schema,
+                )
+            ),
+            cache_status="hit",
+            estimated_db_cost=CostHint(
+                estimated_views=len(view_payloads),
+                estimated_seconds=len(view_payloads) * _PER_VIEW_SECONDS,
+            ),
+        )
+
+
+def _fetch_view_definitions(handle: ConnectorHandle, schema: str) -> list[dict[str, Any]]:
+    """Wrapper so adapters that don't implement the method don't crash."""
+    method = getattr(handle.adapter, "list_views_with_definitions", None)
+    if method is None:
+        return []
+    try:
+        return list(method(handle.engine, schema) or [])
+    except Exception:
+        return []
+
+
+def _build_cache_entries(
+    view_payloads: list[dict[str, Any]],
+    dialect: str,
+) -> list[dict[str, Any]]:
+    """Parse each DDL with sqlglot, build per-view cache rows."""
+    out: list[dict[str, Any]] = []
+    parser = _load_sqlglot_lineage()
+    for vp in view_payloads:
+        view_name = str(vp.get("name") or "")
+        ddl = str(vp.get("definition") or "")
+        if not view_name or not ddl:
+            continue
+        parsed, status, error = _parse_view_lineage(parser, ddl, dialect, view_name)
+        out.append(
+            {
+                "view_name": view_name,
+                "ddl_text": ddl,
+                "dialect": dialect,
+                "parsed_lineage": parsed,
+                "parse_status": status,
+                "parse_error": error,
+            }
+        )
+    return out
+
+
+def _parse_view_lineage(
+    parser: Any | None,
+    ddl: str,
+    dialect: str,
+    view_name: str,
+) -> tuple[list[dict[str, Any]] | None, str, str]:
+    """Walk the SELECT body and collect (target_alias, [source columns]) pairs.
+
+    We deliberately avoid ``sqlglot.lineage.lineage`` here — without a real
+    catalog schema it leaks table names into the leaf set and the resulting
+    edges are noisy. The simpler walk: for each SELECT projection, find the
+    nested ``Column`` references that feed it. Aliased ``FROM`` / ``JOIN``
+    targets resolve to their underlying table name when present.
+    """
+    sqlglot = _load_sqlglot_module()
+    if sqlglot is None:
+        return None, "unsupported_dialect", "sqlglot not installed"
+    try:
+        select_stmt = _select_from_ddl(sqlglot, ddl, dialect)
+        if select_stmt is None:
+            return None, "parse_failed", "could not isolate SELECT in DDL"
+
+        alias_map = _alias_to_table_map(sqlglot, select_stmt)
+        out: list[dict[str, Any]] = []
+        for projection in _select_projections(select_stmt):
+            alias = projection.alias_or_name
+            if not alias:
+                continue
+            sources = _collect_source_columns(sqlglot, projection, alias_map)
+            out.append({"target": str(alias), "sources": sources})
+        return out, "ok", ""
+    except Exception as exc:  # defensive
+        return None, "parse_failed", str(exc).splitlines()[0][:200]
+
+
+def _select_from_ddl(sqlglot: Any, ddl: str, dialect: str) -> Any | None:
+    """Pull the SELECT body out of CREATE VIEW or accept a bare SELECT."""
+    try:
+        tree = sqlglot.parse_one(ddl, dialect=dialect)
+    except Exception:
+        try:
+            tree = sqlglot.parse_one(ddl)
+        except Exception:
+            return None
+    expression = (
+        tree.expression if hasattr(tree, "expression") and tree.expression is not None else tree
+    )
+    return expression
+
+
+def _select_projections(select_stmt: Any) -> list[Any]:
+    """Best-effort: return the SELECT's projection expressions."""
+    try:
+        return list(select_stmt.expressions or [])
+    except Exception:
+        return []
+
+
+def _alias_to_table_map(sqlglot: Any, select_stmt: Any) -> dict[str, str]:
+    """Map ``alias`` → ``table_name`` for FROM / JOIN sources of *select_stmt*."""
+    exp = sqlglot.exp
+    out: dict[str, str] = {}
+    try:
+        for table in select_stmt.find_all(exp.Table):
+            alias = table.alias_or_name
+            base = table.name
+            if alias:
+                out[str(alias)] = str(base or alias)
+    except Exception:
+        return {}
+    return out
+
+
+def _collect_source_columns(
+    sqlglot: Any,
+    projection: Any,
+    alias_map: dict[str, str],
+) -> list[dict[str, str]]:
+    """Return ``[{table, column}, …]`` for every ``Column`` under ``projection``."""
+    exp = sqlglot.exp
+    seen: set[tuple[str, str]] = set()
+    out: list[dict[str, str]] = []
+    # When the SELECT has exactly one underlying table and a column has
+    # no explicit qualifier, attribute it to that table — otherwise the
+    # source FQN is partial and downstream edges never materialise.
+    default_table = ""
+    distinct_tables = {v for v in alias_map.values() if v}
+    if len(distinct_tables) == 1:
+        default_table = next(iter(distinct_tables))
+    try:
+        for col in projection.find_all(exp.Column):
+            column_name = str(col.name or "")
+            if not column_name:
+                continue
+            raw_table = str(col.table or "")
+            resolved_table = alias_map.get(raw_table, raw_table) or default_table
+            key = (resolved_table, column_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append({"table": resolved_table, "column": column_name})
+    except Exception:
+        return []
+    return out
+
+
+def _load_sqlglot_module() -> Any | None:
+    try:
+        import sqlglot  # type: ignore
+
+        return sqlglot
+    except ImportError:
+        # sqlglot is in the optional ``lineage`` extra. Try to
+        # auto-install via amx.utils.optional_deps so first-time users
+        # don't hit a hard wall — the registered bundle prompts before
+        # any large download.
+        try:
+            from amx.utils.optional_deps import ensure
+
+            ensure("lineage", feature="/lineage view-DDL parser")
+            import sqlglot  # type: ignore
+
+            return sqlglot
+        except Exception:
+            return None
+    except Exception:
+        return None
+
+
+def _load_sqlglot_lineage() -> Any | None:
+    """Kept for backwards-compat with the parser parameter; returns sqlglot
+    when available so the legacy call sites continue to short-circuit."""
+    return _load_sqlglot_module()
+
+
+def _edges_from_cached(
+    cached_rows: list[dict[str, Any]],
+    scope: Scope,
+    database: str,
+    schema: str,
+) -> Any:
+    """Emit ``Edge``s from already-parsed cache rows."""
+    for row in cached_rows:
+        if row.get("parse_status") != "ok":
+            continue
+        parsed = row.get("parsed_lineage") or []
+        view_name = row.get("view_name") or ""
+        for col_entry in parsed:
+            target_col = str(col_entry.get("target") or "")
+            if not target_col:
+                continue
+            target_ref = ColumnRef(
+                database=database, schema=schema, table=view_name, column=target_col
+            )
+            for src in col_entry.get("sources") or []:
+                src_table = str(src.get("table") or "")
+                src_col = str(src.get("column") or "")
+                if not src_table or not src_col:
+                    continue
+                yield Edge(
+                    source=ColumnRef(
+                        database=database, schema=schema, table=src_table, column=src_col
+                    ),
+                    target=target_ref,
+                    relationship_type="lineage_view_ddl",
+                    extractor="view_ddl",
+                    confidence=1.0,
+                    evidence=f"view {schema}.{view_name}",
+                )
+
+
+__all__ = ["ViewDDLExtractor", "ConnectorHandle", "ConnectorFactory"]

--- a/amx/lineage/render.py
+++ b/amx/lineage/render.py
@@ -1,0 +1,269 @@
+"""DOT generation + ``dot`` subprocess for lineage diagrams.
+
+The DOT builder is a pure function that converts an edge set + metadata
+into a Graphviz DOT string — no I/O, fully testable. The render entry
+point shells out to the ``dot`` binary (resolved via
+:func:`shutil.which` so Windows / macOS / Linux work identically) to
+turn the DOT into the requested image format.
+
+Cross-platform contract:
+
+* Binary discovery uses ``shutil.which`` only — no hard-coded paths.
+* Subprocess invocation uses a list-form argv with ``shell=False`` —
+  identical quoting behavior on Windows.
+* Temp files live under :func:`tempfile.gettempdir` and are cleaned up
+  in a ``finally`` block.
+* Artifact open helper dispatches on :data:`sys.platform`:
+  ``os.startfile`` on Windows, ``open`` on macOS, ``xdg-open`` on Linux.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from amx.lineage.types import ColumnRef, Edge
+
+# Scale guardrails — referenced by the service layer.
+SOFT_NODE_LIMIT = 200
+HARD_NODE_LIMIT = 500
+HARD_EDGE_LIMIT = 1000
+
+SUPPORTED_FORMATS = ("svg", "png", "jpg")
+
+
+class DotBinaryNotFound(RuntimeError):
+    """Raised when ``shutil.which('dot')`` returns ``None``."""
+
+
+@dataclass
+class RenderInput:
+    """Everything :func:`render_lineage_image` needs.
+
+    ``described_entities`` is the set of entity FQNs that have a description —
+    used to draw the ✓/◌ badge on each node. ``partial_warning`` is the
+    footer banner string (empty when no partial-render banner is needed).
+    """
+
+    edges: list[Edge]
+    anchor: ColumnRef
+    described_entities: set[str]
+    title: str = ""
+    partial_warning: str = ""
+
+
+def build_dot(payload: RenderInput) -> str:
+    """Produce a Graphviz DOT string for the given edges + metadata.
+
+    Side-effect free: no DB, no filesystem. Safe to call from tests.
+    """
+    nodes: dict[str, dict[str, Any]] = {}
+    anchor_id = _node_id(payload.anchor)
+    nodes[anchor_id] = {
+        "label": _node_label(
+            payload.anchor, anchor=True, described=anchor_id in payload.described_entities
+        ),
+        "anchor": True,
+    }
+
+    edge_lines: list[str] = []
+    for edge in payload.edges:
+        src_id = _node_id(edge.source)
+        tgt_id = _node_id(edge.target)
+        nodes.setdefault(
+            src_id,
+            {
+                "label": _node_label(
+                    edge.source, anchor=False, described=src_id in payload.described_entities
+                )
+            },
+        )
+        nodes.setdefault(
+            tgt_id,
+            {
+                "label": _node_label(
+                    edge.target, anchor=False, described=tgt_id in payload.described_entities
+                )
+            },
+        )
+        edge_lines.append(_edge_line(src_id, tgt_id, edge))
+
+    node_lines = [_node_line(node_id, attrs) for node_id, attrs in nodes.items()]
+
+    title_block = ""
+    if payload.title:
+        title_block = (
+            f'  labelloc="t";\n  label={_dot_quote(payload.title)};\n  fontname="Helvetica";\n'
+        )
+
+    footer_block = ""
+    if payload.partial_warning:
+        # Render the warning as an isolated "banner" node with a soft fill.
+        footer_block = (
+            "  __partial__ [shape=note, fontsize=10, "
+            'style="filled", fillcolor="#fff3cd", color="#856404", '
+            f"label={_dot_quote(payload.partial_warning)}];\n"
+        )
+
+    return (
+        "digraph lineage {\n"
+        '  rankdir="LR";\n'
+        '  node [shape=box, style="rounded,filled", fillcolor="#f8f9fa", '
+        'fontname="Helvetica", fontsize=11];\n'
+        '  edge [fontname="Helvetica", fontsize=9];\n'
+        f"{title_block}" + "".join(node_lines) + "".join(edge_lines) + footer_block + "}\n"
+    )
+
+
+def render_lineage_image(
+    *,
+    payload: RenderInput,
+    fmt: str,
+    output_path: Path,
+) -> Path:
+    """Convert ``payload`` to an image at ``output_path`` via ``dot``.
+
+    Returns the resolved output path. Raises :class:`DotBinaryNotFound`
+    when ``dot`` is not on PATH (callers surface an install hint).
+    """
+    fmt = fmt.lower()
+    if fmt not in SUPPORTED_FORMATS:
+        raise ValueError(f"unsupported format {fmt!r}; expected one of {SUPPORTED_FORMATS}")
+
+    dot_binary = shutil.which("dot")
+    if not dot_binary:
+        raise DotBinaryNotFound(
+            "graphviz `dot` is required. Install it: "
+            "macOS `brew install graphviz`; "
+            "Debian/Ubuntu `apt install graphviz`; "
+            "Windows `winget install graphviz` or download from https://graphviz.org/."
+        )
+
+    output_path = Path(output_path).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    dot_text = build_dot(payload)
+    tmpdir = Path(tempfile.gettempdir())
+    dot_file = tmpdir / f"amx-lineage-{os.getpid()}-{output_path.stem}.dot"
+    try:
+        dot_file.write_text(dot_text, encoding="utf-8")
+        cmd = [dot_binary, f"-T{fmt}", str(dot_file), "-o", str(output_path)]
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"graphviz failed (exit {exc.returncode}): {exc.stderr.strip() or 'no stderr'}"
+        ) from exc
+    finally:
+        try:
+            dot_file.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return output_path
+
+
+def open_artifact(path: Path) -> bool:
+    """Cross-platform "open this file in the default viewer".
+
+    Returns ``True`` when the platform dispatch fired without raising,
+    ``False`` when no display is available (headless CI) so callers can
+    fall back to printing the absolute path.
+    """
+    path = Path(path)
+    plat = sys.platform
+    try:
+        if plat == "win32":
+            os.startfile(str(path))  # type: ignore[attr-defined]
+            return True
+        if plat == "darwin":
+            subprocess.run(["open", str(path)], check=False)
+            return True
+        if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+            return False
+        subprocess.run(["xdg-open", str(path)], check=False)
+        return True
+    except Exception:
+        return False
+
+
+def count_nodes(edges: Iterable[Edge], anchor: ColumnRef) -> int:
+    """Count distinct nodes that would appear in a render of ``edges`` + ``anchor``."""
+    ids = {_node_id(anchor)}
+    for edge in edges:
+        ids.add(_node_id(edge.source))
+        ids.add(_node_id(edge.target))
+    return len(ids)
+
+
+# ── internal helpers ─────────────────────────────────────────────────────
+
+
+def _node_id(ref: ColumnRef) -> str:
+    return ".".join(p for p in (ref.database, ref.schema, ref.table, ref.column) if p)
+
+
+def _node_label(ref: ColumnRef, *, anchor: bool, described: bool) -> str:
+    badge = "✓" if described else "○"  # ✓ vs ○ (ASCII-safe ring instead of ◌)
+    main = ".".join(p for p in (ref.schema, ref.table) if p)
+    if ref.column:
+        main = f"{main}.{ref.column}" if main else ref.column
+    if anchor:
+        return f"★ {badge} {main}"
+    return f"{badge} {main}"
+
+
+def _node_line(node_id: str, attrs: dict[str, Any]) -> str:
+    label = attrs["label"]
+    extras = []
+    if attrs.get("anchor"):
+        extras.append("penwidth=2.4")
+        extras.append('fillcolor="#fff4e6"')
+        extras.append('color="#d97706"')
+    extras_text = (", " + ", ".join(extras)) if extras else ""
+    return f"  {_dot_id(node_id)} [label={_dot_quote(label)}{extras_text}];\n"
+
+
+def _edge_line(src_id: str, tgt_id: str, edge: Edge) -> str:
+    if edge.relationship_type == "lineage_name_match":
+        style = ', style="dashed", color="#9ca3af"'
+        label_tag = "≈name"  # ≈name
+    elif edge.relationship_type == "lineage_fk":
+        style = ', color="#1f2937"'
+        label_tag = "fk"
+    elif edge.relationship_type == "lineage_view_ddl":
+        style = ', color="#1f2937"'
+        label_tag = "view"
+    else:
+        style = ""
+        label_tag = edge.extractor
+    return f"  {_dot_id(src_id)} -> {_dot_id(tgt_id)} [label={_dot_quote(label_tag)}{style}];\n"
+
+
+def _dot_id(node_id: str) -> str:
+    """Quote any non-trivial identifier."""
+    return _dot_quote(node_id)
+
+
+def _dot_quote(text: str) -> str:
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+__all__ = [
+    "DotBinaryNotFound",
+    "RenderInput",
+    "SOFT_NODE_LIMIT",
+    "HARD_NODE_LIMIT",
+    "HARD_EDGE_LIMIT",
+    "SUPPORTED_FORMATS",
+    "build_dot",
+    "render_lineage_image",
+    "open_artifact",
+    "count_nodes",
+]

--- a/amx/lineage/render.py
+++ b/amx/lineage/render.py
@@ -13,6 +13,7 @@ does not depend on a ``dot`` binary anywhere.
 
 from __future__ import annotations
 
+import math
 import os
 import subprocess
 import sys
@@ -78,10 +79,13 @@ def render_lineage_image(
 
     fig, ax = plt.subplots(figsize=_figure_size(len(graph)))
     ax.set_axis_off()
+    _set_axis_limits(ax, positions)
     _draw_nodes(ax, positions, node_attrs)
     _draw_edges(ax, positions, edge_attrs)
+    if len(graph) == 1 and anchor_id in positions:
+        _draw_empty_result_caption(ax, positions[anchor_id])
     if payload.title:
-        ax.set_title(payload.title, fontsize=11, loc="left", pad=12)
+        fig.suptitle(payload.title, fontsize=11, x=0.04, ha="left", y=0.96)
     if payload.partial_warning:
         fig.text(
             0.5,
@@ -97,8 +101,12 @@ def render_lineage_image(
             },
         )
 
-    fig.tight_layout()
-    fig.savefig(output_path, format=fmt, dpi=160, bbox_inches="tight")
+    # Explicit margins instead of tight_layout: tight_layout fights
+    # ax.set_axis_off() on near-empty axes and prints a UserWarning when
+    # it gives up. Hard-coded margins also keep the canvas size stable
+    # across renders of the same artifact slot.
+    fig.subplots_adjust(left=0.04, right=0.96, top=0.92, bottom=0.10)
+    fig.savefig(output_path, format=fmt, dpi=160)
     plt.close(fig)
     return output_path
 
@@ -233,6 +241,12 @@ def _load_render_stack() -> tuple[Any, Any]:
         matplotlib.use("Agg", force=True)
         import matplotlib.pyplot as plt
 
+    # Keep SVG text as literal strings instead of glyph paths so the
+    # output is searchable / accessible / smaller. Without this every
+    # character becomes an opaque <use xlink:href="#DejaVuSans-XX">,
+    # which defeats Ctrl-F in any viewer.
+    matplotlib.rcParams["svg.fonttype"] = "none"
+
     return nx, plt
 
 
@@ -333,11 +347,82 @@ def _hierarchical_layout(graph: Any, anchor_id: str, nx: Any) -> dict[str, tuple
 
 
 def _figure_size(node_count: int) -> tuple[float, float]:
-    """Pick a canvas size that scales gently with node count."""
-    base_w, base_h = 10.0, 6.0
-    w = base_w + min(node_count / 20.0, 6.0)
-    h = base_h + min(node_count / 40.0, 4.0)
-    return w, h
+    """Figure size that grows with node count without wasting canvas on tiny graphs.
+
+    The previous implementation started at 10×6 inches regardless of
+    content; that made the single-node case look like an empty page
+    with a tiny anchor marooned in one corner. The curve below starts
+    at 6×4 for the anchor-only case, hits ~7×5 at ten nodes, ~9×6 at a
+    hundred, and ~11×7 at five hundred — enough room as the graph
+    grows, no waste when it doesn't.
+    """
+    base_w, base_h = 6.0, 4.0
+    if node_count <= 1:
+        return base_w, base_h
+    extra = math.log2(max(node_count, 2))
+    return base_w + extra * 0.9, base_h + extra * 0.55
+
+
+def _set_axis_limits(
+    ax: Any,
+    positions: dict[str, tuple[float, float]],
+    *,
+    h_pad: float = 2.0,
+    v_pad: float = 1.2,
+) -> None:
+    """Set xlim/ylim from the node bounding box so the anchor lands centred.
+
+    Without an explicit limit matplotlib autoscales to the data
+    extents, which for a single point at (0, 0) gives a degenerate
+    view that ``bbox_inches="tight"`` then crops into the bottom-left
+    corner. Symmetric padding around the actual content keeps the
+    anchor visually centred even when the BFS-derived layers are
+    asymmetric (e.g. anchor + one upstream + zero downstream).
+    """
+    if not positions:
+        ax.set_xlim(-1, 1)
+        ax.set_ylim(-1, 1)
+        return
+    xs = [p[0] for p in positions.values()]
+    ys = [p[1] for p in positions.values()]
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+    if x_min == x_max:
+        ax.set_xlim(x_min - h_pad, x_max + h_pad)
+    else:
+        ax.set_xlim(x_min - h_pad * 0.5, x_max + h_pad * 0.5)
+    if y_min == y_max:
+        ax.set_ylim(y_min - v_pad, y_max + v_pad)
+    else:
+        ax.set_ylim(y_min - v_pad * 0.5, y_max + v_pad * 0.5)
+
+
+def _draw_empty_result_caption(ax: Any, anchor_pos: tuple[float, float]) -> None:
+    """Render the 'no related entities found' caption under the anchor.
+
+    Replaces what would otherwise be a blank canvas when every
+    extractor returns an empty edge set. The caption tells the user
+    *what happened* and *what to do next* instead of leaving them
+    staring at a single tiny box in the corner.
+    """
+    ax_x, ax_y = anchor_pos
+    ax.text(
+        ax_x,
+        ax_y - 1.2,
+        "No related entities found in cache.\n"
+        "Try /lineage refresh --no-cache to pull view DDL and FK relationships.",
+        ha="center",
+        va="top",
+        fontsize=9,
+        color="#6b7280",
+        wrap=True,
+        bbox={
+            "boxstyle": "round,pad=0.5",
+            "facecolor": "#f3f4f6",
+            "edgecolor": "#d1d5db",
+            "linewidth": 0.8,
+        },
+    )
 
 
 def _draw_nodes(
@@ -395,9 +480,17 @@ def _draw_edges(
         )
         mx = (src[0] + tgt[0]) / 2.0
         my = (src[1] + tgt[1]) / 2.0
+        # Nudge the label off the line so it doesn't sit on top of nodes
+        # that happen to fall along the midpoint axis. The offset is
+        # perpendicular to the edge direction so labels don't cluster.
+        dx, dy = tgt[0] - src[0], tgt[1] - src[1]
+        length = max((dx * dx + dy * dy) ** 0.5, 1e-6)
+        offset_magnitude = 0.18
+        off_x = -dy / length * offset_magnitude
+        off_y = dx / length * offset_magnitude
         ax.text(
-            mx,
-            my,
+            mx + off_x,
+            my + off_y,
             ea["label"],
             fontsize=7,
             color=style["color"],

--- a/amx/lineage/render.py
+++ b/amx/lineage/render.py
@@ -1,29 +1,22 @@
-"""DOT generation + ``dot`` subprocess for lineage diagrams.
+"""Lineage diagram rendering — pip-installable, no system binaries.
 
-The DOT builder is a pure function that converts an edge set + metadata
-into a Graphviz DOT string — no I/O, fully testable. The render entry
-point shells out to the ``dot`` binary (resolved via
-:func:`shutil.which` so Windows / macOS / Linux work identically) to
-turn the DOT into the requested image format.
+The image render path uses ``networkx`` (graph + layout) and
+``matplotlib`` (rasterisation). Both ship as pip wheels on every
+supported platform, so the user never has to install Graphviz,
+Cairo, or any other OS package. AMX auto-installs the bundle via
+:func:`amx.utils.optional_deps.ensure("lineage")` on first render.
 
-Cross-platform contract:
-
-* Binary discovery uses ``shutil.which`` only — no hard-coded paths.
-* Subprocess invocation uses a list-form argv with ``shell=False`` —
-  identical quoting behavior on Windows.
-* Temp files live under :func:`tempfile.gettempdir` and are cleaned up
-  in a ``finally`` block.
-* Artifact open helper dispatches on :data:`sys.platform`:
-  ``os.startfile`` on Windows, ``open`` on macOS, ``xdg-open`` on Linux.
+A pure-string ``build_dot`` helper is kept for tests, debugging, and
+paste-into-graphviz.org workflows — but the user-facing image output
+does not depend on a ``dot`` binary anywhere.
 """
 
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import sys
-import tempfile
+from collections import defaultdict, deque
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,7 +33,7 @@ SUPPORTED_FORMATS = ("svg", "png", "jpg")
 
 
 class DotBinaryNotFound(RuntimeError):
-    """Raised when ``shutil.which('dot')`` returns ``None``."""
+    """Retained for backwards-compatibility; pip-only render never raises this."""
 
 
 @dataclass
@@ -48,7 +41,7 @@ class RenderInput:
     """Everything :func:`render_lineage_image` needs.
 
     ``described_entities`` is the set of entity FQNs that have a description —
-    used to draw the ✓/◌ badge on each node. ``partial_warning`` is the
+    used to draw the ✓/○ badge on each node. ``partial_warning`` is the
     footer banner string (empty when no partial-render banner is needed).
     """
 
@@ -59,10 +52,63 @@ class RenderInput:
     partial_warning: str = ""
 
 
-def build_dot(payload: RenderInput) -> str:
-    """Produce a Graphviz DOT string for the given edges + metadata.
+def render_lineage_image(
+    *,
+    payload: RenderInput,
+    fmt: str,
+    output_path: Path,
+) -> Path:
+    """Rasterise ``payload`` to ``output_path`` via matplotlib + networkx.
 
-    Side-effect free: no DB, no filesystem. Safe to call from tests.
+    ``fmt`` must be one of :data:`SUPPORTED_FORMATS`. Auto-installs the
+    ``lineage`` optional extra (``matplotlib`` + ``networkx`` + ``sqlglot``)
+    on first call so the only thing the user has to do is run
+    ``/lineage create``.
+    """
+    fmt = fmt.lower()
+    if fmt not in SUPPORTED_FORMATS:
+        raise ValueError(f"unsupported format {fmt!r}; expected one of {SUPPORTED_FORMATS}")
+    nx, plt = _load_render_stack()
+
+    output_path = Path(output_path).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    graph, anchor_id, node_attrs, edge_attrs = _build_graph(payload, nx)
+    positions = _hierarchical_layout(graph, anchor_id, nx)
+
+    fig, ax = plt.subplots(figsize=_figure_size(len(graph)))
+    ax.set_axis_off()
+    _draw_nodes(ax, positions, node_attrs)
+    _draw_edges(ax, positions, edge_attrs)
+    if payload.title:
+        ax.set_title(payload.title, fontsize=11, loc="left", pad=12)
+    if payload.partial_warning:
+        fig.text(
+            0.5,
+            0.02,
+            payload.partial_warning,
+            ha="center",
+            fontsize=9,
+            color="#856404",
+            bbox={
+                "boxstyle": "round,pad=0.4",
+                "facecolor": "#fff3cd",
+                "edgecolor": "#856404",
+            },
+        )
+
+    fig.tight_layout()
+    fig.savefig(output_path, format=fmt, dpi=160, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def build_dot(payload: RenderInput) -> str:
+    """Pure-string Graphviz DOT representation of ``payload``.
+
+    The user-facing render path no longer needs the ``dot`` binary, but
+    this helper is kept so callers can serialise a graph for tests,
+    debugging, or paste-into-graphviz.org workflows.
     """
     nodes: dict[str, dict[str, Any]] = {}
     anchor_id = _node_id(payload.anchor)
@@ -105,7 +151,6 @@ def build_dot(payload: RenderInput) -> str:
 
     footer_block = ""
     if payload.partial_warning:
-        # Render the warning as an isolated "banner" node with a soft fill.
         footer_block = (
             "  __partial__ [shape=note, fontsize=10, "
             'style="filled", fillcolor="#fff3cd", color="#856404", '
@@ -120,52 +165,6 @@ def build_dot(payload: RenderInput) -> str:
         '  edge [fontname="Helvetica", fontsize=9];\n'
         f"{title_block}" + "".join(node_lines) + "".join(edge_lines) + footer_block + "}\n"
     )
-
-
-def render_lineage_image(
-    *,
-    payload: RenderInput,
-    fmt: str,
-    output_path: Path,
-) -> Path:
-    """Convert ``payload`` to an image at ``output_path`` via ``dot``.
-
-    Returns the resolved output path. Raises :class:`DotBinaryNotFound`
-    when ``dot`` is not on PATH (callers surface an install hint).
-    """
-    fmt = fmt.lower()
-    if fmt not in SUPPORTED_FORMATS:
-        raise ValueError(f"unsupported format {fmt!r}; expected one of {SUPPORTED_FORMATS}")
-
-    dot_binary = shutil.which("dot")
-    if not dot_binary:
-        raise DotBinaryNotFound(
-            "graphviz `dot` is required. Install it: "
-            "macOS `brew install graphviz`; "
-            "Debian/Ubuntu `apt install graphviz`; "
-            "Windows `winget install graphviz` or download from https://graphviz.org/."
-        )
-
-    output_path = Path(output_path).expanduser().resolve()
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    dot_text = build_dot(payload)
-    tmpdir = Path(tempfile.gettempdir())
-    dot_file = tmpdir / f"amx-lineage-{os.getpid()}-{output_path.stem}.dot"
-    try:
-        dot_file.write_text(dot_text, encoding="utf-8")
-        cmd = [dot_binary, f"-T{fmt}", str(dot_file), "-o", str(output_path)]
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"graphviz failed (exit {exc.returncode}): {exc.stderr.strip() or 'no stderr'}"
-        ) from exc
-    finally:
-        try:
-            dot_file.unlink(missing_ok=True)
-        except OSError:
-            pass
-    return output_path
 
 
 def open_artifact(path: Path) -> bool:
@@ -201,7 +200,235 @@ def count_nodes(edges: Iterable[Edge], anchor: ColumnRef) -> int:
     return len(ids)
 
 
-# ── internal helpers ─────────────────────────────────────────────────────
+# ── internals: render stack loader ───────────────────────────────────────
+
+
+def _load_render_stack() -> tuple[Any, Any]:
+    """Return ``(networkx, matplotlib.pyplot)``. Auto-install on first call.
+
+    The ``lineage`` bundle in :mod:`amx.utils.optional_deps` carries
+    ``networkx`` and ``matplotlib`` so users never have to run pip by
+    hand. If install fails (offline, locked corp env), the underlying
+    ``ImportError`` propagates with the pip command the user can run.
+    """
+    try:
+        import networkx as nx  # type: ignore
+    except ImportError:
+        from amx.utils.optional_deps import ensure
+
+        ensure("lineage", feature="/lineage diagram renderer")
+        import networkx as nx  # type: ignore
+
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+    except ImportError:
+        from amx.utils.optional_deps import ensure
+
+        ensure("lineage", feature="/lineage diagram renderer")
+        import matplotlib
+
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+
+    return nx, plt
+
+
+# ── internals: graph build + layout ──────────────────────────────────────
+
+
+def _build_graph(
+    payload: RenderInput, nx: Any
+) -> tuple[Any, str, dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    """Build a networkx DiGraph and attribute maps for nodes + edges."""
+    graph = nx.DiGraph()
+    anchor_id = _node_id(payload.anchor)
+    node_attrs: dict[str, dict[str, Any]] = {}
+
+    def _add_node(ref: ColumnRef, *, anchor: bool) -> str:
+        node_id = _node_id(ref)
+        if node_id not in node_attrs:
+            node_attrs[node_id] = {
+                "label": _node_label(
+                    ref, anchor=anchor, described=node_id in payload.described_entities
+                ),
+                "anchor": anchor,
+            }
+            graph.add_node(node_id)
+        elif anchor:
+            node_attrs[node_id]["anchor"] = True
+            node_attrs[node_id]["label"] = _node_label(
+                ref, anchor=True, described=node_id in payload.described_entities
+            )
+        return node_id
+
+    _add_node(payload.anchor, anchor=True)
+
+    edge_attrs: list[dict[str, Any]] = []
+    for edge in payload.edges:
+        src_id = _add_node(edge.source, anchor=False)
+        tgt_id = _add_node(edge.target, anchor=False)
+        graph.add_edge(src_id, tgt_id)
+        edge_attrs.append(
+            {
+                "src": src_id,
+                "tgt": tgt_id,
+                "style": _edge_style(edge),
+                "label": _edge_label(edge),
+            }
+        )
+
+    return graph, anchor_id, node_attrs, edge_attrs
+
+
+def _hierarchical_layout(graph: Any, anchor_id: str, nx: Any) -> dict[str, tuple[float, float]]:
+    """Left-right layout: upstream on the left, downstream on the right.
+
+    Walks the graph with BFS from the anchor along incoming and outgoing
+    edges separately to assign layer indices. Nodes sharing a layer are
+    spread evenly along the Y axis. Falls back to ``nx.spring_layout``
+    when the anchor sits in a disconnected node set we cannot layer.
+    """
+    if anchor_id not in graph:
+        return nx.spring_layout(graph, seed=7)
+
+    layers: dict[str, int] = {anchor_id: 0}
+
+    queue: deque[tuple[str, int]] = deque([(anchor_id, 0)])
+    while queue:
+        node, depth = queue.popleft()
+        for pred in graph.predecessors(node):
+            if pred not in layers:
+                layers[pred] = depth - 1
+                queue.append((pred, depth - 1))
+
+    queue = deque([(anchor_id, 0)])
+    while queue:
+        node, depth = queue.popleft()
+        for succ in graph.successors(node):
+            if succ not in layers:
+                layers[succ] = depth + 1
+                queue.append((succ, depth + 1))
+
+    for node in graph.nodes:
+        layers.setdefault(node, 0)
+
+    by_layer: dict[int, list[str]] = defaultdict(list)
+    for node, layer in layers.items():
+        by_layer[layer].append(node)
+
+    pos: dict[str, tuple[float, float]] = {}
+    x_spacing = 3.0
+    y_spacing = 1.4
+    for layer, nodes in by_layer.items():
+        x = layer * x_spacing
+        nodes_sorted = sorted(nodes)
+        n = len(nodes_sorted)
+        for i, node in enumerate(nodes_sorted):
+            y = (i - (n - 1) / 2.0) * y_spacing
+            pos[node] = (x, y)
+    return pos
+
+
+def _figure_size(node_count: int) -> tuple[float, float]:
+    """Pick a canvas size that scales gently with node count."""
+    base_w, base_h = 10.0, 6.0
+    w = base_w + min(node_count / 20.0, 6.0)
+    h = base_h + min(node_count / 40.0, 4.0)
+    return w, h
+
+
+def _draw_nodes(
+    ax: Any,
+    positions: dict[str, tuple[float, float]],
+    node_attrs: dict[str, dict[str, Any]],
+) -> None:
+    """Render labelled rounded boxes for every node."""
+    for node_id, (x, y) in positions.items():
+        attrs = node_attrs.get(node_id, {})
+        is_anchor = bool(attrs.get("anchor"))
+        label = attrs.get("label", node_id)
+        face = "#fff4e6" if is_anchor else "#f8f9fa"
+        edge_color = "#d97706" if is_anchor else "#cccccc"
+        ax.text(
+            x,
+            y,
+            label,
+            ha="center",
+            va="center",
+            fontsize=9,
+            bbox={
+                "boxstyle": "round,pad=0.4",
+                "facecolor": face,
+                "edgecolor": edge_color,
+                "linewidth": 1.6 if is_anchor else 0.8,
+            },
+        )
+
+
+def _draw_edges(
+    ax: Any,
+    positions: dict[str, tuple[float, float]],
+    edge_attrs: list[dict[str, Any]],
+) -> None:
+    """Render straight arrows for every edge with style hints baked in."""
+    for ea in edge_attrs:
+        src = positions.get(ea["src"])
+        tgt = positions.get(ea["tgt"])
+        if src is None or tgt is None:
+            continue
+        style = ea["style"]
+        ax.annotate(
+            "",
+            xy=tgt,
+            xytext=src,
+            arrowprops={
+                "arrowstyle": "->",
+                "linewidth": style["linewidth"],
+                "color": style["color"],
+                "linestyle": style["linestyle"],
+                "shrinkA": 14,
+                "shrinkB": 14,
+            },
+        )
+        mx = (src[0] + tgt[0]) / 2.0
+        my = (src[1] + tgt[1]) / 2.0
+        ax.text(
+            mx,
+            my,
+            ea["label"],
+            fontsize=7,
+            color=style["color"],
+            ha="center",
+            va="center",
+            bbox={
+                "boxstyle": "round,pad=0.1",
+                "facecolor": "white",
+                "edgecolor": "none",
+                "alpha": 0.85,
+            },
+        )
+
+
+# ── internals: per-edge / per-node styling shared with build_dot ─────────
+
+
+def _edge_style(edge: Edge) -> dict[str, Any]:
+    if edge.relationship_type == "lineage_name_match":
+        return {"color": "#9ca3af", "linewidth": 0.8, "linestyle": "dashed"}
+    return {"color": "#1f2937", "linewidth": 1.0, "linestyle": "solid"}
+
+
+def _edge_label(edge: Edge) -> str:
+    if edge.relationship_type == "lineage_name_match":
+        return "≈name"
+    if edge.relationship_type == "lineage_fk":
+        return "fk"
+    if edge.relationship_type == "lineage_view_ddl":
+        return "view"
+    return edge.extractor
 
 
 def _node_id(ref: ColumnRef) -> str:
@@ -209,7 +436,7 @@ def _node_id(ref: ColumnRef) -> str:
 
 
 def _node_label(ref: ColumnRef, *, anchor: bool, described: bool) -> str:
-    badge = "✓" if described else "○"  # ✓ vs ○ (ASCII-safe ring instead of ◌)
+    badge = "✓" if described else "○"
     main = ".".join(p for p in (ref.schema, ref.table) if p)
     if ref.column:
         main = f"{main}.{ref.column}" if main else ref.column
@@ -230,23 +457,17 @@ def _node_line(node_id: str, attrs: dict[str, Any]) -> str:
 
 
 def _edge_line(src_id: str, tgt_id: str, edge: Edge) -> str:
+    label_tag = _edge_label(edge)
     if edge.relationship_type == "lineage_name_match":
         style = ', style="dashed", color="#9ca3af"'
-        label_tag = "≈name"  # ≈name
-    elif edge.relationship_type == "lineage_fk":
+    elif edge.relationship_type in {"lineage_fk", "lineage_view_ddl"}:
         style = ', color="#1f2937"'
-        label_tag = "fk"
-    elif edge.relationship_type == "lineage_view_ddl":
-        style = ', color="#1f2937"'
-        label_tag = "view"
     else:
         style = ""
-        label_tag = edge.extractor
     return f"  {_dot_id(src_id)} -> {_dot_id(tgt_id)} [label={_dot_quote(label_tag)}{style}];\n"
 
 
 def _dot_id(node_id: str) -> str:
-    """Quote any non-trivial identifier."""
     return _dot_quote(node_id)
 
 

--- a/amx/lineage/service.py
+++ b/amx/lineage/service.py
@@ -1,0 +1,641 @@
+"""Lineage orchestration. Imported by the CLI and (in a later slice) Studio.
+
+This module owns the *flow*:
+
+1. Resolve anchor entity from the catalog.
+2. Fan extractors out in ``cache_only`` mode.
+3. If anything reported a cache miss, build a cost report and let the
+   caller decide whether to fill (the actual prompt lives in the CLI so
+   the service stays headless-safe for Studio).
+4. Render once everyone is satisfied.
+5. Persist a ``lineage_artifacts`` row.
+
+The CLI calls :func:`create_lineage` and :func:`refresh_lineage`. The
+non-interactive surface (Studio, tests, automation) calls the same
+functions with ``fill_decision`` set explicitly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from amx.lineage import store as lineage_store
+from amx.lineage.extractors import (
+    FKExtractor,
+    NameMatchExtractor,
+    ViewDDLExtractor,
+)
+from amx.lineage.extractors.view_ddl import ConnectorFactory, ConnectorHandle
+from amx.lineage.render import (
+    HARD_EDGE_LIMIT,
+    HARD_NODE_LIMIT,
+    SOFT_NODE_LIMIT,
+    SUPPORTED_FORMATS,
+    RenderInput,
+    count_nodes,
+    render_lineage_image,
+)
+from amx.lineage.types import (
+    ColumnRef,
+    Edge,
+    ExtractResult,
+    Scope,
+    ScopeFragment,
+)
+
+FillDecision = Literal["fill", "skip", "abort"]
+FillPrompt = Callable[["CacheMissReport"], FillDecision]
+
+
+@dataclass
+class CacheMissReport:
+    """Cost summary handed to the CLI to drive the ``confirm()`` prompt."""
+
+    missing_scopes: list[ScopeFragment] = field(default_factory=list)
+    estimated_views: int = 0
+    estimated_seconds: float = 0.0
+    extractors_with_misses: list[str] = field(default_factory=list)
+
+    def has_misses(self) -> bool:
+        return bool(self.missing_scopes) or bool(self.extractors_with_misses)
+
+
+@dataclass
+class ScaleVerdict:
+    """Pre-render check. Mirrors render.py guardrails."""
+
+    node_count: int
+    edge_count: int
+    needs_soft_confirm: bool
+    blocked: bool
+    blocked_reason: str = ""
+
+
+@dataclass
+class LineageRunResult:
+    """Outcome of :func:`create_lineage` / :func:`refresh_lineage`."""
+
+    artifact_id: int
+    output_path: Path
+    node_count: int
+    edge_count: int
+    extractors_used: list[str]
+    extractors_partial: bool
+    aborted: bool = False
+    abort_reason: str = ""
+
+
+def build_default_extractors(
+    connector_factory: ConnectorFactory | None = None,
+) -> list[Any]:
+    """The three slice-1 extractors in dispatch order."""
+    return [
+        FKExtractor(),
+        ViewDDLExtractor(connector_factory=connector_factory),
+        NameMatchExtractor(),
+    ]
+
+
+def resolve_anchor_entity_id(
+    hs: Any,
+    *,
+    profile: str,
+    anchor: ColumnRef,
+) -> int | None:
+    """Return ``catalog_entities.id`` matching the anchor's kind+identity."""
+    entity_kind = "column" if anchor.column else "table"
+    with hs._connect() as conn:
+        row = conn.execute(
+            """
+            SELECT id FROM catalog_entities
+            WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+              AND table_name = ?
+              AND COALESCE(column_name, '') = COALESCE(?, '')
+              AND entity_kind = ?
+            LIMIT 1
+            """,
+            (
+                profile,
+                anchor.database,
+                anchor.schema,
+                anchor.table,
+                anchor.column or None,
+                entity_kind,
+            ),
+        ).fetchone()
+    return int(row[0]) if row else None
+
+
+def gather_edges(
+    hs: Any,
+    scope: Scope,
+    extractors: list[Any],
+) -> tuple[list[Edge], list[ExtractResult], CacheMissReport]:
+    """Run every extractor in ``cache_only`` mode and aggregate."""
+    edges: list[Edge] = []
+    results: list[ExtractResult] = []
+    miss_report = CacheMissReport()
+    for ext in extractors:
+        result = ext.extract(hs=hs, scope=scope, mode="cache_only")
+        results.append(result)
+        edges.extend(result.edges)
+        if result.cache_status != "hit":
+            miss_report.extractors_with_misses.append(ext.name)
+            miss_report.missing_scopes.extend(result.missing_scope)
+            miss_report.estimated_views += result.estimated_db_cost.estimated_views
+            miss_report.estimated_seconds += result.estimated_db_cost.estimated_seconds
+    return edges, results, miss_report
+
+
+def fill_cache_misses(
+    hs: Any,
+    scope: Scope,
+    extractors: list[Any],
+    miss_report: CacheMissReport,
+) -> tuple[list[Edge], list[ExtractResult]]:
+    """Re-run only the extractors that reported misses in ``db_fill`` mode."""
+    edges: list[Edge] = []
+    results: list[ExtractResult] = []
+    miss_set = set(miss_report.extractors_with_misses)
+    for ext in extractors:
+        if ext.name in miss_set:
+            r = ext.extract(hs=hs, scope=scope, mode="db_fill")
+        else:
+            r = ext.extract(hs=hs, scope=scope, mode="cache_only")
+        results.append(r)
+        edges.extend(r.edges)
+    return edges, results
+
+
+def assess_scale(edges: list[Edge], anchor: ColumnRef) -> ScaleVerdict:
+    node_count = count_nodes(edges, anchor)
+    edge_count = len(edges)
+    blocked = False
+    reason = ""
+    if node_count > HARD_NODE_LIMIT:
+        blocked = True
+        reason = f"node count {node_count} exceeds hard limit {HARD_NODE_LIMIT}"
+    elif edge_count > HARD_EDGE_LIMIT:
+        blocked = True
+        reason = f"edge count {edge_count} exceeds hard limit {HARD_EDGE_LIMIT}"
+    return ScaleVerdict(
+        node_count=node_count,
+        edge_count=edge_count,
+        needs_soft_confirm=(node_count > SOFT_NODE_LIMIT and not blocked),
+        blocked=blocked,
+        blocked_reason=reason,
+    )
+
+
+def described_entities(
+    hs: Any,
+    *,
+    profile: str,
+    refs: list[ColumnRef],
+) -> set[str]:
+    """Return the FQNs (using same convention as render._node_id) that have a description."""
+    if not refs:
+        return set()
+    with hs._connect() as conn:
+        described: set[str] = set()
+        for ref in refs:
+            entity_kind = "column" if ref.column else "table"
+            row = conn.execute(
+                """
+                SELECT effective_description_id FROM catalog_entities
+                WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+                  AND table_name = ?
+                  AND COALESCE(column_name, '') = COALESCE(?, '')
+                  AND entity_kind = ?
+                LIMIT 1
+                """,
+                (
+                    profile,
+                    ref.database,
+                    ref.schema,
+                    ref.table,
+                    ref.column or None,
+                    entity_kind,
+                ),
+            ).fetchone()
+            if row and row[0]:
+                described.add(_fqn(ref))
+    return described
+
+
+def create_lineage(
+    hs: Any,
+    *,
+    scope: Scope,
+    name: str,
+    output_path: Path,
+    fmt: str,
+    fill_prompt: FillPrompt | None = None,
+    fill_decision: FillDecision | None = None,
+    force_scale: bool = False,
+    soft_confirm: Callable[[ScaleVerdict], bool] | None = None,
+    connector_factory: ConnectorFactory | None = None,
+    extractors: list[Any] | None = None,
+) -> LineageRunResult:
+    """End-to-end: extract, render, persist."""
+    fmt = fmt.lower()
+    if fmt not in SUPPORTED_FORMATS:
+        raise ValueError(f"unsupported format {fmt!r}")
+
+    anchor_id = resolve_anchor_entity_id(hs, profile=scope.profile, anchor=scope.anchor)
+    if anchor_id is None:
+        raise LookupError(
+            f"anchor {_fqn(scope.anchor)!r} not found in catalog_entities for profile {scope.profile!r}"
+        )
+
+    extractors = extractors or build_default_extractors(connector_factory=connector_factory)
+
+    edges, _results, miss_report = gather_edges(hs, scope, extractors)
+    extractors_partial = False
+    if miss_report.has_misses():
+        decision = fill_decision
+        if decision is None and fill_prompt is not None:
+            decision = fill_prompt(miss_report)
+        if decision is None:
+            decision = "skip"
+        if decision == "abort":
+            return LineageRunResult(
+                artifact_id=0,
+                output_path=Path(""),
+                node_count=0,
+                edge_count=0,
+                extractors_used=[],
+                extractors_partial=False,
+                aborted=True,
+                abort_reason="user aborted before DB fill",
+            )
+        if decision == "fill":
+            edges, _results = fill_cache_misses(hs, scope, extractors, miss_report)
+        else:
+            extractors_partial = True
+
+    verdict = assess_scale(edges, scope.anchor)
+    if verdict.blocked and not force_scale:
+        return LineageRunResult(
+            artifact_id=0,
+            output_path=Path(""),
+            node_count=verdict.node_count,
+            edge_count=verdict.edge_count,
+            extractors_used=[],
+            extractors_partial=extractors_partial,
+            aborted=True,
+            abort_reason=verdict.blocked_reason + " (use --force to override)",
+        )
+    if verdict.needs_soft_confirm and soft_confirm is not None:
+        if not soft_confirm(verdict):
+            return LineageRunResult(
+                artifact_id=0,
+                output_path=Path(""),
+                node_count=verdict.node_count,
+                edge_count=verdict.edge_count,
+                extractors_used=[],
+                extractors_partial=extractors_partial,
+                aborted=True,
+                abort_reason="user declined large-graph render",
+            )
+
+    # Resolve "has description" badges before rendering.
+    all_refs = list(
+        {
+            _node_id(scope.anchor): scope.anchor,
+            **{_node_id(r): r for e in edges for r in (e.source, e.target)},
+        }.values()
+    )
+    described = described_entities(hs, profile=scope.profile, refs=all_refs)
+
+    warning = ""
+    if extractors_partial:
+        scopes = ", ".join(
+            f"{s.database}.{s.schema}" if s.database else s.schema
+            for s in miss_report.missing_scopes
+        )
+        warning = (
+            f"Partial render — view DDL cache stale for: {scopes}. "
+            f"Run /lineage refresh --no-cache for full coverage."
+        )
+
+    payload = RenderInput(
+        edges=list(edges),
+        anchor=scope.anchor,
+        described_entities=described,
+        title=f"lineage: {_fqn(scope.anchor)} (↑{scope.depth_up} / ↓{scope.depth_down})",
+        partial_warning=warning,
+    )
+    final_path = render_lineage_image(payload=payload, fmt=fmt, output_path=output_path)
+
+    edge_set_hash = lineage_store.compute_edge_set_hash(_edges_for_hash(hs, scope, edges))
+    extractors_used = sorted({e.extractor for e in edges})
+    artifact_id = lineage_store.insert_lineage_artifact(
+        hs,
+        name=name,
+        db_profile=scope.profile,
+        anchor_entity_id=anchor_id,
+        depth_up=scope.depth_up,
+        depth_down=scope.depth_down,
+        fmt=fmt,
+        output_path=str(final_path),
+        edge_set_hash=edge_set_hash,
+        node_count=verdict.node_count,
+        edge_count=verdict.edge_count,
+        extractors_used=extractors_used,
+        extractors_partial=extractors_partial,
+    )
+    return LineageRunResult(
+        artifact_id=artifact_id,
+        output_path=final_path,
+        node_count=verdict.node_count,
+        edge_count=verdict.edge_count,
+        extractors_used=extractors_used,
+        extractors_partial=extractors_partial,
+    )
+
+
+def refresh_lineage(
+    hs: Any,
+    *,
+    artifact: dict[str, Any],
+    fill_prompt: FillPrompt | None = None,
+    fill_decision: FillDecision | None = None,
+    no_cache: bool = False,
+    force_scale: bool = False,
+    soft_confirm: Callable[[ScaleVerdict], bool] | None = None,
+    connector_factory: ConnectorFactory | None = None,
+) -> LineageRunResult:
+    """Re-extract + re-render an existing artifact, preserving its scope."""
+    anchor_ref = _anchor_from_db(hs, artifact["anchor_entity_id"])
+    if anchor_ref is None:
+        raise LookupError(f"anchor entity id {artifact['anchor_entity_id']} no longer in catalog")
+    scope = Scope(
+        profile=artifact["db_profile"],
+        anchor=anchor_ref,
+        depth_up=artifact["depth_up"],
+        depth_down=artifact["depth_down"],
+    )
+    if no_cache:
+        # Invalidate the view-cache for the scope so db_fill picks fresh data.
+        lineage_store.invalidate_view_definitions(
+            hs,
+            db_profile=scope.profile,
+            database=scope.anchor.database,
+            schema=scope.anchor.schema,
+        )
+        # And force fill if user already authorised refresh.
+        if fill_decision is None:
+            fill_decision = "fill"
+
+    extractors = build_default_extractors(connector_factory=connector_factory)
+    edges, _results, miss_report = gather_edges(hs, scope, extractors)
+    extractors_partial = False
+    if miss_report.has_misses():
+        decision = fill_decision
+        if decision is None and fill_prompt is not None:
+            decision = fill_prompt(miss_report)
+        if decision is None:
+            decision = "skip"
+        if decision == "abort":
+            return LineageRunResult(
+                artifact_id=int(artifact["id"]),
+                output_path=Path(artifact["output_path"]),
+                node_count=int(artifact["node_count"]),
+                edge_count=int(artifact["edge_count"]),
+                extractors_used=list(artifact["extractors_used"]),
+                extractors_partial=bool(artifact["extractors_partial"]),
+                aborted=True,
+                abort_reason="user aborted before DB fill",
+            )
+        if decision == "fill":
+            edges, _results = fill_cache_misses(hs, scope, extractors, miss_report)
+        else:
+            extractors_partial = True
+
+    verdict = assess_scale(edges, scope.anchor)
+    if verdict.blocked and not force_scale:
+        return LineageRunResult(
+            artifact_id=int(artifact["id"]),
+            output_path=Path(artifact["output_path"]),
+            node_count=verdict.node_count,
+            edge_count=verdict.edge_count,
+            extractors_used=list(artifact["extractors_used"]),
+            extractors_partial=extractors_partial,
+            aborted=True,
+            abort_reason=verdict.blocked_reason + " (use --force to override)",
+        )
+
+    all_refs = list(
+        {
+            _node_id(scope.anchor): scope.anchor,
+            **{_node_id(r): r for e in edges for r in (e.source, e.target)},
+        }.values()
+    )
+    described = described_entities(hs, profile=scope.profile, refs=all_refs)
+
+    warning = ""
+    if extractors_partial:
+        scopes = ", ".join(
+            f"{s.database}.{s.schema}" if s.database else s.schema
+            for s in miss_report.missing_scopes
+        )
+        warning = (
+            f"Partial render — view DDL cache stale for: {scopes}. "
+            f"Run /lineage refresh --no-cache for full coverage."
+        )
+
+    payload = RenderInput(
+        edges=list(edges),
+        anchor=scope.anchor,
+        described_entities=described,
+        title=f"lineage: {_fqn(scope.anchor)} (↑{scope.depth_up} / ↓{scope.depth_down})",
+        partial_warning=warning,
+    )
+    final_path = render_lineage_image(
+        payload=payload,
+        fmt=str(artifact["format"]),
+        output_path=Path(artifact["output_path"]),
+    )
+
+    edge_set_hash = lineage_store.compute_edge_set_hash(_edges_for_hash(hs, scope, edges))
+    extractors_used = sorted({e.extractor for e in edges})
+    lineage_store.update_lineage_artifact(
+        hs,
+        artifact_id=int(artifact["id"]),
+        edge_set_hash=edge_set_hash,
+        node_count=verdict.node_count,
+        edge_count=verdict.edge_count,
+        extractors_used=extractors_used,
+        extractors_partial=extractors_partial,
+        output_path=str(final_path),
+    )
+    return LineageRunResult(
+        artifact_id=int(artifact["id"]),
+        output_path=final_path,
+        node_count=verdict.node_count,
+        edge_count=verdict.edge_count,
+        extractors_used=extractors_used,
+        extractors_partial=extractors_partial,
+    )
+
+
+def text_tree(
+    hs: Any,
+    *,
+    scope: Scope,
+    connector_factory: ConnectorFactory | None = None,
+) -> list[str]:
+    """Return a text-mode lineage tree for ``/lineage show``.
+
+    Cache-only by design — never calls the wire. Each line is prefixed
+    with ``[✓]`` / ``[ ]`` reflecting description presence.
+    """
+    extractors = build_default_extractors(connector_factory=connector_factory)
+    edges, _, _ = gather_edges(hs, scope, extractors)
+    refs = list(
+        {
+            _node_id(scope.anchor): scope.anchor,
+            **{_node_id(r): r for e in edges for r in (e.source, e.target)},
+        }.values()
+    )
+    described = described_entities(hs, profile=scope.profile, refs=refs)
+
+    def _matches_anchor(ref: ColumnRef) -> bool:
+        # Column-anchor: exact column match. Table-anchor: any column under the same table.
+        if scope.anchor.column:
+            return _node_id(ref) == _node_id(scope.anchor)
+        return (
+            ref.database == scope.anchor.database
+            and ref.schema == scope.anchor.schema
+            and ref.table == scope.anchor.table
+        )
+
+    upstream = [e for e in edges if _matches_anchor(e.target)]
+    downstream = [e for e in edges if _matches_anchor(e.source)]
+
+    lines: list[str] = []
+    lines.append(_tree_line(scope.anchor, described, anchor=True))
+    if upstream:
+        lines.append("upstream:")
+        for e in upstream:
+            lines.append(
+                "  " + _tree_line(e.source, described, anchor=False) + f"   [{e.extractor}]"
+            )
+    if downstream:
+        lines.append("downstream:")
+        for e in downstream:
+            lines.append(
+                "  " + _tree_line(e.target, described, anchor=False) + f"   [{e.extractor}]"
+            )
+    if not upstream and not downstream:
+        lines.append("(no lineage found in cache)")
+    return lines
+
+
+# ── internal helpers ─────────────────────────────────────────────────────
+
+
+def _fqn(ref: ColumnRef) -> str:
+    return ".".join(p for p in (ref.database, ref.schema, ref.table, ref.column) if p)
+
+
+def _node_id(ref: ColumnRef) -> str:
+    # Mirrors amx.lineage.render._node_id so described_entities keys match.
+    return _fqn(ref)
+
+
+def _tree_line(ref: ColumnRef, described: set[str], *, anchor: bool) -> str:
+    badge = "[✓]" if _fqn(ref) in described else "[ ]"
+    marker = "★" if anchor else "·"
+    return f"{marker} {badge} {_fqn(ref)}"
+
+
+def _anchor_from_db(hs: Any, anchor_entity_id: int) -> ColumnRef | None:
+    with hs._connect() as conn:
+        row = conn.execute(
+            "SELECT database_name, schema_name, table_name, column_name "
+            "FROM catalog_entities WHERE id = ?",
+            (int(anchor_entity_id),),
+        ).fetchone()
+    if not row:
+        return None
+    return ColumnRef(
+        database=str(row[0] or ""),
+        schema=str(row[1] or ""),
+        table=str(row[2] or ""),
+        column=str(row[3] or ""),
+    )
+
+
+def _edges_for_hash(hs: Any, scope: Scope, edges: list[Edge]) -> list[tuple[int, int, str, float]]:
+    """Resolve each edge's endpoints to ``catalog_entities.id`` for the hash."""
+    ids: list[tuple[int, int, str, float]] = []
+    cache: dict[tuple[str, str, str, str, str], int] = {}
+    with hs._connect() as conn:
+
+        def _resolve(ref: ColumnRef) -> int:
+            entity_kind = "column" if ref.column else "table"
+            key = (
+                scope.profile,
+                ref.database,
+                ref.schema,
+                ref.table,
+                ref.column or "",
+            )
+            if key in cache:
+                return cache[key]
+            row = conn.execute(
+                """
+                SELECT id FROM catalog_entities
+                WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+                  AND table_name = ?
+                  AND COALESCE(column_name, '') = COALESCE(?, '')
+                  AND entity_kind = ?
+                LIMIT 1
+                """,
+                (
+                    scope.profile,
+                    ref.database,
+                    ref.schema,
+                    ref.table,
+                    ref.column or None,
+                    entity_kind,
+                ),
+            ).fetchone()
+            entity_id = int(row[0]) if row else 0
+            cache[key] = entity_id
+            return entity_id
+
+        for edge in edges:
+            ids.append(
+                (
+                    _resolve(edge.source),
+                    _resolve(edge.target),
+                    edge.relationship_type,
+                    edge.confidence,
+                )
+            )
+    return ids
+
+
+__all__ = [
+    "CacheMissReport",
+    "ScaleVerdict",
+    "LineageRunResult",
+    "FillDecision",
+    "FillPrompt",
+    "ConnectorHandle",
+    "build_default_extractors",
+    "resolve_anchor_entity_id",
+    "gather_edges",
+    "fill_cache_misses",
+    "assess_scale",
+    "described_entities",
+    "create_lineage",
+    "refresh_lineage",
+    "text_tree",
+]

--- a/amx/lineage/store.py
+++ b/amx/lineage/store.py
@@ -1,0 +1,376 @@
+"""SQLite-backed cache for view DDLs + lineage artifact registry.
+
+Follows the pattern of :mod:`amx.storage._history_caches` — each function
+takes the ``SQLiteHistoryStore`` as ``hs`` and reuses its lock + connect
+plumbing. No DDL touched here; tables are created by
+``SQLiteHistoryStore.init()``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from amx.storage.sqlite_store import SQLiteHistoryStore
+
+DEFAULT_VIEW_CACHE_TTL_SECONDS = 1800.0  # 30 min, matches column_comments_cache default
+
+
+def _view_cache_key(*, db_profile: str, database: str, schema: str, view: str) -> str:
+    return f"{db_profile}|{database or ''}|{schema}|{view}"
+
+
+def lookup_view_definitions(
+    hs: SQLiteHistoryStore,
+    *,
+    db_profile: str,
+    database: str,
+    schema: str,
+) -> list[dict[str, Any]]:
+    """Return fresh cached view rows for the given ``(profile, database, schema)``.
+
+    Rows with ``expires_at < now`` are skipped — callers treat their absence
+    as a cache miss for that schema. The returned dicts have keys
+    ``view_name``, ``ddl_text``, ``dialect``, ``parsed_lineage`` (decoded
+    JSON or ``None``), ``parse_status``, ``parse_error``, ``fetched_at``,
+    ``expires_at``.
+    """
+    now = time.time()
+    with hs._connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT view_name, ddl_text, dialect, parsed_lineage_json,
+                   parse_status, parse_error, fetched_at, expires_at
+            FROM view_definitions_cache
+            WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+              AND expires_at >= ?
+            ORDER BY view_name
+            """,
+            (str(db_profile or ""), str(database or ""), str(schema or ""), now),
+        ).fetchall()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        parsed: Any | None
+        try:
+            parsed = json.loads(r[3]) if r[3] else None
+        except (TypeError, ValueError):
+            parsed = None
+        out.append(
+            {
+                "view_name": str(r[0]),
+                "ddl_text": str(r[1]),
+                "dialect": str(r[2]),
+                "parsed_lineage": parsed,
+                "parse_status": str(r[4]),
+                "parse_error": str(r[5] or ""),
+                "fetched_at": float(r[6]),
+                "expires_at": float(r[7]),
+            }
+        )
+    return out
+
+
+def upsert_view_definitions(
+    hs: SQLiteHistoryStore,
+    *,
+    db_profile: str,
+    database: str,
+    schema: str,
+    entries: Iterable[dict[str, Any]],
+    ttl_seconds: float = DEFAULT_VIEW_CACHE_TTL_SECONDS,
+) -> int:
+    """Upsert per-view rows after a ``db_fill`` round-trip.
+
+    Each entry should carry: ``view_name`` (str), ``ddl_text`` (str),
+    ``dialect`` (str), ``parsed_lineage`` (any JSON-serialisable | None),
+    ``parse_status`` (str), ``parse_error`` (str, may be empty).
+    """
+    rows: list[tuple[Any, ...]] = []
+    now = time.time()
+    # ``0`` is the "use default" sentinel; negative TTLs are honoured so
+    # tests can stamp rows as already-expired.
+    if ttl_seconds == 0:
+        ttl_seconds = DEFAULT_VIEW_CACHE_TTL_SECONDS
+    expires_at = now + float(ttl_seconds)
+    for e in entries:
+        view = str(e.get("view_name") or "")
+        if not view:
+            continue
+        parsed_payload = e.get("parsed_lineage")
+        parsed_json = (
+            json.dumps(parsed_payload, ensure_ascii=True) if parsed_payload is not None else None
+        )
+        rows.append(
+            (
+                _view_cache_key(
+                    db_profile=str(db_profile or ""),
+                    database=str(database or ""),
+                    schema=str(schema or ""),
+                    view=view,
+                ),
+                str(db_profile or ""),
+                str(database or ""),
+                str(schema or ""),
+                view,
+                str(e.get("ddl_text") or ""),
+                str(e.get("dialect") or ""),
+                parsed_json,
+                str(e.get("parse_status") or "ok"),
+                str(e.get("parse_error") or ""),
+                now,
+                expires_at,
+            )
+        )
+    if not rows:
+        return 0
+    with hs._lock, hs._connect() as conn:
+        conn.executemany(
+            """
+            INSERT INTO view_definitions_cache
+                (cache_key, db_profile, database_name, schema_name, view_name,
+                 ddl_text, dialect, parsed_lineage_json,
+                 parse_status, parse_error, fetched_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(cache_key) DO UPDATE SET
+                ddl_text            = excluded.ddl_text,
+                dialect             = excluded.dialect,
+                parsed_lineage_json = excluded.parsed_lineage_json,
+                parse_status        = excluded.parse_status,
+                parse_error         = excluded.parse_error,
+                fetched_at          = excluded.fetched_at,
+                expires_at          = excluded.expires_at
+            """,
+            rows,
+        )
+    return len(rows)
+
+
+def invalidate_view_definitions(
+    hs: SQLiteHistoryStore,
+    *,
+    db_profile: str,
+    database: str = "",
+    schema: str = "",
+) -> int:
+    """Delete cached view rows. Empty ``schema`` clears the whole database;
+    empty ``database`` clears the whole profile.
+    """
+    with hs._lock, hs._connect() as conn:
+        if schema:
+            cur = conn.execute(
+                "DELETE FROM view_definitions_cache "
+                "WHERE db_profile = ? AND database_name = ? AND schema_name = ?",
+                (str(db_profile or ""), str(database or ""), str(schema or "")),
+            )
+        elif database:
+            cur = conn.execute(
+                "DELETE FROM view_definitions_cache WHERE db_profile = ? AND database_name = ?",
+                (str(db_profile or ""), str(database or "")),
+            )
+        else:
+            cur = conn.execute(
+                "DELETE FROM view_definitions_cache WHERE db_profile = ?",
+                (str(db_profile or ""),),
+            )
+    return cur.rowcount or 0
+
+
+def gc_view_definitions(hs: SQLiteHistoryStore) -> int:
+    """Drop expired view-cache rows. Returns the deleted count."""
+    now = time.time()
+    with hs._lock, hs._connect() as conn:
+        cur = conn.execute("DELETE FROM view_definitions_cache WHERE expires_at < ?", (now,))
+    return cur.rowcount or 0
+
+
+# ── lineage_artifacts ────────────────────────────────────────────────────
+
+
+def compute_edge_set_hash(edges: Iterable[tuple[int, int, str, float]]) -> str:
+    """Stable hash of the edge set that backs a rendered artifact.
+
+    Each tuple is ``(from_entity_id, to_entity_id, relationship_type, score)``.
+    Inputs are sorted before hashing so two callers with identical edge
+    contents always agree.
+    """
+    materialised = sorted((int(a), int(b), str(c), round(float(d), 6)) for a, b, c, d in edges)
+    payload = json.dumps(materialised, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def insert_lineage_artifact(
+    hs: SQLiteHistoryStore,
+    *,
+    name: str,
+    db_profile: str,
+    anchor_entity_id: int,
+    depth_up: int,
+    depth_down: int,
+    fmt: str,
+    output_path: str,
+    edge_set_hash: str,
+    node_count: int,
+    edge_count: int,
+    extractors_used: list[str],
+    extractors_partial: bool,
+) -> int:
+    """Insert one ``lineage_artifacts`` row. Returns the new row id."""
+    with hs._lock, hs._connect() as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO lineage_artifacts
+                (name, db_profile, anchor_entity_id, depth_up, depth_down,
+                 format, output_path, edge_set_hash, node_count, edge_count,
+                 generated_at, extractors_used, extractors_partial)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(name),
+                str(db_profile or ""),
+                int(anchor_entity_id),
+                int(depth_up),
+                int(depth_down),
+                str(fmt),
+                str(output_path),
+                str(edge_set_hash),
+                int(node_count),
+                int(edge_count),
+                time.time(),
+                json.dumps(sorted(set(extractors_used)), ensure_ascii=True),
+                1 if extractors_partial else 0,
+            ),
+        )
+    return int(cur.lastrowid or 0)
+
+
+def update_lineage_artifact(
+    hs: SQLiteHistoryStore,
+    *,
+    artifact_id: int,
+    edge_set_hash: str,
+    node_count: int,
+    edge_count: int,
+    extractors_used: list[str],
+    extractors_partial: bool,
+    output_path: str | None = None,
+    fmt: str | None = None,
+) -> None:
+    """Refresh artifact metadata after a successful re-render."""
+    sets = [
+        "edge_set_hash = ?",
+        "node_count = ?",
+        "edge_count = ?",
+        "generated_at = ?",
+        "extractors_used = ?",
+        "extractors_partial = ?",
+    ]
+    args: list[Any] = [
+        str(edge_set_hash),
+        int(node_count),
+        int(edge_count),
+        time.time(),
+        json.dumps(sorted(set(extractors_used)), ensure_ascii=True),
+        1 if extractors_partial else 0,
+    ]
+    if output_path is not None:
+        sets.append("output_path = ?")
+        args.append(str(output_path))
+    if fmt is not None:
+        sets.append("format = ?")
+        args.append(str(fmt))
+    args.append(int(artifact_id))
+    with hs._lock, hs._connect() as conn:
+        conn.execute(
+            f"UPDATE lineage_artifacts SET {', '.join(sets)} WHERE id = ?",
+            args,
+        )
+
+
+def delete_lineage_artifact(hs: SQLiteHistoryStore, *, artifact_id: int) -> None:
+    with hs._lock, hs._connect() as conn:
+        conn.execute("DELETE FROM lineage_artifacts WHERE id = ?", (int(artifact_id),))
+
+
+def lookup_lineage_artifact(
+    hs: SQLiteHistoryStore,
+    *,
+    name_or_id: str,
+) -> dict[str, Any] | None:
+    """Resolve an artifact by numeric id or by ``name``. Returns ``None`` if absent."""
+    with hs._connect() as conn:
+        row = None
+        if name_or_id.isdigit():
+            row = conn.execute(_ARTIFACT_SELECT_BY_ID, (int(name_or_id),)).fetchone()
+        if row is None:
+            row = conn.execute(_ARTIFACT_SELECT_BY_NAME, (str(name_or_id),)).fetchone()
+    return _row_to_artifact_dict(row) if row else None
+
+
+def list_lineage_artifacts(
+    hs: SQLiteHistoryStore,
+    *,
+    db_profile: str = "",
+) -> list[dict[str, Any]]:
+    """List artifacts. When ``db_profile`` is empty, returns every row."""
+    with hs._connect() as conn:
+        if db_profile:
+            rows = conn.execute(
+                _ARTIFACT_SELECT_LIST + " WHERE db_profile = ? ORDER BY generated_at DESC",
+                (str(db_profile),),
+            ).fetchall()
+        else:
+            rows = conn.execute(_ARTIFACT_SELECT_LIST + " ORDER BY generated_at DESC").fetchall()
+    return [_row_to_artifact_dict(r) for r in rows]
+
+
+_ARTIFACT_COLUMNS = (
+    "id, name, db_profile, anchor_entity_id, depth_up, depth_down, "
+    "format, output_path, edge_set_hash, node_count, edge_count, "
+    "generated_at, extractors_used, extractors_partial"
+)
+_ARTIFACT_SELECT_BY_ID = f"SELECT {_ARTIFACT_COLUMNS} FROM lineage_artifacts WHERE id = ?"
+_ARTIFACT_SELECT_BY_NAME = f"SELECT {_ARTIFACT_COLUMNS} FROM lineage_artifacts WHERE name = ?"
+_ARTIFACT_SELECT_LIST = f"SELECT {_ARTIFACT_COLUMNS} FROM lineage_artifacts"
+
+
+def _row_to_artifact_dict(row: Any) -> dict[str, Any]:
+    extractors_raw = row[12]
+    try:
+        extractors = list(json.loads(extractors_raw)) if extractors_raw else []
+    except (TypeError, ValueError):
+        extractors = []
+    return {
+        "id": int(row[0]),
+        "name": str(row[1]),
+        "db_profile": str(row[2] or ""),
+        "anchor_entity_id": int(row[3]),
+        "depth_up": int(row[4]),
+        "depth_down": int(row[5]),
+        "format": str(row[6]),
+        "output_path": str(row[7]),
+        "edge_set_hash": str(row[8]),
+        "node_count": int(row[9]),
+        "edge_count": int(row[10]),
+        "generated_at": float(row[11]),
+        "extractors_used": extractors,
+        "extractors_partial": bool(int(row[13] or 0)),
+    }
+
+
+__all__ = [
+    "DEFAULT_VIEW_CACHE_TTL_SECONDS",
+    "lookup_view_definitions",
+    "upsert_view_definitions",
+    "invalidate_view_definitions",
+    "gc_view_definitions",
+    "compute_edge_set_hash",
+    "insert_lineage_artifact",
+    "update_lineage_artifact",
+    "delete_lineage_artifact",
+    "lookup_lineage_artifact",
+    "list_lineage_artifacts",
+]

--- a/amx/lineage/types.py
+++ b/amx/lineage/types.py
@@ -1,0 +1,116 @@
+"""Value objects and the ``LineageExtractor`` protocol used across the lineage package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+CacheStatus = Literal["hit", "partial", "miss"]
+ExtractMode = Literal["cache_only", "db_fill"]
+
+
+@dataclass(frozen=True)
+class ColumnRef:
+    """Stable identifier for a column inside a single DB profile."""
+
+    database: str
+    schema: str
+    table: str
+    column: str
+
+    def fqn(self) -> str:
+        parts = [p for p in (self.database, self.schema, self.table, self.column) if p]
+        return ".".join(parts)
+
+
+@dataclass(frozen=True)
+class Edge:
+    """A directed lineage edge between two columns or tables.
+
+    ``source`` feeds ``target``. Confidence is in [0, 1] with 1.0 reserved for
+    deterministic extractors (FK, parsed view DDL); heuristics use < 1.0.
+    """
+
+    source: ColumnRef
+    target: ColumnRef
+    relationship_type: str  # 'lineage_fk' | 'lineage_view_ddl' | 'lineage_name_match'
+    extractor: str  # 'fk' | 'view_ddl' | 'name_match'
+    confidence: float
+    evidence: str = ""  # short human-readable provenance hint
+
+
+@dataclass(frozen=True)
+class ScopeFragment:
+    """A (database, schema) slice that an extractor flags as needing a DB fetch."""
+
+    database: str
+    schema: str
+    estimated_objects: int = 0
+
+
+@dataclass(frozen=True)
+class CostHint:
+    """Coarse estimate of what filling ``missing_scope`` would cost."""
+
+    estimated_views: int = 0
+    estimated_seconds: float = 0.0
+
+    def __add__(self, other: CostHint) -> CostHint:
+        return CostHint(
+            estimated_views=self.estimated_views + other.estimated_views,
+            estimated_seconds=self.estimated_seconds + other.estimated_seconds,
+        )
+
+
+@dataclass
+class ExtractResult:
+    """One extractor's contribution for a single ``Scope`` call."""
+
+    edges: list[Edge] = field(default_factory=list)
+    cache_status: CacheStatus = "hit"
+    missing_scope: list[ScopeFragment] = field(default_factory=list)
+    estimated_db_cost: CostHint = field(default_factory=CostHint)
+
+
+@dataclass(frozen=True)
+class Scope:
+    """Anchor + radius for a single lineage extraction.
+
+    ``anchor`` is the focal entity. ``depth_up`` / ``depth_down`` cap traversal
+    so no extractor walks the full graph. ``database`` and ``schema`` scope
+    the search to one slice of the profile when set.
+    """
+
+    profile: str
+    anchor: ColumnRef
+    depth_up: int = 1
+    depth_down: int = 1
+    database: str = ""
+    schema: str = ""
+
+
+class LineageExtractor(Protocol):
+    """Pluggable lineage source. Implementations live in :mod:`amx.lineage.extractors`."""
+
+    name: str
+
+    def extract(
+        self,
+        *,
+        hs: Any,
+        scope: Scope,
+        mode: ExtractMode = "cache_only",
+    ) -> ExtractResult: ...
+
+
+__all__ = [
+    "CacheStatus",
+    "ExtractMode",
+    "ColumnRef",
+    "Edge",
+    "ScopeFragment",
+    "CostHint",
+    "ExtractResult",
+    "Scope",
+    "LineageExtractor",
+]

--- a/amx/storage/schema_descriptions.py
+++ b/amx/storage/schema_descriptions.py
@@ -671,6 +671,45 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
         "fetched_at": "UTC epoch seconds the entry was fetched.",
         "expires_at": "UTC epoch seconds at which the entry becomes stale. Indexed.",
     },
+    # ── view_definitions_cache (local only) ───────────────────────────────
+    "view_definitions_cache": {
+        "__table__": (
+            "Per-view cache of CREATE VIEW DDL and its sqlglot-parsed "
+            "column-lineage. Mirrors column_comments_cache discipline so "
+            "/lineage extractors stay off the wire by default. TTL-controlled: "
+            "rows past expires_at count as cache misses and prompt the user "
+            "before any DB round-trip. Storing parsed_lineage_json alongside "
+            "the raw DDL means subsequent reads emit edges without re-parsing."
+        ),
+        "cache_key": ("Composite key 'profile|database|schema|view'. Primary key for upsert."),
+        "db_profile": "DB profile the cached view belongs to.",
+        "database_name": "Database/catalog of the cached view. Empty string on flat backends.",
+        "schema_name": "Schema containing the view.",
+        "view_name": "View identifier within the schema.",
+        "ddl_text": ("Raw CREATE VIEW DDL text as returned by the backend's system catalog."),
+        "dialect": (
+            "sqlglot dialect tag used when the DDL was parsed (postgres | "
+            "snowflake | bigquery | mysql | duckdb | tsql | …)."
+        ),
+        "parsed_lineage_json": (
+            "JSON dump of the column-lineage extracted from this view's DDL: "
+            "a list of {target_column, sources:[{table, column}]} entries. "
+            "NULL when parse_status != 'ok'."
+        ),
+        "parse_status": (
+            "Outcome of the one-shot sqlglot parse at cache-fill time: "
+            "ok | parse_failed | unsupported_dialect. Edges emit only when 'ok'."
+        ),
+        "parse_error": (
+            "One-line excerpt of the parse error when parse_status != 'ok'. "
+            "Empty string otherwise. Surfaces in /lineage list --verbose."
+        ),
+        "fetched_at": "UTC epoch seconds when the DDL was retrieved from the source DB.",
+        "expires_at": (
+            "UTC epoch seconds after which the row is treated as a cache miss. "
+            "Indexed for the gc sweep."
+        ),
+    },
     # ── catalog_entities (local only) ─────────────────────────────────────
     "catalog_entities": {
         "__table__": (
@@ -866,6 +905,52 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
         "last_seen": (
             "UTC epoch seconds of the last sync that observed this edge. "
             "Edges not seen for >30 days are eligible for pruning."
+        ),
+    },
+    # ── lineage_artifacts (local only) ────────────────────────────────────
+    "lineage_artifacts": {
+        "__table__": (
+            "Registry of rendered lineage diagrams. Each row pairs a focal "
+            "entity (anchor) with the on-disk image file produced for it, "
+            "the edge-set hash that backs the image, and the extractors "
+            "used. Drives /lineage open, refresh, delete, list. /open uses "
+            "the hash to detect drift without re-running extractors."
+        ),
+        "id": "Surrogate INT primary key.",
+        "name": (
+            "User-facing slug used by /lineage open|refresh|delete. "
+            "Unique across all artifacts in this history store."
+        ),
+        "db_profile": (
+            "DB profile the anchor entity belongs to. Matches "
+            "catalog_entities.db_profile and disambiguates artifacts with "
+            "the same anchor name across profiles."
+        ),
+        "anchor_entity_id": (
+            "catalog_entities.id of the focal table or column the diagram "
+            "radiates from. Foreign key into catalog_entities."
+        ),
+        "depth_up": "Upstream hops included when this artifact was rendered.",
+        "depth_down": "Downstream hops included when this artifact was rendered.",
+        "format": "Image format on disk: 'png' | 'svg' | 'jpg'.",
+        "output_path": "Absolute filesystem path of the rendered image file.",
+        "edge_set_hash": (
+            "SHA-256 of the sorted (from_id, to_id, type, score) tuples used "
+            "in this render. /lineage open compares against the current hash "
+            "to flag stale renders without re-extracting."
+        ),
+        "node_count": "Number of distinct entity nodes drawn in the diagram.",
+        "edge_count": "Number of edges drawn in the diagram.",
+        "generated_at": "UTC epoch seconds when this artifact was rendered.",
+        "extractors_used": (
+            "JSON array of extractor identifiers that contributed edges, "
+            "e.g. ['fk','view_ddl','name_match']."
+        ),
+        "extractors_partial": (
+            "1 when one or more extractors reported cache misses that the "
+            "user declined to fill — the artifact reflects only cached data. "
+            "0 when every extractor returned a full cache hit or the user "
+            "filled the misses. Renderer adds a footer banner when 1."
         ),
     },
     # ── catalog_usage_evidence (local only) ───────────────────────────────

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -505,6 +505,40 @@ class SQLiteHistoryStore:
                 conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_sc_expires ON schemas_cache(expires_at)"
                 )
+            # ── view_definitions_cache: per-view DDL + pre-parsed lineage ──
+            # /lineage extractors stay off the wire by default. A single
+            # row per (profile, database, schema, view) caches the raw
+            # CREATE VIEW text and its sqlglot-parsed column lineage. TTL
+            # mirrors column_comments_cache so the cache-first guarantee
+            # is automatic on stable warehouses.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS view_definitions_cache (
+                    cache_key            TEXT PRIMARY KEY,
+                    db_profile           TEXT NOT NULL,
+                    database_name        TEXT NOT NULL DEFAULT '',
+                    schema_name          TEXT NOT NULL,
+                    view_name            TEXT NOT NULL,
+                    ddl_text             TEXT NOT NULL,
+                    dialect              TEXT NOT NULL,
+                    parsed_lineage_json  TEXT,
+                    parse_status         TEXT NOT NULL,
+                    parse_error          TEXT NOT NULL DEFAULT '',
+                    fetched_at           REAL NOT NULL,
+                    expires_at           REAL NOT NULL
+                )
+                """
+            )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_vdc_scope "
+                    "ON view_definitions_cache(db_profile, database_name, schema_name)"
+                )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_vdc_expires "
+                    "ON view_definitions_cache(expires_at)"
+                )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_run_results_run_id ON run_results(run_id)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_run_results_asset "
@@ -683,6 +717,42 @@ class SQLiteHistoryStore:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_catalog_relationships_from_to ON catalog_relationships(from_entity_id, to_entity_id, relationship_type)"
             )
+            # ── lineage_artifacts: registry of rendered lineage diagrams ──
+            # Each row binds a focal entity (anchor) to a rendered image
+            # on disk plus the edge-set hash that produced it. Drives
+            # /lineage open|refresh|delete|list and lets /open detect
+            # drift without re-running extractors.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS lineage_artifacts (
+                    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name                TEXT NOT NULL,
+                    db_profile          TEXT NOT NULL,
+                    anchor_entity_id    INTEGER NOT NULL,
+                    depth_up            INTEGER NOT NULL DEFAULT 1,
+                    depth_down          INTEGER NOT NULL DEFAULT 1,
+                    format              TEXT NOT NULL,
+                    output_path         TEXT NOT NULL,
+                    edge_set_hash       TEXT NOT NULL,
+                    node_count          INTEGER NOT NULL,
+                    edge_count          INTEGER NOT NULL,
+                    generated_at        REAL NOT NULL,
+                    extractors_used     TEXT NOT NULL,
+                    extractors_partial  INTEGER NOT NULL DEFAULT 0,
+                    FOREIGN KEY (anchor_entity_id) REFERENCES catalog_entities(id)
+                )
+                """
+            )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS idx_lineage_artifacts_name "
+                    "ON lineage_artifacts(name)"
+                )
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_lineage_artifacts_anchor "
+                    "ON lineage_artifacts(anchor_entity_id)"
+                )
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS catalog_usage_evidence (

--- a/amx/utils/optional_deps.py
+++ b/amx/utils/optional_deps.py
@@ -120,6 +120,14 @@ BUNDLES: dict[str, list[PackageSpec]] = {
     "local_embeddings": [
         ("sentence_transformers", "sentence-transformers>=3.0"),
     ],
+    # /lineage view-DDL parsing relies on sqlglot's column-lineage
+    # walker. graphviz wraps the OS ``dot`` binary that AMX shells out
+    # to for PNG/SVG/JPG render; the binary itself ships outside pip
+    # (brew/apt/winget) and AMX surfaces an install hint when missing.
+    "lineage": [
+        "sqlglot",
+        "graphviz",
+    ],
 }
 
 #: Human-readable labels surfaced in the install banner when a bundle
@@ -127,6 +135,7 @@ BUNDLES: dict[str, list[PackageSpec]] = {
 BUNDLE_LABELS: dict[str, str] = {
     "rag": "shared RAG core (/docs, /search, /code)",
     "docs-extended": "document RAG (/docs ingest)",
+    "lineage": "/lineage view-DDL parser + Graphviz wrapper",
 }
 
 #: Bundles whose total install footprint is large enough (sentence-

--- a/amx/utils/optional_deps.py
+++ b/amx/utils/optional_deps.py
@@ -121,12 +121,14 @@ BUNDLES: dict[str, list[PackageSpec]] = {
         ("sentence_transformers", "sentence-transformers>=3.0"),
     ],
     # /lineage view-DDL parsing relies on sqlglot's column-lineage
-    # walker. graphviz wraps the OS ``dot`` binary that AMX shells out
-    # to for PNG/SVG/JPG render; the binary itself ships outside pip
-    # (brew/apt/winget) and AMX surfaces an install hint when missing.
+    # walker. networkx + matplotlib carry the diagram renderer — both
+    # pure-pip, no OS package, so /lineage works on a vanilla
+    # ``pip install amx-cli`` without brew/apt steps. AMX auto-installs
+    # this bundle on the first /lineage create.
     "lineage": [
         "sqlglot",
-        "graphviz",
+        "networkx",
+        "matplotlib",
     ],
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,16 @@ pdf = [
     "weasyprint>=60",
     "jinja2>=3.1",
 ]
+# /lineage view-DDL parsing + Graphviz rendering. Auto-installed by
+# amx.utils.optional_deps the first time the user runs /lineage
+# create with a view-DDL extractor cache miss. The ``dot`` binary is
+# *not* in this extra — it is an OS package the user installs via
+# brew / apt / winget. AMX surfaces a platform-aware install hint
+# when the binary is missing.
+lineage = [
+    "sqlglot>=23",
+    "graphviz>=0.20",
+]
 # Reference-based and reference-free text-quality metrics for the
 # /history compare flow. Lazy-installed by amx.utils.optional_deps
 # the first time the user opts into Tier 0 quality analysis (CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,15 +127,15 @@ pdf = [
     "weasyprint>=60",
     "jinja2>=3.1",
 ]
-# /lineage view-DDL parsing + Graphviz rendering. Auto-installed by
-# amx.utils.optional_deps the first time the user runs /lineage
-# create with a view-DDL extractor cache miss. The ``dot`` binary is
-# *not* in this extra — it is an OS package the user installs via
-# brew / apt / winget. AMX surfaces a platform-aware install hint
-# when the binary is missing.
+# /lineage view-DDL parsing + diagram rendering. Pure-pip: networkx
+# handles layout, matplotlib rasterises SVG/PNG/JPG, sqlglot parses
+# view DDL into column lineage. No system binaries — the previous
+# ``dot`` requirement is gone. AMX auto-installs this bundle on the
+# first /lineage create.
 lineage = [
     "sqlglot>=23",
-    "graphviz>=0.20",
+    "networkx>=3.0",
+    "matplotlib>=3.7",
 ]
 # Reference-based and reference-free text-quality metrics for the
 # /history compare flow. Lazy-installed by amx.utils.optional_deps

--- a/tests/lineage/conftest.py
+++ b/tests/lineage/conftest.py
@@ -1,0 +1,157 @@
+"""Shared fixtures for ``tests/lineage``.
+
+Each test wants the same scaffolding: a fresh on-disk SQLite history
+store with a seeded catalog. The helpers here keep individual tests
+focused on the behaviour they verify.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def hs(tmp_path: Path) -> SQLiteHistoryStore:
+    store = SQLiteHistoryStore(tmp_path / "history.db")
+    store.init()
+    return store
+
+
+def seed_table_entity(
+    hs: SQLiteHistoryStore,
+    *,
+    profile: str = "p",
+    backend: str = "postgresql",
+    database: str = "",
+    schema: str,
+    table: str,
+    asset_kind: str = "table",
+) -> int:
+    with hs._connect() as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO catalog_entities
+                (db_profile, db_backend, database_name, schema_name, table_name,
+                 entity_kind, asset_kind)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (profile, backend, database, schema, table, "table", asset_kind),
+        )
+    return int(cur.lastrowid)
+
+
+def seed_column_entity(
+    hs: SQLiteHistoryStore,
+    *,
+    profile: str = "p",
+    backend: str = "postgresql",
+    database: str = "",
+    schema: str,
+    table: str,
+    column: str,
+    dtype: str = "integer",
+    with_description_id: int | None = None,
+) -> int:
+    with hs._connect() as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO catalog_entities
+                (db_profile, db_backend, database_name, schema_name, table_name,
+                 column_name, entity_kind, asset_kind, dtype,
+                 effective_description_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                profile,
+                backend,
+                database,
+                schema,
+                table,
+                column,
+                "column",
+                "table",
+                dtype,
+                with_description_id,
+            ),
+        )
+    return int(cur.lastrowid)
+
+
+def seed_foreign_key_relationship(
+    hs: SQLiteHistoryStore,
+    *,
+    from_table_id: int,
+    to_table_id: int,
+    constrained_columns: Iterable[str],
+    referred_columns: Iterable[str],
+    referred_table: str,
+) -> None:
+    payload = {
+        "constrained_columns": list(constrained_columns),
+        "referred_columns": list(referred_columns),
+        "referred_table": referred_table,
+    }
+    with hs._connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO catalog_relationships
+                (from_entity_id, to_entity_id, relationship_type, score, source,
+                 details_json, last_seen)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                from_table_id,
+                to_table_id,
+                "foreign_key",
+                10.0,
+                "database",
+                json.dumps(payload, ensure_ascii=True),
+                time.time(),
+            ),
+        )
+
+
+def seed_column_comments_cache_for_table(
+    hs: SQLiteHistoryStore,
+    *,
+    profile: str = "p",
+    database: str = "",
+    schema: str,
+    table: str,
+    columns: dict[str, dict[str, Any]],
+) -> None:
+    """Write directly so tests can control the payload shape used by
+    NameMatchExtractor (which reads from `columns_json`)."""
+    now = time.time()
+    cache_key = f"{profile}|{database}|{schema}|{table}"
+    with hs._connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO column_comments_cache
+                (cache_key, db_profile, database_name, schema_name, table_name,
+                 table_comment, columns_json, kind, fetched_at, expires_at, bulk_filled)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(cache_key) DO UPDATE SET columns_json=excluded.columns_json
+            """,
+            (
+                cache_key,
+                profile,
+                database,
+                schema,
+                table,
+                None,
+                json.dumps(columns, ensure_ascii=True),
+                "TABLE",
+                now,
+                now + 3600,
+                1,
+            ),
+        )

--- a/tests/lineage/test_cli.py
+++ b/tests/lineage/test_cli.py
@@ -1,0 +1,234 @@
+"""CLI coverage by invoking the registered Click command callbacks directly.
+
+We bypass Click's ``CliRunner`` / ``pass_config`` plumbing so the tests
+stay focused on lineage behaviour rather than wiring. Each subcommand's
+``.callback`` is a plain function whose first parameter is the
+``AMXConfig`` — call it directly and verify side-effects on the seeded
+history store.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from amx.cli import main as cli_main
+from amx.config import AMXConfig, DBConfig
+from amx.lineage import store as lineage_store
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+from .conftest import (
+    seed_column_comments_cache_for_table,
+    seed_foreign_key_relationship,
+    seed_table_entity,
+)
+
+
+@pytest.fixture
+def cli_env(tmp_path):
+    """Set up an AMXConfig with one DuckDB profile and a seeded history store."""
+    hs = SQLiteHistoryStore(tmp_path / "history.db")
+    hs.init()
+
+    profile_cfg = DBConfig(backend="duckdb", database="", host="localhost", port=0)
+    cfg = AMXConfig()
+    cfg.db_profiles = {"local": profile_cfg}
+    cfg.active_db_profile = "local"
+
+    orders_id = seed_table_entity(hs, profile="local", schema="public", table="orders")
+    customers_id = seed_table_entity(hs, profile="local", schema="public", table="customers")
+    seed_foreign_key_relationship(
+        hs,
+        from_table_id=orders_id,
+        to_table_id=customers_id,
+        constrained_columns=["customer_id"],
+        referred_columns=["id"],
+        referred_table="customers",
+    )
+    seed_column_comments_cache_for_table(
+        hs,
+        profile="local",
+        schema="public",
+        table="orders",
+        columns={"customer_id": {"type": "integer"}},
+    )
+    seed_column_comments_cache_for_table(
+        hs,
+        profile="local",
+        schema="public",
+        table="customers",
+        columns={"id": {"type": "integer"}},
+    )
+
+    return cfg, hs
+
+
+def _invoke(name: str, cfg: AMXConfig, /, **kwargs):
+    """Invoke a /lineage subcommand callback under a synthetic Click context.
+
+    The commands are wrapped with ``@pass_config`` (a Click
+    ``make_pass_decorator``) which pulls ``AMXConfig`` from the current
+    Click context. Tests that call the callback directly therefore need
+    a real ``click.Context`` set up with ``obj=cfg``.
+    """
+    import click
+
+    cmd = cli_main.commands["lineage"].commands[name]
+    with click.Context(cmd, obj=cfg) as ctx:
+        return ctx.invoke(cmd, **kwargs)
+
+
+def test_cli_create_cache_only_writes_artifact(cli_env, tmp_path):
+    cfg, hs = cli_env
+    out_path = tmp_path / "lineage.svg"
+
+    with (
+        patch("amx.cli_support.commands.lineage.history_store", return_value=hs),
+        patch("amx.lineage.service.render_lineage_image", return_value=out_path),
+    ):
+        _invoke(
+            "create",
+            cfg,
+            anchor="public.orders",
+            column=None,
+            out=str(out_path),
+            fmt="svg",
+            depth_up=None,
+            depth_down=None,
+            name="orders-cli",
+            profile_flag=None,
+            no_cache=False,
+            cache_only=True,
+            prefetch=False,
+            force=False,
+        )
+
+    artifacts = lineage_store.list_lineage_artifacts(hs)
+    assert len(artifacts) == 1
+    assert artifacts[0]["name"] == "orders-cli"
+    # cache-only with no view-DDL cache => partial render expected.
+    assert artifacts[0]["extractors_partial"] is True
+
+
+def test_cli_cache_only_never_calls_connector_factory(cli_env, tmp_path):
+    cfg, hs = cli_env
+    out_path = tmp_path / "lineage.svg"
+    factory_calls: list[str] = []
+
+    def boom_factory(profile):
+        factory_calls.append(profile)
+        raise AssertionError("cache-only must not open a connector")
+
+    with (
+        patch("amx.cli_support.commands.lineage.history_store", return_value=hs),
+        patch(
+            "amx.cli_support.commands.lineage._build_connector_factory", return_value=boom_factory
+        ),
+        patch("amx.lineage.service.render_lineage_image", return_value=out_path),
+    ):
+        _invoke(
+            "create",
+            cfg,
+            anchor="public.orders",
+            column=None,
+            out=str(out_path),
+            fmt="svg",
+            depth_up=None,
+            depth_down=None,
+            name="no-net",
+            profile_flag=None,
+            no_cache=False,
+            cache_only=True,
+            prefetch=False,
+            force=False,
+        )
+    assert factory_calls == []
+
+
+def test_cli_list_shows_seeded_artifact(cli_env, capsys):
+    cfg, hs = cli_env
+    lineage_store.insert_lineage_artifact(
+        hs,
+        name="x",
+        db_profile="local",
+        anchor_entity_id=1,
+        depth_up=1,
+        depth_down=1,
+        fmt="svg",
+        output_path="/tmp/x.svg",
+        edge_set_hash="h",
+        node_count=2,
+        edge_count=1,
+        extractors_used=["fk"],
+        extractors_partial=False,
+    )
+    with patch("amx.cli_support.commands.lineage.history_store", return_value=hs):
+        _invoke("list", cfg, profile_flag=None)
+    out = capsys.readouterr().out
+    assert "x" in out
+
+
+def test_cli_delete_removes_artifact_and_file(cli_env, tmp_path):
+    cfg, hs = cli_env
+    out_path = tmp_path / "lineage.svg"
+    out_path.write_text("<svg/>")
+    lineage_store.insert_lineage_artifact(
+        hs,
+        name="bye",
+        db_profile="local",
+        anchor_entity_id=1,
+        depth_up=1,
+        depth_down=1,
+        fmt="svg",
+        output_path=str(out_path),
+        edge_set_hash="h",
+        node_count=1,
+        edge_count=0,
+        extractors_used=["fk"],
+        extractors_partial=False,
+    )
+    with patch("amx.cli_support.commands.lineage.history_store", return_value=hs):
+        _invoke("delete", cfg, name_or_id="bye", yes=True)
+    assert lineage_store.lookup_lineage_artifact(hs, name_or_id="bye") is None
+    assert not out_path.exists()
+
+
+def test_cli_show_renders_text_tree(cli_env, capsys):
+    cfg, hs = cli_env
+    with patch("amx.cli_support.commands.lineage.history_store", return_value=hs):
+        _invoke(
+            "show",
+            cfg,
+            anchor="public.orders",
+            column=None,
+            depth_up=1,
+            depth_down=1,
+            profile_flag=None,
+        )
+    out = capsys.readouterr().out
+    assert "public.orders" in out
+
+
+def test_cli_open_reports_missing_file(cli_env, tmp_path, capsys):
+    cfg, hs = cli_env
+    out_path = tmp_path / "lineage.svg"  # NOT created — should trigger warning
+    lineage_store.insert_lineage_artifact(
+        hs,
+        name="ghost",
+        db_profile="local",
+        anchor_entity_id=1,
+        depth_up=1,
+        depth_down=1,
+        fmt="svg",
+        output_path=str(out_path),
+        edge_set_hash="h",
+        node_count=1,
+        edge_count=0,
+        extractors_used=["fk"],
+        extractors_partial=False,
+    )
+    with patch("amx.cli_support.commands.lineage.history_store", return_value=hs):
+        _invoke("open", cfg, name_or_id="ghost")
+    out = capsys.readouterr().out
+    assert "File missing" in out

--- a/tests/lineage/test_cli.py
+++ b/tests/lineage/test_cli.py
@@ -94,8 +94,8 @@ def test_cli_create_cache_only_writes_artifact(cli_env, tmp_path):
             column=None,
             out=str(out_path),
             fmt="svg",
-            depth_up=None,
-            depth_down=None,
+            depth_up=1,
+            depth_down=1,
             name="orders-cli",
             profile_flag=None,
             no_cache=False,
@@ -134,8 +134,8 @@ def test_cli_cache_only_never_calls_connector_factory(cli_env, tmp_path):
             column=None,
             out=str(out_path),
             fmt="svg",
-            depth_up=None,
-            depth_down=None,
+            depth_up=1,
+            depth_down=1,
             name="no-net",
             profile_flag=None,
             no_cache=False,
@@ -232,3 +232,236 @@ def test_cli_open_reports_missing_file(cli_env, tmp_path, capsys):
         _invoke("open", cfg, name_or_id="ghost")
     out = capsys.readouterr().out
     assert "File missing" in out
+
+
+# ── Wizard-flow tests ──────────────────────────────────────────────────────
+#
+# The /lineage commands must walk through pickers when invoked bare (no flags).
+# These tests verify each picker fires and the right answer feeds the service.
+
+
+def _seed_columns_for_wizard(hs):
+    """Add column entities under public.orders so the column picker fires."""
+    from .conftest import seed_column_entity
+
+    seed_column_entity(hs, profile="local", schema="public", table="orders", column="customer_id")
+    seed_column_entity(hs, profile="local", schema="public", table="orders", column="amount")
+
+
+def _picker_router(answers: dict[str, str]):
+    """Build an ``ask_choice`` mock that picks the right answer per question."""
+
+    def fake_ask_choice(question, choices, default="", descriptions=None):
+        for fragment, response in answers.items():
+            if fragment.lower() in question.lower():
+                if response in choices:
+                    return response
+                # Permit positional answers like "1" too.
+                if response.isdigit() and 1 <= int(response) <= len(choices):
+                    return choices[int(response) - 1]
+                return response
+        return default
+
+    return fake_ask_choice
+
+
+def _ask_router(answers: dict[str, str]):
+    """Build an ``ask`` mock that responds based on question fragment match."""
+
+    def fake_ask(question, default=""):
+        for fragment, response in answers.items():
+            if fragment.lower() in question.lower():
+                return response
+        return default
+
+    return fake_ask
+
+
+def test_cli_create_wizard_walks_profile_schema_table_format(cli_env, tmp_path):
+    """Bare ``/lineage create`` walks the full picker chain."""
+    cfg, hs = cli_env
+    _seed_columns_for_wizard(hs)
+    out_path = tmp_path / "wizard.svg"
+
+    choice_answers = {
+        "schema": "public",
+        "table": "orders",
+        "column": "(whole table)",
+        "format": "svg",
+        "cache strategy": "cache-only",
+    }
+    ask_answers = {
+        "Upstream": "1",
+        "Downstream": "1",
+        "slug": "wizard-orders",
+        "Output path": str(out_path),
+    }
+
+    with (
+        patch("amx.cli_support.commands.lineage.history_store", return_value=hs),
+        patch(
+            "amx.cli_support.commands.lineage.ask_choice",
+            side_effect=_picker_router(choice_answers),
+        ),
+        patch(
+            "amx.cli_support.commands.lineage.ask",
+            side_effect=_ask_router(ask_answers),
+        ),
+        patch("amx.lineage.service.render_lineage_image", return_value=out_path),
+    ):
+        _invoke(
+            "create",
+            cfg,
+            anchor=None,
+            column=None,
+            out=None,
+            fmt=None,
+            depth_up=None,
+            depth_down=None,
+            name=None,
+            profile_flag=None,
+            no_cache=False,
+            cache_only=False,
+            prefetch=False,
+            force=False,
+        )
+
+    artifacts = lineage_store.list_lineage_artifacts(hs)
+    assert len(artifacts) == 1
+    assert artifacts[0]["name"] == "wizard-orders"
+    assert artifacts[0]["format"] == "svg"
+    assert artifacts[0]["extractors_partial"] is True  # cache-only strategy
+
+
+def test_cli_create_wizard_errors_when_no_schemas_cached(cli_env, tmp_path, capsys):
+    """If no schemas exist in the catalog, the wizard must surface a clear error."""
+    cfg, hs = cli_env
+    # Wipe the seeded catalog so schema picker has nothing to offer.
+    with hs._connect() as conn:
+        conn.execute("DELETE FROM catalog_entities")
+
+    with (
+        patch("amx.cli_support.commands.lineage.history_store", return_value=hs),
+        patch("amx.cli_support.commands.lineage.ask_choice", return_value=""),
+    ):
+        _invoke(
+            "create",
+            cfg,
+            anchor=None,
+            column=None,
+            out=None,
+            fmt=None,
+            depth_up=None,
+            depth_down=None,
+            name=None,
+            profile_flag=None,
+            no_cache=False,
+            cache_only=False,
+            prefetch=False,
+            force=False,
+        )
+    out = capsys.readouterr().out
+    assert "cached schemas" in out
+    assert lineage_store.list_lineage_artifacts(hs) == []
+
+
+def test_cli_open_wizard_offers_artifact_picker_when_no_arg(cli_env, tmp_path, capsys):
+    cfg, hs = cli_env
+    out_path = tmp_path / "from-picker.svg"
+    out_path.write_text("<svg/>")
+    lineage_store.insert_lineage_artifact(
+        hs,
+        name="picker-target",
+        db_profile="local",
+        anchor_entity_id=1,
+        depth_up=1,
+        depth_down=1,
+        fmt="svg",
+        output_path=str(out_path),
+        edge_set_hash="h",
+        node_count=1,
+        edge_count=0,
+        extractors_used=["fk"],
+        extractors_partial=False,
+    )
+
+    with (
+        patch("amx.cli_support.commands.lineage.history_store", return_value=hs),
+        # ask_choice returns the FIRST option in the list (matches "1").
+        patch(
+            "amx.cli_support.commands.lineage.ask_choice",
+            side_effect=lambda question, choices, default="", descriptions=None: choices[0],
+        ),
+        patch("amx.cli_support.commands.lineage.open_artifact", return_value=True),
+    ):
+        _invoke("open", cfg, name_or_id=None)
+
+    out = capsys.readouterr().out
+    assert "Opening" in out
+    # Path may wrap across lines in the captured Rich output — match by file name.
+    assert out_path.name in out
+
+
+def test_cli_delete_wizard_lists_artifacts_when_no_arg(cli_env, tmp_path):
+    cfg, hs = cli_env
+    out_path = tmp_path / "doomed.svg"
+    out_path.write_text("<svg/>")
+    lineage_store.insert_lineage_artifact(
+        hs,
+        name="doomed",
+        db_profile="local",
+        anchor_entity_id=1,
+        depth_up=1,
+        depth_down=1,
+        fmt="svg",
+        output_path=str(out_path),
+        edge_set_hash="h",
+        node_count=1,
+        edge_count=0,
+        extractors_used=["fk"],
+        extractors_partial=False,
+    )
+
+    with (
+        patch("amx.cli_support.commands.lineage.history_store", return_value=hs),
+        patch(
+            "amx.cli_support.commands.lineage.ask_choice",
+            side_effect=lambda question, choices, default="", descriptions=None: choices[0],
+        ),
+    ):
+        _invoke("delete", cfg, name_or_id=None, yes=True)
+
+    assert lineage_store.lookup_lineage_artifact(hs, name_or_id="doomed") is None
+    assert not out_path.exists()
+
+
+def test_cli_show_wizard_picks_schema_and_table(cli_env, capsys):
+    cfg, hs = cli_env
+    _seed_columns_for_wizard(hs)
+
+    choice_answers = {"schema": "public", "table": "orders", "column": "(whole table)"}
+    ask_answers = {"Upstream": "1", "Downstream": "1"}
+
+    with (
+        patch("amx.cli_support.commands.lineage.history_store", return_value=hs),
+        patch(
+            "amx.cli_support.commands.lineage.ask_choice",
+            side_effect=_picker_router(choice_answers),
+        ),
+        patch(
+            "amx.cli_support.commands.lineage.ask",
+            side_effect=_ask_router(ask_answers),
+        ),
+    ):
+        _invoke(
+            "show",
+            cfg,
+            anchor=None,
+            column=None,
+            depth_up=None,
+            depth_down=None,
+            profile_flag=None,
+        )
+
+    out = capsys.readouterr().out
+    assert "public.orders" in out

--- a/tests/lineage/test_extractors.py
+++ b/tests/lineage/test_extractors.py
@@ -1,0 +1,162 @@
+"""Unit tests for the three slice-1 lineage extractors."""
+
+from __future__ import annotations
+
+from amx.lineage import store as lineage_store
+from amx.lineage.extractors import FKExtractor, NameMatchExtractor, ViewDDLExtractor
+from amx.lineage.extractors.view_ddl import ConnectorHandle
+from amx.lineage.types import ColumnRef, Scope
+
+from .conftest import (
+    seed_column_comments_cache_for_table,
+    seed_foreign_key_relationship,
+    seed_table_entity,
+)
+
+
+def test_fk_extractor_emits_column_level_edges(hs):
+    orders_id = seed_table_entity(hs, schema="public", table="orders")
+    customers_id = seed_table_entity(hs, schema="public", table="customers")
+    seed_foreign_key_relationship(
+        hs,
+        from_table_id=orders_id,
+        to_table_id=customers_id,
+        constrained_columns=["customer_id"],
+        referred_columns=["id"],
+        referred_table="customers",
+    )
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "orders", ""))
+    result = FKExtractor().extract(hs=hs, scope=scope)
+    assert result.cache_status == "hit"
+    assert len(result.edges) == 1
+    edge = result.edges[0]
+    assert edge.source.column == "id"
+    assert edge.target.column == "customer_id"
+    assert edge.confidence == 1.0
+
+
+def test_fk_extractor_empty_when_no_relationship(hs):
+    seed_table_entity(hs, schema="public", table="orders")
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "orders", ""))
+    result = FKExtractor().extract(hs=hs, scope=scope)
+    assert result.edges == []
+    assert result.cache_status == "hit"  # absence is a clean hit, not an error
+
+
+def test_view_ddl_extractor_miss_when_cache_empty(hs):
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "orders_view", ""))
+    result = ViewDDLExtractor(connector_factory=None).extract(hs=hs, scope=scope, mode="cache_only")
+    assert result.cache_status == "miss"
+    assert result.missing_scope and result.missing_scope[0].schema == "public"
+
+
+def test_view_ddl_extractor_hit_from_cache(hs):
+    lineage_store.upsert_view_definitions(
+        hs,
+        db_profile="p",
+        database="",
+        schema="public",
+        entries=[
+            {
+                "view_name": "v_orders",
+                "ddl_text": "SELECT customer_id FROM orders",
+                "dialect": "duckdb",
+                "parsed_lineage": [
+                    {
+                        "target": "customer_id",
+                        "sources": [{"table": "orders", "column": "customer_id"}],
+                    }
+                ],
+                "parse_status": "ok",
+                "parse_error": "",
+            }
+        ],
+    )
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "v_orders", ""))
+    result = ViewDDLExtractor(connector_factory=None).extract(hs=hs, scope=scope, mode="cache_only")
+    assert result.cache_status == "hit"
+    assert len(result.edges) == 1
+    assert result.edges[0].source.column == "customer_id"
+    assert result.edges[0].target.table == "v_orders"
+
+
+def test_view_ddl_extractor_does_not_call_adapter_in_cache_only(hs):
+    """Critical guarantee: cache_only must never reach the wire."""
+
+    class _BoomAdapter:
+        def list_views_with_definitions(self, engine, schema):
+            raise AssertionError("cache_only must not touch the adapter")
+
+    def factory(profile):
+        return ConnectorHandle(engine=object(), adapter=_BoomAdapter(), backend="duckdb")
+
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "v_orders", ""))
+    extractor = ViewDDLExtractor(connector_factory=factory)
+    result = extractor.extract(hs=hs, scope=scope, mode="cache_only")
+    # The extractor must have skipped the adapter call entirely.
+    assert result.cache_status == "miss"
+
+
+def test_view_ddl_extractor_db_fill_populates_cache_via_fake_adapter(hs):
+    """db_fill mode runs the adapter, persists the parsed lineage, emits edges."""
+
+    class _FakeAdapter:
+        def list_views_with_definitions(self, engine, schema):
+            return [
+                {
+                    "name": "v1",
+                    "type": "view",
+                    "definition": "SELECT customer_id AS cid FROM orders",
+                    "comment": None,
+                    "metadata": {},
+                }
+            ]
+
+    def factory(profile):
+        return ConnectorHandle(engine=object(), adapter=_FakeAdapter(), backend="duckdb")
+
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "v1", ""))
+    extractor = ViewDDLExtractor(connector_factory=factory)
+    result = extractor.extract(hs=hs, scope=scope, mode="db_fill")
+    cached = lineage_store.lookup_view_definitions(hs, db_profile="p", database="", schema="public")
+    assert len(cached) == 1
+    assert cached[0]["view_name"] == "v1"
+    # Cache hit on a follow-up cache_only read.
+    result2 = ViewDDLExtractor(connector_factory=None).extract(
+        hs=hs, scope=scope, mode="cache_only"
+    )
+    assert result2.cache_status == "hit"
+    # The fake adapter's SELECT yielded at least one parsable target (cid).
+    if cached[0]["parse_status"] == "ok":
+        assert result.edges or result2.edges
+
+
+def test_name_match_proposes_edges_by_name_and_type(hs):
+    seed_column_comments_cache_for_table(
+        hs,
+        schema="public",
+        table="orders",
+        columns={"customer_id": {"type": "integer"}, "amount": {"type": "decimal"}},
+    )
+    seed_column_comments_cache_for_table(
+        hs,
+        schema="public",
+        table="customers",
+        columns={"id": {"type": "integer"}, "name": {"type": "text"}},
+    )
+    scope = Scope(
+        profile="p",
+        anchor=ColumnRef("", "public", "orders", "customer_id"),
+    )
+    result = NameMatchExtractor().extract(hs=hs, scope=scope)
+    assert result.cache_status == "hit"
+    # 'customers.id' is a suffix-match for 'customer_id' with matching integer type.
+    suggestions = [(e.source.fqn(), e.confidence) for e in result.edges]
+    assert any("customers.id" in src for src, _ in suggestions), suggestions
+
+
+def test_name_match_returns_empty_when_no_columns_cached(hs):
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "orders", "customer_id"))
+    result = NameMatchExtractor().extract(hs=hs, scope=scope)
+    # No cache rows → miss, callers can offer to populate.
+    assert result.cache_status == "miss"

--- a/tests/lineage/test_perf_budget.py
+++ b/tests/lineage/test_perf_budget.py
@@ -1,0 +1,161 @@
+"""Non-negotiable performance guards for ``/lineage create``.
+
+Per the slice-1 contract: a warm-cache run on a 5,000-table / 500-view
+catalog must complete in under 5 seconds. Anything slower means a
+regression in the cache-first plumbing.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import patch
+
+from amx.lineage import service
+from amx.lineage import store as lineage_store
+from amx.lineage.extractors.view_ddl import ConnectorHandle
+from amx.lineage.types import ColumnRef, Scope
+
+from .conftest import (
+    seed_foreign_key_relationship,
+    seed_table_entity,
+)
+
+PERF_BUDGET_SECONDS = 5.0
+
+
+def _seed_large_catalog(hs, *, tables: int = 5000, views: int = 500) -> int:
+    """Insert N table entities + view-cache rows so the warm-cache path can read them all."""
+    anchor_id = seed_table_entity(hs, schema="public", table="orders")
+    for i in range(20):  # a handful of FK edges so FK extractor has work
+        other_id = seed_table_entity(hs, schema="public", table=f"t{i}")
+        seed_foreign_key_relationship(
+            hs,
+            from_table_id=anchor_id,
+            to_table_id=other_id,
+            constrained_columns=[f"c{i}"],
+            referred_columns=["id"],
+            referred_table=f"t{i}",
+        )
+    # bulk-insert column_comments_cache so name-match has many candidates
+    now = time.time()
+    with hs._connect() as conn:
+        rows = [
+            (
+                f"p||public|t{i}",
+                "p",
+                "",
+                "public",
+                f"t{i}",
+                None,
+                json.dumps({"id": {"type": "integer"}, "name": {"type": "text"}}),
+                "TABLE",
+                now,
+                now + 3600,
+                1,
+            )
+            for i in range(tables)
+        ]
+        conn.executemany(
+            "INSERT OR IGNORE INTO column_comments_cache (cache_key, db_profile, database_name, "
+            "schema_name, table_name, table_comment, columns_json, kind, fetched_at, expires_at, "
+            "bulk_filled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+    # view-cache entries
+    lineage_store.upsert_view_definitions(
+        hs,
+        db_profile="p",
+        database="",
+        schema="public",
+        entries=[
+            {
+                "view_name": f"v{i}",
+                "ddl_text": f"SELECT id FROM t{i}",
+                "dialect": "duckdb",
+                "parsed_lineage": [
+                    {"target": "id", "sources": [{"table": f"t{i}", "column": "id"}]}
+                ],
+                "parse_status": "ok",
+                "parse_error": "",
+            }
+            for i in range(views)
+        ],
+    )
+    return anchor_id
+
+
+def test_warm_cache_create_under_perf_budget(hs, tmp_path):
+    """5k tables / 500 views — warm cache — should finish well under 5s."""
+    _seed_large_catalog(hs, tables=5000, views=500)
+
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "orders", ""))
+    out_path = tmp_path / "perf.svg"
+
+    started = time.perf_counter()
+    with patch("amx.lineage.service.render_lineage_image", return_value=out_path):
+        result = service.create_lineage(
+            hs=hs,
+            scope=scope,
+            name="perf-budget",
+            output_path=out_path,
+            fmt="svg",
+            fill_decision="skip",
+            force_scale=True,  # synthetic catalog exceeds the soft guard; perf, not scale
+        )
+    elapsed = time.perf_counter() - started
+
+    assert not result.aborted, result.abort_reason
+    assert elapsed < PERF_BUDGET_SECONDS, (
+        f"warm-cache /lineage create took {elapsed:.2f}s (budget {PERF_BUDGET_SECONDS}s)"
+    )
+
+
+def test_create_with_default_skip_does_not_open_connector(hs, tmp_path):
+    """The most-important UX guarantee: nothing reaches the wire unless the user opts in."""
+    seed_table_entity(hs, schema="public", table="orders")
+    factory_calls = []
+
+    def boom_factory(profile):
+        factory_calls.append(profile)
+        raise AssertionError("default flow must not call the connector factory")
+
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "orders", ""))
+    with patch("amx.lineage.service.render_lineage_image", return_value=tmp_path / "x.svg"):
+        result = service.create_lineage(
+            hs=hs,
+            scope=scope,
+            name="no-connector",
+            output_path=tmp_path / "x.svg",
+            fmt="svg",
+            fill_decision="skip",
+            connector_factory=boom_factory,
+        )
+    assert factory_calls == []
+    assert not result.aborted
+
+
+def test_db_fill_only_fires_after_explicit_decision(hs, tmp_path):
+    """When the caller passes fill_decision='skip', adapter must not be called."""
+
+    class _BoomAdapter:
+        def list_views_with_definitions(self, engine, schema):
+            raise AssertionError("skip decision must not run adapter")
+
+    def factory(profile):
+        return ConnectorHandle(engine=object(), adapter=_BoomAdapter(), backend="duckdb")
+
+    seed_table_entity(hs, schema="public", table="orders")
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "orders", ""))
+    with patch("amx.lineage.service.render_lineage_image", return_value=tmp_path / "x.svg"):
+        result = service.create_lineage(
+            hs=hs,
+            scope=scope,
+            name="never-fills",
+            output_path=tmp_path / "x.svg",
+            fmt="svg",
+            fill_decision="skip",
+            connector_factory=factory,
+        )
+    assert not result.aborted
+    assert result.extractors_partial is True

--- a/tests/lineage/test_render.py
+++ b/tests/lineage/test_render.py
@@ -1,10 +1,8 @@
-"""DOT builder + cross-platform helpers."""
+"""DOT builder + matplotlib renderer + cross-platform helpers."""
 
 from __future__ import annotations
 
 import os
-import subprocess
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -13,7 +11,6 @@ from amx.lineage.render import (
     HARD_NODE_LIMIT,
     SOFT_NODE_LIMIT,
     SUPPORTED_FORMATS,
-    DotBinaryNotFound,
     RenderInput,
     build_dot,
     count_nodes,
@@ -99,46 +96,65 @@ def test_scale_limits_are_sane_defaults():
     assert SUPPORTED_FORMATS == ("svg", "png", "jpg")
 
 
-def test_render_raises_when_dot_binary_missing(tmp_path):
-    with patch("amx.lineage.render.shutil.which", return_value=None):
-        with pytest.raises(DotBinaryNotFound):
-            render_lineage_image(
-                payload=RenderInput(
-                    edges=[],
-                    anchor=ColumnRef("", "public", "orders", ""),
-                    described_entities=set(),
-                ),
-                fmt="svg",
-                output_path=tmp_path / "x.svg",
-            )
-
-
-def test_render_uses_subprocess_list_argv(tmp_path):
-    captured: dict[str, object] = {}
-
-    def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        captured["shell"] = kwargs.get("shell", False)
-        out = Path(cmd[cmd.index("-o") + 1])
-        out.write_text("ok")
-        return subprocess.CompletedProcess(cmd, 0, "", "")
-
-    with (
-        patch("amx.lineage.render.shutil.which", return_value="dot"),
-        patch("amx.lineage.render.subprocess.run", side_effect=fake_run),
-    ):
-        out = render_lineage_image(
+def test_render_unsupported_format_raises():
+    with pytest.raises(ValueError):
+        render_lineage_image(
             payload=RenderInput(
                 edges=[],
                 anchor=ColumnRef("", "public", "orders", ""),
                 described_entities=set(),
             ),
-            fmt="svg",
-            output_path=tmp_path / "x.svg",
+            fmt="bmp",
+            output_path="x.bmp",
         )
-    assert isinstance(captured["cmd"], list)
-    assert captured["shell"] is False
-    assert out.exists()
+
+
+def test_render_writes_svg_with_matplotlib_backend(tmp_path):
+    """End-to-end render: matplotlib + networkx, no graphviz, no system binary."""
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("networkx")
+    out_path = tmp_path / "render.svg"
+    anchor = ColumnRef("", "public", "orders", "")
+    edges = [
+        Edge(
+            source=ColumnRef("", "public", "customers", "id"),
+            target=ColumnRef("", "public", "orders", "customer_id"),
+            relationship_type="lineage_fk",
+            extractor="fk",
+            confidence=1.0,
+            evidence="",
+        ),
+    ]
+    result = render_lineage_image(
+        payload=RenderInput(edges=edges, anchor=anchor, described_entities=set(), title="orders"),
+        fmt="svg",
+        output_path=out_path,
+    )
+    assert result == out_path
+    assert out_path.exists()
+    body = out_path.read_text(encoding="utf-8")
+    # Matplotlib emits an XML SVG header; node label text travels through verbatim.
+    assert body.startswith("<?xml") or "<svg" in body
+    assert "orders" in body
+
+
+def test_render_handles_png_output(tmp_path):
+    """PNG path exercises matplotlib's raster backend (Agg)."""
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("networkx")
+    out_path = tmp_path / "render.png"
+    render_lineage_image(
+        payload=RenderInput(
+            edges=[],
+            anchor=ColumnRef("", "public", "orders", ""),
+            described_entities=set(),
+        ),
+        fmt="png",
+        output_path=out_path,
+    )
+    assert out_path.exists()
+    # PNG magic header: 89 50 4E 47 0D 0A 1A 0A
+    assert out_path.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
 
 def test_open_artifact_dispatches_per_platform(tmp_path):

--- a/tests/lineage/test_render.py
+++ b/tests/lineage/test_render.py
@@ -1,0 +1,190 @@
+"""DOT builder + cross-platform helpers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from amx.lineage.render import (
+    HARD_NODE_LIMIT,
+    SOFT_NODE_LIMIT,
+    SUPPORTED_FORMATS,
+    DotBinaryNotFound,
+    RenderInput,
+    build_dot,
+    count_nodes,
+    open_artifact,
+    render_lineage_image,
+)
+from amx.lineage.types import ColumnRef, Edge
+
+
+def _make_edge(
+    *, src_table: str, src_col: str, tgt_table: str, tgt_col: str, rel: str = "lineage_view_ddl"
+) -> Edge:
+    return Edge(
+        source=ColumnRef("", "public", src_table, src_col),
+        target=ColumnRef("", "public", tgt_table, tgt_col),
+        relationship_type=rel,
+        extractor=rel.split("_", 1)[-1],
+        confidence=1.0,
+        evidence="",
+    )
+
+
+def test_build_dot_contains_anchor_and_edges():
+    anchor = ColumnRef("", "public", "orders", "")
+    edges = [
+        _make_edge(src_table="customers", src_col="id", tgt_table="orders", tgt_col="customer_id"),
+    ]
+    dot = build_dot(RenderInput(edges=edges, anchor=anchor, described_entities=set()))
+    assert "digraph lineage" in dot
+    assert '"public.orders"' in dot
+    assert '"public.customers.id" -> "public.orders.customer_id"' in dot
+
+
+def test_build_dot_marks_described_entities_with_check_badge():
+    anchor = ColumnRef("", "public", "orders", "")
+    edges = [
+        _make_edge(src_table="customers", src_col="id", tgt_table="orders", tgt_col="customer_id")
+    ]
+    described = {"public.customers.id"}
+    dot = build_dot(RenderInput(edges=edges, anchor=anchor, described_entities=described))
+    assert '"✓ public.customers.id"' in dot
+    assert '"○ public.orders.customer_id"' in dot
+
+
+def test_build_dot_includes_partial_warning_banner_when_set():
+    anchor = ColumnRef("", "public", "orders", "")
+    dot = build_dot(
+        RenderInput(
+            edges=[],
+            anchor=anchor,
+            described_entities=set(),
+            partial_warning="Partial render — view DDL cache stale.",
+        )
+    )
+    assert "Partial render" in dot
+    assert "__partial__" in dot
+
+
+def test_name_match_edges_render_as_dashed():
+    anchor = ColumnRef("", "public", "orders", "")
+    edges = [
+        _make_edge(
+            src_table="customers",
+            src_col="id",
+            tgt_table="orders",
+            tgt_col="customer_id",
+            rel="lineage_name_match",
+        )
+    ]
+    dot = build_dot(RenderInput(edges=edges, anchor=anchor, described_entities=set()))
+    assert 'style="dashed"' in dot
+
+
+def test_count_nodes_dedupes_anchor():
+    anchor = ColumnRef("", "public", "orders", "")
+    e1 = _make_edge(src_table="customers", src_col="id", tgt_table="orders", tgt_col="customer_id")
+    e2 = _make_edge(src_table="customers", src_col="id", tgt_table="orders", tgt_col="customer_id")
+    assert count_nodes([e1, e2], anchor) == 3  # anchor + customers.id + orders.customer_id
+
+
+def test_scale_limits_are_sane_defaults():
+    assert SOFT_NODE_LIMIT < HARD_NODE_LIMIT
+    assert SUPPORTED_FORMATS == ("svg", "png", "jpg")
+
+
+def test_render_raises_when_dot_binary_missing(tmp_path):
+    with patch("amx.lineage.render.shutil.which", return_value=None):
+        with pytest.raises(DotBinaryNotFound):
+            render_lineage_image(
+                payload=RenderInput(
+                    edges=[],
+                    anchor=ColumnRef("", "public", "orders", ""),
+                    described_entities=set(),
+                ),
+                fmt="svg",
+                output_path=tmp_path / "x.svg",
+            )
+
+
+def test_render_uses_subprocess_list_argv(tmp_path):
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["shell"] = kwargs.get("shell", False)
+        out = Path(cmd[cmd.index("-o") + 1])
+        out.write_text("ok")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    with (
+        patch("amx.lineage.render.shutil.which", return_value="dot"),
+        patch("amx.lineage.render.subprocess.run", side_effect=fake_run),
+    ):
+        out = render_lineage_image(
+            payload=RenderInput(
+                edges=[],
+                anchor=ColumnRef("", "public", "orders", ""),
+                described_entities=set(),
+            ),
+            fmt="svg",
+            output_path=tmp_path / "x.svg",
+        )
+    assert isinstance(captured["cmd"], list)
+    assert captured["shell"] is False
+    assert out.exists()
+
+
+def test_open_artifact_dispatches_per_platform(tmp_path):
+    """Verify platform-aware open helpers fire on darwin/linux/win32."""
+    f = tmp_path / "x.svg"
+    f.write_text("<svg/>")
+
+    # macOS uses `open`
+    with (
+        patch("amx.lineage.render.sys", autospec=True) as fake_sys,
+        patch("amx.lineage.render.subprocess.run") as fake_run,
+    ):
+        fake_sys.platform = "darwin"
+        open_artifact(f)
+    assert fake_run.call_args is not None
+    assert fake_run.call_args.args[0][0] == "open"
+
+    # Linux uses `xdg-open` (and only when a display is configured)
+    with (
+        patch("amx.lineage.render.sys", autospec=True) as fake_sys,
+        patch("amx.lineage.render.subprocess.run") as fake_run,
+        patch.dict(os.environ, {"DISPLAY": ":0"}, clear=False),
+    ):
+        fake_sys.platform = "linux"
+        open_artifact(f)
+    assert fake_run.call_args.args[0][0] == "xdg-open"
+
+    # Windows uses os.startfile when present
+    with (
+        patch("amx.lineage.render.sys", autospec=True) as fake_sys,
+        patch("amx.lineage.render.os", autospec=True) as fake_os,
+    ):
+        fake_sys.platform = "win32"
+        fake_os.startfile = lambda p: None
+        fake_os.environ = {}
+        ok = open_artifact(f)
+    assert ok is True
+
+
+def test_open_artifact_returns_false_when_headless_linux(tmp_path):
+    f = tmp_path / "x.svg"
+    f.write_text("<svg/>")
+    with (
+        patch("amx.lineage.render.sys", autospec=True) as fake_sys,
+        patch.dict(os.environ, {}, clear=True),
+    ):
+        fake_sys.platform = "linux"
+        ok = open_artifact(f)
+    assert ok is False

--- a/tests/lineage/test_render.py
+++ b/tests/lineage/test_render.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from unittest.mock import patch
 
 import pytest
@@ -12,6 +13,7 @@ from amx.lineage.render import (
     SOFT_NODE_LIMIT,
     SUPPORTED_FORMATS,
     RenderInput,
+    _figure_size,
     build_dot,
     count_nodes,
     open_artifact,
@@ -204,3 +206,135 @@ def test_open_artifact_returns_false_when_headless_linux(tmp_path):
         fake_sys.platform = "linux"
         ok = open_artifact(f)
     assert ok is False
+
+
+# ── Render quality fixes (plan: render-quality follow-up) ───────────────
+
+
+def test_figure_size_tiny_graph_is_small():
+    """Single-node case must not waste a 10x6 canvas on one tiny box."""
+    w, h = _figure_size(1)
+    assert (w, h) == (6.0, 4.0)
+
+
+def test_figure_size_scales_with_node_count():
+    """Bigger graphs get more canvas, but growth is bounded and gentle."""
+    small = _figure_size(1)
+    medium = _figure_size(10)
+    large = _figure_size(100)
+    huge = _figure_size(500)
+    assert medium[0] > small[0] and medium[1] > small[1]
+    assert large[0] > medium[0] and large[1] > medium[1]
+    assert huge[0] > large[0]
+    # Hard ceiling sanity: at 500 nodes we are still well under desktop-wide.
+    assert huge[0] < 16.0 and huge[1] < 12.0
+
+
+def test_empty_result_caption_present_for_anchor_only_graph(tmp_path):
+    """Anchor-only render must surface the 'no related entities' caption."""
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("networkx")
+    out = tmp_path / "empty.svg"
+    render_lineage_image(
+        payload=RenderInput(
+            edges=[],
+            anchor=ColumnRef("", "public", "orders", ""),
+            described_entities=set(),
+            title="lineage: SAP.public.orders",
+        ),
+        fmt="svg",
+        output_path=out,
+    )
+    body = out.read_text(encoding="utf-8")
+    assert "No related entities found in cache." in body
+    assert "/lineage refresh --no-cache" in body
+
+
+def test_anchor_only_render_does_not_emit_tight_layout_warning(tmp_path):
+    """tight_layout fights ax.set_axis_off and warns on empty axes — keep it silent."""
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("networkx")
+    out = tmp_path / "noisefree.svg"
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        render_lineage_image(
+            payload=RenderInput(
+                edges=[],
+                anchor=ColumnRef("", "public", "orders", ""),
+                described_entities=set(),
+                title="orders",
+                partial_warning="Partial render — view DDL cache stale.",
+            ),
+            fmt="svg",
+            output_path=out,
+        )
+    assert out.exists()
+
+
+def test_multi_node_render_sizing_grows(tmp_path):
+    """Multi-edge render uses the scaled-up canvas without a leftover 10x6 default."""
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("networkx")
+    anchor = ColumnRef("", "public", "orders", "")
+    edges = [
+        Edge(
+            source=ColumnRef("", "public", "customers", "id"),
+            target=ColumnRef("", "public", "orders", "customer_id"),
+            relationship_type="lineage_fk",
+            extractor="fk",
+            confidence=1.0,
+            evidence="",
+        ),
+        Edge(
+            source=ColumnRef("", "public", "orders", "customer_id"),
+            target=ColumnRef("", "public", "daily_orders", "cid"),
+            relationship_type="lineage_view_ddl",
+            extractor="view_ddl",
+            confidence=1.0,
+            evidence="",
+        ),
+    ]
+    out = tmp_path / "multi.svg"
+    render_lineage_image(
+        payload=RenderInput(
+            edges=edges,
+            anchor=anchor,
+            described_entities={"public.customers.id"},
+            title="orders lineage",
+        ),
+        fmt="svg",
+        output_path=out,
+    )
+    assert out.exists()
+    body = out.read_text(encoding="utf-8")
+    # Caption must NOT appear when the graph carries real edges.
+    assert "No related entities found in cache." not in body
+    # Both endpoints + the anchor label survive into the SVG.
+    assert "public.customers.id" in body
+    assert "public.orders.customer_id" in body
+    assert "public.daily_orders.cid" in body
+
+
+def test_edge_label_offset_is_perpendicular_to_line(tmp_path):
+    """Edge labels should sit off the midpoint, not on top of it."""
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("networkx")
+    anchor = ColumnRef("", "public", "orders", "")
+    edges = [
+        Edge(
+            source=ColumnRef("", "public", "customers", "id"),
+            target=ColumnRef("", "public", "orders", "customer_id"),
+            relationship_type="lineage_fk",
+            extractor="fk",
+            confidence=1.0,
+            evidence="",
+        ),
+    ]
+    out = tmp_path / "offset.svg"
+    render_lineage_image(
+        payload=RenderInput(edges=edges, anchor=anchor, described_entities=set(), title="offset"),
+        fmt="svg",
+        output_path=out,
+    )
+    body = out.read_text(encoding="utf-8")
+    assert "fk" in body  # edge label survives the offset nudge

--- a/tests/lineage/test_service.py
+++ b/tests/lineage/test_service.py
@@ -1,0 +1,164 @@
+"""Service-layer orchestration: cache-first defaults, fill flow, partial render."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from amx.lineage import service
+from amx.lineage.extractors.view_ddl import ConnectorHandle
+from amx.lineage.types import ColumnRef, Scope
+
+from .conftest import (
+    seed_column_comments_cache_for_table,
+    seed_foreign_key_relationship,
+    seed_table_entity,
+)
+
+
+@pytest.fixture
+def fk_seeded(hs):
+    orders_id = seed_table_entity(hs, schema="public", table="orders")
+    customers_id = seed_table_entity(hs, schema="public", table="customers")
+    seed_foreign_key_relationship(
+        hs,
+        from_table_id=orders_id,
+        to_table_id=customers_id,
+        constrained_columns=["customer_id"],
+        referred_columns=["id"],
+        referred_table="customers",
+    )
+    seed_column_comments_cache_for_table(
+        hs,
+        schema="public",
+        table="orders",
+        columns={"customer_id": {"type": "integer"}},
+    )
+    seed_column_comments_cache_for_table(
+        hs,
+        schema="public",
+        table="customers",
+        columns={"id": {"type": "integer"}},
+    )
+    return orders_id, customers_id
+
+
+def _scope_for_orders():
+    return Scope(profile="p", anchor=ColumnRef("", "public", "orders", ""))
+
+
+def test_default_skip_flag_keeps_render_partial_when_view_cache_empty(hs, fk_seeded, tmp_path):
+    """The 'default skip' contract: no DB hit, partial render flagged."""
+    with patch("amx.lineage.service.render_lineage_image", return_value=tmp_path / "x.svg"):
+        result = service.create_lineage(
+            hs=hs,
+            scope=_scope_for_orders(),
+            name="orders-default",
+            output_path=tmp_path / "x.svg",
+            fmt="svg",
+            fill_decision="skip",
+        )
+    assert not result.aborted
+    assert result.extractors_partial is True
+    assert "fk" in result.extractors_used
+
+
+def test_fill_decision_abort_returns_without_writing_artifact(hs, fk_seeded, tmp_path):
+    from amx.lineage import store as lineage_store
+
+    with patch("amx.lineage.service.render_lineage_image", return_value=tmp_path / "x.svg"):
+        result = service.create_lineage(
+            hs=hs,
+            scope=_scope_for_orders(),
+            name="orders-abort",
+            output_path=tmp_path / "x.svg",
+            fmt="svg",
+            fill_decision="abort",
+        )
+    assert result.aborted
+    assert result.artifact_id == 0
+    assert lineage_store.list_lineage_artifacts(hs) == []
+
+
+def test_db_fill_invokes_connector_factory_and_persists_cache(hs, fk_seeded, tmp_path):
+    """When the user chooses ``fill``, the connector is opened exactly for the
+    extractors with misses and the cache is repopulated."""
+    from amx.lineage import store as lineage_store
+
+    class _FakeAdapter:
+        def __init__(self):
+            self.calls = 0
+
+        def list_views_with_definitions(self, engine, schema):
+            self.calls += 1
+            return [
+                {
+                    "name": "v_orders",
+                    "type": "view",
+                    "definition": "SELECT customer_id FROM orders",
+                    "comment": None,
+                    "metadata": {},
+                }
+            ]
+
+    adapter = _FakeAdapter()
+
+    def factory(profile):
+        return ConnectorHandle(engine=object(), adapter=adapter, backend="duckdb")
+
+    with patch("amx.lineage.service.render_lineage_image", return_value=tmp_path / "x.svg"):
+        result = service.create_lineage(
+            hs=hs,
+            scope=_scope_for_orders(),
+            name="orders-fill",
+            output_path=tmp_path / "x.svg",
+            fmt="svg",
+            fill_decision="fill",
+            connector_factory=factory,
+        )
+    assert not result.aborted
+    assert adapter.calls == 1
+    cached = lineage_store.lookup_view_definitions(hs, db_profile="p", database="", schema="public")
+    assert len(cached) == 1
+    assert result.extractors_partial is False
+
+
+def test_anchor_must_exist_in_catalog(hs, tmp_path):
+    with pytest.raises(LookupError):
+        service.create_lineage(
+            hs=hs,
+            scope=Scope(profile="p", anchor=ColumnRef("", "public", "ghost", "")),
+            name="ghost",
+            output_path=tmp_path / "x.svg",
+            fmt="svg",
+            fill_decision="skip",
+        )
+
+
+def test_scale_guardrail_blocks_huge_graphs(hs, monkeypatch, tmp_path):
+    """Force a tiny hard limit so the synthetic graph trips the guard."""
+    orders_id = seed_table_entity(hs, schema="public", table="orders")
+    for i in range(5):
+        other_id = seed_table_entity(hs, schema="public", table=f"t{i}")
+        seed_foreign_key_relationship(
+            hs,
+            from_table_id=orders_id,
+            to_table_id=other_id,
+            constrained_columns=[f"c{i}"],
+            referred_columns=["id"],
+            referred_table=f"t{i}",
+        )
+
+    monkeypatch.setattr(service, "HARD_NODE_LIMIT", 2)
+    with patch("amx.lineage.service.render_lineage_image", return_value=tmp_path / "x.svg"):
+        result = service.create_lineage(
+            hs=hs,
+            scope=_scope_for_orders(),
+            name="huge",
+            output_path=tmp_path / "x.svg",
+            fmt="svg",
+            fill_decision="skip",
+        )
+    assert result.aborted
+    assert "exceeds hard limit" in result.abort_reason

--- a/tests/lineage/test_store.py
+++ b/tests/lineage/test_store.py
@@ -1,0 +1,168 @@
+"""``view_definitions_cache`` and ``lineage_artifacts`` CRUD."""
+
+from __future__ import annotations
+
+from amx.lineage import store as lineage_store
+
+
+def test_view_cache_upsert_and_lookup(hs):
+    n = lineage_store.upsert_view_definitions(
+        hs,
+        db_profile="p",
+        database="",
+        schema="public",
+        entries=[
+            {
+                "view_name": "v1",
+                "ddl_text": "SELECT 1",
+                "dialect": "duckdb",
+                "parsed_lineage": [{"target": "c1", "sources": []}],
+                "parse_status": "ok",
+                "parse_error": "",
+            }
+        ],
+    )
+    assert n == 1
+    rows = lineage_store.lookup_view_definitions(hs, db_profile="p", database="", schema="public")
+    assert len(rows) == 1
+    assert rows[0]["parsed_lineage"][0]["target"] == "c1"
+
+
+def test_view_cache_upsert_overwrites_existing(hs):
+    lineage_store.upsert_view_definitions(
+        hs,
+        db_profile="p",
+        database="",
+        schema="public",
+        entries=[
+            {
+                "view_name": "v1",
+                "ddl_text": "SELECT 1",
+                "dialect": "duckdb",
+                "parsed_lineage": [{"target": "x", "sources": []}],
+                "parse_status": "ok",
+                "parse_error": "",
+            }
+        ],
+    )
+    lineage_store.upsert_view_definitions(
+        hs,
+        db_profile="p",
+        database="",
+        schema="public",
+        entries=[
+            {
+                "view_name": "v1",
+                "ddl_text": "SELECT 2",
+                "dialect": "duckdb",
+                "parsed_lineage": None,
+                "parse_status": "parse_failed",
+                "parse_error": "oops",
+            }
+        ],
+    )
+    rows = lineage_store.lookup_view_definitions(hs, db_profile="p", database="", schema="public")
+    assert rows[0]["parse_status"] == "parse_failed"
+    assert rows[0]["parsed_lineage"] is None
+
+
+def test_view_cache_expired_rows_treated_as_miss(hs):
+    lineage_store.upsert_view_definitions(
+        hs,
+        db_profile="p",
+        database="",
+        schema="public",
+        entries=[
+            {
+                "view_name": "v1",
+                "ddl_text": "SELECT 1",
+                "dialect": "duckdb",
+                "parsed_lineage": [],
+                "parse_status": "ok",
+                "parse_error": "",
+            }
+        ],
+        ttl_seconds=-1,  # already-expired
+    )
+    rows = lineage_store.lookup_view_definitions(hs, db_profile="p", database="", schema="public")
+    assert rows == []
+
+
+def test_invalidate_view_definitions_by_scope(hs):
+    lineage_store.upsert_view_definitions(
+        hs,
+        db_profile="p",
+        database="",
+        schema="public",
+        entries=[
+            {
+                "view_name": "v1",
+                "ddl_text": "SELECT 1",
+                "dialect": "duckdb",
+                "parsed_lineage": [],
+                "parse_status": "ok",
+                "parse_error": "",
+            }
+        ],
+    )
+    deleted = lineage_store.invalidate_view_definitions(
+        hs, db_profile="p", database="", schema="public"
+    )
+    assert deleted == 1
+    assert (
+        lineage_store.lookup_view_definitions(hs, db_profile="p", database="", schema="public")
+        == []
+    )
+
+
+def test_edge_set_hash_stable_under_reorder(hs):
+    a = lineage_store.compute_edge_set_hash([(1, 2, "x", 1.0), (3, 4, "y", 0.5)])
+    b = lineage_store.compute_edge_set_hash([(3, 4, "y", 0.5), (1, 2, "x", 1.0)])
+    assert a == b
+
+
+def test_edge_set_hash_changes_when_edges_differ(hs):
+    a = lineage_store.compute_edge_set_hash([(1, 2, "x", 1.0)])
+    b = lineage_store.compute_edge_set_hash([(1, 2, "x", 0.99)])
+    assert a != b
+
+
+def test_lineage_artifact_crud(hs):
+    aid = lineage_store.insert_lineage_artifact(
+        hs,
+        name="demo",
+        db_profile="p",
+        anchor_entity_id=1,
+        depth_up=1,
+        depth_down=1,
+        fmt="svg",
+        output_path="/tmp/demo.svg",
+        edge_set_hash="abc",
+        node_count=2,
+        edge_count=1,
+        extractors_used=["fk"],
+        extractors_partial=False,
+    )
+    assert aid > 0
+    art = lineage_store.lookup_lineage_artifact(hs, name_or_id="demo")
+    assert art is not None
+    assert art["edge_set_hash"] == "abc"
+    by_id = lineage_store.lookup_lineage_artifact(hs, name_or_id=str(aid))
+    assert by_id and by_id["id"] == aid
+
+    lineage_store.update_lineage_artifact(
+        hs,
+        artifact_id=aid,
+        edge_set_hash="new",
+        node_count=4,
+        edge_count=3,
+        extractors_used=["fk", "view_ddl"],
+        extractors_partial=True,
+    )
+    art2 = lineage_store.lookup_lineage_artifact(hs, name_or_id="demo")
+    assert art2["edge_set_hash"] == "new"
+    assert art2["extractors_partial"] is True
+    assert "view_ddl" in art2["extractors_used"]
+
+    lineage_store.delete_lineage_artifact(hs, artifact_id=aid)
+    assert lineage_store.lookup_lineage_artifact(hs, name_or_id="demo") is None


### PR DESCRIPTION
## Summary

- New `/lineage` REPL namespace: `create`, `list`, `open`, `refresh`, `delete`, `show`. Inference-driven — AMX derives column-level edges from data it already has and never opens a live DB connection unless the user explicitly confirms after seeing a cost estimate.
- Three pluggable extractors: FK (reads `catalog_relationships`), view DDL (sqlglot column-lineage walker, runs *only* in `db_fill` mode), name+type heuristic (cache-driven fallback). Each returns a cache-status report so the service layer can offer the user a fill-or-skip decision.
- Two local-only SQLite tables with full `schema_descriptions` entries: `view_definitions_cache` (raw DDL + pre-parsed lineage with TTL, mirrors `column_comments_cache` discipline) and `lineage_artifacts` (registry of rendered images with edge-set hash for drift detection). 10 backend adapters carry `list_views_with_definitions`; the base default returns `[]` so adapters without view DDL exposure stay graceful.
- Rendering shells out to `dot` (Graphviz) via `shutil.which`; PNG / SVG / JPG output paths are user-supplied. Cross-platform open helper for `/lineage open` dispatches on `sys.platform`. New optional extra `lineage = ["sqlglot>=23", "graphviz>=0.20"]`, auto-installable through `amx.utils.optional_deps.ensure("lineage")` on first use.

## Test plan

- [x] `pytest tests/lineage/` — 39 new tests covering store CRUD, extractors, render builder, service orchestration, CLI, perf budget, and cross-platform open dispatch.
- [x] `pytest tests/test_local_schema_comments.py tests/test_shared_schema_comments.py` — schema-descriptions CI guards pass for the two new tables.
- [x] Full suite (`pytest tests/` minus the slow `eval/` directory) — 2483 passing, 9 pre-existing skips, zero new failures.
- [x] Perf budget: warm-cache `/lineage create` on a 5,000-table / 500-view synthetic catalog finishes in well under the 5-second slice-1 contract.
- [x] Cache-first guarantee: dedicated tests assert the default flow never opens a connector and `cache_only` mode never reaches the adapter.
- [x] `ruff check` + `ruff format --check` clean on every touched file.
- [x] Local Studio rebuilt via `deploy.sh` so the new editable install picks up the namespace registration before this PR lands.