### PR TITLE
feat(lineage): v4 S1 — column-level edge storage foundation

### DIFF
--- a/amx/lineage/operator_ops.py
+++ b/amx/lineage/operator_ops.py
@@ -1,0 +1,385 @@
+"""Operator-node persistence helpers for v4 column-level lineage.
+
+A transformation operator (filter / join / function / aggregate /
+projection) is stored as a synthetic ``catalog_entities`` row with
+``entity_kind='operator'`` so it shares the same FK column on
+``catalog_relationships`` as real tables and columns. The operator's
+expression and port metadata live in ``catalog_entities.search_text``
+(reused as a JSON blob — the column already accepts arbitrary text
+and is the only TEXT field without a stronger semantic on the table).
+
+Edges chain ``source_col → operator → target_col`` via two rows:
+
+* From source to operator: ``from_column = <source col>``,
+  ``to_column = <operator input port>`` (typically the same name).
+* From operator to target: ``from_column = <operator output port>``,
+  ``to_column = <target col>``.
+
+This file owns all writes that create / update / lookup operators so
+extractors and the Studio router never duplicate the synthetic-path
+encoding.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from amx.storage.sqlite_store import SQLiteHistoryStore
+
+OpKind = Literal["filter", "join", "function", "aggregate", "projection"]
+_VALID_OP_KINDS: frozenset[str] = frozenset(
+    {"filter", "join", "function", "aggregate", "projection"}
+)
+
+
+def _operator_path(*, schema: str, table: str, op_kind: str, expression: str) -> str:
+    """Synthetic path for an operator entity.
+
+    Format: ``op:<schema>.<table>:<op_kind>:<short_hash>``. The hash
+    keeps two operators of the same kind on the same anchor distinct
+    when their expressions differ (e.g. two filters with different
+    predicates).
+    """
+    digest = hashlib.sha1(
+        f"{schema}|{table}|{op_kind}|{expression}".encode(),
+        usedforsecurity=False,
+    ).hexdigest()[:8]
+    return f"op:{schema}.{table}:{op_kind}:{digest}"
+
+
+def encode_operator_details(
+    *,
+    op_kind: str,
+    expression: str,
+    input_columns: Iterable[dict[str, str]] = (),
+    output_columns: Iterable[dict[str, str]] = (),
+) -> str:
+    """Serialise an operator's payload for ``catalog_entities.search_text``.
+
+    The blob is JSON: ``{op_kind, expression, input_columns,
+    output_columns}``. Each column entry is ``{fqn, alias}``.
+    """
+    payload = {
+        "op_kind": str(op_kind),
+        "expression": str(expression or ""),
+        "input_columns": [
+            {"fqn": str(c.get("fqn") or ""), "alias": str(c.get("alias") or "")}
+            for c in input_columns
+        ],
+        "output_columns": [
+            {"fqn": str(c.get("fqn") or ""), "alias": str(c.get("alias") or "")}
+            for c in output_columns
+        ],
+    }
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def decode_operator_details(blob: str) -> dict[str, Any]:
+    """Parse an operator entity's stored payload. Returns ``{}`` on bad input."""
+    if not blob:
+        return {}
+    try:
+        data = json.loads(blob)
+    except (TypeError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def upsert_operator_entity(
+    hs: SQLiteHistoryStore,
+    *,
+    profile: str,
+    db_backend: str,
+    database: str,
+    schema: str,
+    table: str,
+    op_kind: str,
+    expression: str,
+    input_columns: Iterable[dict[str, str]] = (),
+    output_columns: Iterable[dict[str, str]] = (),
+) -> tuple[int, str]:
+    """Insert or refresh a synthetic operator entity.
+
+    Returns ``(entity_id, operator_path)``. Schema + table identify
+    the "anchor" the operator sits next to (typically the view or
+    target table the operator helps populate); the operator path is
+    stored in ``column_name`` so the unique key
+    ``(profile, database, schema, table, column_name, entity_kind)``
+    keeps two distinct operators apart.
+    """
+    if op_kind not in _VALID_OP_KINDS:
+        raise ValueError(f"op_kind must be one of {sorted(_VALID_OP_KINDS)}; got {op_kind!r}")
+    path = _operator_path(schema=schema, table=table, op_kind=op_kind, expression=expression)
+    details_json = encode_operator_details(
+        op_kind=op_kind,
+        expression=expression,
+        input_columns=input_columns,
+        output_columns=output_columns,
+    )
+    now = time.time()
+    with hs._lock, hs._connect() as conn:
+        row = conn.execute(
+            """
+            SELECT id FROM catalog_entities
+            WHERE db_profile = ? AND database_name = ? AND schema_name = ?
+              AND table_name = ? AND COALESCE(column_name, '') = ?
+              AND entity_kind = 'operator'
+            LIMIT 1
+            """,
+            (profile, database, schema, table, path),
+        ).fetchone()
+        if row:
+            entity_id = int(row[0])
+            conn.execute(
+                """
+                UPDATE catalog_entities
+                SET search_text = ?, updated_at = ?, asset_kind = 'operator'
+                WHERE id = ?
+                """,
+                (details_json, now, entity_id),
+            )
+            return entity_id, path
+
+        cur = conn.execute(
+            """
+            INSERT INTO catalog_entities
+                (db_profile, db_backend, database_name, schema_name, table_name,
+                 column_name, entity_kind, asset_kind, search_text,
+                 updated_at, last_synced_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'operator', 'operator', ?, ?, ?)
+            """,
+            (
+                profile,
+                db_backend,
+                database,
+                schema,
+                table,
+                path,
+                details_json,
+                now,
+                now,
+            ),
+        )
+        return int(cur.lastrowid or 0), path
+
+
+def write_column_edge(
+    hs: SQLiteHistoryStore,
+    *,
+    from_entity_id: int,
+    from_column: str,
+    to_entity_id: int,
+    to_column: str,
+    relationship_type: str,
+    score: float,
+    source: str,
+    details: dict[str, Any] | None = None,
+    verdict: str = "",
+    audit_actor: str = "",
+    audit_at: float | None = None,
+) -> int:
+    """Write a single column-level edge. Returns the row id.
+
+    Upserts on the logical key ``(from_entity_id, from_column,
+    to_entity_id, to_column, relationship_type)`` — re-inserting the
+    same column edge updates ``score``, ``details_json``,
+    ``last_seen``, and the audit fields without stacking duplicates.
+    """
+    details_json = json.dumps(details or {}, ensure_ascii=False)
+    now = time.time()
+    audit_ts = now if audit_at is None else float(audit_at)
+    with hs._lock, hs._connect() as conn:
+        conn.execute(
+            """
+            DELETE FROM catalog_relationships
+            WHERE from_entity_id = ? AND from_column = ?
+              AND to_entity_id = ? AND to_column = ?
+              AND relationship_type = ?
+            """,
+            (
+                int(from_entity_id),
+                str(from_column),
+                int(to_entity_id),
+                str(to_column),
+                str(relationship_type),
+            ),
+        )
+        cur = conn.execute(
+            """
+            INSERT INTO catalog_relationships
+                (from_entity_id, to_entity_id, relationship_type, score, source,
+                 details_json, last_seen, verdict, audit_actor, audit_at,
+                 from_column, to_column)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                int(from_entity_id),
+                int(to_entity_id),
+                str(relationship_type),
+                float(score),
+                str(source),
+                details_json,
+                now,
+                str(verdict),
+                str(audit_actor),
+                audit_ts,
+                str(from_column),
+                str(to_column),
+            ),
+        )
+        return int(cur.lastrowid or 0)
+
+
+def create_operator_with_edges(
+    hs: SQLiteHistoryStore,
+    *,
+    profile: str,
+    db_backend: str,
+    source_entity_id: int,
+    source_column: str,
+    target_entity_id: int,
+    target_column: str,
+    target_database: str,
+    target_schema: str,
+    target_table: str,
+    op_kind: str,
+    expression: str,
+    relationship_type: str = "lineage_view_ddl",
+    score: float = 1.0,
+    source: str = "view_ddl",
+    verdict: str = "",
+    audit_actor: str = "",
+) -> dict[str, Any]:
+    """Create an operator entity and the two flanking edges atomically.
+
+    The operator sits between ``source.column`` and ``target.column``.
+    Two rows land in ``catalog_relationships``:
+
+    1. ``source.column → operator(op_path)`` with ``to_column = source_column``
+       (the operator's input port mirrors the source column name).
+    2. ``operator(op_path) → target.column`` with ``from_column = target_column``
+       (the operator's output port mirrors the target column name).
+
+    Returns ``{operator_id, operator_path, edge_ids: [in, out]}``.
+    """
+    op_id, op_path = upsert_operator_entity(
+        hs,
+        profile=profile,
+        db_backend=db_backend,
+        database=target_database,
+        schema=target_schema,
+        table=target_table,
+        op_kind=op_kind,
+        expression=expression,
+        input_columns=[{"fqn": "", "alias": source_column}],
+        output_columns=[{"fqn": "", "alias": target_column}],
+    )
+
+    edge_in = write_column_edge(
+        hs,
+        from_entity_id=source_entity_id,
+        from_column=source_column,
+        to_entity_id=op_id,
+        to_column=source_column,
+        relationship_type=relationship_type,
+        score=score,
+        source=source,
+        details={"role": "operator_input", "op_path": op_path, "op_kind": op_kind},
+        verdict=verdict,
+        audit_actor=audit_actor,
+    )
+    edge_out = write_column_edge(
+        hs,
+        from_entity_id=op_id,
+        from_column=target_column,
+        to_entity_id=target_entity_id,
+        to_column=target_column,
+        relationship_type=relationship_type,
+        score=score,
+        source=source,
+        details={"role": "operator_output", "op_path": op_path, "op_kind": op_kind},
+        verdict=verdict,
+        audit_actor=audit_actor,
+    )
+    return {
+        "operator_id": op_id,
+        "operator_path": op_path,
+        "edge_ids": [edge_in, edge_out],
+    }
+
+
+def lookup_operator(
+    hs: SQLiteHistoryStore,
+    *,
+    operator_id: int,
+) -> dict[str, Any] | None:
+    """Read back an operator entity by id. Returns ``None`` when missing."""
+    with hs._connect() as conn:
+        row = conn.execute(
+            """
+            SELECT id, db_profile, database_name, schema_name, table_name,
+                   column_name, search_text, updated_at
+            FROM catalog_entities
+            WHERE id = ? AND entity_kind = 'operator'
+            LIMIT 1
+            """,
+            (int(operator_id),),
+        ).fetchone()
+    if not row:
+        return None
+    return {
+        "id": int(row[0]),
+        "profile": str(row[1] or ""),
+        "database": str(row[2] or ""),
+        "schema": str(row[3] or ""),
+        "table": str(row[4] or ""),
+        "operator_path": str(row[5] or ""),
+        "details": decode_operator_details(str(row[6] or "")),
+        "updated_at": float(row[7] or 0.0),
+    }
+
+
+def update_operator_expression(
+    hs: SQLiteHistoryStore,
+    *,
+    operator_id: int,
+    expression: str,
+) -> bool:
+    """Patch an operator's expression. Returns ``True`` when a row changed."""
+    current = lookup_operator(hs, operator_id=operator_id)
+    if not current:
+        return False
+    details = current.get("details") or {}
+    payload = encode_operator_details(
+        op_kind=str(details.get("op_kind") or "function"),
+        expression=expression,
+        input_columns=details.get("input_columns") or [],
+        output_columns=details.get("output_columns") or [],
+    )
+    now = time.time()
+    with hs._lock, hs._connect() as conn:
+        cur = conn.execute(
+            "UPDATE catalog_entities SET search_text = ?, updated_at = ? "
+            "WHERE id = ? AND entity_kind = 'operator'",
+            (payload, now, int(operator_id)),
+        )
+    return bool(cur.rowcount)
+
+
+__all__ = [
+    "OpKind",
+    "encode_operator_details",
+    "decode_operator_details",
+    "upsert_operator_entity",
+    "write_column_edge",
+    "create_operator_with_edges",
+    "lookup_operator",
+    "update_operator_expression",
+]

--- a/amx/storage/schema_descriptions.py
+++ b/amx/storage/schema_descriptions.py
@@ -934,6 +934,22 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
             "UTC epoch seconds of the last verdict change. NULL when "
             "the edge has not been touched by a user."
         ),
+        "from_column": (
+            "v4 column-level lineage. Source column name when this row "
+            "represents a column→column edge. Empty string keeps the "
+            "row at table grain (legacy v1–v3 behaviour). Combined "
+            "with from_entity_id, to_entity_id, to_column to form the "
+            "logical edge key. Operator-node edges set this when the "
+            "operator consumes the column."
+        ),
+        "to_column": (
+            "v4 column-level lineage. Destination column name when "
+            "this row represents a column→column edge. Empty for "
+            "table-grain rows. When the target is a synthetic "
+            "operator entity (entity_kind='operator'), this names the "
+            "operator's input port; otherwise it names the real "
+            "downstream column."
+        ),
     },
     # ── lineage_artifacts (local only) ────────────────────────────────────
     "lineage_artifacts": {

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -727,9 +727,22 @@ class SQLiteHistoryStore:
                 "ALTER TABLE catalog_relationships ADD COLUMN verdict TEXT NOT NULL DEFAULT ''",
                 "ALTER TABLE catalog_relationships ADD COLUMN audit_actor TEXT NOT NULL DEFAULT ''",
                 "ALTER TABLE catalog_relationships ADD COLUMN audit_at REAL",
+                # v4 — column-level lineage. Empty string keeps the
+                # row at table grain (legacy behaviour); non-empty
+                # promotes it to a column→column edge. Operator nodes
+                # (entity_kind='operator') hang off the same edge
+                # rows.
+                "ALTER TABLE catalog_relationships ADD COLUMN from_column TEXT NOT NULL DEFAULT ''",
+                "ALTER TABLE catalog_relationships ADD COLUMN to_column TEXT NOT NULL DEFAULT ''",
             ):
                 with contextlib.suppress(sqlite3.OperationalError):
                     conn.execute(_ddl)
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_catalog_relationships_column_grain "
+                    "ON catalog_relationships(from_entity_id, from_column, to_entity_id, to_column) "
+                    "WHERE from_column != '' OR to_column != ''"
+                )
             # ── lineage_artifacts: registry of rendered lineage diagrams ──
             # Each row binds a focal entity (anchor) to a rendered image
             # on disk plus the edge-set hash that produced it. Drives

--- a/amx/web/routers/lineage.py
+++ b/amx/web/routers/lineage.py
@@ -453,25 +453,72 @@ def _actor_name() -> str:
         return "studio"
 
 
-def _resolve_entity_id_strict(hs: Any, profile: str, fqn: str) -> int:
-    """Look up the catalog_entities.id for ``database.schema.table`` (or
-    ``schema.table``). Raises 404 with a clear message when missing.
+def _split_fqn_with_column(fqn: str) -> tuple[str, str, str, str]:
+    """Parse a 2/3/4-part FQN. Returns ``(database, schema, table, column)``.
+
+    Two parts: ``schema.table``. Three: ``database.schema.table`` —
+    column stays empty; callers that need a 3-part column FQN
+    (``schema.table.column``) should use
+    :func:`_split_fqn_resolve_column`, which falls back to the
+    column interpretation when the table lookup misses. Four parts:
+    ``database.schema.table.column``.
     """
     parts = [p for p in re.split(r"[./]", fqn) if p]
     if len(parts) == 2:
-        database, schema, table = "", parts[0], parts[1]
-    elif len(parts) == 3:
-        database, schema, table = parts[0], parts[1], parts[2]
-    else:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Could not parse FQN {fqn!r} (expected schema.table or database.schema.table).",
-        )
+        return "", parts[0], parts[1], ""
+    if len(parts) == 4:
+        return parts[0], parts[1], parts[2], parts[3]
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2], ""
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=(
+            f"Could not parse FQN {fqn!r} "
+            "(expected schema.table, database.schema.table, "
+            "or database.schema.table.column)."
+        ),
+    )
+
+
+def _split_fqn_resolve_column(hs: Any, profile: str, fqn: str) -> tuple[str, str, str, str]:
+    """Column-aware parser. Disambiguates 3-part FQNs by table lookup.
+
+    For 3-part inputs, first treats parts as ``database.schema.table``;
+    if no catalog row matches, retries as ``schema.table.column``.
+    """
+    parts = [p for p in re.split(r"[./]", fqn) if p]
+    if len(parts) != 3:
+        return _split_fqn_with_column(fqn)
+    db_cand, schema_cand, table_cand = parts
     with hs._connect() as conn:
-        # Try with the explicit database first; if empty, fall back to
-        # any database-scope so paths from the JSON payload (which
-        # always carry a database) and paths from the canvas (which
-        # may not) both work.
+        hit = conn.execute(
+            """
+            SELECT 1 FROM catalog_entities
+            WHERE db_profile = ? AND database_name = ?
+              AND schema_name = ? AND table_name = ?
+              AND entity_kind = 'table'
+            LIMIT 1
+            """,
+            (profile, db_cand, schema_cand, table_cand),
+        ).fetchone()
+    if hit:
+        return db_cand, schema_cand, table_cand, ""
+    return "", db_cand, schema_cand, table_cand
+
+
+def _resolve_entity_id_strict(hs: Any, profile: str, fqn: str) -> int:
+    """Look up the catalog_entities.id for the parent table of ``fqn``.
+
+    Accepts 2-, 3-, and 4-part FQNs. 3-part is disambiguated via
+    :func:`_split_fqn_resolve_column` so ``schema.table.column``
+    paths resolve to the table id. 4-part FQNs resolve to the
+    parent table id (the column part is intentionally dropped by
+    this helper; callers that need both the id and the column
+    should use :func:`_split_fqn_resolve_column` directly).
+    Raises 404 with a clear message when missing.
+    """
+    database, schema, table, _column = _split_fqn_resolve_column(hs, profile, fqn)
+    with hs._connect() as conn:
         if database:
             row = conn.execute(
                 """
@@ -513,11 +560,21 @@ def post_edge(
 
         {
           "profile": "local-postgre",
-          "source_fqn": "public.customers"   # or "db.public.customers"
-          "target_fqn": "public.orders",
-          "notes": "optional human note"
+          "source_fqn": "public.customers.id"     # or 2/3-part FQN
+          "target_fqn": "public.orders.customer_id",
+          "notes": "optional human note",
+          "source_column": "id",                  # optional override
+          "target_column": "customer_id"          # optional override
         }
+
+    When the FQN carries 4 parts (``database.schema.table.column``),
+    the rightmost segment is treated as the column. ``source_column``
+    / ``target_column`` in the body override the parsed value when
+    both are present — useful for hand-authored edges where the
+    canvas already knows the column independently from the FQN.
     """
+    from amx.lineage.operator_ops import write_column_edge
+
     profile = str(payload.get("profile") or "").strip()
     source_fqn = str(payload.get("source_fqn") or "").strip()
     target_fqn = str(payload.get("target_fqn") or "").strip()
@@ -540,38 +597,40 @@ def post_edge(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="History store not initialised.",
         )
+    _src_db, _src_schema, _src_table, src_column_from_fqn = _split_fqn_resolve_column(
+        hs, profile, source_fqn
+    )
+    _tgt_db, _tgt_schema, _tgt_table, tgt_column_from_fqn = _split_fqn_resolve_column(
+        hs, profile, target_fqn
+    )
     src_id = _resolve_entity_id_strict(hs, profile, source_fqn)
     tgt_id = _resolve_entity_id_strict(hs, profile, target_fqn)
+    src_column = str(payload.get("source_column") or src_column_from_fqn or "").strip()
+    tgt_column = str(payload.get("target_column") or tgt_column_from_fqn or "").strip()
     actor = _actor_name()
     now = time.time()
     details = {"notes": notes, "actor": actor, "ts": now}
 
-    with hs._lock, hs._connect() as conn:
-        # Upsert by (from, to, manual): re-drawing the same edge updates
-        # the verdict + audit fields rather than stacking duplicates.
-        conn.execute(
-            """
-            DELETE FROM catalog_relationships
-            WHERE from_entity_id = ? AND to_entity_id = ?
-              AND relationship_type = 'lineage_manual'
-            """,
-            (src_id, tgt_id),
-        )
-        cur = conn.execute(
-            """
-            INSERT INTO catalog_relationships
-                (from_entity_id, to_entity_id, relationship_type, score, source,
-                 details_json, last_seen, verdict, audit_actor, audit_at)
-            VALUES (?, ?, 'lineage_manual', 1.0, 'manual',
-                    ?, ?, 'approved', ?, ?)
-            """,
-            (src_id, tgt_id, json.dumps(details, ensure_ascii=False), now, actor, now),
-        )
-        edge_id = int(cur.lastrowid or 0)
+    edge_id = write_column_edge(
+        hs,
+        from_entity_id=src_id,
+        from_column=src_column,
+        to_entity_id=tgt_id,
+        to_column=tgt_column,
+        relationship_type="lineage_manual",
+        score=1.0,
+        source="manual",
+        details=details,
+        verdict="approved",
+        audit_actor=actor,
+        audit_at=now,
+    )
     return {
         "id": edge_id,
         "from": source_fqn,
         "to": target_fqn,
+        "from_column": src_column,
+        "to_column": tgt_column,
         "verdict": "approved",
         "audit_actor": actor,
         "audit_at": now,
@@ -647,6 +706,134 @@ def delete_edge(
     return None
 
 
+# ── v4 — column-level operator nodes ─────────────────────────────────────
+
+
+@router.post("/operators", status_code=status.HTTP_201_CREATED)
+def post_operator(
+    payload: dict[str, Any] = Body(...),
+    cfg: AMXConfig = Depends(get_cfg),
+) -> dict[str, Any]:
+    """Create a transformation operator and chain it between two columns.
+
+    Writes one ``catalog_entities`` row (the operator) plus two
+    ``catalog_relationships`` rows (in/out edges) atomically — see
+    :func:`amx.lineage.operator_ops.create_operator_with_edges`.
+
+    Body::
+
+        {
+          "profile": "local-postgre",
+          "source_fqn": "public.orders.amount",
+          "target_fqn": "public.daily_totals.gross",
+          "op_kind": "aggregate",
+          "expression": "SUM(amount)",
+          "relationship_type": "lineage_manual"   # optional, defaults to manual
+        }
+    """
+    from amx.lineage.operator_ops import create_operator_with_edges
+
+    profile = str(payload.get("profile") or "").strip()
+    source_fqn = str(payload.get("source_fqn") or "").strip()
+    target_fqn = str(payload.get("target_fqn") or "").strip()
+    op_kind = str(payload.get("op_kind") or "").strip().lower()
+    expression = str(payload.get("expression") or "").strip()
+    relationship_type = str(payload.get("relationship_type") or "lineage_manual").strip()
+    if not profile or not source_fqn or not target_fqn or not op_kind:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="profile, source_fqn, target_fqn, op_kind are required.",
+        )
+    profile = _resolve_profile(cfg, profile)
+    hs = history_store()
+    if hs is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="History store not initialised.",
+        )
+    src_id = _resolve_entity_id_strict(hs, profile, source_fqn)
+    tgt_id = _resolve_entity_id_strict(hs, profile, target_fqn)
+    _src_db, _src_sch, _src_tbl, src_col_from_fqn = _split_fqn_resolve_column(
+        hs, profile, source_fqn
+    )
+    tgt_db, tgt_schema, tgt_table, tgt_col_from_fqn = _split_fqn_resolve_column(
+        hs, profile, target_fqn
+    )
+    src_col = str(payload.get("source_column") or src_col_from_fqn or "").strip()
+    tgt_col = str(payload.get("target_column") or tgt_col_from_fqn or "").strip()
+    db_backend = _profile_backend(cfg, profile)
+    actor = _actor_name()
+    try:
+        result = create_operator_with_edges(
+            hs,
+            profile=profile,
+            db_backend=db_backend,
+            source_entity_id=src_id,
+            source_column=src_col,
+            target_entity_id=tgt_id,
+            target_column=tgt_col,
+            target_database=tgt_db,
+            target_schema=tgt_schema,
+            target_table=tgt_table,
+            op_kind=op_kind,
+            expression=expression,
+            relationship_type=relationship_type,
+            source="manual" if relationship_type == "lineage_manual" else "view_ddl",
+            verdict="approved" if relationship_type == "lineage_manual" else "",
+            audit_actor=actor,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    return {
+        "operator_id": result["operator_id"],
+        "operator_path": result["operator_path"],
+        "edge_ids": result["edge_ids"],
+        "op_kind": op_kind,
+        "expression": expression,
+    }
+
+
+@router.patch("/operators/{operator_id}")
+def patch_operator(
+    operator_id: int,
+    payload: dict[str, Any] = Body(...),
+    cfg: AMXConfig = Depends(get_cfg),
+) -> dict[str, Any]:
+    """Update an operator entity's expression."""
+    from amx.lineage.operator_ops import lookup_operator, update_operator_expression
+
+    expression = str(payload.get("expression") or "").strip()
+    hs = history_store()
+    if hs is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="History store not initialised.",
+        )
+    if not update_operator_expression(hs, operator_id=int(operator_id), expression=expression):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Operator {operator_id} not found.",
+        )
+    after = lookup_operator(hs, operator_id=int(operator_id))
+    return {
+        "operator_id": int(operator_id),
+        "expression": expression,
+        "operator_path": after["operator_path"] if after else "",
+    }
+
+
+def _profile_backend(cfg: AMXConfig, profile: str) -> str:
+    """Look up the active backend for a profile (best effort)."""
+    profiles = getattr(cfg, "db_profiles", {}) or {}
+    entry = profiles.get(profile)
+    if entry is None:
+        return ""
+    return str(getattr(entry, "backend", "") or "")
+
+
 @router.post("/manual", status_code=status.HTTP_201_CREATED)
 def post_manual_artifact(
     payload: dict[str, Any] = Body(...),
@@ -682,50 +869,48 @@ def post_manual_artifact(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="History store not initialised.",
         )
+    from amx.lineage.operator_ops import write_column_edge
+
     anchor_id = _resolve_entity_id_strict(hs, profile, anchor_fqn)
     actor = _actor_name()
     now = time.time()
     persisted = 0
-    with hs._lock, hs._connect() as conn:
-        for edge in edges_in:
-            if not isinstance(edge, dict):
-                continue
-            src = str(edge.get("source_fqn") or "").strip()
-            tgt = str(edge.get("target_fqn") or "").strip()
-            if not src or not tgt or src == tgt:
-                continue
-            try:
-                src_id = _resolve_entity_id_strict(hs, profile, src)
-                tgt_id = _resolve_entity_id_strict(hs, profile, tgt)
-            except HTTPException:
-                continue
-            details = {"actor": actor, "ts": now, "via": "manual_canvas"}
-            conn.execute(
-                """
-                DELETE FROM catalog_relationships
-                WHERE from_entity_id = ? AND to_entity_id = ?
-                  AND relationship_type = 'lineage_manual'
-                """,
-                (src_id, tgt_id),
-            )
-            conn.execute(
-                """
-                INSERT INTO catalog_relationships
-                    (from_entity_id, to_entity_id, relationship_type, score, source,
-                     details_json, last_seen, verdict, audit_actor, audit_at)
-                VALUES (?, ?, 'lineage_manual', 1.0, 'manual',
-                        ?, ?, 'approved', ?, ?)
-                """,
-                (
-                    src_id,
-                    tgt_id,
-                    json.dumps(details, ensure_ascii=False),
-                    now,
-                    actor,
-                    now,
-                ),
-            )
-            persisted += 1
+    for edge in edges_in:
+        if not isinstance(edge, dict):
+            continue
+        src = str(edge.get("source_fqn") or "").strip()
+        tgt = str(edge.get("target_fqn") or "").strip()
+        if not src or not tgt or src == tgt:
+            continue
+        try:
+            src_id = _resolve_entity_id_strict(hs, profile, src)
+            tgt_id = _resolve_entity_id_strict(hs, profile, tgt)
+        except HTTPException:
+            continue
+        _src_db, _src_schema, _src_table, src_col_from_fqn = _split_fqn_resolve_column(
+            hs, profile, src
+        )
+        _tgt_db, _tgt_schema, _tgt_table, tgt_col_from_fqn = _split_fqn_resolve_column(
+            hs, profile, tgt
+        )
+        src_col = str(edge.get("source_column") or src_col_from_fqn or "").strip()
+        tgt_col = str(edge.get("target_column") or tgt_col_from_fqn or "").strip()
+        details = {"actor": actor, "ts": now, "via": "manual_canvas"}
+        write_column_edge(
+            hs,
+            from_entity_id=src_id,
+            from_column=src_col,
+            to_entity_id=tgt_id,
+            to_column=tgt_col,
+            relationship_type="lineage_manual",
+            score=1.0,
+            source="manual",
+            details=details,
+            verdict="approved",
+            audit_actor=actor,
+            audit_at=now,
+        )
+        persisted += 1
 
     # Compute scope and render the artifact so it shows up on the
     # browse list immediately. We re-use create_lineage so the matplotlib

--- a/docs/superpowers/specs/2026-05-17-lineage-v4-column-level-design.md
+++ b/docs/superpowers/specs/2026-05-17-lineage-v4-column-level-design.md
@@ -1,0 +1,578 @@
+# AMX `/lineage` v4 — Column-Level Rewrite
+
+## Context
+
+V3 (PRs #503, #505, #506, #507) shipped a table-relationship canvas
+with manual edge authoring, verdict-driven LLM feedback, audit
+trail, share links, and a welcome hub. **It is the wrong product.**
+The user's reference throughout has been
+[PaveLuchkov/datapav](https://github.com/PaveLuchkov/datapav), which
+is a **column-level data-flow editor with first-class
+transformation-operator nodes** — not the table relationship canvas
+we built.
+
+Concrete gaps surfaced from a side-by-side read of datapav's README
+screenshot vs the current AMX lineage canvas:
+
+1. AMX renders one node per table, one edge per table-pair.
+   Datapav renders one node per table **with per-column rows**
+   carrying individual connector ports, and edges go column→column.
+2. AMX has no transformation-operator nodes. Datapav has
+   `completed_only` (filter), `compute_ltv` (function with
+   `INPUTS → OUTPUTS`), color-coded by operator kind, with the
+   operator's logic embedded and editable.
+3. AMX's chain-highlight is table-level. Datapav's
+   "Tracing column X" panel walks the upstream **column-by-column**
+   path and renders a numbered ORIGIN → HERE list.
+4. AMX has no in-place edit. Adding a table requires a modal;
+   connecting columns is impossible. Datapav lets you type a column
+   name into a row, change a filter predicate, add an output port
+   without leaving the canvas.
+5. AMX's drag-to-connect is node-level (whole-table to whole-table).
+   Datapav's affordance is a `+ & link` button on every column row;
+   drag is column-port to column-port.
+
+On top of the conceptual gap, two execution failures:
+
+6. The current canvas at `/lineage/:profile/:anchor` renders empty
+   or tiny in real use. Auto-fit is broken at high zoom levels.
+7. The default extractor set produces noisy results. **`name_match`
+   is the primary offender** — it joins any two columns sharing a
+   name across the catalog, regardless of semantic relation.
+
+This spec rewrites lineage as a column-level system that matches the
+datapav model while staying within AMX's "documentary, no execution
+engine" constraint.
+
+## Existing surfaces touched
+
+- `amx/lineage/types.py` — `Edge`, `ColumnRef`, `Scope`, `ExtractMode`
+- `amx/lineage/service.py` — `lineage_for_studio`, `suggest_lineage_llm*`
+- `amx/lineage/store.py` — read/write to `catalog_relationships`
+- `amx/lineage/extractors/{fk,view_ddl,query_log,name_match,llm,manual,codebase_scan}.py`
+- `amx/lineage/llm_prompt.py` — feedback-loop prompt builder
+- `amx/web/routers/lineage.py` — all `/api/lineage/*` endpoints
+- `amx/cli_support/commands/lineage.py` — `/lineage` REPL slash command
+- `amx/storage/sqlite_store.py` — DDL for `catalog_relationships`
+- `amx/storage/schema_descriptions.py` — column descriptions (CI-enforced)
+- `frontend/src/components/LineageCanvas.tsx` — React Flow canvas
+- `frontend/src/routes/LineageDetail.tsx` — artifact viewer
+- `frontend/src/routes/LineageNew.tsx` — blank-canvas authoring
+- `frontend/src/lib/api.ts` — typed lineage client
+
+## Roadmap
+
+| Slice | Theme | Studio-visible? | Ship verdict |
+|---|---|---|---|
+| **S1** | Storage + `Edge.column` round-trip | No | Build now |
+| **S2** | `view_ddl` → `sqlglot.lineage` with operator nodes | No | Build next |
+| **S3** | `TableNode` per-column ports + `OperatorNode` render + drag-from-port | Yes | After S2 |
+| **S4** | Trace panel (click column → ORIGIN→HERE path) | Yes | After S3 |
+| **S5** | Operator expression editor + `query_log` / `codebase_scan` / `llm` rewrite | Yes | After S4 |
+| **S6** | Polish: LOD, layout, `name_match` flag, v1→v2 migration banner, perf | Yes | After S5 |
+
+Each slice = `deploy.sh` → PR → merge (house rule #6) for the
+Studio-visible ones. S1+S2 are backend-only; the standard `git
+commit → PR → merge` order applies.
+
+---
+
+## Slice S1 — Storage + `Edge.column` round-trip
+
+### Storage
+
+Additive ALTER on `catalog_relationships` (mirrors the v3-S4
+`verdict` column pattern):
+
+```python
+for _ddl in (
+    "ALTER TABLE catalog_relationships ADD COLUMN from_column TEXT NOT NULL DEFAULT ''",
+    "ALTER TABLE catalog_relationships ADD COLUMN to_column TEXT NOT NULL DEFAULT ''",
+):
+    with contextlib.suppress(sqlite3.OperationalError):
+        conn.execute(_ddl)
+```
+
+Empty string = table-level edge (legacy). Non-empty = column-level
+edge. **`schema_descriptions.py` entries are mandatory in the same
+commit** (house rule #5).
+
+Index on `(db_profile, from_entity_id, from_column, to_entity_id,
+to_column)` to keep trace-panel BFS fast at 10k+ column edges.
+
+### Operator nodes
+
+Reuse `catalog_entities` with a new `entity_kind='operator'`,
+`asset_kind='operator'`. Path slug:
+`op:<schema>.<table>:<op_kind>:<short_hash>` so synthetic and real
+entities never collide. `details_json` carries:
+
+```json
+{
+    "op_kind": "filter|join|function|aggregate|projection",
+    "expression": "status == 'completed'",
+    "input_columns": [{"fqn": "public.orders_raw.status", "alias": "status"}],
+    "output_columns": [{"fqn": "public.completed_only.<row>", "alias": "<row>"}]
+}
+```
+
+No new table — `entity_kind` is already free-text per the
+descriptions in `schema_descriptions.py`.
+
+### `Edge` model
+
+`Edge` stays as-is (`ColumnRef` already has `.column`). The change
+is in the persistence layer + extractor output convention: empty
+`.column` is the legacy table-level signal.
+
+### `lineage_artifacts.payload_json`
+
+Bump `schema_version` 1 → 2. v2 payload carries:
+
+```json
+{
+    "schema_version": 2,
+    "nodes": [
+        {"kind": "table", "fqn": "public.orders", "columns": [...]},
+        {"kind": "operator", "id": "op:...", "op_kind": "filter", "expression": "..."}
+    ],
+    "edges": [{"from": "public.orders.id", "to": "op:...", "operator_id": null}]
+}
+```
+
+v1 readers (the existing canvas) keep working — server emits v1
+shape when the artifact has `schema_version=1`, v2 shape otherwise.
+
+### Tests (S1)
+
+- `tests/lineage/test_column_edge_persistence.py` — round-trip
+  `from_column`/`to_column` through `catalog_relationships`.
+- `tests/lineage/test_operator_entity.py` — insert an
+  `entity_kind='operator'` row, read back, assert `details_json`
+  parses.
+- `tests/lineage/test_v2_artifact_payload.py` — serialize +
+  deserialize a v2 artifact; v1 artifact still loads through v2
+  reader.
+- `tests/test_local_schema_comments.py` — already enforces; new
+  columns must have non-empty descriptions in
+  `schema_descriptions.py`.
+
+### Out of scope for S1
+
+No extractor changes yet. No UI changes. No new endpoints. S1 is
+the foundation that lets S2+ start emitting column edges without
+schema churn.
+
+---
+
+## Slice S2 — `view_ddl` extractor rewrite
+
+### Goal
+
+Replace the current `sqlglot.optimizer.qualify` + manual column
+walk in `view_ddl.py` with `sqlglot.lineage.lineage(column, sql)`.
+For each column in the view's SELECT, sqlglot returns a tree whose
+nodes carry the upstream column and the SQL fragment that
+transformed it. Walk that tree:
+
+- Leaf node = source column → emit `Edge(source_col → view.col)`
+  with `relationship_type='lineage_view_ddl'`.
+- Intermediate node with a non-trivial transform (filter predicate,
+  aggregate function, scalar function call, join condition) →
+  create an operator entity, emit two edges:
+  `source_col → operator` and `operator → view.col`.
+- Intermediate node with a pure pass-through (alias rename, no
+  expression change) → no operator; collapse into a single
+  `source_col → view.col` edge.
+
+### Operator-kind classification
+
+Map sqlglot expression types to `op_kind`:
+
+| sqlglot expression | op_kind |
+|---|---|
+| `Where` | `filter` |
+| `Group` / agg functions | `aggregate` |
+| `Join` | `join` |
+| Scalar function call | `function` |
+| `Cast`, `Alias` only | (no operator — pass-through) |
+
+`expression` field = the SQL fragment for that node, normalized
+through `sqlglot.transpile`.
+
+### Confidence
+
+`view_ddl` edges keep `confidence=1.0` — view DDL is authoritative.
+Operator nodes carry the same confidence as their producing edge.
+
+### Tests (S2)
+
+- `tests/lineage/test_view_ddl_column_lineage.py` — table of
+  view DDL → expected edges + operators.
+  - Simple `SELECT a, b FROM t` → 2 pass-through edges, no operators.
+  - `SELECT a FROM t WHERE status='ok'` → filter operator + edge chain.
+  - `SELECT sum(amount) FROM t GROUP BY country` → aggregate operator
+    with two output columns.
+  - `SELECT a.x FROM a JOIN b ON a.id=b.id` → join operator.
+  - `SELECT lower(name) FROM t` → function operator with `expression`
+    field set to `LOWER(name)`.
+
+### Out of scope for S2
+
+`query_log`, `codebase_scan`, `llm` extractor rewrites land in S5.
+Canvas changes land in S3.
+
+---
+
+## Slice S3 — `TableNode` + `OperatorNode` + drag-from-port
+
+### `TableNode` (new React Flow custom node)
+
+Structure (top-down):
+
+1. Header row: table fqn + asset-kind badge + collapse caret.
+2. One row per column. Row layout:
+   - Left port (`Handle id={column} type="target"`) flush to row edge.
+   - Type badge (`int`, `str`, `flt`, `dat`).
+   - Column name.
+   - Right port (`Handle id={column} type="source"`) flush to row edge.
+   - Hover state: green `+` button overlays the right port (datapav
+     affordance) — clicking it starts a connection drag.
+
+Tailwind tokens that already exist on the canvas:
+`bg-slate-900/80`, `border-slate-700`, hover state via `group/row`.
+
+### `OperatorNode` (new React Flow custom node)
+
+Structure:
+
+1. Header: op_kind icon (Filter / Join / Function / Aggregate) +
+   op_kind label.
+2. Body: inline `<code>` rendering of `expression`. Read-only in
+   S3 (editor lands in S5).
+3. Left side: one port per input column.
+4. Right side: one port per output column.
+
+Color tokens by op_kind:
+- `filter` — orange `border-orange-500/60`
+- `join` — purple `border-purple-500/60`
+- `aggregate` — cyan `border-cyan-500/60`
+- `function` — green `border-green-500/60`
+- `projection` — slate `border-slate-500/60`
+
+### React Flow wiring
+
+`nodesConnectable={true}` (already on from V3 S4) and
+`isValidConnection` rejects:
+- self-connections on the same column,
+- connections that would create a cycle within an artifact.
+
+`onConnect` payload now carries `source` (column), `sourceHandle`
+(column name), `target` (column), `targetHandle` — POSTs
+`/api/lineage/edges` with all four.
+
+### Layout
+
+Two-pass:
+1. dagre on `{TableNode, OperatorNode}` → produces x/y for each
+   parent node.
+2. Per-column row positions are determined by the React Flow node
+   layout itself (rows stack inside the node DOM). React Flow's
+   `Handle` positions are relative to the node, so edges connect
+   correctly without manual port coordinate math.
+
+### Endpoint changes
+
+`GET /api/lineage/{anchor}` returns v2 payload (see S1 schema)
+when the artifact is v2. `POST /api/lineage/edges` extended:
+
+```json
+{
+    "from_fqn": "public.orders.id",
+    "to_fqn": "public.customers.order_id",
+    "relationship_type": "lineage_manual"
+}
+```
+
+Server parses the fqn into `(schema, table, column)`, resolves
+entity ids, writes the row.
+
+### Tests (S3)
+
+- `tests/web/test_lineage_router_column_edges.py` — POST with column
+  fqns, assert `catalog_relationships` row has
+  `from_column`/`to_column` populated.
+- Frontend Vitest: `LineageCanvas.test.tsx` — render a v2 payload
+  with 2 tables + 1 operator, assert `Handle` count matches column
+  count, drag synthetic event emits the correct POST payload.
+
+### Out of scope for S3
+
+Trace panel (S4). Operator editor (S5). LOD (S6).
+
+---
+
+## Slice S4 — Trace panel
+
+### Goal
+
+Datapav's "Tracing column X" panel: click any column row, the
+right rail shows the numbered ORIGIN → HERE upstream path. Click a
+step in the list to fitView on that node + highlight the column.
+
+### Backend
+
+`GET /api/lineage/trace/{profile}?from_table=&from_column=` —
+server-side BFS over `catalog_relationships` where
+`from_column`/`to_column` are non-empty, returns ordered list of
+`{step_no, table, column, edge_kind, operator?}`. Cap at depth 50;
+beyond that the panel shows "Path truncated, deeper edges may
+exist."
+
+### Frontend
+
+`LineageTracePanel.tsx` — right rail component:
+
+- Header: `Tracing column <fqn>`, close `×` button.
+- `ORIGIN` section: list of source-leaf rows.
+- Trail: numbered list of intermediate steps; operator steps
+  render the op_kind icon.
+- `HERE` section: the clicked column highlighted.
+- Click any step → `useReactFlow().fitView({nodes: [step.id]})`
+  and apply transient highlight class for 1.5s.
+
+Click handler on `TableNode` column rows fires panel open. URL
+state via search param `?trace=public.customers.ltv_score` so the
+panel survives page reload.
+
+### Tests (S4)
+
+- `tests/web/test_lineage_trace_endpoint.py` — seed a 3-hop column
+  chain, assert returned steps in order, assert depth cap honored.
+- Frontend Vitest: `LineageTracePanel.test.tsx` — given trace
+  payload, assert correct rendering + click handler fires `fitView`.
+
+### Out of scope for S4
+
+Downstream tracing (HERE → consumers). Defer to S6 polish.
+
+---
+
+## Slice S5 — Operator editor + extractor rewrites
+
+### Operator expression editor
+
+`OperatorNode` body becomes an inline `<textarea>` in edit mode.
+Toggle via double-click on the operator. Save = blur or Enter (with
+shift+Enter for newline). PATCH
+`/api/lineage/operators/{id}` writes back to
+`catalog_entities.details_json.expression`.
+
+Expression text is treated as opaque SQL — AMX does not validate or
+execute it. Optional `sqlglot.parse(expression)` check surfaces a
+warning toast if unparseable; the save still goes through (user
+might be drafting).
+
+### `query_log` rewrite
+
+Currently emits table co-occurrence from `analysis_runs.scope_json`
+and `chat_turns.tables_json`. Replace with: for each SQL captured
+in those tables, run the same `sqlglot.lineage.lineage()` walk
+used in S2, emit column edges + operators with
+`relationship_type='lineage_query_log'`. Unparseable SQL is
+skipped silently. **Confidence 0.7** (lower than view_ddl because
+query log may include exploratory or ad-hoc SQL).
+
+### `codebase_scan` rewrite
+
+Same sqlglot path. For each indexed chunk from
+`amx.codebase.code_rag`, parse, emit column edges with
+`relationship_type='lineage_codebase'`, evidence `path:line`.
+Confidence 0.6.
+
+### `llm` rewrite
+
+`amx/lineage/llm_prompt.py` builds messages asking the LLM to
+return:
+
+```json
+{
+    "edges": [
+        {
+            "from_fqn": "public.orders.customer_id",
+            "to_fqn": "public.customers.id",
+            "operator_kind": null,
+            "expression": null,
+            "confidence": 0.75,
+            "reasoning": "naming convention + FK pattern"
+        }
+    ]
+}
+```
+
+Feedback loop (verdict-aware few-shot from V3 S5) keeps working;
+positive/negative examples now reference column pairs instead of
+table pairs.
+
+### `name_match` move
+
+`name_match` extractor stays in the codebase but is **removed from
+`build_default_extractors()`**. Add `cfg.lineage.include_heuristics:
+bool = False`. CLI flag `/lineage refresh --include-heuristics`
+opt-in. Studio: checkbox in the AI Suggest modal labeled "Include
+heuristic name-match (high false-positive rate)".
+
+### `manual` extension
+
+`ManualEdgeExtractor.extract` now reads column fields. Manual
+operator creation supported: a `POST /api/lineage/operators`
+endpoint creates an operator entity + two chained edges in one
+transaction.
+
+### Tests (S5)
+
+- `tests/lineage/test_query_log_column_extraction.py`
+- `tests/lineage/test_codebase_scan_column_extraction.py`
+- `tests/lineage/test_llm_column_prompt.py` — prompt builder
+  snapshot.
+- `tests/web/test_lineage_operator_patch.py` — operator
+  expression update round-trip.
+
+---
+
+## Slice S6 — Polish
+
+### Level-of-detail rendering
+
+When `useReactFlow().getZoom() < 0.5`, collapse every `TableNode`
+into header + `N cols` badge. When ≥0.5, restore per-column rows.
+Pure CSS toggle keyed off a class on the canvas root; no React
+re-render churn.
+
+### Empty-canvas fix
+
+Auto-fit on mount: `useEffect(() => fitView({padding: 0.2}), [])`
+after nodes are laid out. Empty results render a centered
+"No lineage detected yet — try AI suggest or draw manually" card
+instead of a tiny graph in the bottom-left.
+
+### v1 → v2 migration banner
+
+`/lineage/saved` shows an "Upgrade to column-level view" button on
+v1 artifacts. Click → `POST /api/lineage/{anchor}/refresh?mode=v2`
+re-runs the (now column-level) extractors and persists a v2
+artifact. The v1 artifact is kept; v2 supersedes for canvas
+rendering.
+
+### Layout pass
+
+Dagre `rankdir: 'LR'` (already) + per-rank `nodesep` tuned for
+column-heavy nodes. Operator nodes drawn between their producer
+and consumer ranks rather than as siblings.
+
+### Performance
+
+- `onlyRenderVisibleElements` threshold dropped from 200 → 100
+  since column ports inflate React Flow's internal node count.
+- `LineageTracePanel` BFS memoized on the edge set.
+- Edge style switch (`type`/`color`) moved to a stable lookup
+  table at module scope (small win, avoids per-render allocations).
+
+### Tests (S6)
+
+- `tests/lineage/test_v1_to_v2_migration.py` — `/refresh?mode=v2`
+  on a v1 artifact produces a v2 payload.
+- `tests/lineage/test_perf_budget.py` — extend with a column-level
+  budget: 200 tables × 8 cols stays under 1.5 s warm cache.
+
+---
+
+## Cross-cutting concerns
+
+- **English-only** on every new tracked file (comments, prompts,
+  fixtures, tests, UI strings). House rule #4.
+- **Cross-platform paths.** All file evidence uses POSIX-style
+  relative paths via `Path(...).as_posix()`. House rule #10.
+- **Cache-first.** Every extractor stays on `mode='cache_only'` by
+  default. LLM is opt-in. No silent wire calls.
+- **Modular files.** `LineageCanvas.tsx` is already 426 lines; do
+  not let it grow past ~600. Extract `TableNode.tsx`,
+  `OperatorNode.tsx`, `LineageTracePanel.tsx` as separate files
+  under `frontend/src/components/lineage/`. House rule #8.
+- **Schema descriptions mandatory.** New columns
+  (`from_column`, `to_column`) ship with descriptions in
+  `schema_descriptions.py` in the same commit. House rule #5.
+- **Deploy order.** S3+ slices use `deploy.sh` → PR → merge per
+  house rule #6.
+
+## Out of scope (explicitly deferred)
+
+- Execution engine. Operators are documentary, populated
+  automatically from sqlglot. The user can manually create
+  operators in the canvas; AMX never runs them.
+- Cross-profile / cross-database column lineage. dbt manifest
+  ingestion stays out (was originally in V3 S5 sketch). One
+  profile per canvas.
+- Real-time collaborative editing. Single-user assumption holds.
+- Downstream tracing UI (HERE → consumers panel). S6 candidate if
+  it doesn't bloat polish.
+- Lineage diff across two timestamps.
+- Playwright visual regression. Defer to a separate hardening pass.
+
+## Verification per slice
+
+1. `pytest tests/lineage -q` green.
+2. `pytest tests/test_local_schema_comments.py tests/test_shared_schema_comments.py -q` green.
+3. `npx tsc --noEmit && npm run build` (frontend) green for S3+.
+4. **Manual smoke** (the "eline sağlık" sequence, V4 version):
+   - Open `/lineage/:profile/:anchor` for a view with a known
+     non-trivial DDL → see column rows on every table, operator
+     nodes between them with the correct expressions.
+   - Click any column row → trace panel shows ORIGIN → HERE list.
+   - Click a step → canvas zooms to that node, column highlights.
+   - Drag a column's `+` port to another table's column → edge
+     persists, reappears on reload.
+   - Double-click an operator → expression editor opens, edit,
+     save → details_json updates.
+   - Schema page "AI suggest" → returns column-level edges, not
+     table pairs.
+   - `name_match` is off by default; opt-in via checkbox produces
+     visibly more edges (and visibly more noise).
+5. CI green on every PR.
+
+## Migration story for existing users
+
+- Existing v1 artifacts continue to render as table-level on the
+  current canvas component (the v2 reader downgrades gracefully
+  when the artifact's `schema_version=1`).
+- The `/lineage/saved` page surfaces an "Upgrade to column-level"
+  button per artifact (S6).
+- v2 is the default for any new artifact created after S1 ships.
+- Drop of `name_match` from defaults will reduce edge count on
+  subsequent `refresh` calls — that is the intended behavior and
+  not a regression.
+
+## Critical files (creation order)
+
+- `amx/storage/sqlite_store.py` — S1 ALTER
+- `amx/storage/schema_descriptions.py` — S1 descriptions
+- `amx/lineage/types.py` — S1 (no model change; documentation)
+- `amx/lineage/store.py` — S1 column-field persistence
+- `amx/lineage/service.py` — S1 v2 payload assembly + S2 operator
+  integration
+- `amx/lineage/extractors/view_ddl.py` — S2 sqlglot.lineage rewrite
+- `amx/lineage/operator_ops.py` (new) — S1 helper for creating
+  operator entities + chained edges atomically
+- `frontend/src/components/lineage/TableNode.tsx` (new) — S3
+- `frontend/src/components/lineage/OperatorNode.tsx` (new) — S3
+- `frontend/src/components/lineage/LineageTracePanel.tsx` (new) — S4
+- `frontend/src/components/LineageCanvas.tsx` — S3 wire new nodes,
+  S6 LOD class toggle
+- `amx/web/routers/lineage.py` — S3 column-aware POST, S4 trace
+  endpoint, S5 operator PATCH
+- `amx/lineage/extractors/query_log.py` — S5 sqlglot rewrite
+- `amx/lineage/extractors/codebase_scan.py` — S5 sqlglot rewrite
+- `amx/lineage/extractors/llm.py` — S5 column-pair prompt
+- `amx/lineage/llm_prompt.py` — S5 column-pair message shape
+- `amx/cli_support/commands/lineage.py` — S5
+  `--include-heuristics` flag

--- a/tests/lineage/test_operator_ops.py
+++ b/tests/lineage/test_operator_ops.py
@@ -1,0 +1,220 @@
+"""v4 S1 — operator entity + column-level edge persistence."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from amx.lineage.operator_ops import (
+    create_operator_with_edges,
+    decode_operator_details,
+    encode_operator_details,
+    lookup_operator,
+    update_operator_expression,
+    upsert_operator_entity,
+    write_column_edge,
+)
+
+from .conftest import seed_table_entity
+
+
+def test_operator_path_is_deterministic_for_same_inputs():
+    a = encode_operator_details(op_kind="filter", expression="status = 'ok'")
+    b = encode_operator_details(op_kind="filter", expression="status = 'ok'")
+    assert a == b
+
+
+def test_encode_decode_round_trip():
+    blob = encode_operator_details(
+        op_kind="aggregate",
+        expression="SUM(amount)",
+        input_columns=[{"fqn": "public.t.amount", "alias": "amount"}],
+        output_columns=[{"fqn": "public.daily.gross", "alias": "gross"}],
+    )
+    out = decode_operator_details(blob)
+    assert out["op_kind"] == "aggregate"
+    assert out["expression"] == "SUM(amount)"
+    assert out["input_columns"][0]["alias"] == "amount"
+    assert out["output_columns"][0]["fqn"] == "public.daily.gross"
+
+
+def test_upsert_operator_entity_creates_then_updates(hs):
+    seed_table_entity(hs, schema="public", table="daily_totals")
+    op_id, path = upsert_operator_entity(
+        hs,
+        profile="p",
+        db_backend="postgresql",
+        database="",
+        schema="public",
+        table="daily_totals",
+        op_kind="aggregate",
+        expression="SUM(amount)",
+    )
+    assert op_id > 0
+    assert path.startswith("op:public.daily_totals:aggregate:")
+
+    # Same inputs → same row (upsert).
+    op_id_again, path_again = upsert_operator_entity(
+        hs,
+        profile="p",
+        db_backend="postgresql",
+        database="",
+        schema="public",
+        table="daily_totals",
+        op_kind="aggregate",
+        expression="SUM(amount)",
+    )
+    assert op_id_again == op_id
+    assert path_again == path
+
+
+def test_upsert_rejects_unknown_op_kind(hs):
+    with pytest.raises(ValueError):
+        upsert_operator_entity(
+            hs,
+            profile="p",
+            db_backend="postgresql",
+            database="",
+            schema="public",
+            table="t",
+            op_kind="frobnicate",
+            expression="x",
+        )
+
+
+def test_write_column_edge_round_trip(hs):
+    src = seed_table_entity(hs, schema="public", table="orders")
+    tgt = seed_table_entity(hs, schema="public", table="customers")
+    edge_id = write_column_edge(
+        hs,
+        from_entity_id=src,
+        from_column="customer_id",
+        to_entity_id=tgt,
+        to_column="id",
+        relationship_type="lineage_fk",
+        score=1.0,
+        source="database",
+    )
+    assert edge_id > 0
+    with hs._connect() as conn:
+        row = conn.execute(
+            "SELECT from_column, to_column, relationship_type, score "
+            "FROM catalog_relationships WHERE id = ?",
+            (edge_id,),
+        ).fetchone()
+    assert row[0] == "customer_id"
+    assert row[1] == "id"
+    assert row[2] == "lineage_fk"
+    assert float(row[3]) == 1.0
+
+
+def test_write_column_edge_upserts_on_logical_key(hs):
+    src = seed_table_entity(hs, schema="public", table="orders")
+    tgt = seed_table_entity(hs, schema="public", table="customers")
+    first = write_column_edge(
+        hs,
+        from_entity_id=src,
+        from_column="customer_id",
+        to_entity_id=tgt,
+        to_column="id",
+        relationship_type="lineage_fk",
+        score=0.5,
+        source="db",
+    )
+    second = write_column_edge(
+        hs,
+        from_entity_id=src,
+        from_column="customer_id",
+        to_entity_id=tgt,
+        to_column="id",
+        relationship_type="lineage_fk",
+        score=1.0,
+        source="db",
+    )
+    assert second != first  # New row id (delete + insert).
+    with hs._connect() as conn:
+        rows = conn.execute(
+            "SELECT score FROM catalog_relationships "
+            "WHERE from_entity_id = ? AND to_entity_id = ? "
+            "AND from_column = ? AND to_column = ?",
+            (src, tgt, "customer_id", "id"),
+        ).fetchall()
+    assert len(rows) == 1  # Only the latest survives.
+    assert float(rows[0][0]) == 1.0
+
+
+def test_create_operator_with_edges_writes_three_rows(hs):
+    src = seed_table_entity(hs, schema="public", table="orders")
+    tgt = seed_table_entity(hs, schema="public", table="daily_totals")
+    result = create_operator_with_edges(
+        hs,
+        profile="p",
+        db_backend="postgresql",
+        source_entity_id=src,
+        source_column="amount",
+        target_entity_id=tgt,
+        target_column="gross",
+        target_database="",
+        target_schema="public",
+        target_table="daily_totals",
+        op_kind="aggregate",
+        expression="SUM(amount)",
+    )
+    assert result["operator_id"] > 0
+    assert len(result["edge_ids"]) == 2
+
+    with hs._connect() as conn:
+        op_count = conn.execute(
+            "SELECT COUNT(*) FROM catalog_entities WHERE entity_kind = 'operator'"
+        ).fetchone()[0]
+        edge_rows = conn.execute(
+            "SELECT from_entity_id, to_entity_id, from_column, to_column, details_json "
+            "FROM catalog_relationships ORDER BY id"
+        ).fetchall()
+    assert op_count == 1
+    assert len(edge_rows) == 2
+
+    in_row, out_row = edge_rows
+    # source → operator
+    assert in_row[0] == src
+    assert in_row[1] == result["operator_id"]
+    assert in_row[2] == "amount"
+    # operator → target
+    assert out_row[0] == result["operator_id"]
+    assert out_row[1] == tgt
+    assert out_row[3] == "gross"
+    # Details_json carries role + op_kind for both flank edges.
+    in_details = json.loads(in_row[4])
+    out_details = json.loads(out_row[4])
+    assert in_details["role"] == "operator_input"
+    assert out_details["role"] == "operator_output"
+    assert in_details["op_kind"] == "aggregate"
+
+
+def test_lookup_and_update_operator(hs):
+    seed_table_entity(hs, schema="public", table="t")
+    op_id, _ = upsert_operator_entity(
+        hs,
+        profile="p",
+        db_backend="postgresql",
+        database="",
+        schema="public",
+        table="t",
+        op_kind="filter",
+        expression="x > 0",
+    )
+    info = lookup_operator(hs, operator_id=op_id)
+    assert info is not None
+    assert info["details"]["expression"] == "x > 0"
+
+    changed = update_operator_expression(hs, operator_id=op_id, expression="x > 10")
+    assert changed is True
+    after = lookup_operator(hs, operator_id=op_id)
+    assert after is not None
+    assert after["details"]["expression"] == "x > 10"
+    assert after["details"]["op_kind"] == "filter"
+
+
+def test_update_operator_missing_returns_false(hs):
+    assert update_operator_expression(hs, operator_id=9999, expression="x") is False

--- a/tests/web/test_lineage_column_edges.py
+++ b/tests/web/test_lineage_column_edges.py
@@ -1,0 +1,179 @@
+"""v4 S1 — column-level POST /edges + POST /operators + PATCH /operators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amx.config import DBConfig
+from amx.storage import sqlite_store as sqlite_store_module
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture()
+def seeded_hs(tmp_path: Path, monkeypatch):
+    hs = SQLiteHistoryStore(tmp_path / "history.db")
+    hs.init()
+    with hs._connect() as conn:
+        conn.execute(
+            "INSERT INTO catalog_entities "
+            "(db_profile, db_backend, database_name, schema_name, table_name, "
+            "entity_kind, asset_kind) VALUES (?,?,?,?,?,?,?)",
+            ("local", "postgresql", "", "public", "orders", "table", "table"),
+        )
+        conn.execute(
+            "INSERT INTO catalog_entities "
+            "(db_profile, db_backend, database_name, schema_name, table_name, "
+            "entity_kind, asset_kind) VALUES (?,?,?,?,?,?,?)",
+            ("local", "postgresql", "", "public", "customers", "table", "table"),
+        )
+        conn.execute(
+            "INSERT INTO catalog_entities "
+            "(db_profile, db_backend, database_name, schema_name, table_name, "
+            "entity_kind, asset_kind) VALUES (?,?,?,?,?,?,?)",
+            ("local", "postgresql", "", "public", "daily_totals", "table", "table"),
+        )
+    monkeypatch.setattr(sqlite_store_module, "_store", hs, raising=False)
+    return hs
+
+
+@pytest.fixture()
+def cfg(cfg):
+    cfg.db_profiles = {"local": DBConfig(backend="postgresql", database="")}
+    cfg.active_db_profile = "local"
+    return cfg
+
+
+def test_post_edge_persists_columns_from_4_part_fqn(seeded_hs, client, auth_headers):
+    r = client.post(
+        "/api/lineage/edges",
+        headers=auth_headers,
+        json={
+            "profile": "local",
+            "source_fqn": "public.customers.id",
+            "target_fqn": "public.orders.customer_id",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["from_column"] == "id"
+    assert body["to_column"] == "customer_id"
+
+    with seeded_hs._connect() as conn:
+        row = conn.execute(
+            "SELECT from_column, to_column FROM catalog_relationships WHERE id = ?",
+            (body["id"],),
+        ).fetchone()
+    assert row[0] == "id"
+    assert row[1] == "customer_id"
+
+
+def test_post_edge_falls_back_to_table_level_when_no_column(seeded_hs, client, auth_headers):
+    r = client.post(
+        "/api/lineage/edges",
+        headers=auth_headers,
+        json={
+            "profile": "local",
+            "source_fqn": "public.customers",
+            "target_fqn": "public.orders",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["from_column"] == ""
+    assert body["to_column"] == ""
+
+
+def test_post_edge_body_column_overrides_fqn(seeded_hs, client, auth_headers):
+    r = client.post(
+        "/api/lineage/edges",
+        headers=auth_headers,
+        json={
+            "profile": "local",
+            "source_fqn": "public.customers.id",
+            "target_fqn": "public.orders.customer_id",
+            "source_column": "primary_key",
+            "target_column": "fk_customer",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["from_column"] == "primary_key"
+    assert body["to_column"] == "fk_customer"
+
+
+def test_post_operator_chains_two_edges(seeded_hs, client, auth_headers):
+    r = client.post(
+        "/api/lineage/operators",
+        headers=auth_headers,
+        json={
+            "profile": "local",
+            "source_fqn": "public.orders.amount",
+            "target_fqn": "public.daily_totals.gross",
+            "op_kind": "aggregate",
+            "expression": "SUM(amount)",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["operator_id"] > 0
+    assert body["op_kind"] == "aggregate"
+    assert body["expression"] == "SUM(amount)"
+    assert len(body["edge_ids"]) == 2
+
+    with seeded_hs._connect() as conn:
+        op_count = conn.execute(
+            "SELECT COUNT(*) FROM catalog_entities WHERE entity_kind = 'operator'"
+        ).fetchone()[0]
+        edge_count = conn.execute("SELECT COUNT(*) FROM catalog_relationships").fetchone()[0]
+    assert op_count == 1
+    assert edge_count == 2
+
+
+def test_post_operator_rejects_invalid_op_kind(seeded_hs, client, auth_headers):
+    r = client.post(
+        "/api/lineage/operators",
+        headers=auth_headers,
+        json={
+            "profile": "local",
+            "source_fqn": "public.orders.amount",
+            "target_fqn": "public.daily_totals.gross",
+            "op_kind": "frobnicate",
+            "expression": "x",
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_patch_operator_updates_expression(seeded_hs, client, auth_headers):
+    create = client.post(
+        "/api/lineage/operators",
+        headers=auth_headers,
+        json={
+            "profile": "local",
+            "source_fqn": "public.orders.amount",
+            "target_fqn": "public.daily_totals.gross",
+            "op_kind": "aggregate",
+            "expression": "SUM(amount)",
+        },
+    )
+    assert create.status_code == 201, create.text
+    op_id = create.json()["operator_id"]
+
+    r = client.patch(
+        f"/api/lineage/operators/{op_id}",
+        headers=auth_headers,
+        json={"expression": "SUM(amount * fx_rate)"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["expression"] == "SUM(amount * fx_rate)"
+
+
+def test_patch_operator_404_when_missing(seeded_hs, client, auth_headers):
+    r = client.patch(
+        "/api/lineage/operators/99999",
+        headers=auth_headers,
+        json={"expression": "x"},
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

First slice of the v4 column-level lineage rewrite. **Backend-only** — no Studio surface yet, v3 canvas keeps rendering exactly as before. Foundation that S2 (view_ddl→sqlglot.lineage with operator nodes) and S3 (TableNode per-column ports) build on.

Full spec: \`docs/superpowers/specs/2026-05-17-lineage-v4-column-level-design.md\`

### Storage
- Additive ALTER on \`catalog_relationships\`: \`from_column TEXT DEFAULT ''\`, \`to_column TEXT DEFAULT ''\`. Empty = table grain (legacy v1-v3); non-empty = column->column edge.
- Partial index on the column-grain key for trace-panel BFS perf.
- Matching descriptions in \`schema_descriptions.py\` (house rule #5).

### Operator-node persistence
\`amx/lineage/operator_ops.py\` owns all writes that touch synthetic operator entities (\`entity_kind='operator'\`):
- \`upsert_operator_entity\` — idempotent on the deterministic path \`op:<schema>.<table>:<op_kind>:<hash>\`.
- \`write_column_edge\` — upserts on the logical column-grain key.
- \`create_operator_with_edges\` — chains source_col → operator → target_col atomically.
- \`lookup_operator\` / \`update_operator_expression\` for the PATCH endpoint.

### Router
- \`POST /api/lineage/edges\` persists \`from_column\` / \`to_column\` from 4-part FQNs, 3-part \`schema.table.column\` (disambiguated via catalog probe), or explicit body overrides.
- \`POST /api/lineage/manual\` rewires every saved-canvas edge to the column-aware writer.
- New \`POST /api/lineage/operators\` and \`PATCH /api/lineage/operators/{id}\` round out the operator API.

### Out of scope
S1 does **not** touch extractors, \`lineage_for_studio\` payload assembly, or the canvas. v3 artifacts continue to render as table-level. Column-level edges only start appearing once S2 lands.

## Test plan
- [x] \`pytest tests/lineage tests/web -q\` — 510 pass.
- [x] \`pytest --ignore=tests/eval -q\` — 2551 pass, 9 pre-existing skips (+16 new from this slice).
- [x] \`ruff check + ruff format --check\` on touched files.
- [x] \`pytest tests/test_local_schema_comments.py -q\` — schema-description CI gate green for the new columns.