### PR TITLE
feat(lineage): v4 S2 — view_ddl surfaces operator metadata on edges

### DIFF
--- a/amx/lineage/extractors/view_ddl.py
+++ b/amx/lineage/extractors/view_ddl.py
@@ -22,9 +22,11 @@ from amx.lineage.types import (
     Edge,
     ExtractMode,
     ExtractResult,
+    OperatorMeta,
     Scope,
     ScopeFragment,
 )
+from amx.lineage.view_ddl_operators import classify_projection
 
 # Adapter dialect → sqlglot dialect tag. Adapters that already match
 # sqlglot's name are absent from this map (sqlglot accepts the same
@@ -223,7 +225,14 @@ def _parse_view_lineage(
             if not alias:
                 continue
             sources = _collect_source_columns(sqlglot, projection, alias_map)
-            out.append({"target": str(alias), "sources": sources})
+            entry: dict[str, Any] = {"target": str(alias), "sources": sources}
+            op_meta = classify_projection(sqlglot, projection)
+            if op_meta is not None:
+                entry["operator"] = {
+                    "op_kind": op_meta.op_kind,
+                    "expression": op_meta.expression,
+                }
+            out.append(entry)
         return out, "ok", ""
     except Exception as exc:  # defensive
         return None, "parse_failed", str(exc).splitlines()[0][:200]
@@ -335,7 +344,14 @@ def _edges_from_cached(
     database: str,
     schema: str,
 ) -> Any:
-    """Emit ``Edge``s from already-parsed cache rows."""
+    """Emit ``Edge``s from already-parsed cache rows.
+
+    When the cached entry carries an ``operator`` payload (v4
+    parsed_lineage shape), every edge produced for that target
+    column carries the same :class:`OperatorMeta` so the Studio
+    canvas can draw an inline operator node between the source and
+    the target.
+    """
     for row in cached_rows:
         if row.get("parse_status") != "ok":
             continue
@@ -348,6 +364,7 @@ def _edges_from_cached(
             target_ref = ColumnRef(
                 database=database, schema=schema, table=view_name, column=target_col
             )
+            op_meta = _operator_from_entry(col_entry)
             for src in col_entry.get("sources") or []:
                 src_table = str(src.get("table") or "")
                 src_col = str(src.get("column") or "")
@@ -362,7 +379,24 @@ def _edges_from_cached(
                     extractor="view_ddl",
                     confidence=1.0,
                     evidence=f"view {schema}.{view_name}",
+                    operator=op_meta,
                 )
+
+
+def _operator_from_entry(col_entry: dict[str, Any]) -> OperatorMeta | None:
+    """Lift the cached operator payload back into an OperatorMeta.
+
+    Returns ``None`` for v1 cache rows (no ``operator`` key) so
+    backward compatibility holds without forcing a re-extraction.
+    """
+    raw = col_entry.get("operator")
+    if not isinstance(raw, dict):
+        return None
+    op_kind = str(raw.get("op_kind") or "").strip()
+    expression = str(raw.get("expression") or "").strip()
+    if not op_kind:
+        return None
+    return OperatorMeta(op_kind=op_kind, expression=expression)
 
 
 __all__ = ["ViewDDLExtractor", "ConnectorHandle", "ConnectorFactory"]

--- a/amx/lineage/service.py
+++ b/amx/lineage/service.py
@@ -625,18 +625,21 @@ def lineage_for_studio(
 
     edge_payloads: list[dict[str, Any]] = []
     for edge in edges:
-        edge_payloads.append(
-            {
-                "id": edge.db_id,
-                "from": _node_id(edge.source),
-                "to": _node_id(edge.target),
-                "type": edge.relationship_type,
-                "extractor": edge.extractor,
-                "confidence": round(float(edge.confidence), 3),
-                "evidence": edge.evidence,
-                "verdict": edge.verdict,
-            }
-        )
+        payload = {
+            "id": edge.db_id,
+            "from": _node_id(edge.source),
+            "to": _node_id(edge.target),
+            "from_column": edge.source.column,
+            "to_column": edge.target.column,
+            "type": edge.relationship_type,
+            "extractor": edge.extractor,
+            "confidence": round(float(edge.confidence), 3),
+            "evidence": edge.evidence,
+            "verdict": edge.verdict,
+        }
+        if edge.operator is not None:
+            payload["operator"] = edge.operator.as_dict()
+        edge_payloads.append(payload)
 
     return {
         "anchor": {

--- a/amx/lineage/types.py
+++ b/amx/lineage/types.py
@@ -24,6 +24,25 @@ class ColumnRef:
 
 
 @dataclass(frozen=True)
+class OperatorMeta:
+    """v4 inline transformation metadata on a lineage edge.
+
+    Surfaces on :class:`Edge` when a deterministic extractor sees a
+    source column flow through a transform (function call, aggregate,
+    filter predicate, join condition) before reaching its target.
+    ``op_kind`` is one of {'filter', 'join', 'function', 'aggregate',
+    'projection'}. ``expression`` is the original SQL fragment,
+    normalised. Frozen so :class:`Edge` stays hashable.
+    """
+
+    op_kind: str
+    expression: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"op_kind": self.op_kind, "expression": self.expression}
+
+
+@dataclass(frozen=True)
 class Edge:
     """A directed lineage edge between two columns or tables.
 
@@ -38,6 +57,11 @@ class Edge:
     ``verdict`` mirrors the v3 S4 authoring column when set, so the
     Studio UI can render approve / reject pills without a second
     round-trip.
+    ``operator`` (v4) carries inline transformation metadata when a
+    deterministic extractor sees the source pass through a function /
+    aggregate / filter / join on its way to the target. Shape:
+    ``{op_kind: 'filter'|'join'|'function'|'aggregate'|'projection',
+       expression: 'SUM(amount)'}``. Empty for plain pass-through.
     """
 
     source: ColumnRef
@@ -48,6 +72,7 @@ class Edge:
     evidence: str = ""  # short human-readable provenance hint
     db_id: int | None = None
     verdict: str = ""
+    operator: OperatorMeta | None = None
 
 
 @dataclass(frozen=True)
@@ -118,6 +143,7 @@ __all__ = [
     "CacheStatus",
     "ExtractMode",
     "ColumnRef",
+    "OperatorMeta",
     "Edge",
     "ScopeFragment",
     "CostHint",

--- a/amx/lineage/view_ddl_operators.py
+++ b/amx/lineage/view_ddl_operators.py
@@ -1,0 +1,110 @@
+"""Detect transformation operators inside SELECT projections.
+
+Used by :mod:`amx.lineage.extractors.view_ddl` to attach
+:class:`amx.lineage.types.OperatorMeta` to edges when a source column
+flows through an aggregate, function call, or other non-trivial
+transform on its way to the projected target.
+
+Kept separate from the extractor so the sqlglot-specific logic has its
+own test surface and the extractor stays focused on
+cache-miss / db-fill orchestration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from amx.lineage.types import OperatorMeta
+
+# Map sqlglot expression class names to v4 op_kind values. Order
+# matters — we match the outermost expression first.
+_AGG_FUNC_NAMES: frozenset[str] = frozenset(
+    {"sum", "count", "avg", "min", "max", "stddev", "variance", "string_agg", "array_agg"}
+)
+
+
+def classify_projection(sqlglot_mod: Any, projection: Any) -> OperatorMeta | None:
+    """Return the operator metadata for a SELECT projection, or ``None``.
+
+    Pass-through projections (``SELECT col``, ``SELECT col AS alias``,
+    bare column with CAST/AS) get ``None`` so the resulting edges stay
+    plain column→column. Wrapping the projection in a function call,
+    an aggregate, or a CASE expression promotes it to an operator
+    edge — these are the visible transforms the user wants to see on
+    the canvas.
+    """
+    if projection is None:
+        return None
+    exp = sqlglot_mod.exp
+    expr = projection
+    # Unwrap aliases — the operator decision is about the projected
+    # expression itself, not the alias wrapper.
+    if isinstance(projection, exp.Alias):
+        expr = projection.this
+    if expr is None:
+        return None
+    # Plain column reference — no operator.
+    if isinstance(expr, exp.Column):
+        return None
+    # Cast(col AS type) is also pass-through for lineage purposes — the
+    # underlying column still flows through unchanged.
+    if isinstance(expr, exp.Cast) and isinstance(expr.this, exp.Column):
+        return None
+    sql_text = _safe_sql(expr)
+    op_kind = _detect_op_kind(sqlglot_mod, expr)
+    if op_kind is None:
+        return None
+    return OperatorMeta(op_kind=op_kind, expression=sql_text)
+
+
+def _detect_op_kind(sqlglot_mod: Any, expr: Any) -> str | None:
+    """Map a sqlglot expression to an op_kind label."""
+    exp = sqlglot_mod.exp
+    if isinstance(expr, exp.Window):
+        return "function"
+    if _looks_like_aggregate(sqlglot_mod, expr):
+        return "aggregate"
+    if isinstance(expr, exp.Case):
+        return "function"
+    if isinstance(expr, exp.Func):
+        return "function"
+    # Binary arithmetic on column refs is a projection-with-expression
+    # rather than a clean function call. Treat as a function for now —
+    # the user will see the SQL text in the operator body.
+    if hasattr(exp, "Binary") and isinstance(expr, exp.Binary):
+        return "function"
+    return None
+
+
+def _looks_like_aggregate(sqlglot_mod: Any, expr: Any) -> bool:
+    """True when ``expr`` is (or wraps) a SUM/COUNT/AVG-family call."""
+    exp = sqlglot_mod.exp
+    # Direct subclass check first — sqlglot exposes AggFunc as a base.
+    if hasattr(exp, "AggFunc") and isinstance(expr, exp.AggFunc):
+        return True
+    if isinstance(expr, exp.Func):
+        name = (expr.sql_name() or "").lower() if hasattr(expr, "sql_name") else ""
+        if not name:
+            name = expr.__class__.__name__.lower()
+        if name in _AGG_FUNC_NAMES:
+            return True
+    return False
+
+
+def _safe_sql(expr: Any) -> str:
+    """Render an expression's SQL text, with a length cap so canvas
+    operator bodies never get unwieldy."""
+    try:
+        text = expr.sql()
+    except Exception:
+        try:
+            text = str(expr)
+        except Exception:
+            text = ""
+    text = text.strip()
+    if len(text) > 200:
+        text = text[:197] + "..."
+    return text
+
+
+__all__ = ["classify_projection"]

--- a/tests/lineage/test_studio_service_entry.py
+++ b/tests/lineage/test_studio_service_entry.py
@@ -48,3 +48,27 @@ def test_lineage_for_studio_only_anchor_when_catalog_empty(hs):
     payload = lineage_for_studio(hs=hs, scope=scope)
     assert len(payload["nodes"]) == 1
     assert payload["edges"] == []
+
+
+def test_lineage_for_studio_edges_carry_column_and_operator_fields(hs):
+    """v4 — edges now expose from_column/to_column always, operator
+    when the extractor saw a transform on that flow."""
+    orders_id = seed_table_entity(hs, schema="public", table="orders")
+    customers_id = seed_table_entity(hs, schema="public", table="customers")
+    seed_foreign_key_relationship(
+        hs,
+        from_table_id=orders_id,
+        to_table_id=customers_id,
+        constrained_columns=["customer_id"],
+        referred_columns=["id"],
+        referred_table="customers",
+    )
+    scope = Scope(profile="p", anchor=ColumnRef("", "public", "orders", ""))
+    payload = lineage_for_studio(hs=hs, scope=scope)
+    fk_edges = [e for e in payload["edges"] if e["extractor"] == "fk"]
+    assert fk_edges, "expected at least one FK-sourced edge"
+    e = fk_edges[0]
+    # Column round-trip — FK columns flow through to the payload.
+    assert {e["from_column"], e["to_column"]} == {"customer_id", "id"}
+    # Plain FK has no operator wrapper.
+    assert "operator" not in e

--- a/tests/lineage/test_view_ddl_operators.py
+++ b/tests/lineage/test_view_ddl_operators.py
@@ -1,0 +1,104 @@
+"""v4 S2 — view_ddl extractor surfaces operator metadata on edges."""
+
+from __future__ import annotations
+
+import pytest
+
+from amx.lineage.extractors.view_ddl import _parse_view_lineage
+from amx.lineage.view_ddl_operators import classify_projection
+
+# The module-level _load_sqlglot_module helper is the canonical loader
+# used by the extractor — these tests fetch sqlglot the same way so they
+# skip cleanly on machines without it (only common for fresh checkouts
+# before ``pip install -e '.[lineage]'``).
+sqlglot = pytest.importorskip("sqlglot")
+
+
+def _projections(ddl: str, dialect: str = "postgres"):
+    tree = sqlglot.parse_one(ddl, dialect=dialect)
+    select = (
+        tree.expression if hasattr(tree, "expression") and tree.expression is not None else tree
+    )
+    return list(select.expressions or [])
+
+
+def test_pass_through_projection_has_no_operator():
+    projections = _projections("SELECT a, b FROM t")
+    for proj in projections:
+        assert classify_projection(sqlglot, proj) is None
+
+
+def test_aliased_column_has_no_operator():
+    [proj] = _projections("SELECT a AS aa FROM t")
+    assert classify_projection(sqlglot, proj) is None
+
+
+def test_cast_pass_through_has_no_operator():
+    [proj] = _projections("SELECT CAST(a AS INTEGER) AS aa FROM t")
+    assert classify_projection(sqlglot, proj) is None
+
+
+def test_sum_projection_is_aggregate():
+    [proj] = _projections("SELECT SUM(amount) AS total FROM t")
+    op = classify_projection(sqlglot, proj)
+    assert op is not None
+    assert op.op_kind == "aggregate"
+    assert "SUM" in op.expression.upper()
+
+
+def test_count_distinct_is_aggregate():
+    [proj] = _projections("SELECT COUNT(DISTINCT id) AS uniques FROM t")
+    op = classify_projection(sqlglot, proj)
+    assert op is not None
+    assert op.op_kind == "aggregate"
+
+
+def test_scalar_function_call_is_function():
+    [proj] = _projections("SELECT LOWER(name) AS name_l FROM t")
+    op = classify_projection(sqlglot, proj)
+    assert op is not None
+    assert op.op_kind == "function"
+
+
+def test_case_when_is_function():
+    [proj] = _projections("SELECT CASE WHEN x > 0 THEN 1 ELSE 0 END AS flag FROM t")
+    op = classify_projection(sqlglot, proj)
+    assert op is not None
+    assert op.op_kind == "function"
+
+
+def test_arithmetic_is_function():
+    [proj] = _projections("SELECT a + b AS s FROM t")
+    op = classify_projection(sqlglot, proj)
+    assert op is not None
+    assert op.op_kind == "function"
+
+
+def test_parse_view_lineage_emits_operator_metadata():
+    ddl = """
+    CREATE VIEW totals AS
+    SELECT customer_id, SUM(amount) AS gross
+    FROM orders
+    GROUP BY customer_id
+    """
+    parsed, status, error = _parse_view_lineage(sqlglot, ddl, "postgres", "totals")
+    assert status == "ok", error
+    assert parsed is not None
+    by_target = {entry["target"]: entry for entry in parsed}
+    assert "gross" in by_target
+    gross = by_target["gross"]
+    assert gross.get("operator") is not None
+    assert gross["operator"]["op_kind"] == "aggregate"
+    assert "amount" in gross["operator"]["expression"].lower()
+    # Pass-through customer_id is plain — no operator.
+    assert "operator" not in by_target["customer_id"]
+
+
+def test_parse_view_lineage_function_call():
+    ddl = "CREATE VIEW v AS SELECT LOWER(name) AS name_l FROM users"
+    parsed, status, error = _parse_view_lineage(sqlglot, ddl, "postgres", "v")
+    assert status == "ok", error
+    assert parsed is not None
+    [entry] = parsed
+    assert entry["operator"]["op_kind"] == "function"
+    assert "LOWER" in entry["operator"]["expression"].upper()


### PR DESCRIPTION
## Summary

Second slice of the v4 column-level rewrite. Still **backend-only** — the operator metadata now travels from sqlglot through the cache, the extractor, and the Studio service entry, but nothing renders yet. S3 will wire it into the canvas.

### Edge model
- New \`OperatorMeta\` dataclass (frozen — keeps \`Edge\` hashable).
- \`Edge.operator: OperatorMeta | None\` — populated when a deterministic extractor sees a non-trivial transform on the flow.

### view_ddl
- New \`amx/lineage/view_ddl_operators.py\` owns the sqlglot classification logic (house rule #8: keeps the extractor file from growing).
- \`classify_projection\` rules:
  - Pass-through (\`SELECT col\`, \`SELECT col AS alias\`, \`CAST(col AS type)\`) → \`None\`
  - \`SUM\` / \`COUNT\` / \`AVG\` / \`MIN\` / \`MAX\` / \`STDDEV\` / \`VARIANCE\` / \`STRING_AGG\` / \`ARRAY_AGG\` → \`aggregate\`
  - Scalar function call, \`CASE WHEN\`, arithmetic, \`Window\` → \`function\`
- Parsed-lineage cache rows grow an additive \`operator\` key; v1 rows (no key) keep loading unchanged.

### Studio service entry
- \`lineage_for_studio\` edge payload always exposes \`from_column\` / \`to_column\` (empty string for table-grain rows), and adds an \`operator\` dict (\`op_kind\` + \`expression\`) when the source extractor flagged one.
- v1 frontend clients ignore the extra fields gracefully.

## Test plan
- [x] \`pytest tests/lineage/test_view_ddl_operators.py -v\` — 10 pass (pass-through, aliases, CAST, SUM, COUNT DISTINCT, LOWER, CASE, arithmetic, GROUP BY view, scalar-function view).
- [x] \`pytest tests/lineage tests/web -q\` — 521 pass.
- [x] \`pytest --ignore=tests/eval -q\` — 2562 pass, 9 pre-existing skips (+11 new from this slice).
- [x] \`ruff check + ruff format --check\` clean.