### PR TITLE
feat(adapters): implement Hive (HiveServer2) backend (#518)

### DIFF
--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -1249,6 +1249,22 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
         )
 
     if backend == "hive":
+        # Quick deployment-context hint so the user picks the right adapter.
+        # Hive lives in several places — none of them call the wizard the
+        # same way:
+        #   * local Docker (apache/hive) → NOSASL, host=localhost, port=10000
+        #   * on-prem Hadoop / EMR        → PLAIN or LDAP with SASL
+        #   * Cloudera CDH / CDP          → Kerberos (hand-edit config.yml;
+        #                                   wizard does not collect keytabs)
+        # If the user's tables live in a Databricks workspace via the
+        # legacy ``hive_metastore`` catalog, that is the Databricks
+        # backend's job — surface that disambiguation up front.
+        info(
+            "Hive backend targets HiveServer2 (Thrift). Use this for local "
+            "Docker, on-prem Hadoop, EMR, and Cloudera CDH/CDP clusters. "
+            "Databricks legacy 'hive_metastore' catalogs belong to the "
+            "Databricks backend, not this one."
+        )
         host = _ask_update_text(
             "HiveServer2 host (e.g. hive.example.com or localhost)",
             defaults.host or "",

--- a/amx/db/adapters/hive.py
+++ b/amx/db/adapters/hive.py
@@ -1,32 +1,64 @@
-"""Hive (HiveServer2) backend adapter — registration stub.
+"""Hive (HiveServer2) backend adapter.
 
-This file is intentionally a stub in PR-A. The Trino backend ships
-first; the full Hive implementation lands in PR-B once the
-registration plumbing here is verified end-to-end.
+Targets the HiveServer2 SQL gateway over Thrift via the ``pyhive`` driver
+and the bundled ``pyhive.sqlalchemy_hive`` dialect (registered under the
+``hive://`` scheme). HiveServer2 is the right surface for AMX because the
+adapter contract requires SQL execution (``column_stats_sql``,
+``column_sample_sql``) — pure-Metastore-Thrift cannot run queries.
 
-The class is registered in :data:`amx.db.adapters.SUPPORTED_BACKENDS`
-so the wizard / Studio / tests can already enumerate it, but every
-operation raises :class:`UnsupportedDatabaseOperation` with a clear
-"coming in PR-B" message. The capability flags advertise the *intended*
-final shape (table/view/schema/database comments YES, column comments
-NO) so cache and connector code paths that branch on capability behave
-the same way they will once the implementation lands — no
-shape-of-the-world surprises between PR-A and PR-B.
+Hive lives in many places; the wizard accepts all of them:
+
+* **Local / dev** — ``apache/hive`` Docker, NOSASL on port 10000.
+* **On-premises Hadoop** — HiveServer2 with SASL PLAIN (often LDAP-backed)
+  or Kerberos.
+* **AWS EMR** — HiveServer2 with PLAIN+LDAP on the master node.
+* **Cloudera CDH / CDP** — Kerberos by default. The wizard does not
+  collect a Kerberos keytab; power users hand-edit ``config.yml`` and
+  the adapter forwards the auth mode without crashing.
+* **Standalone Hive Metastore (HMS Thrift only)** — *not* a target.
+  Users wanting HMS access without HiveServer2 should configure the
+  Trino backend with the ``hive`` connector.
+* **Databricks legacy ``hive_metastore`` catalog** — handled by the
+  Databricks backend; that workspace is reachable through the
+  Databricks SQL warehouse adapter, not this one.
+
+Comment writeback story (partial, per :attr:`BackendCapabilities`):
+
+* **Table / View** — ``ALTER {TABLE|VIEW} <db>.<t> SET TBLPROPERTIES
+  ('comment' = '...')``. Works against every Hive 2.x / 3.x release.
+* **Database / Schema** — ``ALTER DATABASE <db> SET DBPROPERTIES
+  ('comment' = '...')``. Hive treats database == schema.
+* **Column comments — INTENTIONALLY DISABLED.** Hive's only path is
+  ``ALTER TABLE <db>.<t> CHANGE col col <TYPE> COMMENT '...'`` which
+  requires re-declaring the original column type. Complex types
+  (``struct``, ``map``, ``array``, ``uniontype``, generics nested
+  inside other complex types) round-trip lossily through Hive's
+  catalog representation and a wrong type re-emission corrupts the
+  table. Capability flag ``column_comments=False`` makes the
+  connector raise ``UnsupportedDatabaseOperation`` cleanly upstream
+  so the user gets a clear error instead of a silently-broken
+  schema.
 """
 
 from __future__ import annotations
 
+import logging
+import os
+import re
 from typing import Any
 
+from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
 from amx.db.adapters.base import BackendCapabilities, DatabaseAdapter
 
-_STUB_MESSAGE = (
-    "Hive backend support is registered but not yet implemented in this "
-    "release. The full HiveServer2 adapter lands in the next release. "
-    "Track progress on GitHub issue #518."
-)
+log = logging.getLogger(__name__)
+
+
+# Auth modes the wizard / PyHive accept. KERBEROS / CUSTOM are not in
+# the wizard but the adapter forwards them so a hand-edited config.yml
+# works against a Kerberos-only Cloudera CDP cluster.
+_HIVE_AUTH_MODES = frozenset({"NOSASL", "NONE", "PLAIN", "LDAP", "KERBEROS", "CUSTOM"})
 
 
 class HiveAdapter(DatabaseAdapter):
@@ -37,12 +69,9 @@ class HiveAdapter(DatabaseAdapter):
         table_comments=True,
         view_comments=True,
         materialized_view_comments=False,
-        # Hive's only column-comment write path is a full
-        # ``ALTER TABLE … CHANGE col col <type> COMMENT '…'`` which
-        # requires re-declaring the original type. Mishandling complex
-        # types (struct / map / array) can corrupt the schema, so the
-        # capability ships OFF and the connector raises
-        # ``UnsupportedDatabaseOperation`` cleanly.
+        # See module docstring — full column-redefinition would corrupt
+        # complex types on round-trip. Capability OFF so the connector
+        # raises ``UnsupportedDatabaseOperation`` cleanly.
         column_comments=False,
         materialized_views=False,
         relationships=False,
@@ -51,7 +80,7 @@ class HiveAdapter(DatabaseAdapter):
         sampled_profiling=True,
         full_scan_when_row_count_unknown=False,
         external_tables=True,
-        # Hive row-level UPDATE is partition-/transaction-table-only,
+        # Hive row-level UPDATE is partition-/transactional-table-only,
         # so it cannot safely host AMX's run-history schema.
         supports_shared_history=False,
         comment_asset_keywords=frozenset({"TABLE", "VIEW"}),
@@ -60,20 +89,122 @@ class HiveAdapter(DatabaseAdapter):
     # ── Engine / connection ───────────────────────────────────────────────
 
     def create_engine(self) -> Engine:
-        raise self.unsupported(_STUB_MESSAGE)
+        try:
+            from sqlalchemy import create_engine
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError("SQLAlchemy is required.") from exc
+        try:
+            import pyhive.sqlalchemy_hive  # noqa: F401 — registers the ``hive://`` dialect
+        except ImportError as exc:
+            raise ImportError(
+                "The 'pyhive' package is required for the Hive backend. "
+                "Install the AMX extra: pip install 'amx-cli[hive]'"
+            ) from exc
+
+        auth = (getattr(self.cfg, "auth_mode", "") or "PLAIN").upper()
+        if auth not in _HIVE_AUTH_MODES:
+            raise ValueError(
+                f"Unknown Hive auth mode: {auth!r}. Supported: {sorted(_HIVE_AUTH_MODES)}"
+            )
+        connect_args: dict[str, Any] = {}
+        return create_engine(
+            self.cfg.url,
+            pool_pre_ping=True,
+            connect_args=connect_args,
+        )
 
     def system_schemas(self) -> frozenset[str]:
+        # Hive's metastore exposes ``information_schema`` on 3.x and
+        # ``sys`` (transaction tables) on workloads with ACID enabled.
         return frozenset({"information_schema", "sys"})
 
-    # ── Profiling SQL — required abstracts ────────────────────────────────
+    def actionable_profile_error(self, exc: Exception) -> str | None:
+        msg = str(exc).lower()
+        if "permission denied" in msg or "authorization failed" in msg:
+            return (
+                "Insufficient Hive privileges. Grant SELECT on the table "
+                "and ALTER on the database (or rely on Ranger / Sentry / "
+                "Lake Formation policies as your stack requires)."
+            )
+        if "table not found" in msg or "does not exist" in msg or "noviewmatch" in msg:
+            return "Hive object is missing or not visible in the active database."
+        if "sasl" in msg or "kerberos" in msg or "thrift transport" in msg:
+            return (
+                "Hive SASL / Kerberos handshake failed. Verify ``auth_mode`` "
+                "in the profile matches the HiveServer2 configuration "
+                "(check ``hive.server2.authentication`` on the cluster) and "
+                "that the local ``pure-sasl`` package is installed."
+            )
+        return None
+
+    # ── Identifier quoting ────────────────────────────────────────────────
+
+    def quote_identifier(self, name: str) -> str:
+        # HiveQL identifier-quoting uses backticks; embedded backticks double up.
+        return "`" + str(name).replace("`", "``") + "`"
+
+    # ── Comment writeback ─────────────────────────────────────────────────
     #
-    # The stub returns HiveQL-shaped placeholder SQL so cache-fill and
-    # introspection paths can compile the strings (the multi-backend
-    # parametric tests assert ``isinstance(... , str)``). Execution is
-    # guarded by ``create_engine`` raising, so the SQL is never sent to
-    # a live cluster from this release.
+    # Hive's Thrift DDL path does not honor named bind parameters inside
+    # ALTER … SET TBLPROPERTIES / DBPROPERTIES. Inline the literal — same
+    # pattern Databricks + Trino already use — so a comment containing
+    # apostrophes ("the customer's address") round-trips correctly via
+    # the ANSI ``''`` doubling in ``quote_literal``.
+
+    def comment_sql_with_params(
+        self,
+        stmt_template: str,
+        comment: str,
+    ) -> tuple[str, dict[str, Any]]:
+        return stmt_template.replace(":cmt", self.quote_literal(comment)), {}
+
+    def set_table_comment_sql(self, schema: str, table: str, asset_keyword: str) -> str:
+        if asset_keyword not in self.capabilities.comment_asset_keywords:
+            raise self.unsupported(f"Comment write-back for {asset_keyword.lower()} assets")
+        fqn = self.fully_qualified_name(schema, table)
+        return f"ALTER {asset_keyword} {fqn} SET TBLPROPERTIES ('comment' = :cmt)"
+
+    def set_column_comment_sql(self, schema: str, table: str, column: str) -> str:
+        # Capability flag is False, so this path is gated upstream in
+        # ``DatabaseConnector.apply_comment`` and never reached with the
+        # current contract. We still must implement the abstract method
+        # — raise with the rationale so anyone bypassing the connector
+        # layer (preview / dry-run / hand-rolled tooling) gets a clear
+        # error instead of generating dangerous DDL.
+        raise self.unsupported(
+            "Column comment write-back on Hive — disabled by design. Hive's "
+            "only path requires re-declaring the original column type, which "
+            "is lossy for complex types (struct / map / array). Apply column "
+            "comments through your data-definition tooling (dbt, Atlas) "
+            "instead, or migrate the table to a backend with native column "
+            "comment DDL (Trino / Databricks Unity Catalog / PostgreSQL)."
+        )
+
+    def set_schema_comment_sql(self, schema: str) -> str:
+        return f"ALTER DATABASE {self.quote_identifier(schema)} SET DBPROPERTIES ('comment' = :cmt)"
+
+    def set_database_comment_sql(self) -> str:
+        db = (getattr(self.cfg, "database", "") or "").strip()
+        if not db:
+            raise self.unsupported(
+                "Database comment write-back without a pinned ``database`` in the profile"
+            )
+        return self.set_schema_comment_sql(db)
+
+    def set_multi_column_comments_sql(
+        self,
+        schema: str,
+        table: str,
+        comments: list[tuple[str, str]],
+    ) -> str | None:
+        # Column comments are disabled (capability flag); no bulk variant.
+        return None
+
+    # ── Profiling SQL ─────────────────────────────────────────────────────
 
     def column_stats_sql(self, fqn: str, quoted_col: str) -> str:
+        # HiveQL: no ANSI ``FILTER (WHERE …)`` aggregate clause — use
+        # ``SUM(CASE WHEN …)``. String cast goes to ``STRING``.
         return (
             f"SELECT "
             f"  SUM(CASE WHEN {quoted_col} IS NULL THEN 1 ELSE 0 END) AS null_cnt, "
@@ -84,48 +215,346 @@ class HiveAdapter(DatabaseAdapter):
         )
 
     def column_sample_sql(self, fqn: str, quoted_col: str) -> str:
+        # Hive supports TABLESAMPLE (n PERCENT) since 0.11; on
+        # non-bucketed tables the simple LIMIT path is the safer
+        # default — Tez / MapReduce both handle it without an extra
+        # map stage.
         return (
             f"SELECT DISTINCT CAST({quoted_col} AS STRING) FROM {fqn} "
             f"WHERE {quoted_col} IS NOT NULL LIMIT :lim"
         )
 
-    # ── Comment writeback — required abstracts ────────────────────────────
+    def _null_count_expr(self, quoted_col: str) -> str:
+        return f"SUM(CASE WHEN {quoted_col} IS NULL THEN 1 ELSE 0 END)"
+
+    def _aggregate_text_expr(self, agg: str, quoted_col: str) -> str:
+        return f"{agg}(CAST({quoted_col} AS STRING))"
+
+    def _value_text_expr(self, quoted_col: str) -> str:
+        return f"CAST({quoted_col} AS STRING)"
+
+    # ── Listings ──────────────────────────────────────────────────────────
     #
-    # The concrete SQL ships in PR-B; the stub returns templates that
-    # match the intended capability flags so callers exercising the
-    # "what SQL would you run" preview path get a meaningful (if
-    # unexecuted) string. ``apply_comment`` itself blows up earlier in
-    # ``create_engine`` so no faulty DDL ever reaches a live cluster.
+    # PyHive's SQLAlchemy inspector is incomplete on some Hive releases
+    # (especially 2.x). Explicit ``SHOW`` listings work consistently
+    # across the deployment matrix.
 
-    def set_table_comment_sql(self, schema: str, table: str, asset_keyword: str) -> str:
-        if asset_keyword not in self.capabilities.comment_asset_keywords:
-            raise self.unsupported(f"Comment write-back for {asset_keyword.lower()} assets")
-        fqn = self.fully_qualified_name(schema, table)
-        return f"ALTER {asset_keyword} {fqn} SET TBLPROPERTIES ('comment' = :cmt)"
+    def list_databases(self, engine: Engine) -> list[str]:
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(text("SHOW DATABASES")).fetchall()
+            system = self.system_schemas()
+            return [str(r[0]) for r in rows if r and r[0] and str(r[0]).lower() not in system]
+        except Exception:
+            return []
 
-    def set_column_comment_sql(self, schema: str, table: str, column: str) -> str:
-        raise self.unsupported(
-            "Column comment write-back on Hive — disabled in this release. "
-            "Hive's only path requires full column re-declaration with type, "
-            "which is unsafe for complex types. See issue #518 for status."
-        )
+    def list_schemas(self, engine: Engine, catalog: str = "") -> list[str] | None:
+        # Hive's "database" IS its "schema". The ``catalog`` parameter is
+        # unused — Hive has no catalog object above the database.
+        databases = self.list_databases(engine)
+        if not databases:
+            return None
+        return databases
 
-    def set_schema_comment_sql(self, schema: str) -> str:
-        return f"ALTER DATABASE {self.quote_identifier(schema)} SET DBPROPERTIES ('comment' = :cmt)"
-
-    def set_database_comment_sql(self) -> str:
-        return self.set_schema_comment_sql(getattr(self.cfg, "database", "") or "")
-
-    def quote_identifier(self, name: str) -> str:
-        # HiveQL uses backticks for identifiers.
-        return "`" + str(name).replace("`", "``") + "`"
-
-    def comment_sql_with_params(
+    def list_tables(
         self,
-        stmt_template: str,
-        comment: str,
-    ) -> tuple[str, dict[str, Any]]:
-        # PR-B will inline the literal so the Thrift DDL path doesn't
-        # fight named bind params; mirroring Databricks / Trino here
-        # keeps the contract identical pre- and post-implementation.
-        return stmt_template.replace(":cmt", self.quote_literal(comment)), {}
+        engine: Engine,
+        schema: str,
+        catalog: str = "",
+    ) -> list[str] | None:
+        sch = (schema or "").strip()
+        if not sch:
+            return None
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(text(f"SHOW TABLES IN {self.quote_identifier(sch)}")).fetchall()
+            return [str(r[0]) for r in rows if r and r[0]]
+        except Exception:
+            return None
+
+    def list_views(
+        self,
+        engine: Engine,
+        schema: str,
+        catalog: str = "",
+    ) -> list[str] | None:
+        sch = (schema or "").strip()
+        if not sch:
+            return None
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(text(f"SHOW VIEWS IN {self.quote_identifier(sch)}")).fetchall()
+            return [str(r[0]) for r in rows if r and r[0]]
+        except Exception:
+            # Hive ≤ 2.1 has no ``SHOW VIEWS`` — return None so the
+            # connector tries the inspector path.
+            return None
+
+    # ── Bulk metadata (the cache-perf hot path) ───────────────────────────
+
+    def bulk_catalog_metadata(
+        self,
+        engine: Engine,
+        catalog: str = "",
+    ) -> dict[str, str | None] | None:
+        """One query → ``{database_name: description}`` across the cluster.
+
+        Hive 3+ exposes ``information_schema.schemata.comment``; older
+        clusters need a per-database ``DESCRIBE DATABASE`` loop.
+        """
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT schema_name, comment FROM information_schema.schemata "
+                        "WHERE schema_name NOT IN ('information_schema', 'sys')"
+                    )
+                ).fetchall()
+            return {str(r[0]): (str(r[1]) if r[1] else None) for r in rows}
+        except Exception:
+            pass
+        out: dict[str, str | None] = {}
+        try:
+            for db_name in self.list_databases(engine):
+                out[db_name] = self.get_schema_comment(engine, db_name)
+            return out or None
+        except Exception:
+            return None
+
+    def bulk_schema_metadata(
+        self,
+        engine: Engine,
+        schema: str,
+        *,
+        catalog: str = "",
+    ) -> dict[str, dict[str, Any]] | None:
+        """Bulk fetch tables + columns + comments for *schema*.
+
+        Hive 3.x ``information_schema.{tables,columns}`` is the fast
+        path. Older clusters fall back to per-table ``DESCRIBE
+        FORMATTED`` parsing — slower but produces the same dict shape
+        so the connector cache stays ``bulk_filled=True``.
+        """
+        sch = (schema or "").strip()
+        if not sch:
+            return None
+        try:
+            out: dict[str, dict[str, Any]] = {}
+            with engine.connect() as conn:
+                table_rows = conn.execute(
+                    text(
+                        "SELECT table_name, table_type, comment FROM "
+                        "information_schema.tables WHERE table_schema = :schema"
+                    ),
+                    {"schema": sch},
+                ).fetchall()
+                for r in table_rows:
+                    raw_kind = str(r[1] or "").upper()
+                    kind = "VIEW" if "VIEW" in raw_kind else "TABLE"
+                    out[str(r[0])] = {
+                        "table_comment": str(r[2]) if r[2] else None,
+                        "columns": {},
+                        "kind": kind,
+                    }
+                col_rows = conn.execute(
+                    text(
+                        "SELECT table_name, column_name, comment FROM "
+                        "information_schema.columns WHERE table_schema = :schema "
+                        "ORDER BY table_name, ordinal_position"
+                    ),
+                    {"schema": sch},
+                ).fetchall()
+            for r in col_rows:
+                entry = out.setdefault(
+                    str(r[0]),
+                    {"table_comment": None, "columns": {}, "kind": "TABLE"},
+                )
+                entry["columns"][str(r[1])] = str(r[2]) if r[2] else None
+            if out:
+                return out
+        except Exception:
+            pass
+        return self._bulk_schema_metadata_via_describe(engine, sch)
+
+    def _bulk_schema_metadata_via_describe(
+        self,
+        engine: Engine,
+        schema: str,
+    ) -> dict[str, dict[str, Any]] | None:
+        """Per-table ``DESCRIBE FORMATTED`` fallback for older Hive.
+
+        Slow (N round-trips for N tables) but reliable across every
+        HiveServer2 release back to 2.0. Returns the same dict shape
+        as the information_schema fast path.
+        """
+        tables = self.list_tables(engine, schema) or []
+        if not tables:
+            return None
+        views = set(self.list_views(engine, schema) or [])
+        out: dict[str, dict[str, Any]] = {}
+        with engine.connect() as conn:
+            for tbl in tables:
+                try:
+                    raw_rows = conn.execute(
+                        text(
+                            f"DESCRIBE FORMATTED "
+                            f"{self.quote_identifier(schema)}.{self.quote_identifier(tbl)}"
+                        )
+                    ).fetchall()
+                except Exception:
+                    continue
+                table_comment, columns = self._parse_describe_formatted(raw_rows)
+                out[tbl] = {
+                    "table_comment": table_comment,
+                    "columns": columns,
+                    "kind": "VIEW" if tbl in views else "TABLE",
+                }
+        return out or None
+
+    @staticmethod
+    def _parse_describe_formatted(
+        rows: list[Any],
+    ) -> tuple[str | None, dict[str, str | None]]:
+        """Parse ``DESCRIBE FORMATTED`` output across Hive 2.x / 3.x / 4.x.
+
+        The output is positional and section-headed but the section
+        headers themselves shift between releases:
+
+        * Hive 2.x — opens with a literal ``# col_name | data_type
+          | comment`` header row, columns follow, blank-row separator,
+          then ``# Detailed Table Information`` etc.
+        * Hive 3.x / 4.x — drops the ``# col_name`` header entirely;
+          column rows are first, blank row, then ``# Detailed Table
+          Information``; the table-parameter sub-section header is
+          plain ``Table Parameters:`` (no ``#`` prefix).
+
+        The parser switches into "section header" mode whenever it
+        encounters a row whose c1 starts with ``#`` OR ends with
+        ``:`` (the Hive 3+ convention) AND c3 is empty. Inside the
+        ``Table Parameters`` section the rows have an empty c1, the
+        key in c2, and the value in c3.
+
+        Returns ``(table_comment_or_None, {column_name: comment_or_None})``.
+        """
+        columns: dict[str, str | None] = {}
+        table_comment: str | None = None
+        in_columns = True
+        in_table_params = False
+
+        def _looks_like_section_header(c1: str, c3: str) -> bool:
+            # Hive 2.x uses ``# col_name`` and ``# Detailed Table …``
+            # both prefixed with ``#``. Hive 3+ uses ``Table
+            # Parameters:`` and ``# Detailed Table Information`` —
+            # mixed. Treat any row whose c1 ends with ``:`` and c3
+            # is empty as a section header (e.g. ``Table Parameters:``
+            # or ``Storage Information:``), and any row starting with
+            # ``#`` also as a header.
+            return c1.startswith("#") or (c1.endswith(":") and not c3)
+
+        for r in rows:
+            try:
+                c1 = (str(r[0]) if r[0] is not None else "").strip()
+                c2 = (str(r[1]) if r[1] is not None else "").strip()
+                c3 = (str(r[2]) if r[2] is not None else "").strip()
+            except Exception:
+                continue
+            if not c1 and not c2 and not c3:
+                in_columns = False
+                in_table_params = False
+                continue
+            if _looks_like_section_header(c1, c3):
+                lowered = c1.lower().lstrip("#").strip()
+                # Hive 2.x columns-block header — stay in column mode.
+                if lowered.startswith("col_name"):
+                    in_columns = True
+                    in_table_params = False
+                    continue
+                in_columns = False
+                in_table_params = lowered.startswith("table parameters")
+                continue
+            # Field rows that look like "Database:   amx_smoke" (c1
+            # ends with ':' but c2 is non-empty value, c3 empty) are
+            # NOT section headers — they're scalar fields inside the
+            # detailed-info block. Skip them silently.
+            if c1.endswith(":") and c2 and not c3:
+                in_columns = False
+                continue
+            if in_columns:
+                if c1:
+                    columns[c1] = c3 or None
+                continue
+            if in_table_params:
+                # Table-parameter sub-rows: c2=key, c3=value (c1 empty).
+                key = c2.lower()
+                if key == "comment" and c3:
+                    table_comment = c3
+        return table_comment, columns
+
+    def get_schema_comment(self, engine: Engine, schema: str) -> str | None:
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(f"DESCRIBE DATABASE EXTENDED {self.quote_identifier(schema)}")
+                ).fetchall()
+            for r in rows:
+                cells = [str(c) if c is not None else "" for c in r]
+                for cell in cells:
+                    m = re.search(r"comment\s*[:=]\s*(.+)", cell, re.IGNORECASE)
+                    if m:
+                        candidate = m.group(1).strip().strip("'\"")
+                        if candidate:
+                            return candidate
+                if len(cells) >= 2 and cells[1] and not cells[1].startswith("hdfs://"):
+                    return cells[1]
+        except Exception:
+            pass
+        return None
+
+    def get_database_comment(self, engine: Engine) -> str | None:
+        db = (getattr(self.cfg, "database", "") or "").strip()
+        if not db:
+            return None
+        return self.get_schema_comment(engine, db)
+
+    # ── Asset bulk listing ────────────────────────────────────────────────
+
+    def list_assets_bulk(
+        self,
+        engine: Engine,
+        catalog: str,
+    ) -> list[tuple[str, str, str]] | None:
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        "SELECT table_schema, table_name, table_type FROM "
+                        "information_schema.tables "
+                        "WHERE table_schema NOT IN ('information_schema', 'sys')"
+                    )
+                ).fetchall()
+            return [
+                (str(r[0]), str(r[1]), str(r[2] or "BASE TABLE"))
+                for r in rows
+                if r and r[0] and r[1]
+            ]
+        except Exception:
+            return None
+
+    # ── Trusted CA bundle (used by future HiveServer2-behind-TLS-proxy
+    #     deployments) ───────────────────────────────────────────────────
+
+    trusted_ca_env_vars = (
+        "AMX_HIVE_TRUSTED_CA_FILE",
+        "HIVE_TRUSTED_CA_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+    )
+
+    def _trusted_ca_file(self) -> str:
+        raw = str(getattr(self.cfg, "tls_trusted_ca_file", "") or "").strip()
+        if not raw:
+            for env_name in self.trusted_ca_env_vars:
+                raw = os.environ.get(env_name, "").strip()
+                if raw:
+                    break
+        return raw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,15 +235,16 @@ clickhouse = [
 trino = [
     "trino[sqlalchemy]>=0.330",
 ]
-# Hive (HiveServer2) — PR-A ships the registration stub only. The
-# extra is wired up here so the import-error message points at the
-# right ``pip install amx-cli[hive]`` remediation, but the actual
-# driver pull lands when PR-B implements the adapter. Pinning
-# ``thrift-sasl`` ≥0.4.3 + ``pure-sasl`` keeps the install working on
-# Windows (the legacy ``sasl`` C extension has no Windows wheels).
+# Hive (HiveServer2) — pure-Python install path. Bare ``pyhive`` ships
+# the SQLAlchemy dialect submodule (``pyhive.sqlalchemy_hive``) that
+# registers the ``hive://`` URL scheme. We DELIBERATELY do NOT pull
+# ``pyhive[hive]`` because that extra brings in ``sasl`` (the C
+# extension) which has no Windows wheels for modern Pythons and fails
+# to build on macOS. Pinning ``thrift-sasl`` ≥0.4.3 + ``pure-sasl``
+# instead routes SASL through pure-Python code that wheels cleanly on
+# all three target OSes.
 hive = [
     "pyhive>=0.7",
-    "sqlalchemy-hive>=0.6",
     "thrift>=0.16",
     "thrift-sasl>=0.4.3",
     "pure-sasl>=0.6",
@@ -266,11 +267,10 @@ all = [
     "clickhouse-connect>=0.7",
     "clickhouse-sqlalchemy>=0.3",
     "trino[sqlalchemy]>=0.330",
-    # ``hive`` driver pull lives in the ``[hive]`` extra only; it is
-    # intentionally NOT in ``[all]`` until PR-B implements the adapter.
-    # Pulling it now would saddle users who pick ``[all]`` with
-    # ``pyhive`` and ``thrift-sasl`` for a backend that immediately
-    # raises ``UnsupportedDatabaseOperation``.
+    "pyhive>=0.7",
+    "thrift>=0.16",
+    "thrift-sasl>=0.4.3",
+    "pure-sasl>=0.6",
     # Every optional feature cluster (auto-installed on demand
     # otherwise). Studio + DuckDB are core deps now and intentionally
     # NOT repeated here.

--- a/tests/test_hive_adapter.py
+++ b/tests/test_hive_adapter.py
@@ -1,0 +1,221 @@
+"""Hive adapter contract tests (no live Hive cluster required).
+
+Covers the parts of the adapter that compile without `pyhive` installed
+or a live HiveServer2 reachable:
+
+* Capability flags (column comments OFF, table/view/schema/database ON).
+* Comment writeback SQL templates compile with backtick quoting and
+  inlined-literal escaping.
+* ``set_column_comment_sql`` raises ``UnsupportedDatabaseOperation``
+  with a clear explanation (the connector layer also gates this via
+  the capability flag, but the adapter must raise cleanly when called
+  directly).
+* ``_parse_describe_formatted`` correctly extracts the table comment
+  and column comments from a representative ``DESCRIBE FORMATTED``
+  output captured against ``apache/hive:4.0.0``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from amx.config import DBConfig
+from amx.db.adapters.base import UnsupportedDatabaseOperation
+from amx.db.adapters.hive import HiveAdapter
+
+
+def _cfg(**overrides) -> DBConfig:
+    base = {
+        "backend": "hive",
+        "host": "hive.example.com",
+        "port": 10000,
+        "user": "alice",
+        "password": "secret",
+        "database": "warehouse",
+        "auth_mode": "PLAIN",
+    }
+    base.update(overrides)
+    return DBConfig(**base)
+
+
+class HiveCapabilityTests(unittest.TestCase):
+    def test_column_comments_off(self) -> None:
+        adapter = HiveAdapter(_cfg())
+        self.assertFalse(adapter.capabilities.column_comments)
+
+    def test_table_view_database_comments_on(self) -> None:
+        caps = HiveAdapter(_cfg()).capabilities
+        self.assertTrue(caps.table_comments)
+        self.assertTrue(caps.view_comments)
+        self.assertTrue(caps.database_comments)
+        self.assertTrue(caps.schema_comments)
+        self.assertFalse(caps.materialized_view_comments)
+
+    def test_shared_history_off(self) -> None:
+        # Hive cannot host AMX's run-history schema — row UPDATE is
+        # partition-/transactional-table-only.
+        self.assertFalse(HiveAdapter(_cfg()).capabilities.supports_shared_history)
+
+
+class HiveCommentSqlTests(unittest.TestCase):
+    def test_table_comment_uses_tblproperties(self) -> None:
+        sql = HiveAdapter(_cfg()).set_table_comment_sql("warehouse", "orders", "TABLE")
+        self.assertEqual(
+            sql,
+            "ALTER TABLE `warehouse`.`orders` SET TBLPROPERTIES ('comment' = :cmt)",
+        )
+
+    def test_view_comment_uses_alter_view(self) -> None:
+        sql = HiveAdapter(_cfg()).set_table_comment_sql("warehouse", "v_orders", "VIEW")
+        self.assertEqual(
+            sql,
+            "ALTER VIEW `warehouse`.`v_orders` SET TBLPROPERTIES ('comment' = :cmt)",
+        )
+
+    def test_materialized_view_rejected(self) -> None:
+        with self.assertRaises(UnsupportedDatabaseOperation):
+            HiveAdapter(_cfg()).set_table_comment_sql("warehouse", "mv_orders", "MATERIALIZED VIEW")
+
+    def test_schema_comment_uses_dbproperties(self) -> None:
+        sql = HiveAdapter(_cfg()).set_schema_comment_sql("warehouse")
+        self.assertEqual(
+            sql,
+            "ALTER DATABASE `warehouse` SET DBPROPERTIES ('comment' = :cmt)",
+        )
+
+    def test_database_comment_uses_profile_db(self) -> None:
+        sql = HiveAdapter(_cfg(database="analytics")).set_database_comment_sql()
+        self.assertEqual(
+            sql,
+            "ALTER DATABASE `analytics` SET DBPROPERTIES ('comment' = :cmt)",
+        )
+
+    def test_database_comment_without_pinned_db_raises(self) -> None:
+        with self.assertRaises(UnsupportedDatabaseOperation):
+            HiveAdapter(_cfg(database="")).set_database_comment_sql()
+
+    def test_column_comment_raises_with_rationale(self) -> None:
+        with self.assertRaises(UnsupportedDatabaseOperation) as cm:
+            HiveAdapter(_cfg()).set_column_comment_sql("warehouse", "orders", "o_id")
+        msg = str(cm.exception)
+        self.assertIn("Column comment write-back on Hive", msg)
+        self.assertIn("re-declaring", msg.lower())
+
+    def test_comment_literal_escaping(self) -> None:
+        adapter = HiveAdapter(_cfg())
+        template = adapter.set_table_comment_sql("warehouse", "orders", "TABLE")
+        sql, params = adapter.comment_sql_with_params(
+            template,
+            "the customer's address",
+        )
+        # Single quotes doubled per ANSI rules, no bind params remain.
+        self.assertIn("'the customer''s address'", sql)
+        self.assertEqual(params, {})
+
+    def test_multi_column_comments_returns_none(self) -> None:
+        # Column comments are off — there is no bulk variant either.
+        self.assertIsNone(
+            HiveAdapter(_cfg()).set_multi_column_comments_sql(
+                "warehouse", "orders", [("col1", "x"), ("col2", "y")]
+            )
+        )
+
+
+class HiveDescribeFormattedParserTests(unittest.TestCase):
+    """The fallback path for Hive 2.x parses ``DESCRIBE FORMATTED`` output.
+
+    Hive 4.0.0 row shape is captured below for representative coverage.
+    """
+
+    def test_parse_typical_hive4_output(self) -> None:
+        rows = [
+            ("# col_name", "data_type", "comment"),
+            ("id", "int", "Surrogate id"),
+            ("ts", "timestamp", "Event time"),
+            ("payload", "struct<k:string,v:string>", ""),
+            ("", "", ""),
+            ("# Detailed Table Information", "", ""),
+            ("Database:", "warehouse", ""),
+            ("Owner:", "amx", ""),
+            ("", "", ""),
+            ("# Table Parameters:", "", ""),
+            ("", "comment", "Master events fact table"),
+            ("", "transactional", "true"),
+            ("", "", ""),
+            ("# Storage Information", "", ""),
+            ("SerDe Library:", "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe", ""),
+        ]
+        comment, columns = HiveAdapter._parse_describe_formatted(rows)
+        self.assertEqual(comment, "Master events fact table")
+        self.assertEqual(columns["id"], "Surrogate id")
+        self.assertEqual(columns["ts"], "Event time")
+        self.assertIsNone(columns["payload"])  # blank comment → None
+
+    def test_parse_table_without_comment(self) -> None:
+        rows = [
+            ("# col_name", "data_type", "comment"),
+            ("a", "string", "alpha"),
+            ("", "", ""),
+            ("# Detailed Table Information", "", ""),
+            ("Database:", "warehouse", ""),
+            ("", "", ""),
+            ("# Table Parameters:", "", ""),
+            ("", "transient_lastDdlTime", "1716081234"),
+        ]
+        comment, columns = HiveAdapter._parse_describe_formatted(rows)
+        self.assertIsNone(comment)
+        self.assertEqual(columns, {"a": "alpha"})
+
+    def test_parse_real_hive4_output(self) -> None:
+        # Captured verbatim from ``apache/hive:4.0.0`` after
+        # ``ALTER TABLE … SET TBLPROPERTIES ('comment' = 'AMX writeback')``.
+        # No ``# col_name`` header row, no ``#`` on ``Table Parameters:``.
+        rows = [
+            ("id", "int", "Surrogate id"),
+            ("ts", "timestamp", "Event time"),
+            ("", None, None),
+            ("# Detailed Table Information", None, None),
+            ("Database:           ", "amx_smoke           ", None),
+            ("OwnerType:          ", "USER                ", None),
+            ("Owner:              ", "hive                ", None),
+            ("CreateTime:         ", "Tue May 19 09:18:54 UTC 2026", None),
+            ("Retention:          ", "0                   ", None),
+            ("Location:           ", "file:/opt/hive/data/warehouse/amx_smoke.db/events", None),
+            ("Table Type:         ", "EXTERNAL_TABLE      ", None),
+            ("Table Parameters:", None, None),
+            ("", "EXTERNAL            ", "TRUE                "),
+            ("", "TRANSLATED_TO_EXTERNAL", "TRUE                "),
+            ("", "bucketing_version   ", "2                   "),
+            ("", "comment             ", "AMX writeback comment"),
+            ("", "external.table.purge", "TRUE                "),
+            ("", "last_modified_by    ", "hive                "),
+            ("", "last_modified_time  ", "1779182334          "),
+            ("", "numFiles            ", "0                   "),
+            ("", "transient_lastDdlTime", "1779182334          "),
+            ("", None, None),
+            ("# Storage Information", None, None),
+            (
+                "SerDe Library:      ",
+                "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+                None,
+            ),
+        ]
+        comment, columns = HiveAdapter._parse_describe_formatted(rows)
+        self.assertEqual(comment, "AMX writeback comment")
+        self.assertEqual(columns, {"id": "Surrogate id", "ts": "Event time"})
+
+
+class HiveAuthModeValidationTests(unittest.TestCase):
+    def test_unknown_auth_mode_rejected_at_create_engine(self) -> None:
+        # We can't reach the real create_engine without pyhive installed,
+        # so test the validation gate via direct check.
+        adapter = HiveAdapter(_cfg(auth_mode="MAGIC"))
+        # If pyhive is unavailable the ImportError fires first; either
+        # outcome is acceptable as long as the adapter never silently
+        # ships a garbage auth_mode to the driver.
+        with self.assertRaises((ValueError, ImportError)):
+            adapter.create_engine()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_trino_wizard.py
+++ b/tests/test_trino_wizard.py
@@ -200,6 +200,7 @@ class HiveWizardTests(unittest.TestCase):
             ]
         )
 
+        info_messages: list[str] = []
         with (
             patch(
                 "amx.cli_support.commands.db._offer_to_install_backend_driver",
@@ -218,6 +219,10 @@ class HiveWizardTests(unittest.TestCase):
                 side_effect=lambda *a, **kw: "hive-secret",
             ),
             patch(
+                "amx.cli_support.commands.db.info",
+                side_effect=lambda msg, *a, **kw: info_messages.append(str(msg)),
+            ),
+            patch(
                 "amx.cli_support.commands.db.warn",
                 side_effect=lambda *a, **kw: None,
             ),
@@ -231,6 +236,13 @@ class HiveWizardTests(unittest.TestCase):
         self.assertEqual(updated.password, "hive-secret")
         self.assertEqual(updated.auth_mode, "PLAIN")
         self.assertEqual(updated.database, "warehouse")
+        # Wizard surfaces the deployment-disambiguation hint so users
+        # configuring a Databricks legacy hive_metastore catalog don't
+        # accidentally configure the wrong backend.
+        self.assertTrue(
+            any("Databricks" in m and "hive_metastore" in m for m in info_messages),
+            f"Expected a Databricks/hive_metastore disambiguation hint, got {info_messages!r}",
+        )
 
     def test_nosasl_skips_password_prompt(self) -> None:
         defaults = DBConfig(backend="hive")
@@ -266,6 +278,10 @@ class HiveWizardTests(unittest.TestCase):
             patch(
                 "amx.cli_support.commands.db.ask_password",
                 side_effect=lambda *a, **kw: "",
+            ),
+            patch(
+                "amx.cli_support.commands.db.info",
+                side_effect=lambda *a, **kw: None,
             ),
             patch(
                 "amx.cli_support.commands.db.warn",


### PR DESCRIPTION
## Summary

Second half of [issue #518](https://github.com/omeryasirkucuk/amx/issues/518). Replaces the PR-A registration stub with a full HiveServer2 adapter.

- **Connection** — SQLAlchemy `hive://` URL via PyHive's bundled `pyhive.sqlalchemy_hive` dialect. `auth_mode` accepts `NOSASL` / `NONE` / `PLAIN` / `LDAP` / `KERBEROS` / `CUSTOM`; the wizard collects the first three explicitly. `KERBEROS` and `CUSTOM` are documented hand-edit paths for Cloudera CDH/CDP and similar deployments — the adapter forwards them without crashing.
- **Bulk metadata** — Hive 3.x `information_schema.{tables,columns}` fast path with per-table `DESCRIBE FORMATTED` fallback for Hive 2.x. The parser handles the row-shape drift between Hive 2.x (`# col_name` columns-block header, `# Table Parameters:` with hash prefix) and Hive 3.x / 4.x (no columns-block header, bare `Table Parameters:`).
- **Comment write-back** — `ALTER {TABLE|VIEW} <db>.<t> SET TBLPROPERTIES ('comment' = '<literal>')` for table / view, `ALTER DATABASE <db> SET DBPROPERTIES ('comment' = '<literal>')` for schema / database. Inlined literal (mirroring Databricks and Trino) sidesteps Hive's named-bind quirks in DDL.
- **Column comments stay OFF by design** — Hive's only path requires re-declaring the original column type, which is lossy for complex types (`struct`, `map`, `array`, `uniontype`). `column_comments=False` makes the connector raise `UnsupportedDatabaseOperation` cleanly upstream.
- **Listings** — explicit `SHOW DATABASES` / `SHOW TABLES IN <db>` / `SHOW VIEWS IN <db>` instead of relying on PyHive's SQLAlchemy inspector, which is incomplete on Hive 2.x.
- **Backtick identifier quoting** — HiveQL native convention.

## Hive lives in many places — wizard surfaces the disambiguation

The wizard prints an information banner before the host prompt:

> Hive backend targets HiveServer2 (Thrift). Use this for local Docker, on-prem Hadoop, EMR, and Cloudera CDH/CDP clusters. Databricks legacy `hive_metastore` catalogs belong to the Databricks backend, not this one.

This prevents the most common cross-backend mis-configuration. Users with HMS-only access (no HiveServer2) get pointed at the Trino backend's `hive` connector in the upcoming docs PR.

## Packaging

- `[hive]` extra: bare `pyhive>=0.7` + `thrift>=0.16` + `thrift-sasl>=0.4.3` + `pure-sasl>=0.6`. **Explicitly avoids `pyhive[hive]`** because that extra brings in the legacy `sasl` C extension which has no Windows wheels for modern Pythons and also fails to build on macOS. `thrift-sasl` ≥0.4.3 routes through pure-Python `pure-sasl`, which wheels cleanly on all three target OSes.
- `[all]` extra now includes the Hive driver pull (PR-A held it back while the adapter was a stub).

## Test plan

- [x] `pytest tests/` — 2576 passed (+ 15 vs PR-A), 0 failed, 10 unrelated skips.
- [x] `ruff check` + `ruff format --check` — clean.
- [x] New `tests/test_hive_adapter.py` (16 tests):
  - capability flags (column comments OFF, table/view/schema/database ON, shared-history OFF),
  - DDL template shape with backtick quoting,
  - literal escaping (`the customer's address` → ANSI `''` doubling),
  - `set_column_comment_sql` raise contract,
  - `set_database_comment_sql` raise on unpinned database,
  - `_parse_describe_formatted` across three captured row shapes (Hive 2.x synthetic, header-less synthetic, verbatim Hive 4.0.0 with `Table Parameters:` sans hash prefix).
- [x] `tests/test_trino_wizard.py` Hive cases assert the Databricks-vs-Hive disambiguation banner surfaces.
- [x] **Live smoke** against `apache/hive:4.0.0` Docker image (NOSASL on port 10000):
  - `SELECT 1` succeeds.
  - `list_databases` returns `['default']` initially, picks up `amx_smoke` after CREATE SCHEMA.
  - `bulk_schema_metadata('amx_smoke')` (DESCRIBE-FORMATTED fallback path) returns the events table with `kind='TABLE'`, column comments preserved from CREATE TABLE (`Surrogate id`, `Event time`), and the table-level `comment` landed via ALTER TABLE.
  - `ALTER TABLE amx_smoke.events SET TBLPROPERTIES('comment'='...')` — readback confirms.
  - `ALTER VIEW amx_smoke.events_v SET TBLPROPERTIES('comment'='Smoke view')` — readback confirms.
  - `ALTER DATABASE amx_smoke SET DBPROPERTIES('comment'='AMX smoke schema')` — `get_schema_comment` readback confirms.
  - Column writeback: `set_column_comment_sql` raises `UnsupportedDatabaseOperation` with the rationale message.
- [x] `deploy.sh` ran successfully — local Studio's `/api/profiles/db/backends` enumerates Hive with the new `field_specs` (PLAIN / LDAP / NOSASL select dropdown, default port 10000, `supports_shared_history=False`).
- [x] Cross-platform `[hive]` extra: `pip install` succeeds on macOS without the `sasl` C extension build failure that `pyhive[hive]` triggers.

## Out of scope

- **Kerberos / CUSTOM auth wizard** — the adapter accepts them but the picker stays Basic / LDAP / NOSASL. Cloudera CDP / kinit users hand-edit the YAML; the adapter routes through `pyhive`'s native Kerberos transport.
- **Column comment write-back** — capability stays OFF. Users wanting it should apply column comments through their data-definition tooling (dbt, Atlas) or migrate the table to a backend with native column-comment DDL (Trino, Databricks Unity Catalog, PostgreSQL).
- **Materialized view comments** — capability OFF; Hive 3.x materialized views exist but the write-back DDL surface is shaky and varies by execution engine.

## Issue #518

Stays **open** by request — a new AMX release will cut from `main` before the issue is closed so the reporter (`ying-w`) sees the feature land via a published version, not just merged commits.