### PR TITLE
feat(cli): add /pages REPL namespace and derive tab order from registry

### DIFF
--- a/amx/cli_support/_session_keybindings.py
+++ b/amx/cli_support/_session_keybindings.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.key_binding import KeyBindings
 
+from amx.cli_support.slash_commands import all_namespaces
+
 _NS_STATE: dict[str, str] = {"namespace": ""}
 
 
@@ -28,18 +30,11 @@ def _kb_escape_namespace() -> KeyBindings:
 
         return len(get_app().current_buffer.text) == 0
 
-    tabs = [
-        "",
-        "db",
-        "metadata",
-        "docs",
-        "llm",
-        "code",
-        "analyze",
-        "search",
-        "history",
-        "lineage",
-    ]
+    # Derive the arrow-nav tab order from the slash-command registry so
+    # a new namespace there is reachable by Left/Right immediately —
+    # the historical bug was a hand-maintained copy of this list that
+    # quietly drifted whenever a tab was added.
+    tabs = ["", *all_namespaces()]
 
     @kb.add("escape")
     def _(event) -> None:  # type: ignore[no-untyped-def]

--- a/amx/cli_support/_session_ui.py
+++ b/amx/cli_support/_session_ui.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from amx.cli_support.slash_commands import all_namespaces
 from amx.config import SUPPORTED_BACKENDS, AMXConfig
 from amx.utils.console import console, heading, info
 
@@ -24,18 +25,11 @@ def _canonical_namespace(namespace: str) -> str:
     return "metadata" if namespace == "manual" else namespace
 
 
-_TAB_ORDER = [
-    "root",
-    "db",
-    "metadata",
-    "docs",
-    "llm",
-    "code",
-    "analyze",
-    "search",
-    "history",
-    "lineage",
-]
+# Derive the tab strip from the slash-command registry so adding a new
+# namespace there automatically updates the bar — no manual list to
+# keep in sync (the historical bug where a new tab couldn't be reached
+# by arrow keys because the keybinding's separate copy missed it).
+_TAB_ORDER = ["root", *all_namespaces()]
 
 
 def _print_tab_bar(namespace: str) -> None:
@@ -89,6 +83,11 @@ def _print_namespace_hint(
         info(
             "Render column-level lineage diagrams from cached metadata. "
             "Each subcommand walks a picker — /create starts a guided wizard."
+        )
+    elif namespace == "pages":
+        info(
+            "Compose, edit, and export documentation pages. /new walks a wizard "
+            "(title → assets → intent → sources → LLM compose)."
         )
 
 
@@ -399,6 +398,31 @@ Commands:
 
 SQLite file:
   ~/.amx/history.db
+"""
+        )
+        return
+
+    if namespace == "pages":
+        out.print(
+            """
+[heading]Help — /pages namespace[/heading]
+Compose, edit, and export documentation pages backed by the active LLM. Each
+subcommand runs a wizard when called bare; the flags are optional power-user
+shortcuts.
+
+Commands:
+  1) /back                       Return to root namespace
+  2) /new                        Wizard: title → DB / doc / lineage asset pickers
+                                 → free-text intent → optional local sources →
+                                 LLM composition
+  3) /list                       List active (non-deleted) pages
+  4) /show <page_id>             Print the markdown body to stdout
+  5) /edit <page_id> [--note T]  Open $EDITOR, save the result as a new revision
+  6) /export <page_id>           Export as md or pdf (--format md|pdf [--out PATH])
+  7) /delete <page_id> [--purge] Soft-delete (default) or hard-delete (--purge)
+
+Page bodies, revisions, and source attachments live alongside run history in
+~/.amx/history.db.
 """
         )
         return

--- a/amx/cli_support/commands/pages.py
+++ b/amx/cli_support/commands/pages.py
@@ -1,8 +1,13 @@
-"""Flat ``/pages-*`` commands for the AMX interactive CLI.
+"""``/pages`` namespace commands for the AMX interactive CLI.
 
-Each command lives directly on the root Click group so the REPL
-exposes ``/pages-new``, ``/pages-list``, etc. (per CLAUDE.md rule #9).
-A bare ``/pages-new`` runs the wizard; flags are optional power-user
+Mirrors the ``/lineage`` shape: a single Click group ``pages`` with
+subcommands (``new``, ``list``, ``show``, ``edit``, ``export``,
+``delete``). Inside the ``/pages`` REPL tab the user types ``/new``,
+``/list``, etc.; from any other tab the same commands stay reachable
+as ``/pages new`` / ``/pages list`` thanks to the cross-namespace
+dispatch in :mod:`amx.cli_support.session`.
+
+A bare subcommand call runs the wizard; flags are optional power-user
 shortcuts.
 """
 
@@ -193,11 +198,15 @@ def register_pages_commands(
     main: click.Group,
     *,
     finalize_scope: FinalizeScope | None = None,
-) -> None:
-    """Attach ``/pages-*`` flat commands to the main Click group."""
+) -> click.Group:
+    """Attach the ``/pages`` namespace + subcommands to the main Click group."""
     del finalize_scope  # reserved for future per-asset scope expansion
 
-    @main.command("pages-new")
+    @main.group()
+    def pages() -> None:
+        """Compose, edit, and export documentation pages."""
+
+    @pages.command("new")
     @click.option("--title", default=None, help="Page title (prompted when omitted).")
     @click.option("--intent", default=None, help="Free-text generation intent.")
     @click.option(
@@ -280,13 +289,13 @@ def register_pages_commands(
         success(f"Created page {page_id}")
 
         if no_generate:
-            info("Skipped LLM composition (--no-generate). Use /pages-edit to write the body.")
+            info("Skipped LLM composition (--no-generate). Use /pages edit to write the body.")
             return
 
         try:
             svc.generate(page_id, now=_utcnow())
         except Exception as exc:  # noqa: BLE001
-            error(f"Generation failed: {exc}. Draft was saved; re-run with /pages-edit.")
+            error(f"Generation failed: {exc}. Draft was saved; re-run with /pages edit.")
             return
 
         page = svc.store.get(page_id)
@@ -295,14 +304,14 @@ def register_pages_commands(
         info("Preview (first 10 lines):")
         click.echo(preview)
 
-    @main.command("pages-list")
+    @pages.command("list")
     @click.pass_obj
     def pages_list(cfg: AMXConfig) -> None:
         """List active documentation pages."""
         svc = _svc(cfg)
         rows = svc.store.list_active()
         if not rows:
-            info("No pages yet. Create one with /pages-new.")
+            info("No pages yet. Create one with /pages new.")
             return
         table = Table(title="Documentation pages", show_lines=False)
         table.add_column("ID")
@@ -318,7 +327,7 @@ def register_pages_commands(
             )
         Console().print(table)
 
-    @main.command("pages-show")
+    @pages.command("show")
     @click.argument("page_id")
     @click.pass_obj
     def pages_show(cfg: AMXConfig, page_id: str) -> None:
@@ -330,7 +339,7 @@ def register_pages_commands(
             return
         click.echo(page.get("markdown_body", "") or "")
 
-    @main.command("pages-edit")
+    @pages.command("edit")
     @click.argument("page_id")
     @click.option("--note", default=None, help="Optional revision note.")
     @click.pass_obj
@@ -372,7 +381,7 @@ def register_pages_commands(
         )
         success(f"Saved new revision for {page_id}")
 
-    @main.command("pages-export")
+    @pages.command("export")
     @click.argument("page_id")
     @click.option(
         "--format",
@@ -417,7 +426,7 @@ def register_pages_commands(
         else:
             click.echo(payload, nl=False)
 
-    @main.command("pages-delete")
+    @pages.command("delete")
     @click.argument("page_id")
     @click.option(
         "--purge",
@@ -443,6 +452,8 @@ def register_pages_commands(
 
         svc.soft_delete(page_id, now=_utcnow())
         success(f"Soft-deleted page {page_id}")
+
+    return pages
 
 
 __all__ = ["register_pages_commands"]

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -678,6 +678,7 @@ _CROSS_NAMESPACE_HEADS: frozenset[str] = frozenset(
         "config",
         "studio",
         "lineage",
+        "pages",
     }
 )
 
@@ -854,6 +855,7 @@ def run_interactive_session(
     search_cmd_heads = _registry_cmd_heads("search") | frozenset({"embeddings", "embedding"})
     history_cmd_heads = _registry_cmd_heads("history")
     lineage_cmd_heads = _registry_cmd_heads("lineage")
+    pages_cmd_heads = _registry_cmd_heads("pages")
 
     # SIGWINCH (terminal resize) is POSIX-only — Windows raises
     # AttributeError on signal.SIGWINCH. Guard so the interactive session
@@ -1032,6 +1034,7 @@ def run_interactive_session(
                 "search",
                 "history",
                 "lineage",
+                "pages",
             }:
                 namespace = "metadata" if cmdline == "manual" else cmdline
                 console.clear()
@@ -1087,6 +1090,13 @@ def run_interactive_session(
                 elif head in lineage_cmd_heads:
                     namespace = "lineage"
                     info("Assumed /lineage namespace for this command.")
+                # Pages dispatched last so its generic heads (/list,
+                # /show, /edit, /delete) don't shadow the same heads in
+                # /history, /lineage, /metadata. Pages-unique heads
+                # (/new, /export) still resolve here from root.
+                elif head in pages_cmd_heads:
+                    namespace = "pages"
+                    info("Assumed /pages namespace for this command.")
 
             if namespace == "docs":
                 if parts[0] == "search-docs" and len(parts) == 1:

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -127,6 +127,17 @@ _ROOT_ENTRYPOINTS: tuple[SlashCommand, ...] = (
         ),
     ),
     SlashCommand(
+        "/pages",
+        "root",
+        "Enter /pages namespace",
+        long_desc=(
+            "Compose, edit, and export documentation pages backed by the "
+            "active LLM. Attach DB / doc / lineage assets as context and "
+            "ship the result as Markdown or PDF. Subcommands: new, list, "
+            "show, edit, export, delete."
+        ),
+    ),
+    SlashCommand(
         "/studio",
         "root",
         "Open AMX Studio in your browser",
@@ -504,6 +515,47 @@ _HISTORY_COMMANDS: tuple[SlashCommand, ...] = (
     ),
 )
 
+_PAGES_COMMANDS: tuple[SlashCommand, ...] = (
+    SlashCommand(
+        "/new",
+        "pages",
+        "Create a new documentation page (/new [--title T] [--intent X] [--asset KIND:REF …] [--source PATH …] [--no-generate])",
+        long_desc=(
+            "Bare /new walks a wizard: title prompt → DB / doc / lineage "
+            "asset pickers → free-text intent → optional local source "
+            "files → LLM composition. Power-user flags map 1:1 to the "
+            "wizard steps so existing scripts keep working."
+        ),
+    ),
+    SlashCommand("/list", "pages", "List active documentation pages"),
+    SlashCommand(
+        "/show",
+        "pages",
+        "Print the markdown body of a page (/show <page_id>)",
+    ),
+    SlashCommand(
+        "/edit",
+        "pages",
+        "Open the page body in $EDITOR and save the result as a new revision (/edit <page_id> [--note TEXT])",
+    ),
+    SlashCommand(
+        "/export",
+        "pages",
+        "Export a page as md or pdf (/export <page_id> --format md|pdf [--out PATH])",
+    ),
+    SlashCommand(
+        "/delete",
+        "pages",
+        "Soft-delete a page (/delete <page_id> [--purge])",
+        long_desc=(
+            "Default soft-delete hides the page from /pages list but keeps "
+            "every revision and source row. --purge hard-deletes the page "
+            "and every related row from the history store; not reversible."
+        ),
+    ),
+)
+
+
 _LINEAGE_COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         "/create",
@@ -590,6 +642,7 @@ ALL_COMMANDS: tuple[SlashCommand, ...] = (
     *_SEARCH_COMMANDS,
     *_HISTORY_COMMANDS,
     *_LINEAGE_COMMANDS,
+    *_PAGES_COMMANDS,
 )
 
 
@@ -633,6 +686,8 @@ def commands_for_namespace(namespace: str) -> tuple[SlashCommand, ...]:
         return (*_ROOT_BUILTINS, *_HISTORY_COMMANDS)
     if ns == "lineage":
         return (*_ROOT_BUILTINS, *_LINEAGE_COMMANDS)
+    if ns == "pages":
+        return (*_ROOT_BUILTINS, *_PAGES_COMMANDS)
     return _ROOT_BUILTINS
 
 
@@ -654,6 +709,7 @@ def cmd_heads_for_namespace(namespace: str) -> frozenset[str]:
         "search": _SEARCH_COMMANDS,
         "history": _HISTORY_COMMANDS,
         "lineage": _LINEAGE_COMMANDS,
+        "pages": _PAGES_COMMANDS,
     }
     if ns not in table:
         return frozenset()
@@ -683,7 +739,14 @@ def find_command(slash_or_head: str) -> SlashCommand | None:
 
 
 def all_namespaces() -> tuple[str, ...]:
-    """Distinct namespaces that have at least one command."""
+    """Distinct namespaces that have at least one command.
+
+    This is the single source of truth for the tab order. Both the REPL
+    tab bar (:mod:`amx.cli_support._session_ui`) and the Left/Right
+    arrow navigation in :mod:`amx.cli_support._session_keybindings`
+    derive from this tuple, so adding a new tab here automatically
+    surfaces it everywhere.
+    """
     return (
         "db",
         "metadata",
@@ -694,6 +757,7 @@ def all_namespaces() -> tuple[str, ...]:
         "search",
         "history",
         "lineage",
+        "pages",
     )
 
 

--- a/tests/test_pages_cli.py
+++ b/tests/test_pages_cli.py
@@ -1,4 +1,4 @@
-"""End-to-end CLI tests for ``/pages-*`` (flat REPL commands)."""
+"""End-to-end CLI tests for the ``/pages`` namespace subcommands."""
 
 from __future__ import annotations
 
@@ -44,7 +44,7 @@ class _StubResolver:
 
 @pytest.fixture
 def cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Root Click group with /pages-* commands wired to a tmp history.db."""
+    """Root Click group with the /pages namespace wired to a tmp history.db."""
     hs = SQLiteHistoryStore(tmp_path / "history.db")
     hs.init()
     _store_module._store = hs
@@ -96,7 +96,7 @@ def _make_page(cfg: AMXConfig) -> str:
 def test_pages_list_empty(cli) -> None:
     root, _hs, _cfg = cli
     runner = CliRunner()
-    result = runner.invoke(root, ["pages-list"])
+    result = runner.invoke(root, ["pages", "list"])
     assert result.exit_code == 0, result.output
     assert "No pages yet" in result.output
 
@@ -105,7 +105,7 @@ def test_pages_list_shows_created_page(cli) -> None:
     root, _hs, cfg = cli
     pid = _make_page(cfg)
     runner = CliRunner()
-    result = runner.invoke(root, ["pages-list"])
+    result = runner.invoke(root, ["pages", "list"])
     assert result.exit_code == 0, result.output
     assert "Test Page" in result.output
     assert pid[:8] in result.output
@@ -115,7 +115,7 @@ def test_pages_show_prints_body(cli) -> None:
     root, _hs, cfg = cli
     pid = _make_page(cfg)
     runner = CliRunner()
-    result = runner.invoke(root, ["pages-show", pid])
+    result = runner.invoke(root, ["pages", "show", pid])
     assert result.exit_code == 0, result.output
     assert "Overview" in result.output
     assert "Test body line 1" in result.output
@@ -124,7 +124,7 @@ def test_pages_show_prints_body(cli) -> None:
 def test_pages_show_unknown_id(cli) -> None:
     root, _hs, _cfg = cli
     runner = CliRunner()
-    result = runner.invoke(root, ["pages-show", "no-such-id"])
+    result = runner.invoke(root, ["pages", "show", "no-such-id"])
     assert result.exit_code == 0
     assert "not found" in result.output
 
@@ -134,7 +134,7 @@ def test_pages_export_md_writes_file(cli, tmp_path: Path) -> None:
     pid = _make_page(cfg)
     out = tmp_path / "out.md"
     runner = CliRunner()
-    result = runner.invoke(root, ["pages-export", pid, "--format", "md", "--out", str(out)])
+    result = runner.invoke(root, ["pages", "export", pid, "--format", "md", "--out", str(out)])
     assert result.exit_code == 0, result.output
     assert out.exists()
     body = out.read_text(encoding="utf-8")
@@ -145,11 +145,11 @@ def test_pages_delete_soft(cli) -> None:
     root, _hs, cfg = cli
     pid = _make_page(cfg)
     runner = CliRunner()
-    result = runner.invoke(root, ["pages-delete", pid])
+    result = runner.invoke(root, ["pages", "delete", pid])
     assert result.exit_code == 0, result.output
 
-    # Soft-deleted pages should not appear in /pages-list.
-    list_result = runner.invoke(root, ["pages-list"])
+    # Soft-deleted pages should not appear in /pages list.
+    list_result = runner.invoke(root, ["pages", "list"])
     assert pid not in list_result.output
 
 
@@ -157,6 +157,6 @@ def test_pages_delete_purge_removes_row(cli) -> None:
     root, hs, cfg = cli
     pid = _make_page(cfg)
     runner = CliRunner()
-    result = runner.invoke(root, ["pages-delete", pid, "--purge"])
+    result = runner.invoke(root, ["pages", "delete", pid, "--purge"])
     assert result.exit_code == 0, result.output
     assert hs.get_documentation_page(pid) is None

--- a/tests/test_pages_namespace.py
+++ b/tests/test_pages_namespace.py
@@ -1,0 +1,139 @@
+"""``/pages`` is a first-class REPL namespace.
+
+Pins:
+* ``/pages`` shows up as a root entry-point (so typing it at root
+  switches to the Pages tab instead of "Unknown command").
+* The Pages namespace owns its own subcommands and the dispatch /
+  autocomplete derivations agree on the set.
+* The arrow-nav tab order in the keybindings module + the tab-bar
+  order in the UI module + ``all_namespaces()`` agree — a missing
+  entry in any of those caused the historical bug where a freshly
+  added tab couldn't be reached by Left/Right.
+* ``session_to_click_args`` routes subcommands from any tab.
+"""
+
+from __future__ import annotations
+
+from amx.cli_support._session_keybindings import _kb_escape_namespace
+from amx.cli_support._session_ui import _TAB_ORDER
+from amx.cli_support.session import session_to_click_args
+from amx.cli_support.slash_commands import (
+    _PAGES_COMMANDS,
+    _ROOT_ENTRYPOINTS,
+    all_namespaces,
+    cmd_heads_for_namespace,
+    commands_for_namespace,
+    find_command,
+)
+
+
+def test_pages_is_registered_root_entrypoint() -> None:
+    """Typing ``/pages`` at root must resolve to a known root command."""
+    names = {sc.command for sc in _ROOT_ENTRYPOINTS}
+    assert "/pages" in names
+    sc = find_command("/pages")
+    assert sc is not None
+    assert sc.namespace == "root"
+
+
+def test_pages_namespace_listed_in_all_namespaces() -> None:
+    assert "pages" in all_namespaces()
+
+
+def test_pages_namespace_owns_its_subcommands() -> None:
+    heads = cmd_heads_for_namespace("pages")
+    for expected in ("new", "list", "show", "edit", "export", "delete"):
+        assert expected in heads, f"missing /pages {expected} in dispatch heads"
+
+
+def test_pages_namespace_autocomplete_only_lists_pages_commands() -> None:
+    """Pressing / in the Pages tab shows builtins + the six pages
+    subcommands — NOT history/lineage's identically-named commands."""
+    cmds = commands_for_namespace("pages")
+    cmd_names = {c.command for c in cmds}
+    expected = {"/new", "/list", "/show", "/edit", "/export", "/delete"}
+    assert expected.issubset(cmd_names)
+    # And nothing from sibling tabs leaks in.
+    assert "/profile" not in cmd_names  # /db
+    assert "/run" not in cmd_names  # /analyze
+    assert "/results" not in cmd_names  # /history
+    assert "/create" not in cmd_names  # /lineage
+
+
+def test_pages_subcommand_routes_from_every_namespace() -> None:
+    """``/pages list`` etc. must reach Click as ``pages list`` from
+    any tab — that's the contract behind 'every command reachable
+    from every page'."""
+    for namespace in (
+        "",
+        "db",
+        "metadata",
+        "docs",
+        "llm",
+        "code",
+        "analyze",
+        "search",
+        "history",
+        "lineage",
+        "pages",
+    ):
+        assert session_to_click_args(namespace, ["pages", "list"]) == ["pages", "list"], (
+            f"failed from namespace={namespace!r}"
+        )
+        assert session_to_click_args(namespace, ["pages", "new"]) == ["pages", "new"], (
+            f"failed from namespace={namespace!r}"
+        )
+
+
+def test_pages_subcommand_routes_when_already_in_pages_tab() -> None:
+    """Inside the /pages tab the user types the bare ``/list`` form;
+    dispatch must rewrite it to ``pages list``."""
+    assert session_to_click_args("pages", ["list"]) == ["pages", "list"]
+    assert session_to_click_args("pages", ["new"]) == ["pages", "new"]
+    assert session_to_click_args("pages", ["show", "abc"]) == ["pages", "show", "abc"]
+    assert session_to_click_args("pages", ["export", "abc", "--format", "md"]) == [
+        "pages",
+        "export",
+        "abc",
+        "--format",
+        "md",
+    ]
+
+
+def test_pages_subcommand_definitions_carry_pages_namespace() -> None:
+    """Each entry in the pages registry tuple lives under the
+    ``pages`` namespace so ``commands_for_namespace`` and
+    ``cmd_heads_for_namespace`` reflect it."""
+    for sc in _PAGES_COMMANDS:
+        assert sc.namespace == "pages", (
+            f"{sc.command} declared namespace={sc.namespace!r}, expected 'pages'"
+        )
+
+
+def test_tab_strip_includes_pages_after_lineage() -> None:
+    """Tab bar order — pages renders to the right of lineage."""
+    assert "pages" in _TAB_ORDER
+    assert _TAB_ORDER.index("pages") > _TAB_ORDER.index("lineage")
+
+
+def test_arrow_navigation_reaches_pages_tab() -> None:
+    """Arrow-key Left/Right tab cycling must include the new tab.
+
+    Past regression: a tab added to the UI tab strip + the slash
+    registry was unreachable by arrow keys because the keybinding
+    module kept its own hand-maintained copy of the tab list. The
+    list is now derived from ``all_namespaces()`` — this test pins
+    that derivation.
+    """
+    # The keybinding closure builds its internal tabs list when
+    # invoked; we can't read it directly, so we assert the upstream
+    # source it derives from.
+    _kb_escape_namespace()  # smoke-test the closure builds
+    assert "pages" in all_namespaces()
+
+
+def test_tab_order_agrees_with_registry() -> None:
+    """``_TAB_ORDER`` is just ``("root",) + all_namespaces()`` — any
+    drift here means a tab is visible in the strip but unreachable
+    via the registry-driven dispatch (or vice versa)."""
+    assert tuple(_TAB_ORDER) == ("root", *all_namespaces())


### PR DESCRIPTION
## Summary
- Register `/pages` as a root entry-point and refactor `pages.py` into a Click group (`new`/`list`/`show`/`edit`/`export`/`delete`) so typing `/pages` no longer returns "Unknown command" and the REPL gains a Pages tab next to `/lineage`.
- Wire dispatch, namespace hint, `/help`, and cross-namespace routing so `/pages <sub>` is reachable from every tab while the in-tab autocomplete only lists the six pages subcommands.
- Derive `_TAB_ORDER` (UI strip) and the Left/Right arrow-nav tabs from `all_namespaces()` — this kills the historical regression where a freshly added tab showed in the strip but couldn't be reached by the arrow keys because the keybinding module kept its own hand-maintained copy of the list.

## Test plan
- [x] `pytest tests/test_pages_cli.py tests/test_pages_namespace.py tests/test_session_command_global.py` — 23 passed
- [x] Full `pytest tests/ --ignore=tests/test_studio.py` green
- [x] `ruff check` + `ruff format --check` on touched files
- [ ] Manual: launch `amx-dev`, type `/pages`, confirm tab switches and `/list` works inside the tab; Left/Right arrows cycle through `pages` alongside the other tabs