### PR TITLE
feat(storage): documentation_pages db_profile + attribution + ALTER TABLE migrations (PR-2)

### DIFF
--- a/amx/cli_support/commands/pages.py
+++ b/amx/cli_support/commands/pages.py
@@ -732,9 +732,7 @@ def register_pages_commands(
                     return
                 info("Active pages:")
                 for idx, row in enumerate(active, start=1):
-                    click.echo(
-                        f"  {idx}. [{row.get('slug', '')}] {row.get('title', '')}"
-                    )
+                    click.echo(f"  {idx}. [{row.get('slug', '')}] {row.get('title', '')}")
                 raw = click.prompt("Select page (number or slug)").strip()
                 try:
                     choice = int(raw)

--- a/amx/cli_support/commands/pages.py
+++ b/amx/cli_support/commands/pages.py
@@ -690,6 +690,100 @@ def register_pages_commands(
         svc.soft_delete(page_id, now=_utcnow())
         success(f"Soft-deleted page {page_id}")
 
+    @pages.command("assign-profile")
+    @click.argument("slug", required=False, default=None)
+    @click.option(
+        "--profile",
+        "db_profile",
+        default=None,
+        help="DB profile name to associate with the page (omit to clear).",
+    )
+    @click.pass_obj
+    def pages_assign_profile(
+        cfg: AMXConfig,
+        slug: str | None,
+        db_profile: str | None,
+    ) -> None:
+        """Associate a db_profile with a page for team-scoped filtering.
+
+        When called without arguments, runs an interactive wizard:
+          1. Pick a page from the list of active pages.
+          2. Pick a DB profile from the configured profiles.
+          3. Confirm and apply.
+
+        Power-user shortcut (non-interactive)::
+
+            /pages assign-profile <slug> --profile <name>
+
+        Pass ``--profile ""`` (empty string) or omit ``--profile`` in the
+        wizard to clear the field, marking the page as unscoped /
+        cross-profile.
+        """
+        svc = _svc(cfg)
+
+        # ── Wizard path ───────────────────────────────────────────────────
+        if slug is None or db_profile is None:
+            # Step 1: page picker when slug not supplied.
+            final_slug = slug
+            if final_slug is None:
+                active = svc.store.list_active()
+                if not active:
+                    info("No active pages found. Create one with /pages new.")
+                    return
+                info("Active pages:")
+                for idx, row in enumerate(active, start=1):
+                    click.echo(
+                        f"  {idx}. [{row.get('slug', '')}] {row.get('title', '')}"
+                    )
+                raw = click.prompt("Select page (number or slug)").strip()
+                try:
+                    choice = int(raw)
+                    if 1 <= choice <= len(active):
+                        final_slug = str(active[choice - 1]["slug"])
+                    else:
+                        error(f"Selection out of range: {raw}")
+                        return
+                except ValueError:
+                    final_slug = raw
+
+            # Step 2: profile picker when --profile not supplied.
+            final_profile: str | None = db_profile
+            if final_profile is None:
+                db_names = sorted((cfg.db_profiles or {}).keys())
+                if db_names:
+                    info("Configured DB profiles: " + ", ".join(db_names))
+                raw_profile = click.prompt(
+                    "DB profile to assign (empty to clear / mark unscoped)",
+                    default="",
+                    show_default=False,
+                ).strip()
+                final_profile = raw_profile if raw_profile else None
+
+            # Step 3: confirm.
+            profile_label = f"'{final_profile}'" if final_profile else "(clear / unscoped)"
+            if not click.confirm(
+                f"Assign profile {profile_label} to page '{final_slug}'?", default=True
+            ):
+                info("Cancelled.")
+                return
+        else:
+            final_slug = slug
+            final_profile = db_profile if db_profile else None
+
+        # ── Apply ─────────────────────────────────────────────────────────
+        updated = svc.store.assign_db_profile(
+            slug=final_slug,
+            db_profile=final_profile,
+            now=_utcnow(),
+        )
+        if not updated:
+            error(f"No page with slug '{final_slug}' found.")
+            return
+        if final_profile:
+            success(f"Page '{final_slug}' is now scoped to profile '{final_profile}'.")
+        else:
+            success(f"Page '{final_slug}' is now unscoped (db_profile cleared).")
+
     return pages
 
 

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -553,6 +553,17 @@ _PAGES_COMMANDS: tuple[SlashCommand, ...] = (
             "and every related row from the history store; not reversible."
         ),
     ),
+    SlashCommand(
+        "/assign-profile",
+        "pages",
+        "Associate a db_profile with a page (/assign-profile [<slug>] [--profile <name>])",
+        long_desc=(
+            "Bare /assign-profile runs a wizard: page picker → profile picker "
+            "→ confirm. Power-user shortcut: /assign-profile <slug> --profile <name>. "
+            "Pass an empty --profile or omit it in the wizard to clear the field "
+            "(marks the page as unscoped / cross-profile)."
+        ),
+    ),
 )
 
 

--- a/amx/pages/store.py
+++ b/amx/pages/store.py
@@ -49,6 +49,7 @@ class PageStore:
         sources: Iterable[SourceRef],
         created_by: str | None,
         now: datetime,
+        db_profile: str | None = None,
     ) -> str:
         pid = str(uuid.uuid4())
         self._history.create_documentation_page(
@@ -63,6 +64,7 @@ class PageStore:
             created_by=created_by,
             generation_prompt=intent,
             model_used=None,
+            db_profile=db_profile,
         )
         for a in assets:
             self._history.attach_documentation_page_asset(pid, asset_kind=a.kind, asset_ref=a.ref)
@@ -114,3 +116,16 @@ class PageStore:
 
     def soft_delete(self, page_id: str, *, now: datetime) -> None:
         self._history.soft_delete_documentation_page(page_id, updated_at=now)
+
+    def assign_db_profile(
+        self, *, slug: str, db_profile: str | None, now: datetime
+    ) -> bool:
+        """Update the db_profile field for the page identified by *slug*.
+
+        Returns ``True`` if a row was updated, ``False`` when no page with
+        that slug was found.  Passing ``db_profile=None`` clears the field
+        (marks the page as unscoped / cross-profile).
+        """
+        return self._history.update_documentation_page_db_profile(
+            slug=slug, db_profile=db_profile, updated_at=now
+        )

--- a/amx/pages/store.py
+++ b/amx/pages/store.py
@@ -117,9 +117,7 @@ class PageStore:
     def soft_delete(self, page_id: str, *, now: datetime) -> None:
         self._history.soft_delete_documentation_page(page_id, updated_at=now)
 
-    def assign_db_profile(
-        self, *, slug: str, db_profile: str | None, now: datetime
-    ) -> bool:
+    def assign_db_profile(self, *, slug: str, db_profile: str | None, now: datetime) -> bool:
         """Update the db_profile field for the page identified by *slug*.
 
         Returns ``True`` if a row was updated, ``False`` when no page with

--- a/amx/storage/_history_pages.py
+++ b/amx/storage/_history_pages.py
@@ -33,14 +33,16 @@ def create_documentation_page(
     created_by: str | None,
     generation_prompt: str | None,
     model_used: str | None,
+    db_profile: str | None = None,
 ) -> None:
     with hs._connect() as conn:
         conn.execute(
             """
             INSERT INTO documentation_pages (
                 id, title, slug, markdown_body, rendered_html, status,
-                created_at, updated_at, created_by, generation_prompt, model_used
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                created_at, updated_at, created_by, generation_prompt, model_used,
+                db_profile
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 page_id,
@@ -54,6 +56,7 @@ def create_documentation_page(
                 created_by,
                 generation_prompt,
                 model_used,
+                db_profile,
             ),
         )
 
@@ -107,6 +110,26 @@ def soft_delete_documentation_page(
             "UPDATE documentation_pages SET status = 'deleted', updated_at = ? WHERE id = ?",
             (updated_at.isoformat(), page_id),
         )
+
+
+def update_documentation_page_db_profile(
+    hs: SQLiteHistoryStore,
+    *,
+    slug: str,
+    db_profile: str | None,
+    updated_at: datetime,
+) -> bool:
+    """Set (or clear) the db_profile for the page identified by *slug*.
+
+    Returns ``True`` if a row was updated, ``False`` if no page with that
+    slug was found.
+    """
+    with hs._connect() as conn:
+        cur = conn.execute(
+            "UPDATE documentation_pages SET db_profile = ?, updated_at = ? WHERE slug = ?",
+            (db_profile, updated_at.isoformat(), slug),
+        )
+    return bool(cur.rowcount)
 
 
 def append_documentation_page_version(

--- a/amx/storage/migration.py
+++ b/amx/storage/migration.py
@@ -31,7 +31,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import and_, inspect, insert, select, text
+from sqlalchemy import and_, insert, inspect, select, text
 from sqlalchemy.engine import Engine
 
 from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
@@ -540,9 +540,7 @@ def ensure_column_exists(
     # Pre-flight: skip if column already present.
     try:
         inspector = inspect(engine)
-        existing_cols = {
-            c["name"] for c in inspector.get_columns(table, schema=schema or None)
-        }
+        existing_cols = {c["name"] for c in inspector.get_columns(table, schema=schema or None)}
         if column_name in existing_cols:
             log.debug("ensure_column_exists: %s.%s already has %s", table, schema, column_name)
             return
@@ -559,9 +557,7 @@ def ensure_column_exists(
         # SQLite: suppress "duplicate column name" OperationalError.
         try:
             with engine.begin() as conn:
-                conn.execute(
-                    text(f"ALTER TABLE {fq_table} ADD COLUMN {column_name} {column_spec}")
-                )
+                conn.execute(text(f"ALTER TABLE {fq_table} ADD COLUMN {column_name} {column_spec}"))
         except Exception as exc:  # noqa: BLE001
             err = str(exc).lower()
             if "duplicate column" in err or "already exists" in err:
@@ -572,11 +568,7 @@ def ensure_column_exists(
         # Oracle raises ORA-01430 when the column already exists.
         try:
             with engine.begin() as conn:
-                conn.execute(
-                    text(
-                        f"ALTER TABLE {fq_table} ADD {column_name} {column_spec}"
-                    )
-                )
+                conn.execute(text(f"ALTER TABLE {fq_table} ADD {column_name} {column_spec}"))
         except Exception as exc:  # noqa: BLE001
             err = str(exc)
             if "ORA-01430" in err or "already exists" in err.lower():
@@ -588,9 +580,7 @@ def ensure_column_exists(
         try:
             with engine.begin() as conn:
                 conn.execute(
-                    text(
-                        f"ALTER TABLE {fq_table} ADD COLUMNS ({column_name} {column_spec})"
-                    )
+                    text(f"ALTER TABLE {fq_table} ADD COLUMNS ({column_name} {column_spec})")
                 )
         except Exception as exc:  # noqa: BLE001
             err = str(exc).lower()
@@ -602,10 +592,7 @@ def ensure_column_exists(
         # PostgreSQL, MySQL, Snowflake, BigQuery — all support IF NOT EXISTS.
         with engine.begin() as conn:
             conn.execute(
-                text(
-                    f"ALTER TABLE {fq_table} "
-                    f"ADD COLUMN IF NOT EXISTS {column_name} {column_spec}"
-                )
+                text(f"ALTER TABLE {fq_table} ADD COLUMN IF NOT EXISTS {column_name} {column_spec}")
             )
 
 

--- a/amx/storage/migration.py
+++ b/amx/storage/migration.py
@@ -31,7 +31,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import and_, insert, select
+from sqlalchemy import and_, inspect, insert, select, text
+from sqlalchemy.engine import Engine
 
 from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
 from amx.storage.sqlite_store import SQLiteHistoryStore
@@ -495,4 +496,117 @@ def _dump_or_none(value: Any) -> str | None:
         return None
 
 
-__all__ = ["migrate_local_to_shared", "pull_shared_to_local"]
+def ensure_column_exists(
+    engine: Engine,
+    schema: str | None,
+    table: str,
+    column_name: str,
+    column_spec: str,
+) -> None:
+    """Idempotently add *column_name* to *table* on the given engine.
+
+    Dispatches the correct DDL dialect for each supported backend:
+
+    * **SQLite** — ``ALTER TABLE … ADD COLUMN …`` wrapped in a try/except
+      (SQLite raises ``OperationalError: duplicate column name`` on a
+      second add; we suppress it).
+    * **PostgreSQL / MySQL / Snowflake / BigQuery** — ``ALTER TABLE … ADD
+      COLUMN IF NOT EXISTS …`` (all four support the IF NOT EXISTS clause
+      natively).
+    * **Oracle** — plain ``ALTER TABLE … ADD …`` wrapped in try/except for
+      ``ORA-01430`` (column already exists).
+    * **Databricks** — ``ALTER TABLE … ADD COLUMNS (…)`` (Databricks uses
+      the plural ``COLUMNS`` keyword).
+
+    For every backend, a pre-flight ``inspect(engine).get_columns(table)``
+    check is performed first; if the column is already present the ALTER is
+    skipped entirely to avoid any DDL noise on already-migrated schemas.
+
+    Parameters
+    ----------
+    engine:
+        SQLAlchemy engine connected to the target backend.
+    schema:
+        Schema (or database/namespace) name. ``None`` for SQLite or
+        schema-less connections.
+    table:
+        Unqualified table name.
+    column_name:
+        Name of the column to add.
+    column_spec:
+        Type + optional constraints as a SQL fragment (e.g. ``"TEXT"``,
+        ``"VARCHAR(120) DEFAULT NULL"``).
+    """
+    # Pre-flight: skip if column already present.
+    try:
+        inspector = inspect(engine)
+        existing_cols = {
+            c["name"] for c in inspector.get_columns(table, schema=schema or None)
+        }
+        if column_name in existing_cols:
+            log.debug("ensure_column_exists: %s.%s already has %s", table, schema, column_name)
+            return
+    except Exception:  # noqa: BLE001
+        # If introspection fails (e.g. table does not exist yet), fall
+        # through to the ALTER — it will fail with a meaningful error.
+        pass
+
+    dialect_name = engine.dialect.name.lower()
+
+    fq_table = f"{schema}.{table}" if schema else table
+
+    if dialect_name == "sqlite":
+        # SQLite: suppress "duplicate column name" OperationalError.
+        try:
+            with engine.begin() as conn:
+                conn.execute(
+                    text(f"ALTER TABLE {fq_table} ADD COLUMN {column_name} {column_spec}")
+                )
+        except Exception as exc:  # noqa: BLE001
+            err = str(exc).lower()
+            if "duplicate column" in err or "already exists" in err:
+                pass  # idempotent
+            else:
+                raise
+    elif dialect_name == "oracle":
+        # Oracle raises ORA-01430 when the column already exists.
+        try:
+            with engine.begin() as conn:
+                conn.execute(
+                    text(
+                        f"ALTER TABLE {fq_table} ADD {column_name} {column_spec}"
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001
+            err = str(exc)
+            if "ORA-01430" in err or "already exists" in err.lower():
+                pass  # idempotent
+            else:
+                raise
+    elif dialect_name == "databricks":
+        # Databricks uses plural COLUMNS and does not support IF NOT EXISTS.
+        try:
+            with engine.begin() as conn:
+                conn.execute(
+                    text(
+                        f"ALTER TABLE {fq_table} ADD COLUMNS ({column_name} {column_spec})"
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001
+            err = str(exc).lower()
+            if "already exists" in err:
+                pass  # idempotent
+            else:
+                raise
+    else:
+        # PostgreSQL, MySQL, Snowflake, BigQuery — all support IF NOT EXISTS.
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    f"ALTER TABLE {fq_table} "
+                    f"ADD COLUMN IF NOT EXISTS {column_name} {column_spec}"
+                )
+            )
+
+
+__all__ = ["ensure_column_exists", "migrate_local_to_shared", "pull_shared_to_local"]

--- a/amx/storage/schema_descriptions.py
+++ b/amx/storage/schema_descriptions.py
@@ -1579,6 +1579,13 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
             "LLM model id that produced the last generated draft; supports "
             "reproducibility and attribution."
         ),
+        "db_profile": (
+            "Source database profile this page was authored for. NULL means the page is "
+            "unscoped / cross-profile."
+        ),
+        "hostname": ATTRIBUTION_HOSTNAME,
+        "client_version": ATTRIBUTION_CLIENT_VERSION,
+        "local_id": ATTRIBUTION_LOCAL_ID,
     },
     # ── documentation_page_assets (local + shared) ────────────────────────
     "documentation_page_assets": {

--- a/amx/storage/shared_schema.py
+++ b/amx/storage/shared_schema.py
@@ -129,7 +129,7 @@ DEFAULT_HISTORY_SCHEMA_COMMENT = SHARED_SCHEMA_COMMENT
 # All client versions writing into a shared store record this as their
 # ``schema_version`` so an older client refuses to write into a schema
 # bumped by a newer client (avoids losing columns the new client added).
-SHARED_SCHEMA_VERSION = 2
+SHARED_SCHEMA_VERSION = 3
 
 
 def _desc(table: str, column: str | None = None) -> str:
@@ -562,8 +562,30 @@ def build_metadata(schema: str | None = None) -> MetaData:
             String(120),
             comment=_desc("documentation_pages", "model_used"),
         ),
+        Column(
+            "db_profile",
+            String(120),
+            comment=_desc("documentation_pages", "db_profile"),
+        ),
+        Column(
+            "hostname",
+            String(255),
+            comment=_desc("documentation_pages", "hostname"),
+        ),
+        Column(
+            "client_version",
+            String(40),
+            comment=_desc("documentation_pages", "client_version"),
+        ),
+        Column(
+            "local_id",
+            BigInteger,
+            comment=_desc("documentation_pages", "local_id"),
+        ),
         Index("ix_documentation_pages_status", "status"),
         Index("ix_documentation_pages_updated_at", "updated_at"),
+        Index("ix_documentation_pages_db_profile", "db_profile"),
+        Index("ix_documentation_pages_local_lookup", "hostname", "local_id"),
         comment=_desc("documentation_pages"),
     )
 

--- a/amx/storage/sqlalchemy_store.py
+++ b/amx/storage/sqlalchemy_store.py
@@ -229,8 +229,26 @@ class SQLAlchemyHistoryStore:
         Idempotent. ``MetaData.create_all`` skips tables that already
         exist. Also stamps :data:`SHARED_SCHEMA_VERSION` into
         ``schema_meta`` so older clients can detect a forward-rolled schema.
+
+        Post-create, runs ``ensure_column_exists`` for every column added
+        after the initial schema release so existing shared deployments
+        self-heal on next bootstrap without a manual migration step.
         """
+        from amx.storage.migration import ensure_column_exists
+
         self._md.create_all(self.engine)
+
+        # PR-2 columns on documentation_pages — added after v1 schema release.
+        for _col_name, _col_spec in (
+            ("db_profile", "VARCHAR(120)"),
+            ("hostname", "VARCHAR(255)"),
+            ("client_version", "VARCHAR(40)"),
+            ("local_id", "BIGINT"),
+        ):
+            ensure_column_exists(
+                self.engine, self.schema, "documentation_pages", _col_name, _col_spec
+            )
+
         with self.engine.begin() as conn:
             existing = conn.execute(select(self._t_meta.c.schema_version)).fetchone()
             if existing is None:

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -1135,6 +1135,18 @@ class SQLiteHistoryStore:
                 "CREATE INDEX IF NOT EXISTS idx_documentation_pages_updated_at "
                 "ON documentation_pages(updated_at DESC)"
             )
+            # PR-2: db_profile + attribution columns (idempotent ALTERs for
+            # existing installs; CREATE TABLE above handles fresh databases).
+            for _col_spec in (
+                "db_profile TEXT",
+                "hostname TEXT",
+                "client_version TEXT",
+                "local_id INTEGER",
+            ):
+                with contextlib.suppress(sqlite3.OperationalError):
+                    conn.execute(
+                        f"ALTER TABLE documentation_pages ADD COLUMN {_col_spec}"
+                    )
             # ── documentation_page_assets: per-page asset list ──────────
             conn.execute(
                 """

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -1881,6 +1881,11 @@ class SQLiteHistoryStore:
 
         return list_documentation_page_versions(self, *args, **kwargs)
 
+    def update_documentation_page_db_profile(self, *args, **kwargs):
+        from amx.storage._history_pages import update_documentation_page_db_profile
+
+        return update_documentation_page_db_profile(self, *args, **kwargs)
+
     def _connect(self) -> sqlite3.Connection:
         # ``timeout=30`` and the matching ``PRAGMA busy_timeout`` both
         # bump the lock-wait budget so concurrent Studio + CLI writers

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -1144,9 +1144,7 @@ class SQLiteHistoryStore:
                 "local_id INTEGER",
             ):
                 with contextlib.suppress(sqlite3.OperationalError):
-                    conn.execute(
-                        f"ALTER TABLE documentation_pages ADD COLUMN {_col_spec}"
-                    )
+                    conn.execute(f"ALTER TABLE documentation_pages ADD COLUMN {_col_spec}")
             # ── documentation_page_assets: per-page asset list ──────────
             conn.execute(
                 """

--- a/tests/storage/test_pages_db_profile_schema.py
+++ b/tests/storage/test_pages_db_profile_schema.py
@@ -86,8 +86,9 @@ def test_ensure_column_exists_is_idempotent_on_sqlite(tmp_path: Path) -> None:
     Uses an in-memory SQLite store to exercise the idempotency path of
     the migration helper — the second call must be a silent no-op.
     """
-    from amx.storage.migration import ensure_column_exists
     from sqlalchemy import create_engine, text
+
+    from amx.storage.migration import ensure_column_exists
 
     engine = create_engine("sqlite:///:memory:", future=True)
     with engine.begin() as conn:

--- a/tests/storage/test_pages_db_profile_schema.py
+++ b/tests/storage/test_pages_db_profile_schema.py
@@ -1,0 +1,104 @@
+"""Tests for the db_profile + attribution columns on documentation_pages.
+
+Verifies that the shared SQLAlchemy schema and local SQLite store both
+carry the four new columns added in PR-2: db_profile, hostname,
+client_version, local_id.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amx.storage.shared_schema import build_metadata
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    db = SQLiteHistoryStore(tmp_path / "history.db")
+    db.init()
+    return db
+
+
+def _shared_page_column_names() -> set[str]:
+    md = build_metadata("AMX")
+    table = md.tables["AMX.documentation_pages"]
+    return {c.name for c in table.columns}
+
+
+def _shared_page_index_names() -> set[str]:
+    md = build_metadata("AMX")
+    table = md.tables["AMX.documentation_pages"]
+    return {idx.name for idx in table.indexes}
+
+
+def _local_page_column_names(store: SQLiteHistoryStore) -> set[str]:
+    with store._connect() as conn:
+        rows = conn.execute("PRAGMA table_info(documentation_pages)").fetchall()
+    return {str(r[1]) for r in rows}
+
+
+# ── shared schema tests ───────────────────────────────────────────────────────
+
+
+def test_documentation_pages_has_db_profile_column() -> None:
+    """db_profile column exists in shared schema and has a dedicated index."""
+    cols = _shared_page_column_names()
+    assert "db_profile" in cols, "db_profile column missing from shared documentation_pages"
+    indexes = _shared_page_index_names()
+    assert "ix_documentation_pages_db_profile" in indexes, (
+        "ix_documentation_pages_db_profile index missing from shared documentation_pages"
+    )
+
+
+def test_documentation_pages_has_attribution_columns() -> None:
+    """hostname, client_version, and local_id columns exist in shared schema."""
+    cols = _shared_page_column_names()
+    for col in ("hostname", "client_version", "local_id"):
+        assert col in cols, f"{col} column missing from shared documentation_pages"
+    indexes = _shared_page_index_names()
+    assert "ix_documentation_pages_local_lookup" in indexes, (
+        "ix_documentation_pages_local_lookup composite index missing"
+    )
+
+
+# ── local SQLite tests ────────────────────────────────────────────────────────
+
+
+def test_local_documentation_pages_has_db_profile_column(store: SQLiteHistoryStore) -> None:
+    """db_profile column is present in the local SQLite documentation_pages table."""
+    cols = _local_page_column_names(store)
+    assert "db_profile" in cols, "db_profile column missing from local SQLite documentation_pages"
+
+
+def test_local_documentation_pages_has_attribution_columns(store: SQLiteHistoryStore) -> None:
+    """hostname, client_version, and local_id columns exist in local SQLite store."""
+    cols = _local_page_column_names(store)
+    for col in ("hostname", "client_version", "local_id"):
+        assert col in cols, f"{col} column missing from local SQLite documentation_pages"
+
+
+def test_ensure_column_exists_is_idempotent_on_sqlite(tmp_path: Path) -> None:
+    """ensure_column_exists can be called twice without raising errors.
+
+    Uses an in-memory SQLite store to exercise the idempotency path of
+    the migration helper — the second call must be a silent no-op.
+    """
+    from amx.storage.migration import ensure_column_exists
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE test_table (id INTEGER PRIMARY KEY)"))
+
+    # First call: adds the column.
+    ensure_column_exists(engine, None, "test_table", "extra_col", "TEXT")
+    # Second call: must be idempotent (no error).
+    ensure_column_exists(engine, None, "test_table", "extra_col", "TEXT")
+
+    with engine.begin() as conn:
+        rows = conn.execute(text("PRAGMA table_info(test_table)")).fetchall()
+    col_names = {str(r[1]) for r in rows}
+    assert "extra_col" in col_names, "Column was not added by ensure_column_exists"

--- a/tests/storage/test_pages_db_profile_writes.py
+++ b/tests/storage/test_pages_db_profile_writes.py
@@ -56,9 +56,7 @@ def test_create_page_with_db_profile_round_trip(store: SQLiteHistoryStore) -> No
     page_id = _create_page(store, db_profile="prod")
     row = store.get_documentation_page(page_id)
     assert row is not None, "Page must exist after creation"
-    assert row["db_profile"] == "prod", (
-        f"Expected db_profile='prod', got {row['db_profile']!r}"
-    )
+    assert row["db_profile"] == "prod", f"Expected db_profile='prod', got {row['db_profile']!r}"
 
 
 def test_create_page_without_db_profile_remains_null(store: SQLiteHistoryStore) -> None:
@@ -66,9 +64,7 @@ def test_create_page_without_db_profile_remains_null(store: SQLiteHistoryStore) 
     page_id = _create_page(store, db_profile=None)
     row = store.get_documentation_page(page_id)
     assert row is not None, "Page must exist after creation"
-    assert row["db_profile"] is None, (
-        f"Expected db_profile=None (NULL), got {row['db_profile']!r}"
-    )
+    assert row["db_profile"] is None, f"Expected db_profile=None (NULL), got {row['db_profile']!r}"
 
 
 def test_update_page_preserves_db_profile(store: SQLiteHistoryStore) -> None:

--- a/tests/storage/test_pages_db_profile_writes.py
+++ b/tests/storage/test_pages_db_profile_writes.py
@@ -1,0 +1,124 @@
+"""Tests for db_profile propagation through the pages CRUD layer.
+
+Verifies that create/update operations correctly store and preserve the
+db_profile field and that the update_documentation_page_db_profile helper
+works as expected.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteHistoryStore:
+    db = SQLiteHistoryStore(tmp_path / "history.db")
+    db.init()
+    return db
+
+
+def _create_page(
+    store: SQLiteHistoryStore,
+    *,
+    slug: str = "test-page",
+    db_profile: str | None = None,
+) -> str:
+    page_id = "aaaaaaaa-0000-0000-0000-000000000001"
+    now = _utcnow()
+    store.create_documentation_page(
+        page_id=page_id,
+        title="Test Page",
+        slug=slug,
+        markdown_body="",
+        rendered_html=None,
+        status="draft",
+        created_at=now,
+        updated_at=now,
+        created_by="test_user",
+        generation_prompt="describe the db",
+        model_used=None,
+        db_profile=db_profile,
+    )
+    return page_id
+
+
+def test_create_page_with_db_profile_round_trip(store: SQLiteHistoryStore) -> None:
+    """A page created with db_profile='prod' must return that value on read."""
+    page_id = _create_page(store, db_profile="prod")
+    row = store.get_documentation_page(page_id)
+    assert row is not None, "Page must exist after creation"
+    assert row["db_profile"] == "prod", (
+        f"Expected db_profile='prod', got {row['db_profile']!r}"
+    )
+
+
+def test_create_page_without_db_profile_remains_null(store: SQLiteHistoryStore) -> None:
+    """A page created without db_profile must have db_profile=NULL."""
+    page_id = _create_page(store, db_profile=None)
+    row = store.get_documentation_page(page_id)
+    assert row is not None, "Page must exist after creation"
+    assert row["db_profile"] is None, (
+        f"Expected db_profile=None (NULL), got {row['db_profile']!r}"
+    )
+
+
+def test_update_page_preserves_db_profile(store: SQLiteHistoryStore) -> None:
+    """Updating the page body must not clobber the db_profile field."""
+    page_id = _create_page(store, slug="preserve-test", db_profile="staging")
+    now = _utcnow()
+    store.update_documentation_page_body(
+        page_id,
+        markdown_body="updated content",
+        rendered_html=None,
+        updated_at=now,
+    )
+    row = store.get_documentation_page(page_id)
+    assert row is not None
+    assert row["db_profile"] == "staging", (
+        f"db_profile must survive a body update, got {row['db_profile']!r}"
+    )
+
+
+def test_update_db_profile_by_slug_returns_true_on_match(store: SQLiteHistoryStore) -> None:
+    """update_documentation_page_db_profile returns True when slug matches."""
+    _create_page(store, slug="slug-match")
+    result = store.update_documentation_page_db_profile(
+        slug="slug-match",
+        db_profile="analytics",
+        updated_at=_utcnow(),
+    )
+    assert result is True, "Expected True when a row was updated"
+
+
+def test_update_db_profile_by_slug_returns_false_on_miss(store: SQLiteHistoryStore) -> None:
+    """update_documentation_page_db_profile returns False for unknown slug."""
+    result = store.update_documentation_page_db_profile(
+        slug="does-not-exist",
+        db_profile="analytics",
+        updated_at=_utcnow(),
+    )
+    assert result is False, "Expected False when no row matched the slug"
+
+
+def test_update_db_profile_clear_to_none(store: SQLiteHistoryStore) -> None:
+    """Passing db_profile=None clears the field (marks page as unscoped)."""
+    page_id = _create_page(store, slug="clear-test", db_profile="old_profile")
+    store.update_documentation_page_db_profile(
+        slug="clear-test",
+        db_profile=None,
+        updated_at=_utcnow(),
+    )
+    row = store.get_documentation_page(page_id)
+    assert row is not None
+    assert row["db_profile"] is None, (
+        f"db_profile should be cleared to NULL, got {row['db_profile']!r}"
+    )

--- a/tests/test_pages_cli_assign_profile.py
+++ b/tests/test_pages_cli_assign_profile.py
@@ -1,0 +1,171 @@
+"""Tests for the /pages assign-profile CLI command.
+
+Invokes the command programmatically via Click's test runner and
+asserts that the underlying store is updated correctly.
+
+``build_pages_service`` (imported inside ``_svc``) is patched at the
+factory module level so no real AMXConfig / LLM provider is needed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from amx.pages.service import PagesService
+from amx.pages.store import PageStore
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ── Minimal stub collaborators ────────────────────────────────────────────────
+
+
+class _StubLLMClient:
+    @property
+    def model_name(self) -> str:
+        return "stub"
+
+    @property
+    def cfg(self) -> Any:
+        return None
+
+    def chat(self, messages: list[dict[str, str]], **kw: Any) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+
+class _StubResolver:
+    def resolve_db_asset(self, ref: str) -> str:  # pragma: no cover
+        return ""
+
+    def resolve_doc_profile(self, ref: str, intent: str, k: int = 5) -> list[str]:  # pragma: no cover
+        return []
+
+    def resolve_lineage(self, ref: str) -> str:  # pragma: no cover
+        return ""
+
+    def resolve_source(self, src: Any) -> str:  # pragma: no cover
+        return ""
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_store(tmp_path: Path) -> SQLiteHistoryStore:
+    db = SQLiteHistoryStore(tmp_path / "history.db")
+    db.init()
+    return db
+
+
+def _make_service(store: SQLiteHistoryStore) -> PagesService:
+    return PagesService(
+        store=PageStore(history=store),
+        llm=_StubLLMClient(),
+        resolver=_StubResolver(),
+        model_name="stub",
+    )
+
+
+def _seed_page(store: SQLiteHistoryStore, *, slug: str) -> str:
+    page_id = f"bbbbbbbb-0000-0000-0000-{slug[:12].ljust(12, '0')}"
+    now = _utcnow()
+    store.create_documentation_page(
+        page_id=page_id,
+        title="My Page",
+        slug=slug,
+        markdown_body="",
+        rendered_html=None,
+        status="draft",
+        created_at=now,
+        updated_at=now,
+        created_by=None,
+        generation_prompt=None,
+        model_used=None,
+        db_profile=None,
+    )
+    return page_id
+
+
+def _invoke(
+    store: SQLiteHistoryStore,
+    args: list[str],
+) -> CliRunner:
+    """Register the pages commands with a patched factory and invoke *args*."""
+    svc = _make_service(store)
+
+    @click.group()
+    @click.pass_context
+    def main(ctx: click.Context) -> None:
+        pass
+
+    from amx.cli_support.commands.pages import register_pages_commands
+
+    # ``_svc`` calls the locally-imported name ``build_pages_service``
+    # (imported at the top of pages.py), so the patch must target the name
+    # in the commands module's namespace.
+    target = "amx.cli_support.commands.pages.build_pages_service"
+
+    with patch(target, return_value=svc):
+        register_pages_commands(main)
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            args,
+            obj=object(),  # cfg stub — not used by assign-profile
+            catch_exceptions=False,
+        )
+
+    return result
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_assign_profile_flag_form_updates_row(tmp_store: SQLiteHistoryStore) -> None:
+    """Power-user flag form updates db_profile without interactive prompts."""
+    page_id = _seed_page(tmp_store, slug="flag-page")
+
+    result = _invoke(tmp_store, ["pages", "assign-profile", "flag-page", "--profile", "prod"])
+    assert result.exit_code == 0, f"Command failed:\n{result.output}"
+
+    row = tmp_store.get_documentation_page(page_id)
+    assert row is not None
+    assert row["db_profile"] == "prod", (
+        f"Expected db_profile='prod', got {row['db_profile']!r}\nOutput: {result.output}"
+    )
+
+
+def test_assign_profile_unknown_slug_reports_error(tmp_store: SQLiteHistoryStore) -> None:
+    """A non-existent slug causes an error message and exits cleanly."""
+    result = _invoke(
+        tmp_store, ["pages", "assign-profile", "ghost-page", "--profile", "prod"]
+    )
+    assert result.exit_code == 0, f"Unexpected exception:\n{result.output}"
+    assert "ghost-page" in result.output
+
+
+def test_assign_profile_clear_with_empty_profile(tmp_store: SQLiteHistoryStore) -> None:
+    """Passing an empty --profile string clears db_profile to NULL."""
+    page_id = _seed_page(tmp_store, slug="clear-page")
+    tmp_store.update_documentation_page_db_profile(
+        slug="clear-page", db_profile="staging", updated_at=_utcnow()
+    )
+
+    result = _invoke(tmp_store, ["pages", "assign-profile", "clear-page", "--profile", ""])
+    assert result.exit_code == 0, f"Command failed:\n{result.output}"
+
+    row = tmp_store.get_documentation_page(page_id)
+    assert row is not None
+    assert row["db_profile"] is None, (
+        f"Expected db_profile=None after clearing, got {row['db_profile']!r}"
+    )

--- a/tests/test_pages_cli_assign_profile.py
+++ b/tests/test_pages_cli_assign_profile.py
@@ -47,7 +47,9 @@ class _StubResolver:
     def resolve_db_asset(self, ref: str) -> str:  # pragma: no cover
         return ""
 
-    def resolve_doc_profile(self, ref: str, intent: str, k: int = 5) -> list[str]:  # pragma: no cover
+    def resolve_doc_profile(
+        self, ref: str, intent: str, k: int = 5
+    ) -> list[str]:  # pragma: no cover
         return []
 
     def resolve_lineage(self, ref: str) -> str:  # pragma: no cover
@@ -147,9 +149,7 @@ def test_assign_profile_flag_form_updates_row(tmp_store: SQLiteHistoryStore) -> 
 
 def test_assign_profile_unknown_slug_reports_error(tmp_store: SQLiteHistoryStore) -> None:
     """A non-existent slug causes an error message and exits cleanly."""
-    result = _invoke(
-        tmp_store, ["pages", "assign-profile", "ghost-page", "--profile", "prod"]
-    )
+    result = _invoke(tmp_store, ["pages", "assign-profile", "ghost-page", "--profile", "prod"])
     assert result.exit_code == 0, f"Unexpected exception:\n{result.output}"
     assert "ghost-page" in result.output
 

--- a/tests/test_shared_schema_comments.py
+++ b/tests/test_shared_schema_comments.py
@@ -56,10 +56,11 @@ def test_create_history_tables_ddl_emits_comments_on_postgres() -> None:
 
     assert ddl.count("CREATE TABLE") == 14, "expected 14 CREATE TABLE statements"
     assert ddl.count("COMMENT ON TABLE") == 14, "expected 14 COMMENT ON TABLE statements"
-    # 187 columns (112 original + 21 lineage_artifacts + 20 lineage_artifact_nodes
-    #              + 19 lineage_artifact_edges + 15 lineage_comments)
-    assert ddl.count("COMMENT ON COLUMN") == 187, (
-        f"expected 187 COMMENT ON COLUMN statements, got {ddl.count('COMMENT ON COLUMN')}"
+    # 191 columns (112 original + 21 lineage_artifacts + 20 lineage_artifact_nodes
+    #              + 19 lineage_artifact_edges + 15 lineage_comments
+    #              + 4 added to documentation_pages in PR-2: db_profile + attribution triad)
+    assert ddl.count("COMMENT ON COLUMN") == 191, (
+        f"expected 191 COMMENT ON COLUMN statements, got {ddl.count('COMMENT ON COLUMN')}"
     )
 
 


### PR DESCRIPTION
## Summary

- Adds `db_profile`, `hostname`, `client_version`, `local_id` columns (all nullable) to `documentation_pages` in both shared schema and local SQLite — existing pages stay NULL until retroactively assigned.
- New `ensure_column_exists()` DDL helper in `amx/storage/migration.py` — backend-dispatched ALTER TABLE so existing Postgres / Snowflake / BigQuery / Databricks / MySQL / Oracle / SQLite deploys auto-migrate on the next bootstrap; pre-flight `inspect(engine).get_columns()` short-circuits when the column already exists.
- Pages CRUD (`_history_pages.py`, `amx/pages/store.py`) accepts `db_profile` parameter on create/update.
- New `/pages assign-profile <slug> [--profile <name>]` CLI command with wizard-first invocation (CLAUDE.md feedback_amx_wizard_first_cli) for retroactive profile tagging.
- `SHARED_SCHEMA_VERSION` 1→3 (PR-1 also bumps to 2; final value will be 3 after both land).

This is PR-2 of the history-store team-collaboration 8-PR sequence. Independent of PR-1.

## Test plan

- [x] 79/79 pass on `tests/storage/ tests/test_pages_cli_assign_profile.py tests/test_shared_schema_comments.py tests/test_local_schema_comments.py`
- [x] Broader sweep `-k "pages or schema or document or migration"`: 224 pass + 3 skipped (xhtml2pdf optional dep)
- [x] No "paid" hits; no `Co-Authored-By`; English-only
- [x] `ensure_column_exists` idempotency confirmed (call twice → no error)
- [ ] Manual smoke on a real Postgres warehouse (defer to deploy)