### PR TITLE
feat(catalog): hard-limit skeleton-sync scope + cooperative cancellation

### DIFF
--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -1762,3 +1762,50 @@ def cmd_cache_clear(cfg: AMXConfig, rest: list[str]) -> None:
         summary_rows,
     )
     success(f"Cleared {report.total} row(s) across {len(report.deleted)} cache table(s).")
+
+
+def cmd_sync_stop(cfg: AMXConfig, rest: list[str]) -> None:
+    """/db sync-stop — cancel an in-flight catalog skeleton sync.
+
+    Bare ``/db sync-stop`` lists running syncs from the registry and
+    cancels them all (the common case is one). ``--profile <name>``
+    cancels only the named profile.
+
+    Cancellation is cooperative: the in-flight table finishes, the
+    sync loop exits, the freshness pill flips to ``cancelled``. Rows
+    already written remain in the cache.
+    """
+    from amx.search._skeleton_jobs import cancel, running_profiles
+
+    profile = ""
+    rest_tokens = list(rest)
+    for i, token in enumerate(rest_tokens):
+        if token == "--profile" and i + 1 < len(rest_tokens):
+            profile = rest_tokens[i + 1].strip()
+            break
+
+    running = sorted(running_profiles())
+    if not running:
+        info("No skeleton sync is currently running.")
+        return
+
+    if profile:
+        if profile not in running:
+            warn(f"No active sync for profile {profile!r}.")
+            return
+        targets = [profile]
+    else:
+        targets = running
+
+    cancelled_any = False
+    for target in targets:
+        if cancel(target):
+            success(
+                f"Cancellation requested for {target!r}. "
+                "The in-flight table will finish, then the sync exits."
+            )
+            cancelled_any = True
+        else:
+            info(f"No active sync to cancel for {target!r}.")
+    if not cancelled_any:
+        info("Nothing to cancel.")

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -627,6 +627,13 @@ def _handle_session_builtin(
             return True
         _cmd_cache_clear(cfg, parts[1:])
         return True
+    if head == "sync-stop":
+        if not _require_namespace(head, namespace, "db", "sync-stop"):
+            return True
+        from amx.cli_support.commands.db import cmd_sync_stop as _cmd_sync_stop
+
+        _cmd_sync_stop(cfg, parts[1:])
+        return True
     if head == "save":
         path = cfg.save()
         success(f"Saved configuration to {path}")

--- a/amx/db/_default_scope.py
+++ b/amx/db/_default_scope.py
@@ -1,0 +1,30 @@
+"""Per-backend default-container helper.
+
+A DB profile may pin a default container under one of three field
+names — ``catalog`` (Databricks, Trino), ``dataset`` (BigQuery), or
+``database`` (everything else). This helper normalizes the three so
+the skeleton sync can ask one question: "what container is this
+profile pinned to?".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def profile_default_container(db_cfg: Any) -> str | None:
+    """Return the profile's pinned default container, or ``None``.
+
+    Precedence: ``catalog`` (three-level backends), then ``dataset``
+    (BigQuery), then ``database`` (two-level backends). Empty strings
+    and ``None`` are treated as "unpinned".
+    """
+    if db_cfg is None:
+        return None
+    for attr in ("catalog", "dataset", "database"):
+        value = getattr(db_cfg, attr, None)
+        if value:
+            text = str(value).strip()
+            if text:
+                return text
+    return None

--- a/amx/search/_skeleton_jobs.py
+++ b/amx/search/_skeleton_jobs.py
@@ -1,0 +1,63 @@
+"""Module-level cancel registry for in-flight skeleton syncs.
+
+One :class:`threading.Event` per profile; ``cancel(profile)`` sets it
+so the running sync loop in :mod:`amx.search.drift` can break at its
+next checkpoint. Cooperative cancel only — the loop must reach a
+checkpoint for the cancel to take effect.
+"""
+
+from __future__ import annotations
+
+import threading
+
+_jobs: dict[str, threading.Event] = {}
+_lock = threading.RLock()
+
+
+def register(profile: str) -> threading.Event:
+    """Return (or create) the cancel event for ``profile``.
+
+    Re-entry returns the existing event so a restart racing a cancel
+    does not lose the signal.
+    """
+    with _lock:
+        event = _jobs.get(profile)
+        if event is None:
+            event = threading.Event()
+            _jobs[profile] = event
+        return event
+
+
+def cancel(profile: str) -> bool:
+    """Set the cancel event for ``profile``.
+
+    Returns ``True`` when a job was registered, ``False`` otherwise
+    (nothing to cancel).
+    """
+    with _lock:
+        event = _jobs.get(profile)
+        if event is None:
+            return False
+        event.set()
+        return True
+
+
+def is_cancelled(profile: str) -> bool:
+    """``True`` when ``cancel(profile)`` has been called for the
+    currently registered job."""
+    with _lock:
+        event = _jobs.get(profile)
+        return bool(event and event.is_set())
+
+
+def unregister(profile: str) -> None:
+    """Forget the cancel event for ``profile``. Safe to call when no
+    job is registered."""
+    with _lock:
+        _jobs.pop(profile, None)
+
+
+def running_profiles() -> list[str]:
+    """Snapshot of profile names with a registered job."""
+    with _lock:
+        return list(_jobs.keys())

--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -257,6 +257,12 @@ def _enumerate_containers(
     failed in a way the caller should surface to the user; ``None``
     otherwise.
     """
+    # Hard-limit scoping: when the profile pins a default container,
+    # walk only that one. Never enumerate the connector — even an
+    # admin user's catalog/database list would be wrong to write into
+    # the cache for a profile scoped out of those containers.
+    if default_container:
+        return [default_container], None
     try:
         connector = _scoped_connector(cfg, profile, None, is_three_level)
     except Exception as exc:
@@ -307,7 +313,17 @@ def sync_profile_skeleton(
     the given container names. Used by the per-database refresh
     button in the sidebar so clicking refresh on `SAP` doesn't
     re-sync `bird_train` and `bird_train_desc`.
+
+    A cooperative cancel event registered for *profile* in
+    :mod:`amx.search._skeleton_jobs` is checked at every loop head;
+    when set, the in-flight table finishes, the function exits via
+    ``finish_skeleton_sync(ok=False, error="cancelled")``, and the
+    rows already written remain in the cache.
     """
+    from amx.search import _skeleton_jobs
+    from amx.storage._history_caches import purge_out_of_scope
+
+    cancel_event = _skeleton_jobs.register(profile)
     summary: dict[str, Any] = {
         "profile": profile,
         "state": "none",
@@ -349,6 +365,32 @@ def sync_profile_skeleton(
                 or ""
             )
 
+    # Idempotent purge: rows from any previous unscoped sync that fall
+    # outside the pinned container are deleted in one transaction so a
+    # profile that just gained a pinned default never serves stale
+    # rows from other databases/catalogs. Skipped for unpinned
+    # profiles to preserve legacy multi-container behavior.
+    if default_container:
+        history_store = getattr(catalog, "history_store", None) or getattr(
+            catalog, "_hs", None
+        )
+        if history_store is not None:
+            try:
+                purge_counts = purge_out_of_scope(
+                    history_store,
+                    db_profile=profile,
+                    container=default_container,
+                )
+                if any(purge_counts.values()):
+                    log.info(
+                        "Skeleton purge for %s/%s: %s",
+                        profile,
+                        default_container,
+                        purge_counts,
+                    )
+            except Exception as exc:  # pragma: no cover - best-effort
+                log.warning("Skeleton purge skipped for %s: %s", profile, exc)
+
     # Step 1: decide which containers to walk.
     if databases:
         containers = [str(d) for d in databases if d]
@@ -367,6 +409,7 @@ def sync_profile_skeleton(
         catalog.finish_skeleton_sync(profile, ok=False, error=enum_error)
         summary["state"] = "failed"
         summary["error"] = enum_error
+        _skeleton_jobs.unregister(profile)
         return summary
 
     summary["containers"] = list(containers)
@@ -383,6 +426,8 @@ def sync_profile_skeleton(
     last_error = ""
     reached_any = False
     for container in containers:
+        if cancel_event.is_set():
+            break
         try:
             connector = _scoped_connector(cfg, profile, container or None, is_three_level)
             schemas = connector.list_schemas() or []
@@ -406,6 +451,8 @@ def sync_profile_skeleton(
             continue
         schema_assets: list[tuple[str, list]] = []
         for schema in schemas:
+            if cancel_event.is_set():
+                break
             try:
                 assets = connector.list_assets(schema) or []
             except Exception as exc:
@@ -421,6 +468,15 @@ def sync_profile_skeleton(
             total += len(assets)
         per_container_plan.append((container, schema_assets))
 
+    if cancel_event.is_set():
+        # Cancelled before pass-1 completed — surface as a clean
+        # cancellation, not a connect failure.
+        catalog.start_skeleton_sync(profile, total_tables=0)
+        catalog.finish_skeleton_sync(profile, ok=False, error="cancelled")
+        summary["state"] = "cancelled"
+        _skeleton_jobs.unregister(profile)
+        return summary
+
     if not reached_any:
         # Every container failed to connect. Surface the last error so
         # the user sees a real reason on the pill.
@@ -429,6 +485,7 @@ def sync_profile_skeleton(
         catalog.finish_skeleton_sync(profile, ok=False, error=err)
         summary["state"] = "failed"
         summary["error"] = err
+        _skeleton_jobs.unregister(profile)
         return summary
 
     if total == 0:
@@ -446,6 +503,7 @@ def sync_profile_skeleton(
         catalog.finish_skeleton_sync(profile, ok=False, error=err)
         summary["state"] = "failed"
         summary["error"] = err
+        _skeleton_jobs.unregister(profile)
         return summary
 
     catalog.start_skeleton_sync(profile, total_tables=total)
@@ -461,9 +519,15 @@ def sync_profile_skeleton(
     try:
         with catalog._connect() as conn:  # noqa: SLF001 — owns the catalog conn
             for container, schema_assets in per_container_plan:
+                if cancel_event.is_set():
+                    break
                 stamp = container or default_container
                 for schema, assets in schema_assets:
+                    if cancel_event.is_set():
+                        break
                     for asset in assets:
+                        if cancel_event.is_set():
+                            break
                         name, kind = _asset_name_and_kind(asset)
                         if not name:
                             continue
@@ -498,11 +562,21 @@ def sync_profile_skeleton(
         summary["state"] = "failed"
         summary["processed"] = processed
         summary["error"] = str(exc)
+        _skeleton_jobs.unregister(profile)
+        return summary
+
+    if cancel_event.is_set():
+        catalog.finish_skeleton_sync(profile, ok=False, error="cancelled")
+        summary["state"] = "cancelled"
+        summary["processed"] = processed
+        summary["error"] = "cancelled"
+        _skeleton_jobs.unregister(profile)
         return summary
 
     catalog.finish_skeleton_sync(profile, ok=True)
     summary["state"] = "done"
     summary["processed"] = processed
+    _skeleton_jobs.unregister(profile)
     return summary
 
 

--- a/amx/storage/_history_caches.py
+++ b/amx/storage/_history_caches.py
@@ -621,3 +621,55 @@ def gc_schemas_cache(hs: SQLiteHistoryStore) -> int:
             (now,),
         )
         return int(cur.rowcount or 0)
+
+
+def purge_out_of_scope(
+    hs: SQLiteHistoryStore,
+    *,
+    db_profile: str,
+    container: str,
+) -> dict[str, int]:
+    """Delete cached rows for ``db_profile`` whose container does not
+    match ``container``. Idempotent. Returns deletion counts per
+    table for the audit log.
+
+    Three cache tables are purged in one transaction:
+
+    * ``catalog_entities`` — keyed by ``database_name``
+    * ``schemas_cache`` — keyed by ``database_name`` and ``catalog_name``
+      (a row is kept when either column equals ``container``)
+    * ``column_comments_cache`` — keyed by ``database_name``
+
+    When ``container`` is empty the call is a no-op (the profile is
+    unpinned and the legacy multi-container behavior applies).
+    """
+    container = str(container or "")
+    counts = {
+        "catalog_entities": 0,
+        "schemas_cache": 0,
+        "column_comments_cache": 0,
+    }
+    if not container:
+        return counts
+    with hs._lock, hs._connect() as conn:
+        cur = conn.execute(
+            "DELETE FROM catalog_entities "
+            "WHERE db_profile = ? AND IFNULL(database_name, '') != ?",
+            (db_profile, container),
+        )
+        counts["catalog_entities"] = int(cur.rowcount or 0)
+        cur = conn.execute(
+            "DELETE FROM schemas_cache "
+            "WHERE db_profile = ? "
+            "AND IFNULL(database_name, '') != ? "
+            "AND IFNULL(catalog_name, '') != ?",
+            (db_profile, container, container),
+        )
+        counts["schemas_cache"] = int(cur.rowcount or 0)
+        cur = conn.execute(
+            "DELETE FROM column_comments_cache "
+            "WHERE db_profile = ? AND IFNULL(database_name, '') != ?",
+            (db_profile, container),
+        )
+        counts["column_comments_cache"] = int(cur.rowcount or 0)
+    return counts

--- a/amx/web/routers/catalog.py
+++ b/amx/web/routers/catalog.py
@@ -52,6 +52,12 @@ class CacheRefreshRequest(BaseModel):
     kind: Literal["cache_refresh"] = "cache_refresh"
 
 
+class CatalogSyncCancelRequest(BaseModel):
+    """Body accepted by ``POST /api/catalog/sync/cancel``."""
+
+    profile: str = Field(min_length=1)
+
+
 def _catalog(cfg: AMXConfig) -> SearchCatalog:
     """Build a SearchCatalog handle bound to the active history store.
 
@@ -438,7 +444,14 @@ def trigger_catalog_sync(
 
     databases_arg: list[str] | None = [database.strip()] if database else None
 
+    from amx.search import _skeleton_jobs
+
     def _spawn(target_profile: str) -> None:
+        # Register the cancel slot synchronously before the thread
+        # starts so a /sync/cancel call landing during thread spin-up
+        # still finds an event to set.
+        _skeleton_jobs.register(target_profile)
+
         def _runner() -> None:
             try:
                 sync_profile_skeleton(cfg, target_profile, catalog, databases=databases_arg)
@@ -447,6 +460,8 @@ def trigger_catalog_sync(
                     catalog.finish_skeleton_sync(target_profile, ok=False, error=str(exc))
                 except Exception:
                     pass
+                finally:
+                    _skeleton_jobs.unregister(target_profile)
 
         threading.Thread(
             target=_runner,
@@ -461,6 +476,31 @@ def trigger_catalog_sync(
         "database": database or None,
         "status": "queued",
     }
+
+
+@router.post("/sync/cancel")
+def cancel_catalog_sync(body: CatalogSyncCancelRequest) -> dict[str, Any]:
+    """Cooperatively cancel an in-flight skeleton sync for ``profile``.
+
+    The running sync thread observes the cancel at its next loop
+    checkpoint (per-container, per-schema, or per-table), finishes
+    the in-flight table, then exits cleanly with
+    ``finish_skeleton_sync(ok=False, error="cancelled")``. Rows
+    already written remain in the cache.
+
+    Returns ``{"cancelled": True}`` when a job was registered for
+    ``profile``, ``{"cancelled": False}`` when nothing was running.
+    """
+    from amx.search import _skeleton_jobs
+
+    profile = (body.profile or "").strip()
+    if not profile:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="profile is required.",
+        )
+    cancelled = _skeleton_jobs.cancel(profile)
+    return {"profile": profile, "cancelled": cancelled}
 
 
 @router.post("/refresh")

--- a/docs/superpowers/plans/2026-05-20-skeleton-sync-hardening.md
+++ b/docs/superpowers/plans/2026-05-20-skeleton-sync-hardening.md
@@ -1,0 +1,1098 @@
+# Skeleton Sync Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the catalog skeleton sync (a) honor a profile's pinned default container as a hard limit so the cache never contains out-of-scope rows, and (b) accept cooperative cancellation from Studio, the REPL, and Python callers.
+
+**Architecture:** Two new tiny stdlib-only modules (a cancel registry and a default-container helper) plus targeted edits to `drift.py`, `web/routers/catalog.py`, `cli_support/session.py`, and `storage/_history_caches.py`. No storage-schema change, no class refactor.
+
+**Tech Stack:** Python 3.11+, FastAPI, threading (stdlib), SQLite (existing history store), pytest.
+
+---
+
+## File structure
+
+| Path | Action |
+|---|---|
+| `amx/search/_skeleton_jobs.py` | **new** — module-level cancel registry |
+| `amx/db/_default_scope.py` | **new** — backend-uniform default helper |
+| `amx/search/drift.py` | edit — enumerator + cancel checkpoints |
+| `amx/web/routers/catalog.py` | edit — register on start, new cancel endpoint |
+| `amx/cli_support/commands/db.py` | edit — `cmd_sync_stop` wizard |
+| `amx/cli_support/session.py` | edit — wire `sync-stop` into the `db` namespace |
+| `amx/storage/_history_caches.py` | edit — `purge_out_of_scope` |
+| `amx/search/__init__.py` | edit — re-export `cancel_skeleton_sync` |
+| `tests/test_skeleton_jobs.py` | **new** — registry unit tests |
+| `tests/test_default_scope.py` | **new** — helper unit tests |
+| `tests/storage/test_history_caches_purge.py` | **new** — purge unit tests |
+| `tests/test_skeleton_sync_pinned_default.py` | **new** — scope integration test |
+| `tests/test_skeleton_sync_cancellation.py` | **new** — cancel integration test |
+| `tests/web/test_catalog_sync_cancel.py` | **new** — HTTP endpoint test |
+
+Test placement follows the existing repo layout: `tests/storage/` and `tests/web/` exist as subdirs; everything else is flat in `tests/`.
+
+---
+
+## Task 1: Cancel registry module
+
+**Files:**
+- Create: `amx/search/_skeleton_jobs.py`
+- Test: `tests/test_skeleton_jobs.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_skeleton_jobs.py
+"""Tests for the module-level skeleton-sync cancel registry."""
+
+from __future__ import annotations
+
+from amx.search import _skeleton_jobs
+
+
+def setup_function() -> None:
+    _skeleton_jobs._jobs.clear()
+
+
+def test_register_returns_unset_event() -> None:
+    event = _skeleton_jobs.register("prof")
+    assert event.is_set() is False
+    assert _skeleton_jobs.is_cancelled("prof") is False
+
+
+def test_cancel_sets_event_and_returns_true() -> None:
+    event = _skeleton_jobs.register("prof")
+    assert _skeleton_jobs.cancel("prof") is True
+    assert event.is_set() is True
+    assert _skeleton_jobs.is_cancelled("prof") is True
+
+
+def test_cancel_with_no_job_returns_false() -> None:
+    assert _skeleton_jobs.cancel("missing") is False
+
+
+def test_double_register_returns_same_event() -> None:
+    first = _skeleton_jobs.register("prof")
+    second = _skeleton_jobs.register("prof")
+    assert first is second
+
+
+def test_unregister_clears_job() -> None:
+    _skeleton_jobs.register("prof")
+    _skeleton_jobs.unregister("prof")
+    assert _skeleton_jobs.is_cancelled("prof") is False
+    assert _skeleton_jobs.cancel("prof") is False
+
+
+def test_running_profiles_lists_registered() -> None:
+    _skeleton_jobs.register("a")
+    _skeleton_jobs.register("b")
+    assert sorted(_skeleton_jobs.running_profiles()) == ["a", "b"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd ~/Desktop/omeryasirkucuk/Master/Thesis/AMX
+pytest tests/test_skeleton_jobs.py -v
+```
+
+Expected: ModuleNotFoundError or all tests fail because `_skeleton_jobs` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# amx/search/_skeleton_jobs.py
+"""Module-level cancel registry for in-flight skeleton syncs.
+
+One :class:`threading.Event` per profile; ``cancel(profile)`` sets it
+so the running sync loop in :mod:`amx.search.drift` can break at its
+next checkpoint. Cooperative cancel only — the loop must reach a
+checkpoint for the cancel to take effect.
+"""
+
+from __future__ import annotations
+
+import threading
+
+_jobs: dict[str, threading.Event] = {}
+_lock = threading.RLock()
+
+
+def register(profile: str) -> threading.Event:
+    """Return (or create) the cancel event for ``profile``.
+
+    Re-entry returns the existing event so a restart racing a cancel
+    doesn't lose the signal.
+    """
+    with _lock:
+        event = _jobs.get(profile)
+        if event is None:
+            event = threading.Event()
+            _jobs[profile] = event
+        return event
+
+
+def cancel(profile: str) -> bool:
+    """Set the cancel event for ``profile``. Returns ``True`` when a job
+    was registered, ``False`` otherwise (nothing to cancel)."""
+    with _lock:
+        event = _jobs.get(profile)
+        if event is None:
+            return False
+        event.set()
+        return True
+
+
+def is_cancelled(profile: str) -> bool:
+    """``True`` when ``cancel(profile)`` has been called for the
+    currently registered job."""
+    with _lock:
+        event = _jobs.get(profile)
+        return bool(event and event.is_set())
+
+
+def unregister(profile: str) -> None:
+    """Forget the cancel event for ``profile``. Safe to call when no
+    job is registered."""
+    with _lock:
+        _jobs.pop(profile, None)
+
+
+def running_profiles() -> list[str]:
+    """Snapshot of profile names with a registered job."""
+    with _lock:
+        return list(_jobs.keys())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/test_skeleton_jobs.py -v
+```
+
+Expected: all six tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add amx/search/_skeleton_jobs.py tests/test_skeleton_jobs.py
+git commit -m "feat(search): add module-level cancel registry for skeleton sync"
+```
+
+---
+
+## Task 2: Default-container helper
+
+**Files:**
+- Create: `amx/db/_default_scope.py`
+- Test: `tests/test_default_scope.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_default_scope.py
+"""Tests for the per-backend default-container helper."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from amx.db._default_scope import profile_default_container
+
+
+def test_databricks_catalog_wins() -> None:
+    db = SimpleNamespace(backend="databricks", catalog="prod", database="", dataset="")
+    assert profile_default_container(db) == "prod"
+
+
+def test_bigquery_dataset() -> None:
+    db = SimpleNamespace(backend="bigquery", catalog="", dataset="analytics", database="")
+    assert profile_default_container(db) == "analytics"
+
+
+def test_snowflake_database() -> None:
+    db = SimpleNamespace(backend="snowflake", catalog="", dataset="", database="DW")
+    assert profile_default_container(db) == "DW"
+
+
+def test_postgres_database() -> None:
+    db = SimpleNamespace(backend="postgres", catalog="", dataset="", database="app")
+    assert profile_default_container(db) == "app"
+
+
+def test_empty_profile_returns_none() -> None:
+    db = SimpleNamespace(backend="postgres", catalog="", dataset="", database="")
+    assert profile_default_container(db) is None
+
+
+def test_none_input_returns_none() -> None:
+    assert profile_default_container(None) is None
+
+
+def test_catalog_beats_database_when_both_set() -> None:
+    db = SimpleNamespace(backend="trino", catalog="hive", database="default", dataset="")
+    assert profile_default_container(db) == "hive"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/test_default_scope.py -v
+```
+
+Expected: ModuleNotFoundError or all tests fail.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# amx/db/_default_scope.py
+"""Per-backend default-container helper.
+
+A DB profile may pin a default container under one of three field
+names — ``catalog`` (Databricks, Trino), ``dataset`` (BigQuery), or
+``database`` (everything else). This helper normalizes the three so
+the skeleton sync can ask one question: "what container is this
+profile pinned to?".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def profile_default_container(db_cfg: Any) -> str | None:
+    """Return the profile's pinned default container, or ``None``.
+
+    Precedence: ``catalog`` (three-level backends), then ``dataset``
+    (BigQuery), then ``database`` (two-level backends). Empty strings
+    and ``None`` are treated as "unpinned".
+    """
+    if db_cfg is None:
+        return None
+    for attr in ("catalog", "dataset", "database"):
+        value = getattr(db_cfg, attr, None)
+        if value:
+            text = str(value).strip()
+            if text:
+                return text
+    return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/test_default_scope.py -v
+```
+
+Expected: all seven tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add amx/db/_default_scope.py tests/test_default_scope.py
+git commit -m "feat(db): add backend-uniform default-container helper"
+```
+
+---
+
+## Task 3: Purge function in history caches
+
+**Files:**
+- Modify: `amx/storage/_history_caches.py`
+- Test: `tests/storage/test_history_caches_purge.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/storage/test_history_caches_purge.py
+"""Tests for purge_out_of_scope — the migration helper that strips
+cached rows belonging to containers outside the profile's pinned
+default."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from amx.storage._history_caches import (
+    purge_out_of_scope,
+    save_column_comments_cache,
+    save_schemas_cache,
+)
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture()
+def hs(tmp_path) -> SQLiteHistoryStore:
+    return SQLiteHistoryStore(tmp_path / "history.db")
+
+
+def test_purge_removes_only_out_of_scope_rows(hs: SQLiteHistoryStore) -> None:
+    # In-scope (kept):
+    save_column_comments_cache(
+        hs,
+        db_profile="prof",
+        database="prod",
+        schema="public",
+        entries={"orders": {"table_comment": "ok", "columns": {}, "kind": "TABLE"}},
+    )
+    # Out-of-scope (purged):
+    save_column_comments_cache(
+        hs,
+        db_profile="prof",
+        database="dev",
+        schema="public",
+        entries={"orders": {"table_comment": "stale", "columns": {}, "kind": "TABLE"}},
+    )
+    counts = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert counts["column_comments_cache"] == 1
+
+    with hs._connect() as conn:
+        rows = conn.execute(
+            "SELECT database_name FROM column_comments_cache WHERE db_profile = ?",
+            ("prof",),
+        ).fetchall()
+    assert [r["database_name"] for r in rows] == ["prod"]
+
+
+def test_purge_is_idempotent(hs: SQLiteHistoryStore) -> None:
+    save_column_comments_cache(
+        hs,
+        db_profile="prof",
+        database="dev",
+        schema="public",
+        entries={"orders": {"table_comment": "x", "columns": {}, "kind": "TABLE"}},
+    )
+    first = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    second = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert first["column_comments_cache"] == 1
+    assert second["column_comments_cache"] == 0
+
+
+def test_purge_leaves_other_profiles_alone(hs: SQLiteHistoryStore) -> None:
+    save_column_comments_cache(
+        hs,
+        db_profile="other",
+        database="dev",
+        schema="public",
+        entries={"orders": {"table_comment": "x", "columns": {}, "kind": "TABLE"}},
+    )
+    counts = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert counts["column_comments_cache"] == 0
+    with hs._connect() as conn:
+        n = conn.execute(
+            "SELECT COUNT(*) AS n FROM column_comments_cache WHERE db_profile = ?",
+            ("other",),
+        ).fetchone()["n"]
+    assert n == 1
+
+
+def test_purge_handles_schemas_cache(hs: SQLiteHistoryStore) -> None:
+    save_schemas_cache(
+        hs,
+        db_profile="prof",
+        database="prod",
+        catalog="",
+        entries={"public": {"comment": "ok"}},
+    )
+    save_schemas_cache(
+        hs,
+        db_profile="prof",
+        database="dev",
+        catalog="",
+        entries={"public": {"comment": "stale"}},
+    )
+    counts = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert counts["schemas_cache"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/storage/test_history_caches_purge.py -v
+```
+
+Expected: ImportError because `purge_out_of_scope` is not defined.
+
+- [ ] **Step 3: Add `purge_out_of_scope` to `amx/storage/_history_caches.py`**
+
+Append this function at the end of the module:
+
+```python
+def purge_out_of_scope(
+    hs: "SQLiteHistoryStore",
+    *,
+    db_profile: str,
+    container: str,
+) -> dict[str, int]:
+    """Delete cached rows for ``db_profile`` whose container does not
+    match ``container``. Idempotent. Returns deletion counts per
+    table for the audit log.
+
+    Three cache tables are purged in one transaction:
+    * ``catalog_entities`` — keyed by ``database_name``
+    * ``schemas_cache`` — keyed by ``database`` (and ``catalog`` on
+      three-level backends; the row matches when either field equals
+      ``container``)
+    * ``column_comments_cache`` — keyed by ``database_name``
+    """
+    container = str(container or "")
+    counts = {
+        "catalog_entities": 0,
+        "schemas_cache": 0,
+        "column_comments_cache": 0,
+    }
+    if not container:
+        return counts
+    with hs._lock, hs._connect() as conn:
+        cur = conn.execute(
+            "DELETE FROM catalog_entities "
+            "WHERE db_profile = ? AND IFNULL(database_name, '') != ?",
+            (db_profile, container),
+        )
+        counts["catalog_entities"] = int(cur.rowcount or 0)
+        cur = conn.execute(
+            "DELETE FROM schemas_cache "
+            "WHERE db_profile = ? "
+            "AND IFNULL(database, '') != ? "
+            "AND IFNULL(catalog, '') != ?",
+            (db_profile, container, container),
+        )
+        counts["schemas_cache"] = int(cur.rowcount or 0)
+        cur = conn.execute(
+            "DELETE FROM column_comments_cache "
+            "WHERE db_profile = ? AND IFNULL(database_name, '') != ?",
+            (db_profile, container),
+        )
+        counts["column_comments_cache"] = int(cur.rowcount or 0)
+    return counts
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/storage/test_history_caches_purge.py -v
+```
+
+Expected: all four tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add amx/storage/_history_caches.py tests/storage/test_history_caches_purge.py
+git commit -m "feat(storage): purge out-of-scope cached rows before skeleton sync"
+```
+
+---
+
+## Task 4: Wire helpers into drift.py
+
+**Files:**
+- Modify: `amx/search/drift.py:243-506`
+- Test: `tests/test_skeleton_sync_pinned_default.py` (added in Task 8)
+
+- [ ] **Step 1: Read the current enumerator + sync function**
+
+`_enumerate_containers` lives at `amx/search/drift.py:243-283`, `sync_profile_skeleton` at lines 286-506.
+
+- [ ] **Step 2: Apply the hard-limit short-circuit to `_enumerate_containers`**
+
+At the top of the function body (after the docstring), short-circuit when the profile pins a default container:
+
+```python
+def _enumerate_containers(
+    cfg,
+    profile: str,
+    db_backend: str,
+    default_container: str,
+    is_three_level: bool,
+) -> tuple[list[str], str | None]:
+    """..."""
+    # Hard-limit scoping: when the profile pins a default container,
+    # walk only that one. Never enumerate the connector — even an
+    # admin user's catalog/database list would be wrong to write into
+    # the cache for a profile scoped out of those containers.
+    if default_container:
+        return [default_container], None
+    # ... existing body unchanged
+```
+
+- [ ] **Step 3: Add purge + cancel checkpoints to `sync_profile_skeleton`**
+
+Two edits in `sync_profile_skeleton`:
+
+(a) After the `default_container` resolution block (right before the `# Step 1` comment, around current line 352), call purge and register the cancel event:
+
+```python
+    from amx.search import _skeleton_jobs
+    from amx.storage._history_caches import purge_out_of_scope
+
+    # Register a cancel slot so /api/catalog/sync/cancel can find us.
+    # The caller (catalog router / worker) already registered when
+    # invoked via HTTP; calling again returns the same event.
+    cancel_event = _skeleton_jobs.register(profile)
+
+    # Purge stale rows from any previous unscoped sync. Skip when
+    # the profile is unpinned (legacy multi-container behavior).
+    if default_container:
+        history_store = getattr(catalog, "history_store", None) or getattr(
+            catalog, "_hs", None
+        )
+        if history_store is not None:
+            try:
+                purge_out_of_scope(
+                    history_store,
+                    db_profile=profile,
+                    container=default_container,
+                )
+            except Exception as exc:  # pragma: no cover - best-effort
+                log.warning("Skeleton purge skipped for %s: %s", profile, exc)
+```
+
+(b) Inject cancel checkpoints at three loop heads — the two pass-1 loops (lines 385, 408) and the three pass-2 loops (lines 463, 465, 466). At each loop head, before doing work:
+
+```python
+        if cancel_event.is_set():
+            break
+```
+
+And wrap the final return paths so the registry slot is freed. The cleanest shape is to wrap the whole function body in `try/finally`:
+
+```python
+    try:
+        # ... existing body ...
+    finally:
+        _skeleton_jobs.unregister(profile)
+```
+
+When the cancel event fires, replace the normal `finish_skeleton_sync(ok=True)` with a cancelled finalizer. After the pass-2 loop, change:
+
+```python
+    catalog.finish_skeleton_sync(profile, ok=True)
+    summary["state"] = "done"
+    summary["processed"] = processed
+    return summary
+```
+
+to:
+
+```python
+    if cancel_event.is_set():
+        catalog.finish_skeleton_sync(profile, ok=False, error="cancelled")
+        summary["state"] = "cancelled"
+        summary["processed"] = processed
+        return summary
+    catalog.finish_skeleton_sync(profile, ok=True)
+    summary["state"] = "done"
+    summary["processed"] = processed
+    return summary
+```
+
+- [ ] **Step 4: Run the existing drift tests to confirm nothing regressed**
+
+```bash
+pytest tests/ -k "drift or skeleton" -v
+```
+
+Expected: all green (or only the new not-yet-written ones fail).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add amx/search/drift.py
+git commit -m "feat(search): scope skeleton sync to pinned container + cooperative cancel"
+```
+
+---
+
+## Task 5: Re-export `cancel_skeleton_sync`
+
+**Files:**
+- Modify: `amx/search/__init__.py`
+
+- [ ] **Step 1: Add the public alias**
+
+Append:
+
+```python
+from amx.search._skeleton_jobs import cancel as cancel_skeleton_sync  # noqa: F401
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add amx/search/__init__.py
+git commit -m "feat(search): expose cancel_skeleton_sync as public helper"
+```
+
+---
+
+## Task 6: Catalog router — register on start + cancel endpoint
+
+**Files:**
+- Modify: `amx/web/routers/catalog.py`
+- Test: `tests/web/test_catalog_sync_cancel.py`
+
+- [ ] **Step 1: Write the failing endpoint test**
+
+```python
+# tests/web/test_catalog_sync_cancel.py
+"""POST /api/catalog/sync/cancel — cooperative cancel surface."""
+
+from __future__ import annotations
+
+from amx.search import _skeleton_jobs
+
+
+def setup_function() -> None:
+    _skeleton_jobs._jobs.clear()
+
+
+def test_cancel_returns_true_when_job_registered(client, auth_headers) -> None:
+    _skeleton_jobs.register("prod_dwh")
+    response = client.post(
+        "/api/catalog/sync/cancel",
+        json={"profile": "prod_dwh"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json() == {"profile": "prod_dwh", "cancelled": True}
+
+
+def test_cancel_returns_false_when_no_job(client, auth_headers) -> None:
+    response = client.post(
+        "/api/catalog/sync/cancel",
+        json={"profile": "missing"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json() == {"profile": "missing", "cancelled": False}
+
+
+def test_cancel_requires_profile(client, auth_headers) -> None:
+    response = client.post(
+        "/api/catalog/sync/cancel", json={}, headers=auth_headers
+    )
+    assert response.status_code == 422
+```
+
+- [ ] **Step 2: Run to verify it fails (404 or missing route)**
+
+```bash
+pytest tests/web/test_catalog_sync_cancel.py -v
+```
+
+- [ ] **Step 3: Wire the registry call into the existing `/sync` endpoint**
+
+In `amx/web/routers/catalog.py:441-455`, inject `_skeleton_jobs.register(target_profile)` inside the runner so the slot is live for the entire thread lifetime:
+
+```python
+    from amx.search import _skeleton_jobs
+
+    def _spawn(target_profile: str) -> None:
+        _skeleton_jobs.register(target_profile)
+
+        def _runner() -> None:
+            try:
+                sync_profile_skeleton(cfg, target_profile, catalog, databases=databases_arg)
+            except Exception as exc:  # pragma: no cover - best-effort
+                try:
+                    catalog.finish_skeleton_sync(target_profile, ok=False, error=str(exc))
+                except Exception:
+                    pass
+
+        threading.Thread(
+            target=_runner,
+            name=f"amx-catalog-skeleton-sync-{target_profile}",
+            daemon=True,
+        ).start()
+```
+
+- [ ] **Step 4: Add the cancel endpoint**
+
+Add this Pydantic request model near the top of `catalog.py` (next to `CacheRefreshRequest`):
+
+```python
+class CatalogSyncCancelRequest(BaseModel):
+    profile: str
+```
+
+Then append the endpoint after `trigger_catalog_sync`:
+
+```python
+@router.post("/sync/cancel")
+def cancel_catalog_sync(body: CatalogSyncCancelRequest) -> dict[str, Any]:
+    """Cooperatively cancel an in-flight skeleton sync for ``profile``.
+
+    The running sync thread observes the cancel at its next loop
+    checkpoint (per-container, per-schema, or per-table), finishes
+    the in-flight table, then exits cleanly with
+    ``finish_skeleton_sync(ok=False, error="cancelled")``. Rows
+    already written remain in the cache.
+
+    Returns ``{"cancelled": True}`` when a job was registered for
+    ``profile``, ``{"cancelled": False}`` when nothing was running.
+    """
+    from amx.search import _skeleton_jobs
+
+    profile = (body.profile or "").strip()
+    if not profile:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="profile is required.",
+        )
+    cancelled = _skeleton_jobs.cancel(profile)
+    return {"profile": profile, "cancelled": cancelled}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+```bash
+pytest tests/web/test_catalog_sync_cancel.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add amx/web/routers/catalog.py tests/web/test_catalog_sync_cancel.py
+git commit -m "feat(web): register skeleton sync and expose /sync/cancel endpoint"
+```
+
+---
+
+## Task 7: REPL `/db sync-stop` command
+
+**Files:**
+- Modify: `amx/cli_support/commands/db.py`
+- Modify: `amx/cli_support/session.py`
+
+- [ ] **Step 1: Add `cmd_sync_stop` to `db.py`**
+
+Append after `cmd_cache_clear` (around line 1732):
+
+```python
+def cmd_sync_stop(cfg: AMXConfig, rest: list[str]) -> None:
+    """Cancel an in-flight skeleton sync.
+
+    Bare ``/db sync-stop`` lists running syncs from the registry,
+    user picks one, confirmation prompt, then cancel. The optional
+    ``--profile <name>`` shortcut skips the picker for scripts.
+    """
+    from amx.search import _skeleton_jobs
+
+    profile = ""
+    for i, token in enumerate(rest):
+        if token == "--profile" and i + 1 < len(rest):
+            profile = rest[i + 1].strip()
+
+    running = sorted(_skeleton_jobs.running_profiles())
+    if not running:
+        info("No skeleton sync is currently running.")
+        return
+
+    if not profile:
+        from amx.cli_support._picker import pick_one
+
+        profile = pick_one(
+            "Pick a profile to cancel sync for",
+            running,
+        ) or ""
+        if not profile:
+            info("Cancelled.")
+            return
+
+    if profile not in running:
+        warn(f"No active sync for profile {profile!r}.")
+        return
+
+    cancelled = _skeleton_jobs.cancel(profile)
+    if cancelled:
+        success(
+            f"Cancellation requested for {profile!r}. "
+            "The in-flight table will finish, then the sync exits."
+        )
+    else:
+        info(f"No active sync to cancel for {profile!r}.")
+```
+
+If `pick_one` does not exist in `amx/cli_support/_picker.py`, replace the picker call with a numbered-prompt fallback using the existing input helpers in `db.py` (look for how `cmd_use` or `cmd_remove_profile` prompts).
+
+- [ ] **Step 2: Wire into the session dispatcher**
+
+In `amx/cli_support/session.py`, after the existing `cache-clear` handler (around line 629), add:
+
+```python
+    if head == "sync-stop":
+        if not _require_namespace(head, namespace, "db", "sync-stop"):
+            return True
+        from amx.cli_support.commands.db import cmd_sync_stop as _cmd_sync_stop
+
+        _cmd_sync_stop(cfg, parts[1:])
+        return True
+```
+
+- [ ] **Step 3: Smoke check the import**
+
+```bash
+python -c "from amx.cli_support.commands.db import cmd_sync_stop; print(cmd_sync_stop)"
+```
+
+Expected: prints the function object.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add amx/cli_support/commands/db.py amx/cli_support/session.py
+git commit -m "feat(cli): /db sync-stop cancels a running skeleton sync"
+```
+
+---
+
+## Task 8: Integration test — pinned default
+
+**Files:**
+- Create: `tests/test_skeleton_sync_pinned_default.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/test_skeleton_sync_pinned_default.py
+"""sync_profile_skeleton must walk only the pinned container."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def fake_connector():
+    conn = MagicMock()
+    conn.list_catalogs.return_value = ["prod", "dev", "scratch"]
+    conn.list_databases.return_value = ["prod", "dev", "scratch"]
+    conn.list_schemas.return_value = ["public"]
+    conn.list_assets.return_value = [{"name": "orders", "kind": "table"}]
+    return conn
+
+
+def test_pinned_catalog_short_circuits_enumeration(fake_connector) -> None:
+    from amx.search import drift
+
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(backend="databricks", catalog="prod", database=""),
+        }
+    )
+    catalog = MagicMock()
+    catalog._connect.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    catalog._connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch.object(drift, "_scoped_connector", return_value=fake_connector):
+        summary = drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert summary["containers"] == ["prod"]
+    fake_connector.list_catalogs.assert_not_called()
+    fake_connector.list_databases.assert_not_called()
+
+
+def test_unpinned_profile_falls_back_to_enumeration(fake_connector) -> None:
+    from amx.search import drift
+
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(backend="databricks", catalog="", database=""),
+        }
+    )
+    catalog = MagicMock()
+    catalog._connect.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    catalog._connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch.object(drift, "_scoped_connector", return_value=fake_connector):
+        summary = drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert set(summary["containers"]) == {"prod", "dev", "scratch"}
+    fake_connector.list_catalogs.assert_called()
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pytest tests/test_skeleton_sync_pinned_default.py -v
+```
+
+Expected: both PASS once Task 4 is in.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_skeleton_sync_pinned_default.py
+git commit -m "test(search): skeleton sync honors pinned default container"
+```
+
+---
+
+## Task 9: Integration test — cooperative cancel
+
+**Files:**
+- Create: `tests/test_skeleton_sync_cancellation.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/test_skeleton_sync_cancellation.py
+"""sync_profile_skeleton must observe a cancel event at its loop heads."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from amx.search import _skeleton_jobs, drift
+
+
+def setup_function() -> None:
+    _skeleton_jobs._jobs.clear()
+
+
+def test_pre_set_cancel_exits_without_writing() -> None:
+    fake = MagicMock()
+    fake.list_schemas.return_value = ["public"]
+    fake.list_assets.return_value = [{"name": "orders", "kind": "table"}]
+
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(backend="postgres", catalog="", database="app"),
+        }
+    )
+    catalog = MagicMock()
+    catalog._connect.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    catalog._connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    event = _skeleton_jobs.register("prof")
+    event.set()
+
+    with patch.object(drift, "_scoped_connector", return_value=fake):
+        summary = drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert summary["state"] == "cancelled"
+    catalog.finish_skeleton_sync.assert_called_with(
+        "prof", ok=False, error="cancelled"
+    )
+
+
+def test_normal_run_does_not_trigger_cancel_path() -> None:
+    fake = MagicMock()
+    fake.list_schemas.return_value = ["public"]
+    fake.list_assets.return_value = [{"name": "orders", "kind": "table"}]
+
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(backend="postgres", catalog="", database="app"),
+        }
+    )
+    catalog = MagicMock()
+    catalog._connect.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    catalog._connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch.object(drift, "_scoped_connector", return_value=fake):
+        summary = drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert summary["state"] in {"done", "syncing"}
+    # `finish_skeleton_sync` called with ok=True at the happy path.
+    args, kwargs = catalog.finish_skeleton_sync.call_args
+    assert kwargs.get("ok") is True or (len(args) >= 2 and args[1] is True)
+```
+
+- [ ] **Step 2: Run + commit**
+
+```bash
+pytest tests/test_skeleton_sync_cancellation.py -v
+git add tests/test_skeleton_sync_cancellation.py
+git commit -m "test(search): cooperative skeleton-sync cancellation"
+```
+
+---
+
+## Task 10: Verify whole suite + lint
+
+- [ ] **Step 1: Run new + adjacent tests**
+
+```bash
+pytest tests/test_skeleton_jobs.py tests/test_default_scope.py tests/test_skeleton_sync_pinned_default.py tests/test_skeleton_sync_cancellation.py tests/storage/test_history_caches_purge.py tests/web/test_catalog_sync_cancel.py tests/test_db_cache_ops.py tests/test_catalog_cache_hardening.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Full pytest run**
+
+```bash
+pytest -q
+```
+
+Expected: green (or only pre-existing failures that exist on main).
+
+- [ ] **Step 3: Lint + types**
+
+```bash
+ruff check amx/search/_skeleton_jobs.py amx/db/_default_scope.py amx/search/drift.py amx/web/routers/catalog.py amx/cli_support/commands/db.py amx/cli_support/session.py amx/storage/_history_caches.py amx/search/__init__.py
+mypy amx/search amx/db amx/web/routers/catalog.py amx/storage/_history_caches.py 2>&1 | tail -20
+```
+
+Expected: zero new ruff/mypy errors.
+
+---
+
+## Task 11: Deploy → PR → Merge
+
+Per AMX house rule 6: deploy first, then open the PR, then merge.
+
+- [ ] **Step 1: Run the deploy script**
+
+Run the local deploy script that ships the new code to the live
+Studio so reviewers can verify the Stop button against the running
+deployment. The script lives outside the public repo per the
+"private infra stays private" policy; invoke whichever local path
+you have configured.
+
+- [ ] **Step 2: Push branch + open PR**
+
+```bash
+cd ~/Desktop/omeryasirkucuk/Master/Thesis/AMX
+git push -u origin feat/skeleton-sync-hardening
+gh pr create --title "feat(catalog): skeleton-sync hardening — scope + cancel" --body "$(cat <<'EOF'
+## Summary
+- Hard-limit cache scoping: profiles with a pinned default container now write only that container's rows. Out-of-scope rows from prior unscoped syncs are purged in a single idempotent transaction at the start of the next sync.
+- Cooperative skeleton-sync cancellation via a module-level cancel registry (`amx/search/_skeleton_jobs.py`). Surfaces: `POST /api/catalog/sync/cancel`, REPL `/db sync-stop`, and a public `cancel_skeleton_sync(profile)` helper.
+
+## Test plan
+- [ ] `pytest tests/test_skeleton_jobs.py tests/test_default_scope.py tests/test_skeleton_sync_pinned_default.py tests/test_skeleton_sync_cancellation.py tests/storage/test_history_caches_purge.py tests/web/test_catalog_sync_cancel.py`
+- [ ] `pytest tests/test_db_cache_ops.py tests/test_catalog_cache_hardening.py` (no-regression)
+- [ ] Manual: pin a default container on a Databricks profile, kick off sync, verify only that catalog's rows land in `catalog_entities`.
+- [ ] Manual: start sync, hit Stop in Studio, verify pill flips to `cancelled` and partial rows remain.
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge**
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+If `gh pr merge --auto` triggers a harness permission prompt, run the explicit squash form above.
+
+---
+
+## Self-review checklist
+
+- [ ] Every code block uses tabs/spaces consistent with the repo (4-space Python).
+- [ ] Run `grep -ri "p<no-token>aid"` substitute check (the OSS-neutral token policy in AMX rule 2) — no hits in new files.
+- [ ] No Turkish characters or words in any tracked file (per AMX rule 4).
+- [ ] No agent attribution trailer (any co-author line referencing an automated tool) and no third-party tool attribution in commit messages or PR body.
+- [ ] Every new column/table description gate (rule 5) is not triggered — storage schema unchanged.
+- [ ] Cross-platform: only stdlib `threading` and standard SQLite — no POSIX-only paths or signals.
+- [ ] All file paths in step bodies are absolute or repo-relative; no placeholders.

--- a/docs/superpowers/specs/2026-05-20-skeleton-sync-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-20-skeleton-sync-hardening-design.md
@@ -1,0 +1,271 @@
+# Skeleton Sync Hardening — Cache Scoping + Cancellation
+
+## Context
+
+The catalog skeleton sync currently has two related defects in the same
+subsystem (`amx/search/drift.py` + `amx/web/routers/catalog.py`):
+
+1. **Cache scoping ignores pinned defaults.** When a DB profile pins a
+   default container (`database` / `catalog` / `dataset`),
+   `sync_profile_skeleton`'s container enumerator at
+   `amx/search/drift.py:243-283` still calls the connector's
+   `list_catalogs()` or `list_databases()` and walks every container on
+   the server. The cache tables (`catalog_entities`, `schemas_cache`,
+   `column_comments_cache`) then accumulate rows from containers the
+   user explicitly scoped out of the profile. The cache keys themselves
+   are shaped correctly — `(db_profile, database, catalog, schema,
+   table)` per `amx/storage/_history_caches.py:176,424` — so the bug is
+   in what gets *written*, not how it is *keyed*.
+
+2. **Sync cannot be cancelled.** `amx/web/routers/catalog.py:445-462`
+   spawns the sync as a bare daemon `threading.Thread` with no cancel
+   handle, no event, and no UI-bound endpoint. Grepping
+   `cancel|abort|stop|is_cancelled` across `drift.py`,
+   `_catalog/sync.py`, and `db_cache.py` returns zero matches — there
+   is no cancellation primitive at all. Once a sync starts, only a
+   process restart stops it.
+
+Both defects live in the same code path; the cancel checkpoints and the
+scope-aware enumerator are fixed together so `drift.py` is touched once.
+
+## Decisions
+
+These were locked through brainstorming and are non-negotiable inputs
+to the implementation plan.
+
+| Axis | Decision |
+|---|---|
+| Scoping rule | **Hard limit.** If a profile has a pinned default container, sync walks only that container — no escape, no override flag. Users who want other catalogs create another profile. |
+| Existing rows | **Idempotent purge.** The first hard-limit sync deletes out-of-scope rows from the three cache tables in a single transaction before the walk starts. No banner, no manual command required. |
+| Cancellation model | **Cooperative cancel.** Checkpoints at the head of each container / schema / table loop. Cancel finishes the in-flight table, then exits cleanly with `finish_skeleton_sync(ok=False, error="cancelled")`. Partial rows are kept. |
+| Cancel surfaces | All three: Studio HTTP `POST /api/catalog/sync/cancel`, REPL `/db sync stop`, and a Python helper `cancel_skeleton_sync(profile)` for tests and the worker. |
+| Backend coverage | Uniform via a single helper `profile_default_container(db_cfg)` that normalizes per-backend field names (`catalog` for Databricks/Trino, `dataset` for BigQuery, `database` for Snowflake/Hive/Postgres/MySQL/MSSQL). |
+| Implementation shape | **Minimal patch + module-level cancel registry.** No `SkeletonSyncJob` class refactor, no asyncio migration. Smallest surface change that fixes both defects. |
+
+## Architecture
+
+### New modules
+
+- **`amx/search/_skeleton_jobs.py`** — module-level cancel registry.
+  - `_jobs: dict[str, threading.Event]`, `_lock: threading.RLock`
+  - `register(profile) -> threading.Event`
+  - `cancel(profile) -> bool` (returns True if a job was registered)
+  - `is_cancelled(profile) -> bool`
+  - `unregister(profile) -> None`
+  - Re-entry: if `register` is called for a profile that already has an
+    event, return the existing event (race-safe with cancel-then-restart).
+  - Zero external dependencies; pure stdlib threading.
+
+- **`amx/db/_default_scope.py`** — backend-uniform pinned-default helper.
+  - `profile_default_container(db_cfg) -> str | None`
+  - Order of precedence: `catalog` (if non-empty), then `dataset`, then
+    `database`. Returns `None` when all three are empty/None.
+  - Pure function; no I/O. Easy to unit-test per backend config shape.
+
+### Edited modules
+
+- **`amx/search/drift.py`**
+  - `_enumerate_containers()` (current lines ~243-283): if
+    `profile_default_container()` returns a non-empty value, return
+    `[default]` immediately. Do not call `connector.list_catalogs()` or
+    `list_databases()`. When the helper returns `None`, fall back to the
+    existing enumeration so single-container backends and unpinned
+    profiles keep their current behavior.
+  - `sync_profile_skeleton()` (current line ~286):
+    1. Resolve `default` via `profile_default_container()` once at the
+       top.
+    2. If `default` is non-empty, call
+       `purge_out_of_scope(db_profile=profile, container=default)`
+       before `start_skeleton_sync`. Skip purge when unpinned
+       (preserves legacy multi-container behavior).
+    3. Inject `is_cancelled(profile)` checkpoints at three loop heads:
+       outer `for container in containers`, middle
+       `for schema in schemas`, inner `for asset in assets`.
+    4. On cancellation, call
+       `finish_skeleton_sync(profile, ok=False, error="cancelled")`
+       and return; do not raise.
+    5. Wrap normal/error/cancel exit in a `try/finally` that calls
+       `_skeleton_jobs.unregister(profile)`.
+
+- **`amx/web/routers/catalog.py`**
+  - The existing `POST /sync` endpoint calls
+    `_skeleton_jobs.register(profile)` for each target before spawning
+    the daemon thread.
+  - New endpoint: `POST /api/catalog/sync/cancel` with body
+    `{"profile": "<name>"}`. Handler calls
+    `_skeleton_jobs.cancel(profile)` and returns
+    `{"cancelled": bool}` synchronously. Returns 404 when no job is
+    registered for that profile.
+
+- **`amx/cli_support/commands/db.py`**
+  - New REPL command surface under the existing `db` namespace:
+    `/db sync stop`. Wizard-first: bare invocation lists running syncs
+    (from the registry), user picks one, confirmation prompt, then
+    call the Python helper. `--profile <name>` is the optional
+    power-user shortcut.
+  - Python helper exposed from `amx/search/__init__.py` as
+    `cancel_skeleton_sync(profile)` — thin wrapper over
+    `_skeleton_jobs.cancel`.
+
+- **`amx/storage/_history_caches.py`**
+  - New function:
+    ```python
+    def purge_out_of_scope(
+        *, db_profile: str, container: str
+    ) -> dict[str, int]:
+    ```
+    Deletes rows from `catalog_entities`, `schemas_cache`, and
+    `column_comments_cache` where the row's database/catalog does not
+    match `container`. Single transaction. Returns deletion counts per
+    table for the audit log. Idempotent (re-runs are no-ops).
+  - Catalog descriptions / profile state side tables: if FK CASCADE is
+    in place, no extra DELETE; otherwise add a second DELETE inside
+    the same transaction.
+
+### Storage schema
+
+No schema change. No new columns. `amx/storage/schema_descriptions.py`
+is not touched. The cache keys are already correctly shaped; we are
+tightening write discipline, not changing storage.
+
+## Data flow
+
+### Sync start (e.g. `POST /api/catalog/sync?profile=prod_dwh`)
+
+1. Handler calls `_skeleton_jobs.register("prod_dwh")` → cancel event.
+2. `catalog.start_skeleton_sync(profile, total_tables=0)`.
+3. Daemon thread spawn → `sync_profile_skeleton(cfg, "prod_dwh", catalog)`.
+4. `sync_profile_skeleton` first resolves
+   `default = profile_default_container(cfg.db_profiles[profile])`.
+5. If `default` is non-empty:
+   `purge_out_of_scope(db_profile=profile, container=default)` in one
+   transaction. Audit log entry emitted.
+6. `_enumerate_containers()` returns `[default]` (no connector
+   enumeration). When `default` is `None`, legacy enumeration path
+   runs.
+7. Outer loop `for container in containers` — checkpoint
+   `if is_cancelled(profile): break`.
+8. Middle `for schema in schemas` — same checkpoint.
+9. Inner `for asset in assets` — same checkpoint before
+   `_upsert_entity`.
+10. Normal end → `finish_skeleton_sync(ok=True)` →
+    `_skeleton_jobs.unregister(profile)`.
+11. Cancellation → `finish_skeleton_sync(ok=False, error="cancelled")`
+    → `_skeleton_jobs.unregister(profile)`.
+12. Exception → `finish_skeleton_sync(ok=False, error=str(exc))` →
+    `_skeleton_jobs.unregister(profile)`.
+
+### Cancel (e.g. Studio "Stop" button)
+
+1. Studio sends `POST /api/catalog/sync/cancel {"profile":"prod_dwh"}`.
+2. Handler calls `_skeleton_jobs.cancel("prod_dwh")` → event set.
+3. Endpoint returns `{"cancelled": true}` immediately.
+4. The running thread reaches the next checkpoint, finishes the
+   in-flight table, exits the loop.
+5. `finish_skeleton_sync(ok=False, error="cancelled")` flips
+   `catalog_profile_state` so the freshness pill renders the
+   cancelled state on the next poll.
+6. Rows already written remain in the cache (cooperative semantics).
+
+### Idempotency and races
+
+- Re-running sync immediately after cancel: `register` returns the
+  existing event if not yet `unregister`-ed; otherwise creates a fresh
+  one. The new thread observes the right event.
+- Double-clicking sync start while one is running is out of scope —
+  the existing code does not guard against it; we keep that behavior.
+- `purge_out_of_scope` is a `DELETE WHERE`, not a `DROP`, so repeated
+  calls are no-ops once the cache is in scope.
+
+## Critical files
+
+- `amx/search/drift.py` — enumerator + main sync loop (heaviest edit)
+- `amx/web/routers/catalog.py` — sync start + new cancel endpoint
+- `amx/cli_support/commands/db.py` — `/db sync stop` wizard
+- `amx/storage/_history_caches.py` — `purge_out_of_scope`
+- `amx/search/_skeleton_jobs.py` — **new**, cancel registry
+- `amx/db/_default_scope.py` — **new**, default-container helper
+- `amx/search/__init__.py` — re-export `cancel_skeleton_sync`
+
+## Reused existing pieces
+
+- `catalog.start_skeleton_sync` / `finish_skeleton_sync` in
+  `amx/search/_catalog/sync.py:100+` — state-machine API for the
+  freshness pill. The cancel path reuses
+  `finish_skeleton_sync(ok=False)` with a `"cancelled"` error string;
+  no new state column is needed.
+- `_history_caches.lookup_schemas_cache`
+  (`amx/storage/_history_caches.py:490-510`) and
+  `lookup_column_comments_cache` (`amx/db/connector.py:648-656`)
+  already filter reads by `database` / `catalog` — they need no change.
+- Connector field accessor `_cache_database_key()` at
+  `amx/db/connector.py:634-636` already picks `database or catalog` —
+  the new `profile_default_container()` helper mirrors and extends
+  this for per-backend uniformity.
+
+## Verification
+
+End-to-end test plan once the implementation lands:
+
+1. **Unit — default helper.** Parametrize `profile_default_container`
+   over each backend's `DBConfig` shape (Databricks `catalog`,
+   BigQuery `dataset`, Snowflake/Hive/Postgres/MySQL/MSSQL `database`,
+   empty profile). Add to `tests/db/test_default_scope.py`.
+
+2. **Unit — cancel registry.** `register`, `cancel`, `is_cancelled`,
+   `unregister`, double-register, cancel-with-no-job. Add to
+   `tests/search/test_skeleton_jobs.py`.
+
+3. **Unit — purge.** Seed `catalog_entities`, `schemas_cache`,
+   `column_comments_cache` with mixed-scope rows; call
+   `purge_out_of_scope(db_profile=p, container=c)`; assert only
+   matching rows survive. Idempotency: re-call is a no-op. Add to
+   `tests/storage/test_history_caches_purge.py`.
+
+4. **Integration — skeleton sync respects pinned default.** Using a
+   fake connector that reports two catalogs, with a profile pinned to
+   one, run `sync_profile_skeleton` and assert `catalog_entities`
+   contains rows only for the pinned catalog. Add to
+   `tests/search/test_drift_pinned_default.py`.
+
+5. **Integration — cooperative cancel.** Fake connector that yields
+   schemas with a deliberate delay; spawn sync; call
+   `cancel_skeleton_sync(profile)`; assert thread exits within a
+   bounded time, `catalog_profile_state` shows `error="cancelled"`,
+   and partial rows remain in `catalog_entities`. Add to
+   `tests/search/test_drift_cancel.py`.
+
+6. **HTTP — cancel endpoint.** TestClient hits
+   `POST /api/catalog/sync` then `POST /api/catalog/sync/cancel`.
+   Assert 200 + `cancelled=true` and the registry shows no job
+   afterwards. Add to `tests/web/routers/test_catalog_sync_cancel.py`.
+
+7. **Manual smoke — REPL.** `/db profile add` a pinned
+   Databricks/BigQuery profile, kick off a sync, then in a second
+   terminal `/db sync stop`. Verify state pill, log, and
+   `catalog_entities` contents in the dev history DB.
+
+8. **Manual smoke — Studio.** Start sync from the `DbCache` page,
+   click Stop, observe the freshness pill flip to "cancelled".
+   Re-trigger to confirm the purge cleaned legacy out-of-scope rows.
+
+9. **No-regression.**
+   - Run the existing `tests/test_db_cache_ops.py` and
+     `tests/test_catalog_cache_hardening.py` suites unchanged — they
+     must stay green (cache key shape did not change).
+   - Critical-path benchmark: time `sync_profile_skeleton` against a
+     fixture profile before/after. Confirm under 5% regression.
+
+10. **Studio deploy.** This change touches the Studio `DbCache` page
+    (Stop button becomes functional). Run the project's deploy
+    script before opening the PR so the remote Studio reflects the
+    new endpoint when reviewers click through.
+
+## Out of scope
+
+- `SkeletonSyncJob` class refactor or async migration.
+- Guarding against concurrent `start` for the same profile.
+- Resume-from-checkpoint after cancel (deferred — covered as a
+  follow-up if needed).
+- Changes to `schemas_cache` / `column_comments_cache` key shape.
+- The scheduler launchd job (`com.amx.scheduler`) — separate concern.

--- a/tests/storage/test_history_caches_purge.py
+++ b/tests/storage/test_history_caches_purge.py
@@ -1,0 +1,153 @@
+"""Tests for purge_out_of_scope — the migration helper that strips
+cached rows belonging to containers outside the profile's pinned
+default."""
+
+from __future__ import annotations
+
+import pytest
+
+from amx.storage._history_caches import (
+    purge_out_of_scope,
+    save_column_comments_cache,
+    save_schemas_cache,
+)
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture()
+def hs(tmp_path) -> SQLiteHistoryStore:
+    s = SQLiteHistoryStore(tmp_path / "history.db")
+    s.init()
+    return s
+
+
+def test_purge_removes_only_out_of_scope_rows(hs: SQLiteHistoryStore) -> None:
+    save_column_comments_cache(
+        hs,
+        db_profile="prof",
+        database="prod",
+        schema="public",
+        entries={"orders": {"table_comment": "ok", "columns": {}, "kind": "TABLE"}},
+    )
+    save_column_comments_cache(
+        hs,
+        db_profile="prof",
+        database="dev",
+        schema="public",
+        entries={"orders": {"table_comment": "stale", "columns": {}, "kind": "TABLE"}},
+    )
+    counts = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert counts["column_comments_cache"] == 1
+
+    with hs._connect() as conn:
+        rows = conn.execute(
+            "SELECT database_name FROM column_comments_cache WHERE db_profile = ?",
+            ("prof",),
+        ).fetchall()
+    assert [r["database_name"] for r in rows] == ["prod"]
+
+
+def test_purge_is_idempotent(hs: SQLiteHistoryStore) -> None:
+    save_column_comments_cache(
+        hs,
+        db_profile="prof",
+        database="dev",
+        schema="public",
+        entries={"orders": {"table_comment": "x", "columns": {}, "kind": "TABLE"}},
+    )
+    first = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    second = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert first["column_comments_cache"] == 1
+    assert second["column_comments_cache"] == 0
+
+
+def test_purge_leaves_other_profiles_alone(hs: SQLiteHistoryStore) -> None:
+    save_column_comments_cache(
+        hs,
+        db_profile="other",
+        database="dev",
+        schema="public",
+        entries={"orders": {"table_comment": "x", "columns": {}, "kind": "TABLE"}},
+    )
+    counts = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert counts["column_comments_cache"] == 0
+    with hs._connect() as conn:
+        n = conn.execute(
+            "SELECT COUNT(*) AS n FROM column_comments_cache WHERE db_profile = ?",
+            ("other",),
+        ).fetchone()["n"]
+    assert n == 1
+
+
+def test_purge_handles_schemas_cache_by_database(hs: SQLiteHistoryStore) -> None:
+    save_schemas_cache(
+        hs,
+        db_profile="prof",
+        database="prod",
+        catalog="",
+        entries={"public": "ok"},
+    )
+    save_schemas_cache(
+        hs,
+        db_profile="prof",
+        database="dev",
+        catalog="",
+        entries={"public": "stale"},
+    )
+    counts = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert counts["schemas_cache"] == 1
+
+
+def test_purge_handles_schemas_cache_by_catalog(hs: SQLiteHistoryStore) -> None:
+    save_schemas_cache(
+        hs,
+        db_profile="prof",
+        database="",
+        catalog="prod",
+        entries={"public": "ok"},
+    )
+    save_schemas_cache(
+        hs,
+        db_profile="prof",
+        database="",
+        catalog="dev",
+        entries={"public": "stale"},
+    )
+    counts = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert counts["schemas_cache"] == 1
+
+
+def test_purge_handles_catalog_entities(hs: SQLiteHistoryStore) -> None:
+    with hs._lock, hs._connect() as conn:
+        for db_name in ("prod", "dev"):
+            conn.execute(
+                "INSERT INTO catalog_entities "
+                "(db_profile, db_backend, database_name, schema_name, "
+                "table_name, entity_kind) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("prof", "databricks", db_name, "public", "orders", "table"),
+            )
+    counts = purge_out_of_scope(hs, db_profile="prof", container="prod")
+    assert counts["catalog_entities"] == 1
+    with hs._connect() as conn:
+        rows = conn.execute(
+            "SELECT database_name FROM catalog_entities WHERE db_profile = ?",
+            ("prof",),
+        ).fetchall()
+    assert [r["database_name"] for r in rows] == ["prod"]
+
+
+def test_purge_with_empty_container_is_noop(hs: SQLiteHistoryStore) -> None:
+    save_column_comments_cache(
+        hs,
+        db_profile="prof",
+        database="dev",
+        schema="public",
+        entries={"orders": {"table_comment": "x", "columns": {}, "kind": "TABLE"}},
+    )
+    counts = purge_out_of_scope(hs, db_profile="prof", container="")
+    assert counts == {
+        "catalog_entities": 0,
+        "schemas_cache": 0,
+        "column_comments_cache": 0,
+    }

--- a/tests/test_catalog_skeleton_sync.py
+++ b/tests/test_catalog_skeleton_sync.py
@@ -323,16 +323,38 @@ class _PerDBConnector:
         return list(self._schemas.get(schema, []))
 
 
+class _UnpinnedStubCfg:
+    """Variant of :class:`_StubCfg` with no pinned default database.
+
+    Used by the multi-database enumeration test below: with no
+    ``database`` pinned on the profile, the skeleton sync falls back
+    to ``list_databases()`` enumeration and walks every reachable
+    database. The hard-limit short-circuit added for pinned profiles
+    is intentionally bypassed.
+    """
+
+    class _DB:
+        backend = "postgresql"
+        database = ""
+        catalog = ""
+        project = ""
+
+    db = _DB()
+
+
 def test_sync_walks_every_database(
     fresh_catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The skeleton sync enumerates every database under a profile and
-    upserts each table with its own ``database_name`` stamp.
+    """When the profile pins no default database, the skeleton sync
+    enumerates every database under it and upserts each table with
+    its own ``database_name`` stamp.
 
     Regression guard for the user-reported screenshot where
     ``LOCAL-POSTGRE`` showed identical schemas under SAP, bird_train,
-    and bird_train_desc because the sync only walked the pinned
-    database AND the unique index didn't include ``database_name``.
+    and bird_train_desc because the sync only walked one database
+    AND the unique index didn't include ``database_name``. The
+    pinned-default case is now hard-limited; see
+    ``tests/test_skeleton_sync_pinned_default.py`` for that path.
     """
     databases_payload: dict[str, dict[str, list[tuple[str, str]]]] = {
         "SAP": {"public": [("sap_users", "table"), ("sap_orders", "table")]},
@@ -383,7 +405,7 @@ def test_sync_walks_every_database(
 
     monkeypatch.setattr(drift, "_scoped_connector", _fake_scoped)
 
-    summary = sync_profile_skeleton(_StubCfg(), "local-postgre", fresh_catalog)
+    summary = sync_profile_skeleton(_UnpinnedStubCfg(), "local-postgre", fresh_catalog)
     assert summary["state"] == "done", summary
     assert summary["total"] == 5
     assert summary["processed"] == 5

--- a/tests/test_default_scope.py
+++ b/tests/test_default_scope.py
@@ -1,0 +1,41 @@
+"""Tests for the per-backend default-container helper."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from amx.db._default_scope import profile_default_container
+
+
+def test_databricks_catalog_wins() -> None:
+    db = SimpleNamespace(backend="databricks", catalog="prod", database="", dataset="")
+    assert profile_default_container(db) == "prod"
+
+
+def test_bigquery_dataset() -> None:
+    db = SimpleNamespace(backend="bigquery", catalog="", dataset="analytics", database="")
+    assert profile_default_container(db) == "analytics"
+
+
+def test_snowflake_database() -> None:
+    db = SimpleNamespace(backend="snowflake", catalog="", dataset="", database="DW")
+    assert profile_default_container(db) == "DW"
+
+
+def test_postgres_database() -> None:
+    db = SimpleNamespace(backend="postgres", catalog="", dataset="", database="app")
+    assert profile_default_container(db) == "app"
+
+
+def test_empty_profile_returns_none() -> None:
+    db = SimpleNamespace(backend="postgres", catalog="", dataset="", database="")
+    assert profile_default_container(db) is None
+
+
+def test_none_input_returns_none() -> None:
+    assert profile_default_container(None) is None
+
+
+def test_catalog_beats_database_when_both_set() -> None:
+    db = SimpleNamespace(backend="trino", catalog="hive", database="default", dataset="")
+    assert profile_default_container(db) == "hive"

--- a/tests/test_skeleton_jobs.py
+++ b/tests/test_skeleton_jobs.py
@@ -1,0 +1,45 @@
+"""Tests for the module-level skeleton-sync cancel registry."""
+
+from __future__ import annotations
+
+from amx.search import _skeleton_jobs
+
+
+def setup_function() -> None:
+    _skeleton_jobs._jobs.clear()
+
+
+def test_register_returns_unset_event() -> None:
+    event = _skeleton_jobs.register("prof")
+    assert event.is_set() is False
+    assert _skeleton_jobs.is_cancelled("prof") is False
+
+
+def test_cancel_sets_event_and_returns_true() -> None:
+    event = _skeleton_jobs.register("prof")
+    assert _skeleton_jobs.cancel("prof") is True
+    assert event.is_set() is True
+    assert _skeleton_jobs.is_cancelled("prof") is True
+
+
+def test_cancel_with_no_job_returns_false() -> None:
+    assert _skeleton_jobs.cancel("missing") is False
+
+
+def test_double_register_returns_same_event() -> None:
+    first = _skeleton_jobs.register("prof")
+    second = _skeleton_jobs.register("prof")
+    assert first is second
+
+
+def test_unregister_clears_job() -> None:
+    _skeleton_jobs.register("prof")
+    _skeleton_jobs.unregister("prof")
+    assert _skeleton_jobs.is_cancelled("prof") is False
+    assert _skeleton_jobs.cancel("prof") is False
+
+
+def test_running_profiles_lists_registered() -> None:
+    _skeleton_jobs.register("a")
+    _skeleton_jobs.register("b")
+    assert sorted(_skeleton_jobs.running_profiles()) == ["a", "b"]

--- a/tests/test_skeleton_sync_cancellation.py
+++ b/tests/test_skeleton_sync_cancellation.py
@@ -1,0 +1,87 @@
+"""sync_profile_skeleton must observe a cancel event at its loop heads."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from amx.search import _skeleton_jobs, drift
+
+
+def setup_function() -> None:
+    _skeleton_jobs._jobs.clear()
+
+
+def _make_catalog() -> MagicMock:
+    catalog = MagicMock()
+    conn = MagicMock()
+    catalog._connect.return_value.__enter__ = MagicMock(return_value=conn)
+    catalog._connect.return_value.__exit__ = MagicMock(return_value=False)
+    catalog.history_store = None
+    return catalog
+
+
+def _fake_connector():
+    fake = MagicMock()
+    fake.list_schemas.return_value = ["public"]
+    fake.list_assets.return_value = [("orders", "table")]
+    return fake
+
+
+def test_pre_set_cancel_exits_without_completing() -> None:
+    event = _skeleton_jobs.register("prof")
+    event.set()
+
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(
+                backend="postgres", catalog="", database="app", dataset=""
+            ),
+        }
+    )
+    catalog = _make_catalog()
+
+    with patch.object(drift, "_scoped_connector", return_value=_fake_connector()):
+        summary = drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert summary["state"] == "cancelled"
+    catalog.finish_skeleton_sync.assert_called_with(
+        "prof", ok=False, error="cancelled"
+    )
+
+
+def test_normal_run_finishes_with_ok_true() -> None:
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(
+                backend="postgres", catalog="", database="app", dataset=""
+            ),
+        }
+    )
+    catalog = _make_catalog()
+
+    with patch.object(drift, "_scoped_connector", return_value=_fake_connector()):
+        summary = drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert summary["state"] == "done"
+    final_calls = [
+        call for call in catalog.finish_skeleton_sync.call_args_list
+        if call.kwargs.get("ok") is True
+    ]
+    assert final_calls, "expected at least one finish_skeleton_sync(..., ok=True)"
+
+
+def test_unregister_is_called_after_normal_run() -> None:
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(
+                backend="postgres", catalog="", database="app", dataset=""
+            ),
+        }
+    )
+    catalog = _make_catalog()
+
+    with patch.object(drift, "_scoped_connector", return_value=_fake_connector()):
+        drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert "prof" not in _skeleton_jobs.running_profiles()

--- a/tests/test_skeleton_sync_pinned_default.py
+++ b/tests/test_skeleton_sync_pinned_default.py
@@ -1,0 +1,91 @@
+"""sync_profile_skeleton must walk only the pinned container."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from amx.search import _skeleton_jobs
+
+
+def setup_function() -> None:
+    _skeleton_jobs._jobs.clear()
+
+
+@pytest.fixture()
+def fake_connector():
+    conn = MagicMock()
+    conn.list_catalogs.return_value = ["prod", "dev", "scratch"]
+    conn.list_databases.return_value = ["prod", "dev", "scratch"]
+    conn.list_schemas.return_value = ["public"]
+    conn.list_assets.return_value = [("orders", "table")]
+    return conn
+
+
+def _make_catalog() -> MagicMock:
+    catalog = MagicMock()
+    conn = MagicMock()
+    catalog._connect.return_value.__enter__ = MagicMock(return_value=conn)
+    catalog._connect.return_value.__exit__ = MagicMock(return_value=False)
+    catalog.history_store = None
+    return catalog
+
+
+def test_pinned_catalog_short_circuits_enumeration(fake_connector) -> None:
+    from amx.search import drift
+
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(
+                backend="databricks", catalog="prod", database="", dataset=""
+            ),
+        }
+    )
+    catalog = _make_catalog()
+
+    with patch.object(drift, "_scoped_connector", return_value=fake_connector):
+        summary = drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert summary["containers"] == ["prod"]
+    fake_connector.list_catalogs.assert_not_called()
+    fake_connector.list_databases.assert_not_called()
+
+
+def test_pinned_database_short_circuits_enumeration(fake_connector) -> None:
+    from amx.search import drift
+
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(
+                backend="postgres", catalog="", database="app", dataset=""
+            ),
+        }
+    )
+    catalog = _make_catalog()
+
+    with patch.object(drift, "_scoped_connector", return_value=fake_connector):
+        summary = drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert summary["containers"] == ["app"]
+    fake_connector.list_databases.assert_not_called()
+
+
+def test_unpinned_profile_falls_back_to_enumeration(fake_connector) -> None:
+    from amx.search import drift
+
+    cfg = SimpleNamespace(
+        db_profiles={
+            "prof": SimpleNamespace(
+                backend="databricks", catalog="", database="", dataset=""
+            ),
+        }
+    )
+    catalog = _make_catalog()
+
+    with patch.object(drift, "_scoped_connector", return_value=fake_connector):
+        summary = drift.sync_profile_skeleton(cfg, "prof", catalog)
+
+    assert set(summary["containers"]) == {"prod", "dev", "scratch"}
+    fake_connector.list_catalogs.assert_called()

--- a/tests/web/test_catalog_sync_cancel.py
+++ b/tests/web/test_catalog_sync_cancel.py
@@ -1,0 +1,37 @@
+"""POST /api/catalog/sync/cancel — cooperative cancel surface."""
+
+from __future__ import annotations
+
+from amx.search import _skeleton_jobs
+
+
+def setup_function() -> None:
+    _skeleton_jobs._jobs.clear()
+
+
+def test_cancel_returns_true_when_job_registered(client, auth_headers) -> None:
+    _skeleton_jobs.register("prod_dwh")
+    response = client.post(
+        "/api/catalog/sync/cancel",
+        json={"profile": "prod_dwh"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json() == {"profile": "prod_dwh", "cancelled": True}
+
+
+def test_cancel_returns_false_when_no_job(client, auth_headers) -> None:
+    response = client.post(
+        "/api/catalog/sync/cancel",
+        json={"profile": "missing"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json() == {"profile": "missing", "cancelled": False}
+
+
+def test_cancel_requires_non_empty_profile(client, auth_headers) -> None:
+    response = client.post(
+        "/api/catalog/sync/cancel", json={"profile": ""}, headers=auth_headers
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

Two related defects in the catalog skeleton sync subsystem are fixed together since both live in `amx/search/drift.py` + `amx/web/routers/catalog.py`:

- **Cache scoping ignored pinned defaults.** When a DB profile pinned a default container (`catalog`/`dataset`/`database`), `sync_profile_skeleton` still enumerated every container on the server and wrote rows from out-of-scope containers into `catalog_entities`, `schemas_cache`, and `column_comments_cache`. The cache keys were already shaped correctly — the bug was the write set. The enumerator now short-circuits to `[default_container]` for pinned profiles, and the first pinned sync purges out-of-scope rows in one transaction.
- **Sync could not be cancelled.** The `/sync` endpoint spawned a bare daemon thread with no cancel handle. A module-level `threading.Event` registry (`amx/search/_skeleton_jobs.py`) is now checked at every container/schema/table loop head; the in-flight table finishes, then the loop exits with `finish_skeleton_sync(ok=False, error="cancelled")`. Three surfaces trigger cancellation: `POST /api/catalog/sync/cancel`, REPL `/db sync-stop`, and the module-level `cancel()` helper.

Backend-uniform default resolution lives in `amx/db/_default_scope.py` (`catalog` → `dataset` → `database` precedence). The pre-existing multi-database regression test is split: pinned profiles take the new hard-limit path, unpinned profiles keep the enumeration fallback.

## Test plan

- [x] `pytest tests/test_skeleton_jobs.py tests/test_default_scope.py tests/test_skeleton_sync_pinned_default.py tests/test_skeleton_sync_cancellation.py tests/storage/test_history_caches_purge.py tests/web/test_catalog_sync_cancel.py` — 29/29 green
- [x] `pytest tests/test_catalog_skeleton_sync.py tests/test_db_cache_ops.py tests/test_catalog_cache_hardening.py tests/test_column_comments_cache.py tests/web/test_catalog.py tests/web/test_db_cache_router.py` — 55/55 green (no regression)
- [x] `ruff check` on every touched file — clean
- [ ] Manual: pin a default catalog on a Databricks profile, kick off sync, verify only that catalog's rows land in `catalog_entities`.
- [ ] Manual (Studio): start a sync from DbCache page, click Stop, observe the freshness pill flip to `cancelled` and partial rows remain.
- [ ] Manual (REPL): start sync, run `/db sync-stop` in a second session, observe the same end state.

## Spec + plan

- Design: `docs/superpowers/specs/2026-05-20-skeleton-sync-hardening-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-20-skeleton-sync-hardening.md`