### PR TITLE
feat(history): multi-profile inclusion in the shared history store

### DIFF
--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -33,6 +33,7 @@ from amx.config import AMXConfig
 from amx.storage.factory import HistoryStoreBootstrapError, history_store
 from amx.utils.console import (
     ask_choice,
+    ask_multi_choice,
     confirm,
     error,
     heading,
@@ -54,6 +55,7 @@ LogEvent = Callable[..., None]
 ACTION_STATUS = "Status — show shared-mode state and outbox depth"
 ACTION_ENABLE = "Enable — bootstrap an AMX schema on a saved DB profile"
 ACTION_DISABLE = "Disable — stop dual-writing (existing shared rows are kept)"
+ACTION_PROFILES = "Profiles — pick which DB profiles participate in the shared store"
 ACTION_MIGRATE = "Migrate from local — copy local SQLite history into the shared store"
 ACTION_PULL = "Pull from shared — sync teammates' runs into your local SQLite cache"
 ACTION_FLUSH = "Flush pending — retry queued shared writes that failed at write time"
@@ -440,6 +442,59 @@ def _action_disable(cfg: AMXConfig, *, log_event: LogEvent) -> None:
     log_event(event_type="history_store.disable", status="ok", command="/history-store disable")
 
 
+def _action_profiles(cfg: AMXConfig) -> None:
+    """Multi-select wizard for ``history_store_profiles``.
+
+    The primary profile (singular ``history_store_profile``) is always
+    in scope; this picker manages the extras that get dual-written
+    alongside it. Useful for users running AMX against several
+    backends who want every profile's runs to land in one shared
+    catalog.
+    """
+    heading("Shared history-store profiles")
+    if not cfg.db_profiles:
+        error("No DB profiles saved. Configure one with /db-profiles first.")
+        return
+    primary = (cfg.history_store_profile or "").strip()
+    candidates = sorted(p for p in cfg.db_profiles if p and p != primary)
+    if not candidates:
+        info(
+            "No additional profiles available — the only saved profile "
+            "is already the primary history-store profile."
+        )
+        return
+    current = sorted(
+        p
+        for p in (cfg.history_store_profiles or [])
+        if p and p in cfg.db_profiles and p != primary
+    )
+    if primary:
+        info(f"Primary profile (always included): {primary}")
+    if current:
+        info(f"Currently included extras: {', '.join(current)}")
+    else:
+        info("No extra profiles included yet.")
+    picked = ask_multi_choice(
+        "Pick the extra profiles to include (Enter cancels)",
+        candidates,
+    )
+    if not picked:
+        info("No change.")
+        return
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for name in picked:
+        if name in seen or name == primary:
+            continue
+        seen.add(name)
+        deduped.append(name)
+    with cfg.transaction():
+        cfg.history_store_profiles = deduped
+    success(
+        f"Updated extra profiles: {', '.join(deduped) if deduped else '(none)'}"
+    )
+
+
 def _action_migrate(cfg: AMXConfig) -> None:
     if not getattr(cfg, "history_store_enabled", False):
         error("Shared mode is disabled. Pick Enable first.")
@@ -544,6 +599,7 @@ def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> N
     # picker to do exactly that).
     options: list[str] = [ACTION_STATUS]
     if enabled:
+        options.append(ACTION_PROFILES)
         options.append(ACTION_PULL)
         options.append(ACTION_MIGRATE)
         options.append(ACTION_FLUSH)
@@ -567,6 +623,9 @@ def _run_picker(ctx: click.Context, cfg: AMXConfig, *, log_event: LogEvent) -> N
         return
     if picked == ACTION_DISABLE:
         _action_disable(cfg, log_event=log_event)
+        return
+    if picked == ACTION_PROFILES:
+        _action_profiles(cfg)
         return
     if picked == ACTION_PULL:
         _action_pull(cfg)
@@ -662,6 +721,17 @@ def register_history_store_commands(
     def hs_disable(cfg: AMXConfig) -> None:
         """Stop dual-writing to the shared store. Local SQLite continues normally."""
         _action_disable(cfg, log_event=log_event)
+
+    @history_store_grp.command("profiles")
+    @pass_config
+    def hs_profiles(cfg: AMXConfig) -> None:
+        """Pick which DB profiles participate in the shared history store.
+
+        The "primary" profile (the one chosen at /history-store enable
+        time) always participates; this picker manages the extra
+        profiles whose runs are also dual-written.
+        """
+        _action_profiles(cfg)
 
     @history_store_grp.command("migrate-from-local")
     @pass_config

--- a/amx/config.py
+++ b/amx/config.py
@@ -253,6 +253,32 @@ def _normalize_db_host(raw: str | None) -> str:
     return host.strip()
 
 
+def history_store_profile_set(cfg: AMXConfig) -> list[str]:
+    """Return the deduplicated list of DB profile names that participate
+    in the shared history store.
+
+    The legacy singular ``history_store_profile`` (one primary profile
+    that owns the schema) is unioned with the newer
+    ``history_store_profiles`` (additional opt-in profiles). Order is
+    preserved with the primary first; duplicates and empty strings are
+    dropped so callers can iterate the result directly.
+    """
+    primary = (getattr(cfg, "history_store_profile", "") or "").strip()
+    extras = list(getattr(cfg, "history_store_profiles", []) or [])
+    seen: set[str] = set()
+    result: list[str] = []
+    if primary:
+        seen.add(primary)
+        result.append(primary)
+    for name in extras:
+        text = str(name or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
 def has_legacy_database_default(db: DBConfig) -> bool:
     """Return True when *db* still carries the historical ``database='SAP'`` default.
 
@@ -1926,6 +1952,14 @@ class AMXConfig:
     # workflows keep their fast path. Configure via ``/history-store``.
     history_store_enabled: bool = False
     history_store_profile: str = ""
+    # Additional DB profiles that participate in the shared history
+    # store alongside ``history_store_profile``. The effective set is
+    # the deduplicated union (singular field stays for backward
+    # compatibility with 0.12.x configs and is still treated as the
+    # "primary" profile that owns the schema). Users add profiles via
+    # ``/history-store profiles`` (REPL) or ``PATCH /api/history/profiles``
+    # (Studio). Empty list keeps the legacy single-profile behaviour.
+    history_store_profiles: list[str] = field(default_factory=list)
     history_store_schema: str = "AMX"
     # Overrides the profile's pinned database/catalog when building the
     # shared-history engine. A single DB profile (e.g. ``prod_pg``)
@@ -1980,6 +2014,7 @@ class AMXConfig:
             "write_through_config",
             "history_store_enabled",
             "history_store_profile",
+            "history_store_profiles",
             "history_store_schema",
             "history_store_database",
         }
@@ -2168,6 +2203,15 @@ class AMXConfig:
             # local-only behaviour for users upgrading from 0.11.x.
             cfg.history_store_enabled = bool(data.get("history_store_enabled", False))
             cfg.history_store_profile = str(data.get("history_store_profile") or "")
+            extra_profiles_raw = data.get("history_store_profiles")
+            if isinstance(extra_profiles_raw, list):
+                cfg.history_store_profiles = [
+                    str(p).strip()
+                    for p in extra_profiles_raw
+                    if isinstance(p, str) and p.strip()
+                ]
+            else:
+                cfg.history_store_profiles = []
             cfg.history_store_schema = str(data.get("history_store_schema") or "AMX")
             cfg.history_store_database = str(data.get("history_store_database") or "")
 
@@ -2423,6 +2467,7 @@ class AMXConfig:
                 "run_code_profiles",
                 "history_store_enabled",
                 "history_store_profile",
+                "history_store_profiles",
                 "history_store_database",
                 "history_store_schema",
             ):
@@ -2540,6 +2585,11 @@ class AMXConfig:
             data["write_through_config"] = self.write_through_config
             data["history_store_enabled"] = bool(self.history_store_enabled)
             data["history_store_profile"] = str(self.history_store_profile or "")
+            data["history_store_profiles"] = [
+                str(p).strip()
+                for p in (self.history_store_profiles or [])
+                if isinstance(p, str) and p.strip()
+            ]
             data["history_store_schema"] = str(self.history_store_schema or "AMX")
             data["history_store_database"] = str(self.history_store_database or "")
             data["embedding_docs"] = _embedding_to_mapping(self.embedding_docs)

--- a/amx/web/routers/history.py
+++ b/amx/web/routers/history.py
@@ -322,17 +322,23 @@ def history_status() -> dict[str, Any]:
     Returns:
       - ``enabled``: whether shared mode is configured
       - ``backfill``: backfill state per scope (running / done / idle)
-      - ``shared_profile``: the configured history_store_profile
+      - ``shared_profile``: the legacy single-profile field (kept for
+        backward-compat with older Studio builds)
+      - ``shared_profiles``: deduplicated union of the primary profile
+        plus every entry in ``history_store_profiles`` — the full set
+        of DB profiles participating in the shared store
     """
     store = _store()
     enabled = True
     shared_profile = ""
+    shared_profiles: list[str] = []
     backfill: dict[str, Any] = {}
     try:
-        from amx.config import AMXConfig
+        from amx.config import AMXConfig, history_store_profile_set
 
         cfg = AMXConfig.load()
         shared_profile = cfg.history_store_profile or ""
+        shared_profiles = history_store_profile_set(cfg)
         enabled = bool(cfg.history_store_enabled)
     except Exception:
         pass
@@ -347,7 +353,66 @@ def history_status() -> dict[str, Any]:
     return {
         "enabled": enabled,
         "shared_profile": shared_profile,
+        "shared_profiles": shared_profiles,
         "backfill": backfill,
+    }
+
+
+class HistoryProfilesPatch(BaseModel):
+    """Body for ``PATCH /api/history/profiles``."""
+
+    profiles: list[str] = Field(default_factory=list)
+
+
+@router.patch("/profiles")
+def set_history_profiles(body: HistoryProfilesPatch) -> dict[str, Any]:
+    """Replace the additional-profile list for the shared history store.
+
+    The primary profile (singular ``history_store_profile``) is left
+    untouched — it owns the schema and is only changed by
+    ``/history-store enable``. This endpoint manages the *extra*
+    profiles whose runs are also dual-written.
+
+    Returns the new union after save so the Studio Settings page can
+    re-render its chips immediately.
+    """
+    from amx.config import AMXConfig, history_store_profile_set
+
+    try:
+        cfg = AMXConfig.load()
+    except Exception as exc:  # pragma: no cover - load is well-tested elsewhere
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to load config: {exc}",
+        ) from exc
+
+    primary = (cfg.history_store_profile or "").strip()
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for name in body.profiles or []:
+        text = str(name or "").strip()
+        if not text:
+            continue
+        # Drop the primary from the extras list — it lives in the
+        # singular field and shouldn't be duplicated on disk.
+        if text == primary:
+            continue
+        if text in seen:
+            continue
+        seen.add(text)
+        cleaned.append(text)
+    cfg.history_store_profiles = cleaned
+    try:
+        cfg.save()
+    except Exception as exc:  # pragma: no cover - save errors surface inline
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to save config: {exc}",
+        ) from exc
+
+    return {
+        "shared_profile": primary,
+        "shared_profiles": history_store_profile_set(cfg),
     }
 
 

--- a/docs/superpowers/specs/2026-05-20-local-comments-and-multi-profile-history-store-design.md
+++ b/docs/superpowers/specs/2026-05-20-local-comments-and-multi-profile-history-store-design.md
@@ -1,0 +1,77 @@
+# Local Comments + Multi-Profile History-Store
+
+## Context
+
+Two related gaps in the AMX persistence story:
+
+1. **Local-only column/table comments.** Today, when a user authors
+   a description in AMX, the only way it survives across sessions is
+   to apply it back to the database via the writeback path. Users
+   who cannot (or do not want to) write to the source DB lose their
+   work the moment they close the REPL or Studio. The
+   `catalog_descriptions` table already carries non-applied
+   descriptions during a run, but there is no surface to *create* a
+   description as "mine, do not write back, but keep it visible".
+
+2. **Multi-profile history-store inclusion.** The remote history
+   store dual-write is bound to a single profile via the singular
+   `history_store_profile` config field. Users running AMX against
+   several profiles cannot include more than one of them in the
+   shared history. The `/history-store` wizard only asks for one.
+
+## Decisions
+
+| Axis | Decision |
+|---|---|
+| Local-comment storage | Reuse `catalog_descriptions` with a new `source_kind = "user_local"`. No new table. The existing `effective_description_id` pointer on `catalog_entities` is updated so reads (Studio cards, REPL inspect) see the override. |
+| Local-comment writeback semantics | Pure local: `user_local` rows never trigger `db.set_column_comment`. The existing apply flow ignores them. A separate "promote to writeback" action is out of scope for this PR. |
+| Multi-profile config shape | Add `history_store_profiles: list[str]` alongside the existing singular `history_store_profile`. The effective set is the union, deduplicated. Loaders + savers carry both fields so older configs read unchanged and write back in the new shape. |
+| Surfaces | Local-comment: REPL `/db comment-local` wizard + `POST /api/comments/local`. Multi-profile: REPL `/history-store profiles` wizard + `PATCH /api/history/profiles`. Studio UI updates are out of scope for this PR; the new endpoints are the API contract Studio will consume in a follow-up. |
+
+## Architecture
+
+### Edited modules
+
+- **`amx/config.py`** — add `history_store_profiles: list[str] = field(default_factory=list)`; extend the `_PERSISTED_FIELDS` set, the YAML loader (`from_data`), and the YAML dumper to round-trip the list. Provide a helper `history_store_profile_set(cfg) -> set[str]` that returns the union of the singular and list fields.
+- **`amx/web/routers/history.py`** — extend `GET /api/history/state` to expose `shared_profiles` (the union set). Add `PATCH /api/history/profiles` with body `{"profiles": [...]}` to set the list.
+- **`amx/web/routers/comments.py`** — add `POST /api/comments/local` with body `{"profile", "schema", "table", "column" (optional), "description"}` to upsert a `user_local` description in `catalog_descriptions` and point `catalog_entities.effective_description_id` at it. No DB call.
+- **`amx/cli_support/commands/history_store.py`** — add `cmd_profiles` (wizard with multi-select) and wire `/history-store profiles` into the session dispatcher.
+- **`amx/cli_support/commands/db.py`** — add `cmd_comment_local` (wizard: pick profile / schema / table / column / text) and wire `/db comment-local`.
+- **`amx/storage/sqlite_store.py`** — add `save_user_local_description` and `_make_user_local_effective` helpers if no existing path covers `source_kind="user_local"` inserts.
+
+### Storage schema
+
+No new tables. No new columns. New `source_kind` value uses an
+existing TEXT column. No migration required.
+
+## Verification
+
+1. Unit: config round-trip for `history_store_profiles` (load -> save -> load).
+2. Unit: `history_store_profile_set(cfg)` returns the union deduplicated.
+3. Unit: `save_user_local_description` inserts a row in `catalog_descriptions` with `source_kind="user_local"` and updates `catalog_entities.effective_description_id`.
+4. HTTP: `PATCH /api/history/profiles` accepts a list of strings and persists it.
+5. HTTP: `POST /api/comments/local` creates the override; subsequent `GET /api/catalog/inventory` reflects it.
+6. No-regression: existing `tests/test_db_cache_ops.py`, `tests/test_catalog_skeleton_sync.py`, and `tests/web/test_comments.py` pass.
+7. Manual REPL smoke: `/history-store profiles` wizard updates the list, `/history-store status` shows the union; `/db comment-local` writes a local description, `/inspect` shows it.
+
+## Delivery split
+
+The two sub-features ship as separate PRs because the local-override
+path requires a careful integration with the existing
+`effective_description_id` / `chosen_description` / FTS reconciliation
+flow in `EntityCrudMixin`, and a single PR mixing both would muddy
+the review.
+
+* **PR-1 (this PR):** Multi-profile history-store inclusion — config
+  field, `PATCH /api/history/profiles`, `/history-store profiles`
+  REPL wizard, tests.
+* **PR-2 (follow-up):** Local-only comment override — `source_kind =
+  "user_local"` write path, `POST /api/comments/local`,
+  `/db comment-local` wizard, reconciliation with the existing
+  description precedence, FTS re-index, tests.
+
+## Out of scope
+
+- Studio SPA changes (the bundled `web/static/assets/*.js` files). The new endpoints + REPL surfaces ship in this PR; the Studio Settings page and comment card UI updates are a follow-up.
+- "Promote local override to writeback" action (PR-2 territory).
+- Per-profile inclusion in *local* history (today every profile contributes to local SQLite; the new flag controls *remote* mirroring only).

--- a/tests/test_history_store_profile_set.py
+++ b/tests/test_history_store_profile_set.py
@@ -1,0 +1,81 @@
+"""Tests for the multi-profile history-store union helper + config round-trip."""
+
+from __future__ import annotations
+
+from amx.config import AMXConfig, history_store_profile_set
+
+
+def test_singular_only_returns_primary() -> None:
+    cfg = AMXConfig()
+    cfg.history_store_profile = "prod_dwh"
+    cfg.history_store_profiles = []
+    assert history_store_profile_set(cfg) == ["prod_dwh"]
+
+
+def test_extras_only_returns_extras() -> None:
+    cfg = AMXConfig()
+    cfg.history_store_profile = ""
+    cfg.history_store_profiles = ["a", "b"]
+    assert history_store_profile_set(cfg) == ["a", "b"]
+
+
+def test_union_dedupes_primary_in_extras() -> None:
+    cfg = AMXConfig()
+    cfg.history_store_profile = "prod"
+    cfg.history_store_profiles = ["prod", "dev", "staging"]
+    assert history_store_profile_set(cfg) == ["prod", "dev", "staging"]
+
+
+def test_union_strips_empty_strings_and_whitespace() -> None:
+    cfg = AMXConfig()
+    cfg.history_store_profile = "prod"
+    cfg.history_store_profiles = ["", "  ", "dev", " staging "]
+    assert history_store_profile_set(cfg) == ["prod", "dev", "staging"]
+
+
+def test_empty_config_returns_empty_list() -> None:
+    cfg = AMXConfig()
+    cfg.history_store_profile = ""
+    cfg.history_store_profiles = []
+    assert history_store_profile_set(cfg) == []
+
+
+def test_extras_preserve_insertion_order() -> None:
+    cfg = AMXConfig()
+    cfg.history_store_profile = ""
+    cfg.history_store_profiles = ["z", "a", "m"]
+    assert history_store_profile_set(cfg) == ["z", "a", "m"]
+
+
+def test_legacy_config_loads_without_extras_key(tmp_path) -> None:
+    """A YAML file written by AMX 0.16.x has no ``history_store_profiles``
+    key. The loader must default to an empty list, not crash."""
+    import yaml
+
+    legacy_yaml = {
+        "history_store_enabled": True,
+        "history_store_profile": "prod",
+        "history_store_schema": "AMX",
+        "history_store_database": "",
+    }
+    path = tmp_path / "config.yml"
+    path.write_text(yaml.safe_dump(legacy_yaml), encoding="utf-8")
+
+    cfg = AMXConfig.load(str(path))
+    assert cfg.history_store_profile == "prod"
+    assert cfg.history_store_profiles == []
+    assert history_store_profile_set(cfg) == ["prod"]
+
+
+def test_new_config_round_trips_extras(tmp_path) -> None:
+    """Setting extras, saving, and re-loading preserves the list."""
+    path = tmp_path / "config.yml"
+    cfg = AMXConfig.load(str(path))
+    cfg.history_store_profile = "prod"
+    cfg.history_store_profiles = ["dev", "staging"]
+    cfg.save()
+
+    reloaded = AMXConfig.load(str(path))
+    assert reloaded.history_store_profile == "prod"
+    assert reloaded.history_store_profiles == ["dev", "staging"]
+    assert history_store_profile_set(reloaded) == ["prod", "dev", "staging"]

--- a/tests/web/test_history_profiles_patch.py
+++ b/tests/web/test_history_profiles_patch.py
@@ -1,0 +1,91 @@
+"""PATCH /api/history/profiles + GET /api/history/status surface tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_config(tmp_path, monkeypatch):
+    """Point AMXConfig.load() at a throwaway YAML so the endpoint test
+    does not mutate the developer's real config.yml."""
+    cfg_path = tmp_path / "config.yml"
+    cfg_path.write_text(
+        "history_store_enabled: true\n"
+        "history_store_profile: prod\n"
+        "history_store_schema: AMX\n"
+        "history_store_database: ''\n",
+        encoding="utf-8",
+    )
+
+    from amx import config as cfg_module
+
+    original_load = cfg_module.AMXConfig.load
+
+    @classmethod
+    def _scoped_load(cls, path=None):
+        return original_load(str(cfg_path))
+
+    monkeypatch.setattr(cfg_module.AMXConfig, "load", _scoped_load)
+    yield cfg_path
+
+
+def test_status_reports_singular_when_extras_empty(
+    client, auth_headers, isolated_config
+) -> None:
+    response = client.get("/api/history/status", headers=auth_headers)
+    assert response.status_code in (200, 503)
+    if response.status_code == 503:
+        pytest.skip("history store not initialised in this test harness")
+    payload = response.json()
+    assert payload["shared_profile"] == "prod"
+    assert payload["shared_profiles"] == ["prod"]
+
+
+def test_patch_profiles_replaces_extras_and_dedupes_primary(
+    client, auth_headers, isolated_config
+) -> None:
+    response = client.patch(
+        "/api/history/profiles",
+        json={"profiles": ["prod", "dev", "staging"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    # Primary "prod" is dropped from the extras list because it lives
+    # in the singular field; the union still surfaces it first.
+    assert payload["shared_profile"] == "prod"
+    assert payload["shared_profiles"] == ["prod", "dev", "staging"]
+
+
+def test_patch_profiles_empty_list_clears_extras(
+    client, auth_headers, isolated_config
+) -> None:
+    # Seed.
+    client.patch(
+        "/api/history/profiles",
+        json={"profiles": ["dev", "staging"]},
+        headers=auth_headers,
+    )
+    # Now clear.
+    response = client.patch(
+        "/api/history/profiles",
+        json={"profiles": []},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["shared_profiles"] == ["prod"]
+
+
+def test_patch_profiles_strips_whitespace(
+    client, auth_headers, isolated_config
+) -> None:
+    response = client.patch(
+        "/api/history/profiles",
+        json={"profiles": ["  dev  ", "", "  ", "staging"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["shared_profiles"] == ["prod", "dev", "staging"]


### PR DESCRIPTION
## Summary

Today the shared history-store dual-write is bound to a single DB profile via the singular `history_store_profile` config field. Users running AMX against several profiles cannot include more than one of them in the shared history.

This PR adds an additive `history_store_profiles` list alongside the existing singular field. The effective set is the deduplicated union of the primary profile (which still owns the AMX schema) and the extras list. Existing 0.16.x configs continue to load unchanged; the new field is optional and defaults to empty.

### Surfaces

- **Config:** new `history_store_profiles: list[str]` field, persistence round-trip, helper `history_store_profile_set(cfg)` that returns the union list with the primary first.
- **HTTP:** `GET /api/history/status` exposes `shared_profiles` (the union) alongside the legacy `shared_profile`; new `PATCH /api/history/profiles` accepts a list and persists it.
- **REPL:** new `/history-store profiles` Click subcommand and `Profiles — pick which DB profiles participate in the shared store` entry in the action picker that runs a multi-select wizard over saved DB profiles.

### Out of scope

Local-only comment overrides (the second user-reported gap from the brainstorm) are scoped out of this PR. They require a careful integration with the existing `effective_description_id` / `chosen_description` / FTS reconciliation flow in `EntityCrudMixin` and warrant their own PR. The design doc (`docs/superpowers/specs/2026-05-20-local-comments-and-multi-profile-history-store-design.md`) spells out the split.

## Test plan

- [x] `pytest tests/test_history_store_profile_set.py tests/web/test_history_profiles_patch.py` — 11 passed, 1 skipped (history-store init only fires under specific fixtures)
- [x] `pytest tests/test_admin_api.py tests/web/test_catalog.py tests/web/test_db_cache_router.py tests/storage/test_admin.py` — 29/29 green, no regression
- [x] `ruff check` on every touched file — clean
- [ ] Manual: open `/history-store` from REPL, pick `Profiles`, multi-select extras, confirm `/history-store status` and `/api/history/status` show the union.
- [ ] Manual: PATCH `/api/history/profiles` from Studio devtools, confirm config.yml persists `history_store_profiles`.