### PR TITLE
feat(catalog): local-only comment override (POST /api/comments/local)

### DIFF
--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -1809,3 +1809,134 @@ def cmd_sync_stop(cfg: AMXConfig, rest: list[str]) -> None:
             info(f"No active sync to cancel for {target!r}.")
     if not cancelled_any:
         info("Nothing to cancel.")
+
+
+def _parse_comment_local_args(rest: list[str]) -> dict[str, str | None]:
+    """Pull ``--profile/--schema/--table/--column/--description`` from
+    ``rest``. Every flag is optional — the wizard fills in whatever
+    is missing.
+    """
+    args: dict[str, str | None] = {
+        "profile": None,
+        "schema": None,
+        "table": None,
+        "column": None,
+        "description": None,
+    }
+    i = 0
+    while i < len(rest):
+        token = rest[i]
+        if token.startswith("--") and i + 1 < len(rest):
+            key = token[2:]
+            if key in args:
+                args[key] = rest[i + 1].strip()
+            i += 2
+            continue
+        i += 1
+    return args
+
+
+def cmd_comment_local(cfg: AMXConfig, rest: list[str]) -> None:
+    """/db comment-local — write a local-only description override.
+
+    The description is recorded in the catalog with
+    ``source_kind="user_local"`` and immediately outranks every other
+    source for the targeted entity. **No COMMENT statement is sent
+    to the source database.** Use this when you don't have write
+    privileges, want to keep private annotations, or simply don't
+    want your edits to leak back to a shared DB.
+
+    Bare ``/db comment-local`` runs an interactive wizard. Every
+    ``--profile/--schema/--table/--column/--description`` flag is
+    optional and short-circuits the corresponding picker.
+    """
+    from amx.db._default_scope import profile_default_container
+    from amx.search.catalog import SearchCatalog
+
+    args = _parse_comment_local_args(rest)
+
+    if not cfg.db_profiles:
+        error(
+            "No DB profiles saved. Configure one with /db-profiles "
+            "before recording a local comment."
+        )
+        return
+
+    profile = args["profile"] or ""
+    if not profile:
+        active = cfg.active_db_profile or next(iter(cfg.db_profiles))
+        profile = ask_choice(
+            "Pick a DB profile",
+            sorted(cfg.db_profiles.keys()),
+            default=active,
+        )
+    if not profile:
+        info("Cancelled.")
+        return
+    if profile not in cfg.db_profiles:
+        error(f"Unknown DB profile: {profile!r}.")
+        return
+
+    schema_name = args["schema"] or ask("Schema name")
+    if not schema_name:
+        info("Cancelled.")
+        return
+    table_name = args["table"] or ask("Table name")
+    if not table_name:
+        info("Cancelled.")
+        return
+
+    column_name: str | None
+    if args["column"] is not None:
+        # An explicit empty --column flag means "table-level".
+        column_name = args["column"].strip() or None
+    else:
+        column_input = ask("Column name (leave blank for table-level)").strip()
+        column_name = column_input or None
+
+    description = args["description"] or ask("Description text")
+    if not description:
+        info("Cancelled.")
+        return
+
+    target_label = (
+        f"{profile}.{schema_name}.{table_name}"
+        + (f".{column_name}" if column_name else " (table-level)")
+    )
+    if args["description"] is None and not confirm(
+        f"Save local description for {target_label}?",
+        default=True,
+    ):
+        info("Cancelled.")
+        return
+
+    catalog = SearchCatalog.from_history_store()
+    if catalog is None:
+        error(
+            "History store isn't initialised yet — activate a DB "
+            "profile first so the local catalog can open."
+        )
+        return
+
+    db_cfg = cfg.db_profiles[profile]
+    db_backend = str(getattr(db_cfg, "backend", "") or "")
+    database_name = profile_default_container(db_cfg) or ""
+    entity_kind = "column" if column_name else "table"
+
+    result = catalog.record_user_local_description(
+        db_profile=profile,
+        db_backend=db_backend,
+        database_name=database_name,
+        schema_name=schema_name,
+        table_name=table_name,
+        column_name=column_name,
+        entity_kind=entity_kind,
+        asset_kind="table",
+        description=description,
+    )
+    success(
+        f"Saved local description for {target_label} "
+        f"(entity_id={result['entity_id']}, "
+        f"description_id={result['description_id']}). "
+        "No COMMENT statement was sent to the source database."
+    )

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -634,6 +634,13 @@ def _handle_session_builtin(
 
         _cmd_sync_stop(cfg, parts[1:])
         return True
+    if head == "comment-local":
+        if not _require_namespace(head, namespace, "db", "comment-local"):
+            return True
+        from amx.cli_support.commands.db import cmd_comment_local as _cmd_comment_local
+
+        _cmd_comment_local(cfg, parts[1:])
+        return True
     if head == "save":
         path = cfg.save()
         success(f"Saved configuration to {path}")

--- a/amx/search/_catalog/_constants.py
+++ b/amx/search/_catalog/_constants.py
@@ -20,6 +20,14 @@ from typing import Any
 # pick which candidate description wins when several sources contribute
 # rows for the same entity.
 SOURCE_PRIORITY: dict[str, int] = {
+    # ``user_local`` is an explicit local-only override authored
+    # through ``POST /api/comments/local`` or ``/db comment-local``.
+    # It outranks every other source on purpose: the user opted into
+    # this surface specifically to override what AMX already had —
+    # generated suggestions, the live DB COMMENT, even a prior
+    # ``manual`` edit that wrote back to the DB. The row never gets
+    # ``applied_to_db=1`` so it stays a private annotation.
+    "user_local": 5,
     "manual": 4,
     "reviewed": 3,
     "generated": 2,

--- a/amx/search/_catalog/usage.py
+++ b/amx/search/_catalog/usage.py
@@ -260,6 +260,63 @@ class UsageMixin:
             self._resolve_effective_description(conn, entity_id)
             self._index_entity(conn, entity_id)
 
+    def record_user_local_description(
+        self,
+        *,
+        db_profile: str,
+        db_backend: str,
+        database_name: str,
+        schema_name: str,
+        table_name: str,
+        column_name: str | None,
+        entity_kind: str,
+        asset_kind: str,
+        description: str,
+    ) -> dict[str, int]:
+        """Record a local-only description override.
+
+        Mirror of :meth:`record_manual_description` with two
+        deliberate differences:
+
+        * ``source_kind="user_local"`` (priority 5 in
+          ``SOURCE_PRIORITY``) so the override wins the precedence
+          race against every other source — generated suggestions,
+          the imported live-DB comment, even a prior ``manual``
+          row that wrote back to the DB.
+        * The row is never picked up by the writeback path
+          (``applied_to_db`` stays 0). Promoting a local override to
+          a DB write is a separate, user-initiated action.
+
+        Returns a small dict with the freshly created
+        ``entity_id`` + ``description_id`` so HTTP / CLI callers can
+        echo them back to the user (and the Studio SPA can refetch
+        the asset card without guessing).
+        """
+        with self._connect() as conn:
+            entity_id = self._upsert_entity(
+                conn,
+                db_profile=db_profile,
+                db_backend=db_backend,
+                database_name=database_name,
+                schema_name=schema_name,
+                table_name=table_name,
+                column_name=column_name,
+                entity_kind=entity_kind,
+                asset_kind=asset_kind,
+            )
+            description_id = self._insert_description(
+                conn,
+                entity_id=entity_id,
+                description_text=description,
+                source_kind="user_local",
+                source_agent="user_local.create",
+                confidence="high",
+                chosen=True,
+            )
+            self._resolve_effective_description(conn, entity_id)
+            self._index_entity(conn, entity_id)
+        return {"entity_id": int(entity_id), "description_id": int(description_id)}
+
     def record_dedup_decision(
         self,
         *,

--- a/amx/web/routers/comments.py
+++ b/amx/web/routers/comments.py
@@ -20,7 +20,7 @@ disagreed with ``cfg.active_db_profile``.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from amx.config import AMXConfig
 from amx.db.connector import AssetKind, DatabaseConnector
@@ -34,6 +34,24 @@ class CommentBody(BaseModel):
     """Common shape for every comment write-back endpoint."""
 
     comment: str
+
+
+class LocalCommentBody(BaseModel):
+    """Body accepted by ``POST /api/comments/local``.
+
+    ``column`` is optional: when omitted (or empty) the description
+    is attached to the table-level entity row instead of a column.
+    The local override never triggers a writeback to the source DB —
+    that is the whole point of the surface.
+    """
+
+    profile: str = Field(min_length=1)
+    schema_: str = Field(min_length=1, alias="schema")
+    table: str = Field(min_length=1)
+    column: str | None = None
+    description: str = Field(min_length=1)
+
+    model_config = {"populate_by_name": True}
 
 
 def _scoped_connector(
@@ -141,3 +159,69 @@ def set_column_comment(
     # fetch refreshes the entire table's column dict in one bulk call.
     db.invalidate_column_comments_cache(schema=schema, table=table)
     return {"ok": "true"}
+
+
+@router.post("/local")
+def save_local_comment(
+    body: LocalCommentBody,
+    cfg: AMXConfig = Depends(get_cfg),
+) -> dict[str, object]:
+    """Create a local-only description override for one entity.
+
+    Unlike the PUT endpoints above, this path never issues a
+    ``COMMENT ON …`` to the source DB. The description is recorded
+    as ``source_kind="user_local"`` in ``catalog_descriptions`` and
+    immediately becomes the effective description for the entity
+    (the new source outranks every existing one — see
+    ``SOURCE_PRIORITY``). The Studio asset card / REPL inspect / FTS
+    search will surface it on the next read.
+    """
+    from amx.db._default_scope import profile_default_container
+    from amx.search.catalog import SearchCatalog
+
+    profile = body.profile.strip()
+    db_cfg = (cfg.db_profiles or {}).get(profile)
+    if db_cfg is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"Unknown DB profile: {profile!r}. Save the profile "
+                "via /db-profiles or pick an existing one."
+            ),
+        )
+
+    catalog = SearchCatalog.from_history_store()
+    if catalog is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "History store isn't initialised — activate any DB "
+                "profile first so the local catalog can open."
+            ),
+        )
+
+    column = (body.column or "").strip() or None
+    entity_kind = "column" if column else "table"
+    db_backend = str(getattr(db_cfg, "backend", "") or "")
+    database_name = profile_default_container(db_cfg) or ""
+
+    result = catalog.record_user_local_description(
+        db_profile=profile,
+        db_backend=db_backend,
+        database_name=database_name,
+        schema_name=body.schema_,
+        table_name=body.table,
+        column_name=column,
+        entity_kind=entity_kind,
+        asset_kind="table",
+        description=body.description,
+    )
+    return {
+        "ok": True,
+        "profile": profile,
+        "schema": body.schema_,
+        "table": body.table,
+        "column": column,
+        "entity_id": result["entity_id"],
+        "description_id": result["description_id"],
+    }

--- a/docs/superpowers/specs/2026-05-20-local-comments-and-multi-profile-history-store-design.md
+++ b/docs/superpowers/specs/2026-05-20-local-comments-and-multi-profile-history-store-design.md
@@ -62,13 +62,16 @@ path requires a careful integration with the existing
 flow in `EntityCrudMixin`, and a single PR mixing both would muddy
 the review.
 
-* **PR-1 (this PR):** Multi-profile history-store inclusion — config
-  field, `PATCH /api/history/profiles`, `/history-store profiles`
+* **PR-1 (landed as PR #538):** Multi-profile history-store inclusion —
+  config field, `PATCH /api/history/profiles`, `/history-store profiles`
   REPL wizard, tests.
-* **PR-2 (follow-up):** Local-only comment override — `source_kind =
-  "user_local"` write path, `POST /api/comments/local`,
-  `/db comment-local` wizard, reconciliation with the existing
-  description precedence, FTS re-index, tests.
+* **PR-2 (this PR):** Local-only comment override — new
+  `source_kind="user_local"` (priority 5 above `manual=4`),
+  `record_user_local_description` helper on `SearchCatalog`,
+  `POST /api/comments/local` endpoint, `/db comment-local` wizard.
+  No new tables, no schema migration: the existing
+  `_resolve_effective_description` precedence machinery + FTS
+  reindex carry the change automatically.
 
 ## Out of scope
 

--- a/tests/test_user_local_description.py
+++ b/tests/test_user_local_description.py
@@ -1,0 +1,190 @@
+"""Tests for the local-only comment override path.
+
+Covers the new ``record_user_local_description`` helper on
+:class:`SearchCatalog`, the precedence promotion of
+``source_kind="user_local"`` over ``"manual"``, and the FTS / search
+text mirror update so the override is searchable on the next read.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amx.search._catalog._constants import SOURCE_PRIORITY
+from amx.search.catalog import SearchCatalog
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture()
+def fresh_catalog(tmp_path: Path) -> SearchCatalog:
+    db = tmp_path / "history.db"
+    SQLiteHistoryStore(db).init()
+    return SearchCatalog(db)
+
+
+def _entity_row(catalog: SearchCatalog) -> dict:
+    with catalog._connect() as conn:  # noqa: SLF001
+        return dict(conn.execute("SELECT * FROM catalog_entities LIMIT 1").fetchone())
+
+
+def _description_rows(catalog: SearchCatalog) -> list[dict]:
+    with catalog._connect() as conn:  # noqa: SLF001
+        return [
+            dict(r)
+            for r in conn.execute(
+                "SELECT id, source_kind, chosen_description, applied_to_db, description_text "
+                "FROM catalog_descriptions ORDER BY id"
+            ).fetchall()
+        ]
+
+
+def test_source_priority_ranks_user_local_above_manual() -> None:
+    assert SOURCE_PRIORITY["user_local"] == 5
+    assert SOURCE_PRIORITY["user_local"] > SOURCE_PRIORITY["manual"]
+
+
+def test_roundtrip_inserts_user_local_row(fresh_catalog: SearchCatalog) -> None:
+    result = fresh_catalog.record_user_local_description(
+        db_profile="prod-pg",
+        db_backend="postgresql",
+        database_name="analytics",
+        schema_name="sales",
+        table_name="orders",
+        column_name="amount",
+        entity_kind="column",
+        asset_kind="table",
+        description="Net invoice amount in account currency.",
+    )
+    assert result["entity_id"] > 0
+    assert result["description_id"] > 0
+
+    rows = _description_rows(fresh_catalog)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["source_kind"] == "user_local"
+    assert row["chosen_description"] == 1
+    assert row["applied_to_db"] == 0
+    assert row["description_text"] == "Net invoice amount in account currency."
+
+
+def test_effective_description_points_at_new_row(fresh_catalog: SearchCatalog) -> None:
+    fresh_catalog.record_user_local_description(
+        db_profile="prod-pg",
+        db_backend="postgresql",
+        database_name="analytics",
+        schema_name="sales",
+        table_name="orders",
+        column_name="amount",
+        entity_kind="column",
+        asset_kind="table",
+        description="Net invoice amount.",
+    )
+    entity = _entity_row(fresh_catalog)
+    descs = _description_rows(fresh_catalog)
+    assert entity["effective_description_id"] == descs[0]["id"]
+    assert entity["effective_source_kind"] == "user_local"
+
+
+def test_user_local_beats_manual_when_both_present(
+    fresh_catalog: SearchCatalog,
+) -> None:
+    fresh_catalog.record_manual_description(
+        db_profile="prod-pg",
+        db_backend="postgresql",
+        database_name="analytics",
+        schema_name="sales",
+        table_name="orders",
+        column_name="amount",
+        entity_kind="column",
+        asset_kind="table",
+        description="OLD manual edit that was written back to the DB.",
+    )
+    fresh_catalog.record_user_local_description(
+        db_profile="prod-pg",
+        db_backend="postgresql",
+        database_name="analytics",
+        schema_name="sales",
+        table_name="orders",
+        column_name="amount",
+        entity_kind="column",
+        asset_kind="table",
+        description="NEW local override that should win.",
+    )
+    entity = _entity_row(fresh_catalog)
+    with fresh_catalog._connect() as conn:  # noqa: SLF001
+        winner = conn.execute(
+            "SELECT description_text, source_kind FROM catalog_descriptions WHERE id = ?",
+            (entity["effective_description_id"],),
+        ).fetchone()
+    assert winner["source_kind"] == "user_local"
+    assert winner["description_text"] == "NEW local override that should win."
+
+
+def test_two_calls_reuse_entity_row(fresh_catalog: SearchCatalog) -> None:
+    first = fresh_catalog.record_user_local_description(
+        db_profile="prod-pg",
+        db_backend="postgresql",
+        database_name="analytics",
+        schema_name="sales",
+        table_name="orders",
+        column_name="amount",
+        entity_kind="column",
+        asset_kind="table",
+        description="First note.",
+    )
+    second = fresh_catalog.record_user_local_description(
+        db_profile="prod-pg",
+        db_backend="postgresql",
+        database_name="analytics",
+        schema_name="sales",
+        table_name="orders",
+        column_name="amount",
+        entity_kind="column",
+        asset_kind="table",
+        description="Second note that supersedes the first.",
+    )
+    assert first["entity_id"] == second["entity_id"]
+    assert first["description_id"] != second["description_id"]
+    rows = _description_rows(fresh_catalog)
+    assert len(rows) == 2
+
+
+def test_table_level_record_has_null_column_name(fresh_catalog: SearchCatalog) -> None:
+    fresh_catalog.record_user_local_description(
+        db_profile="prod-pg",
+        db_backend="postgresql",
+        database_name="analytics",
+        schema_name="sales",
+        table_name="orders",
+        column_name=None,
+        entity_kind="table",
+        asset_kind="table",
+        description="Customer purchase orders, one row per order.",
+    )
+    entity = _entity_row(fresh_catalog)
+    assert entity["column_name"] is None
+    assert entity["entity_kind"] == "table"
+
+
+def test_search_text_includes_user_local(fresh_catalog: SearchCatalog) -> None:
+    fresh_catalog.record_user_local_description(
+        db_profile="prod-pg",
+        db_backend="postgresql",
+        database_name="analytics",
+        schema_name="sales",
+        table_name="orders",
+        column_name="amount",
+        entity_kind="column",
+        asset_kind="table",
+        description="Vehicle plate of the courier that fulfilled the order.",
+    )
+    with fresh_catalog._connect() as conn:  # noqa: SLF001
+        entity = conn.execute("SELECT id, search_text FROM catalog_entities").fetchone()
+        assert "Vehicle plate" in (entity["search_text"] or "")
+        fts_row = conn.execute(
+            "SELECT rowid FROM catalog_entities_fts WHERE search_text MATCH 'plate'"
+        ).fetchone()
+        assert fts_row is not None
+        assert int(fts_row["rowid"]) == int(entity["id"])

--- a/tests/web/test_comments_local.py
+++ b/tests/web/test_comments_local.py
@@ -1,0 +1,136 @@
+"""POST /api/comments/local — local-only override endpoint tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture()
+def history_db(tmp_path, monkeypatch):
+    """Seed a real on-disk history store and bind it as the module
+    singleton so ``SearchCatalog.from_history_store()`` returns
+    something usable."""
+    from amx.storage import sqlite_store as ss
+
+    db_path = tmp_path / "history.db"
+    SQLiteHistoryStore(db_path).init()
+    store = SQLiteHistoryStore(db_path)
+    monkeypatch.setattr(ss, "_store", store, raising=False)
+    yield store
+    monkeypatch.setattr(ss, "_store", None, raising=False)
+
+
+@pytest.fixture()
+def cfg_with_profile(cfg):
+    """Attach one DBConfig-shaped profile so the endpoint can resolve
+    the backend + default container without opening a real engine."""
+    cfg.db_profiles = {
+        "prod-pg": SimpleNamespace(
+            backend="postgresql",
+            catalog="",
+            dataset="",
+            database="analytics",
+            project="",
+        )
+    }
+    return cfg
+
+
+def test_save_local_comment_happy_path(
+    client, auth_headers, history_db, cfg_with_profile
+) -> None:
+    response = client.post(
+        "/api/comments/local",
+        json={
+            "profile": "prod-pg",
+            "schema": "sales",
+            "table": "orders",
+            "column": "amount",
+            "description": "Net invoice amount in account currency.",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["profile"] == "prod-pg"
+    assert payload["schema"] == "sales"
+    assert payload["table"] == "orders"
+    assert payload["column"] == "amount"
+    assert isinstance(payload["entity_id"], int) and payload["entity_id"] > 0
+    assert isinstance(payload["description_id"], int) and payload["description_id"] > 0
+
+
+def test_save_local_comment_table_level_when_column_omitted(
+    client, auth_headers, history_db, cfg_with_profile
+) -> None:
+    response = client.post(
+        "/api/comments/local",
+        json={
+            "profile": "prod-pg",
+            "schema": "sales",
+            "table": "orders",
+            "description": "Customer purchase orders, one row per order.",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["column"] is None
+
+    with history_db._connect() as conn:
+        row = conn.execute(
+            "SELECT entity_kind, column_name FROM catalog_entities WHERE id = ?",
+            (payload["entity_id"],),
+        ).fetchone()
+    assert row["entity_kind"] == "table"
+    assert row["column_name"] is None
+
+
+def test_save_local_comment_unknown_profile_returns_404(
+    client, auth_headers, history_db, cfg
+) -> None:
+    cfg.db_profiles = {}
+    response = client.post(
+        "/api/comments/local",
+        json={
+            "profile": "ghost",
+            "schema": "s",
+            "table": "t",
+            "description": "x",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert "ghost" in response.json()["detail"]
+
+
+def test_save_local_comment_missing_required_field_returns_422(
+    client, auth_headers, history_db, cfg_with_profile
+) -> None:
+    response = client.post(
+        "/api/comments/local",
+        json={"schema": "s", "table": "t", "description": "x"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 422
+
+
+def test_save_local_comment_blank_description_returns_422(
+    client, auth_headers, history_db, cfg_with_profile
+) -> None:
+    response = client.post(
+        "/api/comments/local",
+        json={
+            "profile": "prod-pg",
+            "schema": "s",
+            "table": "t",
+            "description": "",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

Closes the final sub-feature from the 2026-05-20 brainstorm. Today a user-authored description only survives across sessions if it is applied back to the source DB. Users who lack DDL/COMMENT privileges, work against snapshots they don't own, or want private annotations had no surface for "save locally, never write back".

This change adds a single new `source_kind` (`user_local`, priority 5 above `manual`=4) plus a thin write helper. No new tables, no schema migration.

### Surfaces

- **Helper:** `SearchCatalog.record_user_local_description(...)` in `amx/search/_catalog/usage.py`, mirror of `record_manual_description` with `source_kind="user_local"`, `source_agent="user_local.create"`, returns `{entity_id, description_id}`. The row never gets `applied_to_db=1`, so no writeback path picks it up.
- **HTTP:** `POST /api/comments/local` with `{profile, schema, table, column?, description}`. 200 on success, 404 on unknown profile, 422 on missing required fields or blank description.
- **REPL:** `/db comment-local` wizard under the `db` namespace, with `--profile/--schema/--table/--column/--description` flags as power-user shortcuts. Empty `--column` means table-level. The success message states explicitly that no `COMMENT` was sent to the source DB.
- **Precedence:** `SOURCE_PRIORITY["user_local"] = 5` in `_constants.py`. The existing `_resolve_effective_description` ranker promotes the new row over every other source; `_update_search_text` mirrors it into the FTS5 search index. Read paths (`/search ask`, Studio asset cards, `/db inspect`) reflect the override on the next read with zero additional plumbing.

## Test plan

- [x] `pytest tests/test_user_local_description.py tests/web/test_comments_local.py` — 12/12 green
- [x] `pytest tests/test_column_comments_cache.py tests/test_catalog_skeleton_sync.py tests/web/test_comments.py tests/web/test_catalog.py tests/test_catalog_cache_hardening.py` — 47/47 green, no regression
- [x] `ruff check` on every touched file — clean
- [ ] Manual REPL smoke: `/db comment-local --profile <p> --schema sales --table orders --column amount --description "..."` then `/db inspect` shows the new description with `source_kind=user_local`
- [ ] Manual HTTP smoke: `curl -X POST .../api/comments/local -d '{...}'` then `GET /api/catalog/inventory` reflects the override
- [ ] Manual confirmation against a read-only DB profile: the connector log shows zero `COMMENT ON COLUMN` statements

## Spec

- Design doc: `docs/superpowers/specs/2026-05-20-local-comments-and-multi-profile-history-store-design.md` (now marks both PR-1 and PR-2 as landed)

## Closes the trio

This is the third and final PR from the original brainstorm. PRs #537 (skeleton-sync hardening), #538 (multi-profile history-store inclusion), and this one (local-only overrides) collectively address every gap surfaced in the user prompt.