### PR TITLE
fix(web): salvage table page when live introspector returns empty

### DIFF
--- a/amx/web/routers/live_db.py
+++ b/amx/web/routers/live_db.py
@@ -196,6 +196,154 @@ def _require_profile(profile: str | None) -> str:
     return name
 
 
+def _columns_from_cache(
+    profile: str,
+    schema: str,
+    table: str,
+    *,
+    database_scope: str | None,
+) -> list[dict[str, Any]]:
+    """Return cached column rows for ``(profile, schema, table)`` from the
+    best available source. Two layers, in order:
+
+    1. ``catalog_entities`` via ``SearchCatalog.fetch_columns_for_table``
+       — written by deep syncs and agent runs. Carries dtype + nullable.
+    2. ``column_comments_cache.columns_json`` via the history store
+       lookup — written every time the live introspector ran. Carries
+       column names + comments but no dtype/nullable.
+
+    Falling back through both layers means a table that has been seen
+    *at all* (even if it was later dropped from the live DB) still
+    surfaces something in Studio instead of "no introspectable
+    columns". Returned shape is the same as the live path:
+    ``[{"name", "dtype", "nullable", "comment"}]``.
+    """
+    rows: list[dict[str, Any]] = []
+    try:
+        from amx.search.catalog import SearchCatalog
+
+        cat = SearchCatalog.from_history_store()
+    except Exception:
+        cat = None
+    if cat is not None:
+        try:
+            cached = cat.fetch_columns_for_table(
+                profile,
+                schema_name=schema,
+                table_name=table,
+                database_name=database_scope,
+            )
+        except Exception:
+            cached = []
+        if cached:
+            return [
+                {
+                    "name": c["name"],
+                    "dtype": c.get("dtype") or "",
+                    "nullable": bool(c.get("nullable", True)),
+                    "comment": "",
+                }
+                for c in cached
+            ]
+
+    # Second-chance fallback: the column_comments_cache row carries the
+    # last live read's column list as a JSON map (name -> comment).
+    # That's enough to render the Studio table page when the catalog
+    # only has a skeleton table-level row and the live DB is currently
+    # returning empty (NoSuchTableError swallowed by list_column_profiles).
+    try:
+        from amx.storage._history_caches import lookup_column_comments_cache
+        from amx.storage.sqlite_store import history_store as _history_store
+
+        hs = _history_store()
+    except Exception:
+        hs = None
+    if hs is not None:
+        try:
+            entry = lookup_column_comments_cache(
+                hs,
+                db_profile=profile,
+                database=database_scope or "",
+                schema=schema,
+                table=table,
+            )
+        except Exception:
+            entry = None
+        columns_map = (entry or {}).get("columns") if entry else None
+        if columns_map:
+            for col_name, comment in columns_map.items():
+                if not col_name:
+                    continue
+                rows.append(
+                    {
+                        "name": str(col_name),
+                        "dtype": "",
+                        "nullable": True,
+                        "comment": str(comment or ""),
+                    }
+                )
+    return rows
+
+
+def _writethrough_columns_to_catalog(
+    profile: str,
+    schema: str,
+    table: str,
+    *,
+    database_scope: str | None,
+    db_backend: str,
+    columns: list[dict[str, Any]],
+) -> None:
+    """Persist freshly-introspected columns into ``catalog_entities``.
+
+    Best-effort: failures are swallowed so a Studio request never
+    breaks because of catalog write contention. The next visit to the
+    same table benefits from the cache-first hit even though this
+    request absorbed the live round-trip cost.
+    """
+    if not columns:
+        return
+    try:
+        from amx.search.catalog import SearchCatalog
+
+        cat = SearchCatalog.from_history_store()
+        if cat is None:
+            return
+        with cat._connect() as conn:  # noqa: SLF001 — same access pattern as drift.py
+            cat._upsert_entity(  # noqa: SLF001
+                conn,
+                db_profile=profile,
+                db_backend=db_backend,
+                database_name=database_scope or "",
+                schema_name=schema,
+                table_name=table,
+                column_name=None,
+                entity_kind="table",
+                asset_kind="table",
+            )
+            for col in columns:
+                name = (col.get("name") or "").strip()
+                if not name:
+                    continue
+                cat._upsert_entity(  # noqa: SLF001
+                    conn,
+                    db_profile=profile,
+                    db_backend=db_backend,
+                    database_name=database_scope or "",
+                    schema_name=schema,
+                    table_name=table,
+                    column_name=name,
+                    entity_kind="column",
+                    asset_kind="table",
+                    dtype=str(col.get("dtype") or ""),
+                    nullable=1 if col.get("nullable", True) else 0,
+                )
+    except Exception:
+        # Write-through is a cache-warming nice-to-have. Never fail
+        # the user-facing request because of it.
+        return
+
+
 def _active_scope_for_profile(cfg: AMXConfig, profile_name: str) -> dict[str, Any]:
     """Return the wizard-driven scope envelope for a profile.
 
@@ -660,48 +808,85 @@ def list_columns(
     name = _require_profile(profile)
     cache_scope = database or catalog
     if not force_live:
-        try:
-            from amx.search.catalog import SearchCatalog
-
-            cat = SearchCatalog.from_history_store()
-        except Exception:
-            cat = None
-        if cat is not None:
-            try:
-                cached = cat.fetch_columns_for_table(
-                    name,
-                    schema_name=schema,
-                    table_name=table,
-                    database_name=cache_scope,
-                )
-            except Exception:
-                cached = []
-            if cached:
-                return {
-                    "schema": schema,
-                    "table": table,
-                    "columns": [
-                        {
-                            "name": c["name"],
-                            "dtype": c["dtype"],
-                            "nullable": c["nullable"],
-                        }
-                        for c in cached
-                    ],
-                    "count": len(cached),
-                    "source": "catalog",
-                    "possibly_partial": not _profile_is_fully_synced(name),
-                }
+        cached_rows = _columns_from_cache(
+            name, schema, table, database_scope=cache_scope
+        )
+        if cached_rows:
+            return {
+                "schema": schema,
+                "table": table,
+                "columns": [
+                    {
+                        "name": c["name"],
+                        "dtype": c["dtype"],
+                        "nullable": c["nullable"],
+                    }
+                    for c in cached_rows
+                ],
+                "count": len(cached_rows),
+                "source": "catalog",
+                "possibly_partial": not _profile_is_fully_synced(name),
+            }
     db = _connector_for_scope(cfg, name, database=database, catalog=catalog)
     cols = _coerce_or_500(
         f"Listing columns of {schema}.{table}",
         lambda: db.list_column_profiles(schema, table),
     )
+    live_columns = [
+        {"name": c.name, "dtype": c.dtype, "nullable": bool(c.nullable)}
+        for c in cols
+    ]
+    if live_columns and not force_live:
+        # Cache-warm for next time: write the column rows into
+        # ``catalog_entities`` so a subsequent visit to the same table
+        # serves from the catalog instead of repeating the live
+        # round-trip. Best-effort — swallowed on failure.
+        db_backend = ""
+        try:
+            db_cfg = cfg.db_profiles.get(name) if cfg.db_profiles else None
+            db_backend = str(getattr(db_cfg, "backend", "") or "") if db_cfg else ""
+        except Exception:
+            db_backend = ""
+        _writethrough_columns_to_catalog(
+            name,
+            schema,
+            table,
+            database_scope=cache_scope,
+            db_backend=db_backend,
+            columns=live_columns,
+        )
+    if not live_columns:
+        # Live introspector returned nothing — could be a genuinely
+        # empty table, a ghost row left over from a code-RAG ingest, or
+        # a swallowed ``NoSuchTableError`` (``list_column_profiles``
+        # degrades gracefully for the code-agent path). One last
+        # fallback to the column_comments_cache so the Studio page
+        # still shows column names + comments when the live DB has
+        # since lost the table.
+        salvage = _columns_from_cache(
+            name, schema, table, database_scope=cache_scope
+        )
+        if salvage:
+            return {
+                "schema": schema,
+                "table": table,
+                "columns": [
+                    {
+                        "name": c["name"],
+                        "dtype": c["dtype"],
+                        "nullable": c["nullable"],
+                    }
+                    for c in salvage
+                ],
+                "count": len(salvage),
+                "source": "cache-fallback",
+                "possibly_partial": True,
+            }
     return {
         "schema": schema,
         "table": table,
-        "columns": [{"name": c.name, "dtype": c.dtype, "nullable": bool(c.nullable)} for c in cols],
-        "count": len(cols),
+        "columns": live_columns,
+        "count": len(live_columns),
         "source": "live",
     }
 
@@ -717,10 +902,71 @@ def table_snapshot(
 ) -> dict[str, Any]:
     """Return the lightweight metadata snapshot the orchestrator uses:
     column names + dtypes + comments + table comment. No profiling.
+
+    Resilient against partial introspection: when the live snapshot
+    comes back with zero columns (the table was removed from the live
+    DB after a code-RAG ingest, the user lacks ``USAGE`` on the
+    schema, or the connector swallowed a ``NoSuchTableError``), we
+    fall back to the cached column list so the Studio Table page
+    still renders something useful instead of an empty card.
     """
     name = _require_profile(profile)
+    cache_scope = database or catalog
     db = _connector_for_scope(cfg, name, database=database, catalog=catalog)
-    return _coerce_or_500(
-        f"Reading metadata snapshot of {schema}.{table}",
-        lambda: db.get_table_metadata_snapshot(schema, table),
-    )
+    try:
+        snapshot = db.get_table_metadata_snapshot(schema, table)
+    except Exception as exc:
+        # Live snapshot blew up entirely (most often
+        # ``NoSuchTableError`` propagated from ``get_column_comments``).
+        # Try to salvage from the caches before giving up.
+        salvage = _columns_from_cache(
+            name, schema, table, database_scope=cache_scope
+        )
+        if not salvage:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    f"Reading metadata snapshot of {schema}.{table} "
+                    f"failed: {exc.__class__.__name__}: {exc}"
+                ),
+            ) from exc
+        return {
+            "schema": schema,
+            "table": table,
+            "table_comment": "",
+            "columns": [
+                {
+                    "name": c["name"],
+                    "dtype": c["dtype"],
+                    "nullable": c["nullable"],
+                    "comment": c["comment"],
+                }
+                for c in salvage
+            ],
+            "source": "cache-fallback",
+        }
+    columns = snapshot.get("columns") or []
+    if not columns:
+        # Live introspector returned zero columns but didn't raise —
+        # ``list_column_profiles`` quietly returns ``[]`` on
+        # ``NoSuchTableError``. Try the same fallback path the
+        # ``/columns`` endpoint uses so the Studio page surfaces names
+        # + comments instead of an empty list.
+        salvage = _columns_from_cache(
+            name, schema, table, database_scope=cache_scope
+        )
+        if salvage:
+            return {
+                **snapshot,
+                "columns": [
+                    {
+                        "name": c["name"],
+                        "dtype": c["dtype"],
+                        "nullable": c["nullable"],
+                        "comment": c["comment"],
+                    }
+                    for c in salvage
+                ],
+                "source": "cache-fallback",
+            }
+    return snapshot

--- a/tests/web/test_live_db_columns_fallback.py
+++ b/tests/web/test_live_db_columns_fallback.py
@@ -1,0 +1,307 @@
+"""Live-DB columns endpoint — cache fallback + write-through tests.
+
+Covers the resilience added on top of ``list_columns`` and
+``table_snapshot`` so that:
+
+1. A table whose ``catalog_entities`` has only a skeleton table-level
+   row but whose ``column_comments_cache`` has a populated columns map
+   still surfaces the columns to Studio.
+2. A live introspector call that returns non-empty columns gets
+   written through to ``catalog_entities`` so the next visit is
+   served from the cache instead of hitting the live DB again.
+3. A live snapshot that returns 0 columns falls back to the same
+   cache so the Studio Table page doesn't render
+   "no introspectable columns" for a table whose metadata is known
+   to the catalog.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from amx.config import DBConfig
+from amx.search.catalog import SearchCatalog
+from amx.storage import sqlite_store as ss
+from amx.storage._history_caches import save_column_comments_cache
+from amx.storage.sqlite_store import SQLiteHistoryStore
+from amx.web.routers import live_db
+
+PROFILE = "test-profile"
+
+
+@pytest.fixture(autouse=True)
+def _wipe_connector_cache() -> None:
+    live_db._CONNECTOR_CACHE.clear()
+    yield
+    live_db._CONNECTOR_CACHE.clear()
+
+
+@pytest.fixture()
+def history(tmp_path: Path, monkeypatch):
+    """Real on-disk history store bound as the module singleton so
+    ``SearchCatalog.from_history_store()`` returns something usable."""
+    db_path = tmp_path / "history.db"
+    SQLiteHistoryStore(db_path).init()
+    store = SQLiteHistoryStore(db_path)
+    monkeypatch.setattr(ss, "_store", store, raising=False)
+    yield store
+    monkeypatch.setattr(ss, "_store", None, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _register_profile(cfg) -> None:
+    cfg.db_profiles[PROFILE] = DBConfig(
+        backend="postgresql",
+        host="pg.test",
+        user="amx",
+        database="appdb",
+    )
+
+
+def _q(extra: str = "") -> str:
+    base = f"?profile={PROFILE}"
+    return base + (f"&{extra}" if extra else "")
+
+
+def _patch_connector(monkeypatch, builder) -> MagicMock:
+    instance = builder()
+    monkeypatch.setattr(live_db, "DatabaseConnector", lambda *_a, **_kw: instance)
+    return instance
+
+
+def test_columns_endpoint_falls_back_to_comments_cache(
+    client, auth_headers, monkeypatch, history
+) -> None:
+    """When catalog_entities has no column rows, the
+    column_comments_cache row populated by a prior snapshot read is
+    surfaced to Studio via the cache-first reader. The live
+    introspector is never even called in this path."""
+    save_column_comments_cache(
+        history,
+        db_profile=PROFILE,
+        database="appdb",
+        schema="sales",
+        entries={
+            "orders": {
+                "table_comment": "Customer purchase orders",
+                "columns": {
+                    "order_id": "Primary key",
+                    "amount": "Net total",
+                },
+                "kind": "TABLE",
+            }
+        },
+    )
+    live_mock = MagicMock(list_column_profiles=MagicMock(return_value=[]))
+    monkeypatch.setattr(live_db, "DatabaseConnector", lambda *_a, **_kw: live_mock)
+    response = client.get(
+        f"/api/live/schemas/sales/tables/orders/columns{_q('database=appdb')}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    # Cache-first wins over the live mock: source is "catalog" (the
+    # unified cache-first reader covers both ``catalog_entities`` and
+    # ``column_comments_cache``).
+    assert payload["source"] == "catalog"
+    assert {c["name"] for c in payload["columns"]} == {"order_id", "amount"}
+    # The live mock must NOT have been called — cache-first short-circuits.
+    live_mock.list_column_profiles.assert_not_called()
+
+
+def test_columns_endpoint_uses_cache_fallback_when_force_live_and_live_empty(
+    client, auth_headers, monkeypatch, history
+) -> None:
+    """``?force_live=true`` bypasses the cache-first path. When live
+    also returns empty (NoSuchTableError swallowed), the endpoint
+    salvages from column_comments_cache and tags the source so the
+    SPA can show a degraded state."""
+    save_column_comments_cache(
+        history,
+        db_profile=PROFILE,
+        database="appdb",
+        schema="sales",
+        entries={
+            "orders": {
+                "table_comment": "Customer purchase orders",
+                "columns": {"order_id": "Primary key"},
+                "kind": "TABLE",
+            }
+        },
+    )
+    _patch_connector(
+        monkeypatch,
+        lambda: MagicMock(list_column_profiles=MagicMock(return_value=[])),
+    )
+    response = client.get(
+        f"/api/live/schemas/sales/tables/orders/columns{_q('database=appdb&force_live=true')}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source"] == "cache-fallback"
+    assert {c["name"] for c in payload["columns"]} == {"order_id"}
+
+
+def test_columns_endpoint_writes_through_to_catalog(
+    client, auth_headers, monkeypatch, history, tmp_path
+) -> None:
+    """A live introspector hit warms the catalog so the next visit
+    serves from the cache instead of hitting live again."""
+    cp1 = MagicMock()
+    cp1.name = "id"
+    cp1.dtype = "BIGINT"
+    cp1.nullable = False
+    cp2 = MagicMock()
+    cp2.name = "email"
+    cp2.dtype = "VARCHAR"
+    cp2.nullable = True
+    _patch_connector(
+        monkeypatch,
+        lambda: MagicMock(list_column_profiles=MagicMock(return_value=[cp1, cp2])),
+    )
+
+    response = client.get(
+        f"/api/live/schemas/sales/tables/customers/columns{_q('database=appdb')}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["source"] == "live"
+
+    catalog = SearchCatalog.from_history_store()
+    assert catalog is not None
+    cached = catalog.fetch_columns_for_table(
+        PROFILE,
+        schema_name="sales",
+        table_name="customers",
+        database_name="appdb",
+    )
+    assert {c["name"] for c in cached} == {"id", "email"}
+
+
+def test_columns_endpoint_serves_writethrough_on_second_call(
+    client, auth_headers, monkeypatch, history
+) -> None:
+    """Second visit reuses catalog_entities (source=catalog) even
+    though the live mock would still return columns. This proves the
+    write-through path actually feeds the cache-first read."""
+    cp1 = MagicMock()
+    cp1.name = "id"
+    cp1.dtype = "BIGINT"
+    cp1.nullable = False
+    live_mock = MagicMock(list_column_profiles=MagicMock(return_value=[cp1]))
+    monkeypatch.setattr(live_db, "DatabaseConnector", lambda *_a, **_kw: live_mock)
+
+    client.get(
+        f"/api/live/schemas/sales/tables/orders/columns{_q('database=appdb')}",
+        headers=auth_headers,
+    )
+    second = client.get(
+        f"/api/live/schemas/sales/tables/orders/columns{_q('database=appdb')}",
+        headers=auth_headers,
+    )
+    assert second.status_code == 200
+    assert second.json()["source"] == "catalog"
+
+
+def test_snapshot_endpoint_falls_back_when_live_returns_zero_columns(
+    client, auth_headers, monkeypatch, history
+) -> None:
+    """When ``get_table_metadata_snapshot`` returns successfully but
+    with an empty columns list, the endpoint salvages from
+    column_comments_cache so the Studio page is not blank."""
+    save_column_comments_cache(
+        history,
+        db_profile=PROFILE,
+        database="appdb",
+        schema="sales",
+        entries={
+            "orders": {
+                "table_comment": "Customer purchase orders",
+                "columns": {"order_id": "Primary key"},
+                "kind": "TABLE",
+            }
+        },
+    )
+    _patch_connector(
+        monkeypatch,
+        lambda: MagicMock(
+            get_table_metadata_snapshot=MagicMock(
+                return_value={
+                    "schema": "sales",
+                    "table": "orders",
+                    "table_comment": "Customer purchase orders",
+                    "columns": [],
+                }
+            )
+        ),
+    )
+    response = client.get(
+        f"/api/live/schemas/sales/tables/orders/snapshot{_q('database=appdb')}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source"] == "cache-fallback"
+    assert {c["name"] for c in payload["columns"]} == {"order_id"}
+
+
+def test_snapshot_endpoint_salvages_on_connector_exception(
+    client, auth_headers, monkeypatch, history
+) -> None:
+    """If the connector raises (e.g. NoSuchTableError bubbling from
+    get_column_comments), the endpoint salvages from the cache
+    instead of returning 500."""
+    save_column_comments_cache(
+        history,
+        db_profile=PROFILE,
+        database="appdb",
+        schema="sales",
+        entries={
+            "orders": {
+                "table_comment": "ok",
+                "columns": {"order_id": "Primary key"},
+                "kind": "TABLE",
+            }
+        },
+    )
+    _patch_connector(
+        monkeypatch,
+        lambda: MagicMock(
+            get_table_metadata_snapshot=MagicMock(
+                side_effect=RuntimeError("NoSuchTableError: sales.orders")
+            )
+        ),
+    )
+    response = client.get(
+        f"/api/live/schemas/sales/tables/orders/snapshot{_q('database=appdb')}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source"] == "cache-fallback"
+    assert {c["name"] for c in payload["columns"]} == {"order_id"}
+
+
+def test_snapshot_endpoint_500s_when_no_cache_and_live_raises(
+    client, auth_headers, monkeypatch, history
+) -> None:
+    """No cached row and live raises — surface the 500 verbatim
+    instead of pretending the table exists with no columns."""
+    _patch_connector(
+        monkeypatch,
+        lambda: MagicMock(
+            get_table_metadata_snapshot=MagicMock(
+                side_effect=RuntimeError("connect timed out")
+            )
+        ),
+    )
+    response = client.get(
+        f"/api/live/schemas/sales/tables/orders/snapshot{_q('database=appdb')}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 500
+    assert "connect timed out" in response.json()["detail"]


### PR DESCRIPTION
## Summary

The Studio Table page sometimes rendered "This table has no introspectable columns" for tables that did have cached metadata. Symptom: navigate to `/cat/<profile>/<db>/<schema>/<table>` and see the description filled in (cached) but zero columns and the empty-state message.

**Root cause:** `list_column_profiles` deliberately swallows `NoSuchTableError` so the code-agent path can degrade gracefully when a SAP-style table referenced by a codebase is missing from the connected DB. The Studio `/columns` and `/snapshot` endpoints inherited that silence and rendered an empty card even though `column_comments_cache` still had the columns from a prior live read.

## Fix

Two changes in `amx/web/routers/live_db.py`:

1. **`_columns_from_cache` helper** unifies the two cache layers:
   - First: `catalog_entities` via `SearchCatalog.fetch_columns_for_table` — written by deep syncs / agent runs, carries dtype + nullable.
   - Fallback: `column_comments_cache.columns_json` via `lookup_column_comments_cache` — written every time the live introspector ran, carries names + comments.
2. **`list_columns` endpoint** uses the helper for cache-first reads (zero live calls when the catalog already knows the table). When live IS used and returns non-empty, `_writethrough_columns_to_catalog` warms `catalog_entities` so the next visit serves from the cache. When live returns empty (table missing from the live DB), the cache-fallback path produces a payload tagged `source="cache-fallback"`.
3. **`table_snapshot` endpoint** applies the same fallback both when the connector returns 0 columns and when it raises. A genuine connector failure with no cache available still surfaces a 500 verbatim.

### Net effect

Tables that have ever been read by AMX (skeleton sync, agent run, or a single previous Table page visit) consistently show their columns + comments, regardless of whether the underlying table still exists in the live DB.

## Test plan

- [x] `pytest tests/web/test_live_db_columns_fallback.py` — 7/7 green (cache-first wins, write-through populates catalog, second visit serves from catalog, force_live fallback, snapshot zero-cols salvage, snapshot exception salvage, snapshot 500 when no cache)
- [x] `pytest tests/web/test_live_db.py tests/web/test_catalog.py tests/web/test_db_cache_router.py tests/test_catalog_skeleton_sync.py tests/test_catalog_cache_hardening.py tests/test_column_comments_cache.py` — 60/60 no regression
- [x] `ruff check` clean
- [ ] Manual: open the same SAP-style table page that previously showed "no introspectable columns" — columns + comments must appear from the cache
- [ ] Manual: open a fresh table (never visited), confirm live read succeeds + the next visit returns `source: "catalog"`