### PR TITLE
fix(web): scope-agnostic third-chance cache fallback for table page

### DIFF
--- a/amx/web/routers/live_db.py
+++ b/amx/web/routers/live_db.py
@@ -282,6 +282,56 @@ def _columns_from_cache(
                         "comment": str(comment or ""),
                     }
                 )
+        if rows:
+            return rows
+
+    # Third-chance fallback: scope-agnostic lookup against
+    # ``column_comments_cache``. The SPA's URL pattern
+    # ``/cat/<profile>/<database>/<schema>/<table>`` *should* pass the
+    # database query parameter, but builds out in the wild have been
+    # observed sending ``database=`` (empty) on cold catalog navigation
+    # — and our second-chance lookup needs an exact ``(db_profile,
+    # database, schema, table)`` match. When the user is clearly
+    # asking about a specific ``(profile, schema, table)`` and there
+    # is exactly one fresh cache row for it (any database), it is
+    # almost always the right one. Return that row so the Studio Table
+    # page stops rendering empty just because the URL didn't carry the
+    # database scope.
+    if hs is not None:
+        import json as _json
+        import time as _time
+
+        try:
+            with hs._connect() as conn:  # noqa: SLF001 — same access as helpers
+                cache_rows = conn.execute(
+                    """
+                    SELECT database_name, columns_json
+                    FROM column_comments_cache
+                    WHERE db_profile = ? AND schema_name = ? AND table_name = ?
+                      AND expires_at >= ?
+                    ORDER BY fetched_at DESC
+                    LIMIT 1
+                    """,
+                    (profile, schema, table, _time.time()),
+                ).fetchall()
+        except Exception:
+            cache_rows = []
+        if cache_rows:
+            try:
+                columns_map = _json.loads(cache_rows[0]["columns_json"]) or {}
+            except Exception:
+                columns_map = {}
+            for col_name, comment in columns_map.items():
+                if not col_name:
+                    continue
+                rows.append(
+                    {
+                        "name": str(col_name),
+                        "dtype": "",
+                        "nullable": True,
+                        "comment": str(comment or ""),
+                    }
+                )
     return rows
 
 

--- a/tests/web/test_live_db_columns_fallback.py
+++ b/tests/web/test_live_db_columns_fallback.py
@@ -286,6 +286,53 @@ def test_snapshot_endpoint_salvages_on_connector_exception(
     assert {c["name"] for c in payload["columns"]} == {"order_id"}
 
 
+def test_cache_fallback_scope_agnostic_when_url_omits_database(
+    client, auth_headers, monkeypatch, history
+) -> None:
+    """When the SPA sends ``database=`` (empty) but the cache has a row
+    stamped with a real ``database_name`` (e.g. ``SAP``), the
+    scope-agnostic third-chance lookup still surfaces the columns.
+
+    Regression guard for SAP-style profiles where the browse URL
+    pattern ``/cat/<profile>/<database>/<schema>/<table>`` is mapped
+    to an API call without the database query parameter — observed
+    in the wild against ``sap_s6p.adrt`` / ``sap_s6p.bseg``.
+    """
+    save_column_comments_cache(
+        history,
+        db_profile=PROFILE,
+        database="SAP",
+        schema="sap_s6p",
+        entries={
+            "adrt": {
+                "table_comment": "Technical address-change tracking table.",
+                "columns": {
+                    "client": None,
+                    "addrnumber": None,
+                    "date_from": None,
+                },
+                "kind": "TABLE",
+            }
+        },
+    )
+    _patch_connector(
+        monkeypatch,
+        lambda: MagicMock(list_column_profiles=MagicMock(return_value=[])),
+    )
+    response = client.get(
+        f"/api/live/schemas/sap_s6p/tables/adrt/columns{_q('force_live=true')}",
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source"] == "cache-fallback"
+    assert {c["name"] for c in payload["columns"]} == {
+        "client",
+        "addrnumber",
+        "date_from",
+    }
+
+
 def test_snapshot_endpoint_500s_when_no_cache_and_live_raises(
     client, auth_headers, monkeypatch, history
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #540. The previous fallback only fired when the cache row's ``database`` exactly matched the URL's ``database`` query parameter. Studio's Catalog browse URL pattern ``/cat/<profile>/<database>/<schema>/<table>`` sometimes maps to an API call without the database parameter, leaving the scope empty. The exact-match lookup then missed even though the cache held the row under the real database name (e.g. ``"SAP"``).

Net effect: SAP-style schemas where the browse URL doesn't carry the database scope now render columns + comments instead of "This table has no introspectable columns". Observed across many tables: ``sap_s6p.adrt``, ``sap_s6p.bseg``, etc.

## Fix

Third-chance lookup in ``_columns_from_cache``: when the exact-scope ``lookup_column_comments_cache`` misses, fall back to the most recent fresh ``column_comments_cache`` row for ``(db_profile, schema, table)`` regardless of ``database_name``. The user is clearly asking about one specific table; if exactly one fresh cache row exists for it, that's almost always the right one.

Verified locally against the user's live history.db:
- ``sap_s6p.adrt`` with ``database_scope=""`` → returns 11 columns
- ``sap_s6p.bseg`` with ``database_scope=""`` → returns 356 columns

## Test plan

- [x] ``pytest tests/web/test_live_db_columns_fallback.py tests/web/test_live_db.py`` — 22/22 green
- [x] ``ruff check`` clean
- [ ] Manual: open any SAP table page that previously showed "no introspectable columns" — columns now visible