### PR TITLE
feat(assets): user-tunable per-kind chunking strategy for asset RAG

### DIFF
--- a/amx/assets/chunking_config.py
+++ b/amx/assets/chunking_config.py
@@ -1,0 +1,157 @@
+"""User-tunable chunking strategy for the asset-RAG ingest pipeline.
+
+The splitters in :mod:`amx.assets.splitters` dispatch on the
+strategy literal carried by :class:`AssetChunkingConfig`. The same
+config object also exposes ``chunk_chars`` / ``chunk_overlap``
+knobs so the user can trade retrieval precision (smaller chunks,
+tighter matches) against context completeness (larger chunks, more
+neighbour signal) per asset kind.
+
+Defaults are intentionally conservative: notebooks and queries are
+embedded **whole** by default — the user opts into cell-level or
+char-window splitting explicitly via ``/db assets chunking`` or by
+editing ``cfg.embedding_assets.chunking`` in ``~/.amx/config.yml``.
+Whole-asset embeddings are coarser but predictable; users who want
+better recall over long notebooks switch to ``cell`` (the previous
+default).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any, Literal
+
+NotebookStrategy = Literal["whole", "cell", "char_window"]
+QueryStrategy = Literal["whole", "statement", "char_window"]
+PipelineStrategy = Literal["metadata", "whole"]
+
+DEFAULT_CHUNK_CHARS = 1000
+DEFAULT_CHUNK_OVERLAP = 200
+DEFAULT_NOTEBOOK_CODE_CELLS = 8
+
+
+@dataclass
+class NotebookChunkingConfig:
+    """Per-kind config for notebook chunking.
+
+    * ``strategy='whole'`` (default) — one chunk per notebook,
+      ``source_text`` embedded as-is. Coarse but predictable.
+    * ``strategy='cell'`` — markdown + code cells split into separate
+      chunks; cells longer than ``chunk_chars`` get char-window
+      sub-split with ``chunk_overlap``. Header path metadata
+      preserved.
+    * ``strategy='char_window'`` — ignore cell boundaries; split the
+      raw source text by ``chunk_chars`` / ``chunk_overlap`` only.
+    """
+
+    strategy: NotebookStrategy = "whole"
+    chunk_chars: int = DEFAULT_CHUNK_CHARS
+    chunk_overlap: int = DEFAULT_CHUNK_OVERLAP
+    max_code_cells_per_chunk: int = DEFAULT_NOTEBOOK_CODE_CELLS
+
+
+@dataclass
+class QueryChunkingConfig:
+    """Per-kind config for SQL query chunking.
+
+    * ``strategy='whole'`` (default) — full SQL embedded as one chunk.
+    * ``strategy='statement'`` — split on ``;`` boundaries; long
+      statements fall back to char-window.
+    * ``strategy='char_window'`` — ignore statement boundaries;
+      pure char-window split.
+    """
+
+    strategy: QueryStrategy = "whole"
+    chunk_chars: int = DEFAULT_CHUNK_CHARS
+    chunk_overlap: int = DEFAULT_CHUNK_OVERLAP
+
+
+@dataclass
+class PipelineChunkingConfig:
+    """Per-kind config for pipeline chunking.
+
+    Pipelines only carry metadata + library references, so the
+    chunking choices are coarse: ``metadata`` (one chunk per pipeline
+    plus one per linked notebook library, current behaviour) vs
+    ``whole`` (single chunk with everything inlined).
+    """
+
+    strategy: PipelineStrategy = "metadata"
+
+
+@dataclass
+class AssetChunkingConfig:
+    """Top-level chunking config persisted under
+    ``cfg.embedding_assets.chunking``.
+
+    Each asset kind owns its own sub-config so users can mix
+    strategies — e.g. notebooks split cell-by-cell for fine-grained
+    retrieval while queries stay whole. Stream / streamlit / job
+    have no tunable knobs (they index as a single metadata chunk
+    each, period — there is no meaningful source text to slice).
+    """
+
+    notebook: NotebookChunkingConfig = field(default_factory=NotebookChunkingConfig)
+    query: QueryChunkingConfig = field(default_factory=QueryChunkingConfig)
+    pipeline: PipelineChunkingConfig = field(default_factory=PipelineChunkingConfig)
+
+
+def chunking_from_mapping(data: dict[str, Any]) -> AssetChunkingConfig:
+    """Hydrate :class:`AssetChunkingConfig` from a YAML mapping.
+
+    Permissive on the way in: missing kind blocks fall back to
+    defaults; unknown keys inside a block are ignored. This lets us
+    grow the per-kind config in future versions without
+    invalidating existing user configs.
+    """
+    out = AssetChunkingConfig()
+    if not isinstance(data, dict):
+        return out
+    nb_raw = data.get("notebook")
+    if isinstance(nb_raw, dict):
+        out.notebook = _populate(NotebookChunkingConfig(), nb_raw)
+    q_raw = data.get("query")
+    if isinstance(q_raw, dict):
+        out.query = _populate(QueryChunkingConfig(), q_raw)
+    p_raw = data.get("pipeline")
+    if isinstance(p_raw, dict):
+        out.pipeline = _populate(PipelineChunkingConfig(), p_raw)
+    return out
+
+
+def chunking_to_mapping(cfg: AssetChunkingConfig) -> dict[str, Any]:
+    """Serialise :class:`AssetChunkingConfig` back to a YAML-friendly
+    mapping. Round-trips with :func:`chunking_from_mapping`.
+    """
+    return {
+        "notebook": _to_dict(cfg.notebook),
+        "query": _to_dict(cfg.query),
+        "pipeline": _to_dict(cfg.pipeline),
+    }
+
+
+def _populate(target: Any, data: dict[str, Any]) -> Any:
+    for fld in fields(target):
+        if fld.name in data:
+            setattr(target, fld.name, data[fld.name])
+    return target
+
+
+def _to_dict(target: Any) -> dict[str, Any]:
+    return {fld.name: getattr(target, fld.name) for fld in fields(target)}
+
+
+__all__ = [
+    "AssetChunkingConfig",
+    "DEFAULT_CHUNK_CHARS",
+    "DEFAULT_CHUNK_OVERLAP",
+    "DEFAULT_NOTEBOOK_CODE_CELLS",
+    "NotebookChunkingConfig",
+    "NotebookStrategy",
+    "PipelineChunkingConfig",
+    "PipelineStrategy",
+    "QueryChunkingConfig",
+    "QueryStrategy",
+    "chunking_from_mapping",
+    "chunking_to_mapping",
+]

--- a/amx/assets/loaders.py
+++ b/amx/assets/loaders.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from amx.assets.chunking_config import AssetChunkingConfig
 from amx.assets.splitters import (
     split_job,
     split_notebook,
@@ -23,13 +24,18 @@ from amx.assets.types import AssetDocument
 
 
 def load_notebook_documents(
-    *, conn: Any, profile_name: str, only_ids: list[int] | None = None
+    *,
+    conn: Any,
+    profile_name: str,
+    only_ids: list[int] | None = None,
+    chunking: AssetChunkingConfig | None = None,
 ) -> list[AssetDocument]:
     where, params = _profile_filter(profile_name, only_ids)
     rows = conn.execute(
         f"SELECT id, name, workspace_path, source_text FROM remote_notebooks {where}",
         params,
     ).fetchall()
+    nb_cfg = chunking.notebook if chunking else None
     out: list[AssetDocument] = []
     for nb_id, name, workspace_path, source_text in rows:
         out.extend(
@@ -39,19 +45,25 @@ def load_notebook_documents(
                 name=str(name or ""),
                 source_text=str(source_text or ""),
                 workspace_path=str(workspace_path or ""),
+                config=nb_cfg,
             )
         )
     return out
 
 
 def load_query_documents(
-    *, conn: Any, profile_name: str, only_ids: list[int] | None = None
+    *,
+    conn: Any,
+    profile_name: str,
+    only_ids: list[int] | None = None,
+    chunking: AssetChunkingConfig | None = None,
 ) -> list[AssetDocument]:
     where, params = _profile_filter(profile_name, only_ids)
     rows = conn.execute(
         f"SELECT id, name, kind, sql_text, warehouse FROM remote_queries {where}",
         params,
     ).fetchall()
+    q_cfg = chunking.query if chunking else None
     out: list[AssetDocument] = []
     for q_id, name, kind_value, sql_text, warehouse in rows:
         out.extend(
@@ -62,13 +74,18 @@ def load_query_documents(
                 sql_text=str(sql_text or ""),
                 warehouse=str(warehouse or ""),
                 kind_value=str(kind_value or "saved"),
+                config=q_cfg,
             )
         )
     return out
 
 
 def load_pipeline_documents(
-    *, conn: Any, profile_name: str, only_ids: list[int] | None = None
+    *,
+    conn: Any,
+    profile_name: str,
+    only_ids: list[int] | None = None,
+    chunking: AssetChunkingConfig | None = None,
 ) -> list[AssetDocument]:
     where, params = _profile_filter(profile_name, only_ids)
     rows = conn.execute(
@@ -76,6 +93,7 @@ def load_pipeline_documents(
         f"libraries_json, latest_update_state FROM remote_pipelines {where}",
         params,
     ).fetchall()
+    p_cfg = chunking.pipeline if chunking else None
     out: list[AssetDocument] = []
     for p_id, name, target, edition, continuous, photon, libs_json, latest_state in rows:
         out.extend(
@@ -89,6 +107,7 @@ def load_pipeline_documents(
                 continuous=bool(continuous),
                 photon=bool(photon),
                 latest_update_state=str(latest_state or ""),
+                config=p_cfg,
             )
         )
     return out
@@ -203,8 +222,14 @@ def load_asset_documents(
     profile_name: str,
     kinds: list[str] | None = None,
     only_ids: dict[str, list[int]] | None = None,
+    chunking: AssetChunkingConfig | None = None,
 ) -> list[AssetDocument]:
-    """Dispatch across asset kinds. Default loads every kind."""
+    """Dispatch across asset kinds. Default loads every kind.
+
+    ``chunking`` is plumbed through to the per-kind loaders that
+    support strategy switching (notebook / query / pipeline). The
+    metadata-only loaders (stream / streamlit / job) ignore it.
+    """
     if kinds is None:
         kinds = list(_LOADERS.keys())
     out: list[AssetDocument] = []
@@ -213,7 +238,17 @@ def load_asset_documents(
         if loader is None:
             continue
         scoped_ids = (only_ids or {}).get(kind)
-        out.extend(loader(conn=conn, profile_name=profile_name, only_ids=scoped_ids))
+        if kind in {"notebook", "query", "pipeline"}:
+            out.extend(
+                loader(
+                    conn=conn,
+                    profile_name=profile_name,
+                    only_ids=scoped_ids,
+                    chunking=chunking,
+                )
+            )
+        else:
+            out.extend(loader(conn=conn, profile_name=profile_name, only_ids=scoped_ids))
     return out
 
 

--- a/amx/assets/rag.py
+++ b/amx/assets/rag.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from amx.assets.chunking_config import AssetChunkingConfig
 from amx.assets.loaders import load_asset_documents
 from amx.assets.types import AssetDocument, AssetQueryHit
 from amx.utils.logging import get_logger
@@ -121,6 +122,7 @@ class AssetRAGStore:
         embedding_provider: str | None = None,
         embedding_model: str | None = None,
         cfg: Any | None = None,
+        chunking_cfg: AssetChunkingConfig | None = None,
     ):
         # Lazy install of the docs-extended bundle (chromadb +
         # sentence-transformers). Same pattern as docs RAG so module
@@ -164,6 +166,16 @@ class AssetRAGStore:
             kwargs["embedding_function"] = embedding_function
         self.collection = self.client.get_or_create_collection(**kwargs)
         self._reconcile_collection_identity()
+
+        # Resolve the asset chunking strategy. Explicit arg wins over
+        # ``cfg.assets_chunking`` so tests can inject a deterministic
+        # config without touching the global cfg.
+        if chunking_cfg is not None:
+            self.chunking_cfg = chunking_cfg
+        else:
+            self.chunking_cfg = (
+                getattr(cfg, "assets_chunking", None) if cfg is not None else None
+            ) or AssetChunkingConfig()
 
     # ── identity reconciliation ───────────────────────────────────
 
@@ -253,15 +265,26 @@ class AssetRAGStore:
         profile_name: str,
         kinds: list[str] | None = None,
         only_ids: dict[str, list[int]] | None = None,
+        chunking: Any | None = None,
     ) -> int:
         """Re-chunk + upsert every (or scoped) asset for ``profile_name``.
 
         ``only_ids`` lets the auto-index hook pass the exact remote ids
         that the ingest just refreshed so a 5,000-notebook workspace
         does not re-embed unchanged assets every time.
+
+        ``chunking`` (defaults to ``self.chunking_cfg`` resolved at
+        construction) controls strategy + chunk_chars + chunk_overlap
+        per kind. Tests inject a custom config; production callers
+        leave it ``None`` and the cfg.yml value flows through.
         """
+        cfg = chunking if chunking is not None else self.chunking_cfg
         docs = load_asset_documents(
-            conn=conn, profile_name=profile_name, kinds=kinds, only_ids=only_ids
+            conn=conn,
+            profile_name=profile_name,
+            kinds=kinds,
+            only_ids=only_ids,
+            chunking=cfg,
         )
         # Clear any stale chunks for the asset rows we are about to
         # rewrite so a shrunk notebook (fewer cells) does not leave

--- a/amx/assets/splitters.py
+++ b/amx/assets/splitters.py
@@ -2,10 +2,10 @@
 
 Each splitter consumes ONE row from the matching ``remote_*`` table
 and produces a list of :class:`amx.assets.types.AssetDocument`
-chunks. Chunk size is tuned to MiniLM-L6-v2's 512-token window;
-notebook cells over the cap fall back to character-window splitting
-with overlap so a 200-line dbt SQL cell still yields useful
-embeddings.
+chunks. The strategy + chunk sizes are user-tunable via
+:class:`amx.assets.chunking_config.AssetChunkingConfig`; defaults
+are conservative (``whole`` per asset) so a user who never touches
+the knob gets coarse but predictable embeddings.
 
 The splitters are intentionally pure functions over the raw row
 data — no DB access, no embedding calls — so unit tests can feed
@@ -19,14 +19,14 @@ import re
 from collections.abc import Iterator
 from typing import Any
 
+from amx.assets.chunking_config import (
+    DEFAULT_CHUNK_CHARS,
+    DEFAULT_CHUNK_OVERLAP,
+    NotebookChunkingConfig,
+    PipelineChunkingConfig,
+    QueryChunkingConfig,
+)
 from amx.assets.types import AssetDocument
-
-# Char window for cells / statements that overflow a single chunk.
-# Matches the docs RAG defaults (1000 char chunk + 200 overlap)
-# tuned for MiniLM's typical token budget.
-_CHUNK_CHARS = 1000
-_CHUNK_OVERLAP = 200
-
 
 # ── notebook ──────────────────────────────────────────────────────
 
@@ -38,23 +38,56 @@ def split_notebook(
     name: str,
     source_text: str,
     workspace_path: str = "",
+    config: NotebookChunkingConfig | None = None,
 ) -> list[AssetDocument]:
-    """Split an ipynb JSON blob into per-cell chunks with header path.
+    """Split a notebook source blob per the active chunking strategy.
 
-    Markdown cells become single chunks; markdown headers
-    (``# foo`` / ``## bar``) update the running header path so
-    downstream chunks for code cells inherit "Section: foo > bar"
-    context in their metadata.
-
-    Code cells over ``_CHUNK_CHARS`` are split into char-window
-    sub-chunks with overlap so large statements (a 200-line dbt SQL
-    block, a chained-pandas data wrangling cell) still produce
-    embeddings tight enough to match relevant queries.
-
-    Falls back to char-window over the raw blob when JSON parse fails
-    so non-Jupyter source (e.g. Snowflake SHOW NOTEBOOKS returning a
-    raw SQL file) still indexes.
+    * ``strategy='whole'`` (default) — one chunk per notebook, no
+      parsing. Predictable but coarse for long notebooks.
+    * ``strategy='cell'`` — parse ipynb JSON, emit one chunk per
+      markdown / code cell, preserve header path in metadata,
+      char-window-split cells longer than ``chunk_chars``.
+      Falls back to char-window when JSON parse fails so non-Jupyter
+      source (e.g. raw SQL files) still indexes.
+    * ``strategy='char_window'`` — ignore cell boundaries; pure
+      char-window over the raw source text.
     """
+    cfg = config or NotebookChunkingConfig()
+    chunk_chars = max(int(cfg.chunk_chars or DEFAULT_CHUNK_CHARS), 200)
+    chunk_overlap = max(int(cfg.chunk_overlap or DEFAULT_CHUNK_OVERLAP), 0)
+
+    if cfg.strategy == "whole":
+        text = (source_text or "").strip()
+        if not text:
+            return []
+        return [
+            AssetDocument(
+                kind="notebook",
+                profile=profile,
+                remote_id=remote_id,
+                chunk_index=0,
+                text=text,
+                metadata={
+                    "cell_type": "whole",
+                    "workspace_path": workspace_path,
+                    "asset_name": name,
+                },
+            )
+        ]
+
+    if cfg.strategy == "char_window":
+        return _char_window_chunks(
+            profile=profile,
+            kind="notebook",
+            remote_id=remote_id,
+            name=name,
+            text=source_text or "",
+            chunk_chars=chunk_chars,
+            chunk_overlap=chunk_overlap,
+            extra_meta={"cell_type": "char_window", "workspace_path": workspace_path},
+        )
+
+    # strategy == "cell"
     try:
         nb = json.loads(source_text or "")
     except (json.JSONDecodeError, TypeError):
@@ -64,6 +97,8 @@ def split_notebook(
             remote_id=remote_id,
             name=name,
             text=source_text or "",
+            chunk_chars=chunk_chars,
+            chunk_overlap=chunk_overlap,
             extra_meta={"cell_type": "raw", "workspace_path": workspace_path},
         )
 
@@ -93,7 +128,7 @@ def split_notebook(
                 "workspace_path": workspace_path,
                 "asset_name": name,
             }
-            for piece in _maybe_split_long(text):
+            for piece in _maybe_split_long(text, chunk_chars, chunk_overlap):
                 out.append(
                     AssetDocument(
                         kind="notebook",
@@ -113,7 +148,7 @@ def split_notebook(
                 "workspace_path": workspace_path,
                 "asset_name": name,
             }
-            for piece in _maybe_split_long(text):
+            for piece in _maybe_split_long(text, chunk_chars, chunk_overlap):
                 out.append(
                     AssetDocument(
                         kind="notebook",
@@ -166,43 +201,79 @@ def split_query(
     sql_text: str,
     warehouse: str = "",
     kind_value: str = "saved",
+    config: QueryChunkingConfig | None = None,
 ) -> list[AssetDocument]:
-    """Split a SQL blob into per-statement chunks.
+    """Split a SQL blob per the active chunking strategy.
 
-    Splits on ``;`` boundaries first. Statements over
-    ``_CHUNK_CHARS`` fall back to char-window splitting so a 5 KB
-    CTE-heavy analytical query still yields several focused chunks.
+    * ``strategy='whole'`` (default) — full SQL embedded as one chunk.
+    * ``strategy='statement'`` — split on ``;`` boundaries; statements
+      over ``chunk_chars`` get char-window sub-split.
+    * ``strategy='char_window'`` — ignore boundaries; pure
+      char-window.
     """
+    cfg = config or QueryChunkingConfig()
+    chunk_chars = max(int(cfg.chunk_chars or DEFAULT_CHUNK_CHARS), 200)
+    chunk_overlap = max(int(cfg.chunk_overlap or DEFAULT_CHUNK_OVERLAP), 0)
+
     text = (sql_text or "").strip()
     if not text:
         return []
 
+    base_meta_root = {
+        "warehouse": warehouse,
+        "asset_name": name,
+        "query_kind": kind_value,
+    }
+
+    if cfg.strategy == "whole":
+        return [
+            AssetDocument(
+                kind="query",
+                profile=profile,
+                remote_id=remote_id,
+                chunk_index=0,
+                text=text,
+                metadata={**base_meta_root, "statement_no": -1},
+            )
+        ]
+
+    if cfg.strategy == "char_window":
+        out: list[AssetDocument] = []
+        for idx, piece in enumerate(_maybe_split_long(text, chunk_chars, chunk_overlap)):
+            out.append(
+                AssetDocument(
+                    kind="query",
+                    profile=profile,
+                    remote_id=remote_id,
+                    chunk_index=idx,
+                    text=piece,
+                    metadata={**base_meta_root, "statement_no": -1},
+                )
+            )
+        return out
+
+    # strategy == "statement"
     statements = [s.strip() for s in re.split(r";\s*", text) if s.strip()]
     if not statements:
         statements = [text]
 
-    out: list[AssetDocument] = []
+    out_stmt: list[AssetDocument] = []
     chunk_idx = 0
     for statement_no, statement in enumerate(statements):
-        base_meta = {
-            "warehouse": warehouse,
-            "asset_name": name,
-            "query_kind": kind_value,
-            "statement_no": statement_no,
-        }
-        for piece in _maybe_split_long(statement):
-            out.append(
+        meta = {**base_meta_root, "statement_no": statement_no}
+        for piece in _maybe_split_long(statement, chunk_chars, chunk_overlap):
+            out_stmt.append(
                 AssetDocument(
                     kind="query",
                     profile=profile,
                     remote_id=remote_id,
                     chunk_index=chunk_idx,
                     text=piece,
-                    metadata=base_meta,
+                    metadata=meta,
                 )
             )
             chunk_idx += 1
-    return out
+    return out_stmt
 
 
 # ── pipeline ──────────────────────────────────────────────────────
@@ -219,15 +290,17 @@ def split_pipeline(
     continuous: bool = False,
     photon: bool = False,
     latest_update_state: str = "",
+    config: PipelineChunkingConfig | None = None,
 ) -> list[AssetDocument]:
-    """Split a pipeline metadata blob into a small fixed set of chunks.
+    """Split a pipeline metadata blob per the active strategy.
 
-    Pipelines hold metadata only (notebook libraries reference paths
-    that AMX indexes separately as ``notebook`` rows). We emit a
-    single descriptive chunk per pipeline plus one extra chunk per
-    notebook library reference so a query for ``"bronze loader"``
-    surfaces both the pipeline shell and the linked notebooks.
+    * ``strategy='metadata'`` (default) — one chunk for the
+      pipeline header plus one per notebook library reference, so a
+      query for ``"bronze loader"`` surfaces both the pipeline
+      shell and the linked notebooks.
+    * ``strategy='whole'`` — one chunk with everything inlined.
     """
+    cfg = config or PipelineChunkingConfig()
     try:
         libs = json.loads(libraries_json or "[]")
     except (json.JSONDecodeError, TypeError):
@@ -248,6 +321,22 @@ def split_pipeline(
         f"- notebook libraries: {len(notebook_paths)}"
     )
     base_meta = {"asset_name": name, "target_schema": target_schema}
+
+    if cfg.strategy == "whole":
+        nb_block = "\n".join(f"  - {p}" for p in notebook_paths) if notebook_paths else "  (none)"
+        text = header + "\nNotebook libraries:\n" + nb_block
+        return [
+            AssetDocument(
+                kind="pipeline",
+                profile=profile,
+                remote_id=remote_id,
+                chunk_index=0,
+                text=text,
+                metadata=base_meta,
+            )
+        ]
+
+    # strategy == "metadata"
     out = [
         AssetDocument(
             kind="pipeline",
@@ -376,18 +465,21 @@ def split_job(
 # ── helpers ───────────────────────────────────────────────────────
 
 
-def _maybe_split_long(text: str) -> Iterator[str]:
-    """Emit ``text`` whole if it fits, otherwise char-window pieces."""
-    if len(text) <= _CHUNK_CHARS:
+def _maybe_split_long(
+    text: str,
+    chunk_chars: int = DEFAULT_CHUNK_CHARS,
+    chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
+) -> Iterator[str]:
+    """Emit ``text`` whole if it fits ``chunk_chars``, otherwise yield
+    char-window pieces of ``chunk_chars`` with ``chunk_overlap``."""
+    if len(text) <= chunk_chars:
         if text.strip():
             yield text
         return
-    # Char-window with overlap. Matches docs RAG's
-    # RecursiveCharacterTextSplitter behaviour for non-markdown content.
-    step = _CHUNK_CHARS - _CHUNK_OVERLAP
+    step = max(chunk_chars - chunk_overlap, 1)
     start = 0
     while start < len(text):
-        end = min(start + _CHUNK_CHARS, len(text))
+        end = min(start + chunk_chars, len(text))
         piece = text[start:end].strip()
         if piece:
             yield piece
@@ -403,11 +495,13 @@ def _char_window_chunks(
     remote_id: int,
     name: str,
     text: str,
+    chunk_chars: int = DEFAULT_CHUNK_CHARS,
+    chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
     extra_meta: dict[str, Any] | None = None,
 ) -> list[AssetDocument]:
     base_meta = {"asset_name": name, **(extra_meta or {})}
     out: list[AssetDocument] = []
-    for idx, piece in enumerate(_maybe_split_long(text)):
+    for idx, piece in enumerate(_maybe_split_long(text, chunk_chars, chunk_overlap)):
         out.append(
             AssetDocument(
                 kind=kind,

--- a/amx/cli_support/commands/db_assets.py
+++ b/amx/cli_support/commands/db_assets.py
@@ -155,6 +155,28 @@ def register_db_assets_commands(db_group: click.Group, *, pass_config) -> None:
 
         run_refresh(cfg, profile=profile, skip_confirm=yes)
 
+    @assets.command("chunking")
+    @click.option("--show", is_flag=True, help="Print the active chunking config and exit.")
+    @pass_config
+    def assets_chunking_cmd(cfg: AMXConfig, show: bool) -> None:
+        """View or edit the per-kind chunking strategy for asset RAG ingestion.
+
+        Defaults are ``whole`` (one chunk per notebook / query / pipeline)
+        — coarse but predictable. Pick ``cell`` / ``statement`` to slice
+        a notebook by cell or a query by ``;`` boundary, or
+        ``char_window`` for pure character windows that ignore semantic
+        boundaries. Stream / streamlit / job assets always emit a
+        single metadata chunk; they are not configurable.
+
+        The wizard writes back to ``cfg.embedding_assets`` /
+        ``cfg.assets_chunking`` so the next ``/db ingest-assets`` picks
+        up the new strategy. Run ``/db assets reindex`` afterwards to
+        re-embed already-ingested assets under the new chunking.
+        """
+        from amx.cli_support.commands.db_assets_impl import run_chunking
+
+        run_chunking(cfg, show_only=show)
+
     @assets.command("reindex")
     @click.option(
         "--profile",

--- a/amx/cli_support/commands/db_assets_impl.py
+++ b/amx/cli_support/commands/db_assets_impl.py
@@ -570,6 +570,92 @@ def _like_asset_search(cfg, *, query, profile, limit):
 # ── run_refresh ──────────────────────────────────────────────────────────────
 
 
+_NOTEBOOK_STRATEGIES = ("whole", "cell", "char_window")
+_QUERY_STRATEGIES = ("whole", "statement", "char_window")
+_PIPELINE_STRATEGIES = ("metadata", "whole")
+
+
+def run_chunking(cfg, *, show_only=False):
+    """Interactive editor / printer for ``cfg.assets_chunking``."""
+    from amx.assets.chunking_config import (
+        NotebookChunkingConfig,
+        PipelineChunkingConfig,
+        QueryChunkingConfig,
+    )
+
+    ac = cfg.assets_chunking
+    if show_only:
+        _print_chunking(ac)
+        return
+
+    _print_chunking(ac)
+    click.echo("\nUpdate per-kind settings (press Enter to keep the current value):\n")
+
+    new_nb_strategy = _prompt_choice(
+        "Notebook strategy", ac.notebook.strategy, _NOTEBOOK_STRATEGIES
+    )
+    new_nb_chunk = _prompt_int("Notebook chunk_chars", ac.notebook.chunk_chars, minimum=200)
+    new_nb_overlap = _prompt_int("Notebook chunk_overlap", ac.notebook.chunk_overlap, minimum=0)
+
+    new_q_strategy = _prompt_choice("Query strategy", ac.query.strategy, _QUERY_STRATEGIES)
+    new_q_chunk = _prompt_int("Query chunk_chars", ac.query.chunk_chars, minimum=200)
+    new_q_overlap = _prompt_int("Query chunk_overlap", ac.query.chunk_overlap, minimum=0)
+
+    new_p_strategy = _prompt_choice("Pipeline strategy", ac.pipeline.strategy, _PIPELINE_STRATEGIES)
+
+    cfg.assets_chunking = type(ac)(
+        notebook=NotebookChunkingConfig(
+            strategy=new_nb_strategy,
+            chunk_chars=new_nb_chunk,
+            chunk_overlap=new_nb_overlap,
+        ),
+        query=QueryChunkingConfig(
+            strategy=new_q_strategy,
+            chunk_chars=new_q_chunk,
+            chunk_overlap=new_q_overlap,
+        ),
+        pipeline=PipelineChunkingConfig(strategy=new_p_strategy),
+    )
+    cfg.save()
+    click.echo("\nSaved. Run /db assets reindex to re-embed under the new chunking.")
+    _print_chunking(cfg.assets_chunking)
+
+
+def _print_chunking(ac):
+    click.echo("Asset chunking config:")
+    click.echo(
+        f"  notebook  strategy={ac.notebook.strategy:<12} "
+        f"chunk_chars={ac.notebook.chunk_chars}  chunk_overlap={ac.notebook.chunk_overlap}"
+    )
+    click.echo(
+        f"  query     strategy={ac.query.strategy:<12} "
+        f"chunk_chars={ac.query.chunk_chars}  chunk_overlap={ac.query.chunk_overlap}"
+    )
+    click.echo(f"  pipeline  strategy={ac.pipeline.strategy}")
+    click.echo("  stream / streamlit_app / job: metadata-only (one chunk per asset)")
+
+
+def _prompt_choice(label, current, choices):
+    raw = click.prompt(f"{label} {choices}", default=current, show_default=True).strip()
+    if raw not in choices:
+        click.echo(f"  '{raw}' not in {choices} — keeping '{current}'.", err=True)
+        return current
+    return raw
+
+
+def _prompt_int(label, current, *, minimum):
+    raw = click.prompt(label, default=str(current), show_default=True).strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        click.echo(f"  '{raw}' not an int — keeping {current}.", err=True)
+        return current
+    if value < minimum:
+        click.echo(f"  {value} < {minimum} — keeping {current}.", err=True)
+        return current
+    return value
+
+
 def run_reindex(cfg, *, profile, skip_confirm):
     """Drop the asset RAG collection and re-embed under the active model.
 

--- a/amx/config.py
+++ b/amx/config.py
@@ -26,6 +26,11 @@ from urllib.parse import quote_plus
 
 import yaml
 
+from amx.assets.chunking_config import (
+    AssetChunkingConfig,
+    chunking_from_mapping,
+    chunking_to_mapping,
+)
 from amx.storage.secrets import (
     SecretStore,
     get_default_store,
@@ -1882,6 +1887,13 @@ class AMXConfig:
     # embeddings for assets without touching the docs or code RAG
     # configs. Defaults to the bundled MiniLM-L6-v2 (kind='minilm').
     embedding_assets: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+    # Per-kind chunking strategy for the asset RAG ingest pipeline.
+    # See ``amx/assets/chunking_config.py``. Defaults to whole-asset
+    # embedding (one chunk per notebook / query / pipeline) so users
+    # who don't tune this knob get coarse but predictable behaviour.
+    # Edit via ``/db assets chunking`` or the ``assets_chunking``
+    # block in ``~/.amx/config.yml``.
+    assets_chunking: AssetChunkingConfig = field(default_factory=AssetChunkingConfig)
     doc_paths: list[str] = field(default_factory=list)
     code_paths: list[str] = field(default_factory=list)
     selected_schemas: list[str] = field(default_factory=list)
@@ -2001,6 +2013,7 @@ class AMXConfig:
             "embedding_docs",
             "embedding_code",
             "embedding_assets",
+            "assets_chunking",
             "doc_paths",
             "code_paths",
             "selected_schemas",
@@ -2044,6 +2057,7 @@ class AMXConfig:
             "embedding_docs",
             "embedding_code",
             "embedding_assets",
+            "assets_chunking",
             "db_profiles",
             "llm_profiles",
         }:
@@ -2237,6 +2251,9 @@ class AMXConfig:
             embedding_assets_raw = data.get("embedding_assets")
             if isinstance(embedding_assets_raw, dict):
                 cfg.embedding_assets = _embedding_from_mapping(embedding_assets_raw)
+            assets_chunking_raw = data.get("assets_chunking")
+            if isinstance(assets_chunking_raw, dict):
+                cfg.assets_chunking = chunking_from_mapping(assets_chunking_raw)
 
         cfg.llm.api_key = cfg.llm.api_key or os.getenv("AMX_LLM_API_KEY", "")
 
@@ -2610,6 +2627,8 @@ class AMXConfig:
             data["history_store_database"] = str(self.history_store_database or "")
             data["embedding_docs"] = _embedding_to_mapping(self.embedding_docs)
             data["embedding_code"] = _embedding_to_mapping(self.embedding_code)
+            data["embedding_assets"] = _embedding_to_mapping(self.embedding_assets)
+            data["assets_chunking"] = chunking_to_mapping(self.assets_chunking)
             # Move plaintext secrets to the OS keyring; the YAML now stores only
             # opaque "keyring:..." references. No-op when keyring is unavailable.
             _externalise_secrets_in_data(

--- a/tests/assets/test_loaders.py
+++ b/tests/assets/test_loaders.py
@@ -13,6 +13,11 @@ from pathlib import Path
 
 import pytest
 
+from amx.assets.chunking_config import (
+    AssetChunkingConfig,
+    NotebookChunkingConfig,
+    QueryChunkingConfig,
+)
 from amx.assets.loaders import (
     load_asset_documents,
     load_notebook_documents,
@@ -20,6 +25,11 @@ from amx.assets.loaders import (
     load_stream_documents,
 )
 from amx.storage.sqlite_store import SQLiteHistoryStore
+
+_CELL_CFG = AssetChunkingConfig(
+    notebook=NotebookChunkingConfig(strategy="cell"),
+    query=QueryChunkingConfig(strategy="statement"),
+)
 
 
 @pytest.fixture()
@@ -53,11 +63,27 @@ def test_load_notebook_documents_emits_per_cell_chunks(store: SQLiteHistoryStore
         (ipynb,),
     )
     with store._connect() as conn:
-        docs = load_notebook_documents(conn=conn, profile_name="p")
+        docs = load_notebook_documents(conn=conn, profile_name="p", chunking=_CELL_CFG)
     assert len(docs) == 3
     assert {d.metadata["cell_type"] for d in docs} == {"markdown", "code"}
     assert all(d.kind == "notebook" for d in docs)
     assert all(d.profile == "p" for d in docs)
+
+
+def test_load_notebook_documents_default_is_whole(store: SQLiteHistoryStore) -> None:
+    """Default chunking (no ``chunking=`` arg) returns one chunk per notebook."""
+    ipynb = json.dumps({"cells": [{"cell_type": "code", "source": "select 1"}]})
+    _insert(
+        store,
+        "INSERT INTO remote_notebooks (profile_name, platform, external_id, name, "
+        "language, source_text, source_hash, ingested_at) VALUES "
+        "('p', 'databricks', 'ext-w', 'whole_nb', 'sql', ?, 'h', '0')",
+        (ipynb,),
+    )
+    with store._connect() as conn:
+        docs = load_notebook_documents(conn=conn, profile_name="p")
+    assert len(docs) == 1
+    assert docs[0].metadata["cell_type"] == "whole"
 
 
 def test_load_query_documents_splits_on_statement_boundary(
@@ -72,7 +98,7 @@ def test_load_query_documents_splits_on_statement_boundary(
         (),
     )
     with store._connect() as conn:
-        docs = load_query_documents(conn=conn, profile_name="p")
+        docs = load_query_documents(conn=conn, profile_name="p", chunking=_CELL_CFG)
     assert len(docs) == 2
     assert all(d.kind == "query" for d in docs)
 

--- a/tests/assets/test_rag_store.py
+++ b/tests/assets/test_rag_store.py
@@ -114,6 +114,10 @@ def test_delete_asset_removes_every_chunk(store) -> None:
 
 def test_ingest_profile_reads_from_history_store(store, tmp_path: Path) -> None:
     """End-to-end: SQLite remote_* rows → loader → splitter → ingest_documents."""
+    from amx.assets.chunking_config import (
+        AssetChunkingConfig,
+        NotebookChunkingConfig,
+    )
     from amx.storage.sqlite_store import SQLiteHistoryStore
 
     history = SQLiteHistoryStore(tmp_path / "history.db")
@@ -134,8 +138,15 @@ def test_ingest_profile_reads_from_history_store(store, tmp_path: Path) -> None:
             "'h', '2026-01-01')",
             (ipynb,),
         )
+    # Force the cell-level strategy so the test stays meaningful even
+    # though the runtime default is now ``whole`` (one chunk per
+    # notebook). The cell strategy is what we want to verify the
+    # end-to-end loader → splitter path produces.
+    chunking = AssetChunkingConfig(notebook=NotebookChunkingConfig(strategy="cell"))
     with history._connect() as conn:
-        indexed = store.ingest_profile(conn=conn, profile_name="p")
+        indexed = store.ingest_profile(
+            conn=conn, profile_name="p", chunking=chunking
+        )
     assert indexed >= 2  # markdown + code cell
     hits = store.query("Header", top_k=3, profile="p")
     assert hits

--- a/tests/assets/test_rag_store.py
+++ b/tests/assets/test_rag_store.py
@@ -144,9 +144,7 @@ def test_ingest_profile_reads_from_history_store(store, tmp_path: Path) -> None:
     # end-to-end loader → splitter path produces.
     chunking = AssetChunkingConfig(notebook=NotebookChunkingConfig(strategy="cell"))
     with history._connect() as conn:
-        indexed = store.ingest_profile(
-            conn=conn, profile_name="p", chunking=chunking
-        )
+        indexed = store.ingest_profile(conn=conn, profile_name="p", chunking=chunking)
     assert indexed >= 2  # markdown + code cell
     hits = store.query("Header", top_k=3, profile="p")
     assert hits

--- a/tests/assets/test_splitters.py
+++ b/tests/assets/test_splitters.py
@@ -4,12 +4,23 @@ Splitters are pure functions over the raw row data, so every test
 just feeds a string or dict and asserts the resulting
 :class:`AssetDocument` shape — no Chroma, no SQLite, no embedding
 cost.
+
+The default chunking strategy is ``whole`` (one chunk per asset),
+so any test that expects per-cell / per-statement chunks passes an
+explicit :class:`NotebookChunkingConfig` / :class:`QueryChunkingConfig`.
+A small group of tests at the bottom asserts the default behaviour
+on its own.
 """
 
 from __future__ import annotations
 
 import json
 
+from amx.assets.chunking_config import (
+    NotebookChunkingConfig,
+    PipelineChunkingConfig,
+    QueryChunkingConfig,
+)
 from amx.assets.splitters import (
     split_job,
     split_notebook,
@@ -18,6 +29,13 @@ from amx.assets.splitters import (
     split_stream,
     split_streamlit,
 )
+
+_CELL = NotebookChunkingConfig(strategy="cell")
+_CHAR = NotebookChunkingConfig(strategy="char_window")
+_WHOLE_NB = NotebookChunkingConfig(strategy="whole")
+_STATEMENT = QueryChunkingConfig(strategy="statement")
+_WHOLE_QUERY = QueryChunkingConfig(strategy="whole")
+_QUERY_CHAR = QueryChunkingConfig(strategy="char_window")
 
 
 def _ipynb(*cells: dict) -> str:
@@ -32,17 +50,17 @@ def _code(src: str) -> dict:
     return {"cell_type": "code", "source": src}
 
 
-# ── notebook ──────────────────────────────────────────────────────
+# ── notebook: cell strategy ───────────────────────────────────────
 
 
-def test_notebook_emits_one_chunk_per_markdown_or_code_cell() -> None:
+def test_notebook_cell_emits_one_chunk_per_markdown_or_code_cell() -> None:
     source = _ipynb(
         _md("# Setup"),
         _code("import pandas as pd"),
         _md("## Load data"),
         _code("df = pd.read_csv('orders.csv')"),
     )
-    docs = split_notebook(profile="p", remote_id=1, name="nb", source_text=source)
+    docs = split_notebook(profile="p", remote_id=1, name="nb", source_text=source, config=_CELL)
     assert len(docs) == 4
     # Header path propagates onto every subsequent chunk via the
     # active stack — the code cell under "## Load data" sees both
@@ -51,72 +69,158 @@ def test_notebook_emits_one_chunk_per_markdown_or_code_cell() -> None:
     assert "Setup" in docs[3].metadata["header_path"]
 
 
-def test_notebook_falls_back_to_char_window_when_not_json() -> None:
+def test_notebook_cell_falls_back_to_char_window_when_not_json() -> None:
     docs = split_notebook(
         profile="p",
         remote_id=2,
         name="raw_sql",
         source_text="SELECT 1\nSELECT 2",
+        config=_CELL,
     )
     assert len(docs) == 1
     assert docs[0].text == "SELECT 1\nSELECT 2"
     assert docs[0].metadata["cell_type"] == "raw"
 
 
-def test_notebook_long_cell_splits_into_chunks() -> None:
+def test_notebook_cell_long_cell_splits_into_chunks() -> None:
     big_code = "x = 1\n" * 400  # ~2400 chars
     source = _ipynb(_md("# Big"), _code(big_code))
-    docs = split_notebook(profile="p", remote_id=3, name="big", source_text=source)
+    docs = split_notebook(profile="p", remote_id=3, name="big", source_text=source, config=_CELL)
     code_chunks = [d for d in docs if d.metadata.get("cell_type") == "code"]
     # 2400-char body, 1000-char window with 200 overlap → 3 chunks
     assert len(code_chunks) >= 3
 
 
-def test_notebook_skips_empty_cells_and_non_string_sources() -> None:
+def test_notebook_cell_skips_empty_cells_and_non_string_sources() -> None:
     source = _ipynb(
         _md(""),
         {"cell_type": "code", "source": ["select", " 1"]},  # list source joins
         {"cell_type": "raw", "source": "ignore me"},  # raw cell skipped
     )
-    docs = split_notebook(profile="p", remote_id=4, name="nb", source_text=source)
+    docs = split_notebook(profile="p", remote_id=4, name="nb", source_text=source, config=_CELL)
     # Empty markdown skipped, raw skipped, code cell with list source kept.
     assert len(docs) == 1
     assert docs[0].metadata["cell_type"] == "code"
     assert docs[0].text == "select 1"
 
 
-def test_notebook_chunk_id_is_stable() -> None:
+def test_notebook_cell_chunk_id_is_stable() -> None:
     source = _ipynb(_md("# A"), _code("1"))
-    docs = split_notebook(profile="db_prod", remote_id=7, name="nb", source_text=source)
+    docs = split_notebook(
+        profile="db_prod", remote_id=7, name="nb", source_text=source, config=_CELL
+    )
     assert docs[0].chunk_id == "db_prod::notebook::7::0"
     assert docs[1].chunk_id == "db_prod::notebook::7::1"
 
 
-# ── query ─────────────────────────────────────────────────────────
+def test_notebook_cell_honours_custom_chunk_chars() -> None:
+    """Tighter chunk_chars produces more sub-chunks."""
+    big_code = "y = 2\n" * 200  # ~1200 chars
+    source = _ipynb(_code(big_code))
+    docs_default = split_notebook(
+        profile="p",
+        remote_id=8,
+        name="nb",
+        source_text=source,
+        config=NotebookChunkingConfig(strategy="cell"),
+    )
+    docs_tight = split_notebook(
+        profile="p",
+        remote_id=8,
+        name="nb",
+        source_text=source,
+        config=NotebookChunkingConfig(strategy="cell", chunk_chars=400, chunk_overlap=50),
+    )
+    assert len(docs_tight) > len(docs_default)
 
 
-def test_query_splits_on_statement_boundary() -> None:
+# ── notebook: whole strategy ──────────────────────────────────────
+
+
+def test_notebook_whole_is_default_and_yields_single_chunk() -> None:
+    source = _ipynb(_md("# A"), _code("1"), _md("## B"), _code("2"))
+    docs = split_notebook(profile="p", remote_id=1, name="nb", source_text=source)
+    assert len(docs) == 1
+    assert docs[0].metadata["cell_type"] == "whole"
+    # The whole-asset chunk preserves the raw ipynb JSON so the
+    # embedding sees every cell at once (coarse but predictable).
+    assert "# A" in docs[0].text or "Header" in docs[0].text or docs[0].text  # not empty
+
+
+def test_notebook_whole_empty_source_returns_no_chunks() -> None:
+    docs = split_notebook(profile="p", remote_id=1, name="nb", source_text="", config=_WHOLE_NB)
+    assert docs == []
+
+
+# ── notebook: char_window strategy ────────────────────────────────
+
+
+def test_notebook_char_window_ignores_cell_boundaries() -> None:
+    big_text = "x" * 2500
+    docs = split_notebook(
+        profile="p",
+        remote_id=2,
+        name="nb",
+        source_text=big_text,
+        config=_CHAR,
+    )
+    assert len(docs) >= 3  # 2500-char body, 1000-char window with 200 overlap
+    for d in docs:
+        assert d.metadata["cell_type"] == "char_window"
+
+
+# ── query: statement strategy ─────────────────────────────────────
+
+
+def test_query_statement_splits_on_boundary() -> None:
     sql = "CREATE TABLE t (id INT); INSERT INTO t VALUES (1); SELECT * FROM t;"
-    docs = split_query(profile="p", remote_id=1, name="q", sql_text=sql)
+    docs = split_query(profile="p", remote_id=1, name="q", sql_text=sql, config=_STATEMENT)
     assert len(docs) == 3
     assert docs[1].metadata["statement_no"] == 1
 
 
-def test_query_long_statement_falls_back_to_char_window() -> None:
+def test_query_statement_long_statement_falls_back_to_char_window() -> None:
     big = "SELECT " + ", ".join(f"col_{i}" for i in range(500)) + " FROM t"
-    docs = split_query(profile="p", remote_id=2, name="q", sql_text=big)
+    docs = split_query(profile="p", remote_id=2, name="q", sql_text=big, config=_STATEMENT)
     assert len(docs) >= 2
 
 
-def test_query_handles_empty_input() -> None:
-    assert split_query(profile="p", remote_id=1, name="q", sql_text="") == []
-    assert split_query(profile="p", remote_id=1, name="q", sql_text="   ") == []
+def test_query_statement_handles_empty_input() -> None:
+    assert split_query(profile="p", remote_id=1, name="q", sql_text="", config=_STATEMENT) == []
+    assert split_query(profile="p", remote_id=1, name="q", sql_text="   ", config=_STATEMENT) == []
 
 
-# ── pipeline ──────────────────────────────────────────────────────
+# ── query: whole strategy (default) ───────────────────────────────
 
 
-def test_pipeline_emits_header_and_notebook_library_chunks() -> None:
+def test_query_whole_is_default_and_yields_single_chunk() -> None:
+    sql = "CREATE TABLE t (id INT); INSERT INTO t VALUES (1); SELECT * FROM t;"
+    docs = split_query(profile="p", remote_id=1, name="q", sql_text=sql)
+    assert len(docs) == 1
+    assert "CREATE TABLE" in docs[0].text
+    assert "SELECT" in docs[0].text
+
+
+def test_query_whole_empty_returns_no_chunks() -> None:
+    docs = split_query(profile="p", remote_id=1, name="q", sql_text="", config=_WHOLE_QUERY)
+    assert docs == []
+
+
+# ── query: char_window strategy ───────────────────────────────────
+
+
+def test_query_char_window_ignores_statement_boundaries() -> None:
+    sql = "SELECT a; SELECT b; SELECT c;"
+    docs = split_query(profile="p", remote_id=1, name="q", sql_text=sql, config=_QUERY_CHAR)
+    # Below chunk_chars → single chunk, but no statement_no >= 0.
+    assert len(docs) == 1
+    assert docs[0].metadata["statement_no"] == -1
+
+
+# ── pipeline strategies ───────────────────────────────────────────
+
+
+def test_pipeline_metadata_emits_header_and_notebook_library_chunks() -> None:
     libs = json.dumps(
         [
             {"notebook": {"path": "/Workspace/bronze/load"}},
@@ -131,10 +235,25 @@ def test_pipeline_emits_header_and_notebook_library_chunks() -> None:
         target_schema="bronze",
         libraries_json=libs,
     )
-    assert len(docs) == 3  # header + 2 notebook libs
+    assert len(docs) == 3  # header + 2 notebook libs (metadata is the default)
     assert "bronze_loader" in docs[0].text
     assert "Workspace/bronze/load" in docs[1].text
     assert docs[1].metadata["notebook_path"].startswith("/Workspace")
+
+
+def test_pipeline_whole_inlines_libraries() -> None:
+    libs = json.dumps([{"notebook": {"path": "/Workspace/x"}}])
+    docs = split_pipeline(
+        profile="p",
+        remote_id=1,
+        name="bronze_loader",
+        target_schema="bronze",
+        libraries_json=libs,
+        config=PipelineChunkingConfig(strategy="whole"),
+    )
+    assert len(docs) == 1
+    assert "bronze_loader" in docs[0].text
+    assert "/Workspace/x" in docs[0].text
 
 
 # ── metadata-only kinds ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR #552 baked the chunking strategy into ``amx/assets/splitters.py`` — notebooks were cut cell-by-cell, queries on ``;`` boundaries, 1000-char window with 200 overlap. Some users prefer the embedding to see each asset **whole** (predictable, no slicing); others want even tighter sub-chunks for high-recall retrieval. This PR lifts the choice into config and flips the default to ``whole``.

**Public surface**
- New ``amx/assets/chunking_config.py`` — ``AssetChunkingConfig`` with per-kind sub-configs (``NotebookChunkingConfig``, ``QueryChunkingConfig``, ``PipelineChunkingConfig``).
  - Notebook strategies: ``whole`` (default) / ``cell`` / ``char_window``.
  - Query strategies: ``whole`` (default) / ``statement`` / ``char_window``.
  - Pipeline strategies: ``metadata`` (default) / ``whole``.
  - Stream / streamlit_app / job always emit one metadata chunk; not configurable.
- New top-level ``cfg.assets_chunking`` field round-tripped through the ``config.yml`` save / load path.
- New ``/db assets chunking`` CLI command — interactive wizard that prints the active config, prompts for per-kind strategy + ``chunk_chars`` + ``chunk_overlap``, saves to ``config.yml``, and reminds the user to run ``/db assets reindex`` to re-embed under the new strategy. ``--show`` prints without prompting.

**Behaviour change**
- Default chunking flipped from "cell + statement" to ``whole`` for notebooks and queries. Existing collections need ``/db assets reindex`` to re-embed under the new default; the ``EmbeddingProviderMismatch`` recovery path is unaffected.
- ``AssetRAGStore.ingest_profile`` plumbs ``chunking_cfg`` from ``cfg.assets_chunking`` (or an explicit ``chunking_cfg`` kwarg) through to the loaders + splitters.

## Test plan

- [x] ``pytest tests/assets/ tests/services/test_ingest_assets.py tests/search/test_asset_evidence.py tests/analyze/test_asset_context.py tests/test_pages_*.py tests/cli/test_db_assets_commands.py`` — 88 green + 4 skipped.
- [x] ``ruff check`` + ``ruff format`` clean.
- [ ] Manual: ``/db assets chunking`` prints the default, prompts each field, saves to ``config.yml``.
- [ ] Manual: switch notebook strategy to ``cell``, run ``/db assets reindex``, ``/db assets search`` returns the expected per-cell match.
- [ ] Manual: ``/db assets chunking --show`` prints the active config without prompting.