### PR TITLE
feat(assets): incremental embed (source_hash gate) (PR-D)

### DIFF
--- a/amx/assets/rag.py
+++ b/amx/assets/rag.py
@@ -21,6 +21,7 @@ degrade across vector spaces; ``reset_collection`` (used by
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -266,6 +267,7 @@ class AssetRAGStore:
         kinds: list[str] | None = None,
         only_ids: dict[str, list[int]] | None = None,
         chunking: Any | None = None,
+        only_changed: bool = True,
     ) -> int:
         """Re-chunk + upsert every (or scoped) asset for ``profile_name``.
 
@@ -277,6 +279,14 @@ class AssetRAGStore:
         construction) controls strategy + chunk_chars + chunk_overlap
         per kind. Tests inject a custom config; production callers
         leave it ``None`` and the cfg.yml value flows through.
+
+        ``only_changed`` (PR-D): when true (the default), notebooks /
+        queries / pipelines whose current content hash already matches
+        ``last_embedded_hash`` are skipped before chunking. The hash
+        update happens after a successful embed so a crashed run
+        leaves the row eligible for retry. Set to ``False`` for the
+        ``/db assets reindex --force`` path that drops and rebuilds
+        unconditionally.
         """
         cfg = chunking if chunking is not None else self.chunking_cfg
         docs = load_asset_documents(
@@ -286,11 +296,28 @@ class AssetRAGStore:
             only_ids=only_ids,
             chunking=cfg,
         )
+        if only_changed:
+            # PR-D: drop documents whose underlying row's current
+            # content hash already matches what we last embedded.
+            # Other kinds (jobs / streams / streamlit_apps) fall
+            # through unchanged — their content is metadata-only and
+            # cheap to re-embed.
+            current = _current_hashes_for_kinds(conn, profile_name, docs)
+            last = _last_embedded_hashes_for_kinds(conn, profile_name, docs)
+            skipped: set[tuple[str, int]] = set()
+            for (kind, rid), curr_hash in current.items():
+                if curr_hash and last.get((kind, rid)) == curr_hash:
+                    skipped.add((kind, rid))
+            if skipped:
+                docs = [d for d in docs if (d.kind, d.remote_id) not in skipped]
         # Clear any stale chunks for the asset rows we are about to
         # rewrite so a shrunk notebook (fewer cells) does not leave
         # orphaned chunks at the tail.
         self.delete_chunks_for_assets([(d.kind, d.profile, d.remote_id) for d in docs])
-        return self.ingest_documents(docs)
+        written = self.ingest_documents(docs)
+        if only_changed and written:
+            _update_last_embedded_hashes(conn, profile_name, docs)
+        return written
 
     def delete_chunks_for_assets(self, refs: list[tuple[str, str, int]]) -> int:
         """Delete every chunk for a list of ``(kind, profile, remote_id)``.
@@ -366,8 +393,17 @@ class AssetRAGStore:
         conn: Any,
         profile_name: str,
         kinds: list[str] | None = None,
+        force: bool = True,
     ) -> int:
-        """Drop and rebuild the index for ``profile_name`` from scratch."""
+        """Drop and rebuild the index for ``profile_name`` from scratch.
+
+        PR-D: ``force=True`` (the default for this entry point —
+        the user invoked ``/db assets reindex`` for a reason)
+        wipes every chunk for the profile, NULLs out the per-row
+        ``last_embedded_hash``, and re-embeds unconditionally.
+        ``force=False`` is the cheap path for the ingest auto-hook
+        — it skips assets whose hash matches the last embed.
+        """
         # Delete every existing chunk for this profile first so an
         # asset that was removed since the last ingest does not linger.
         try:
@@ -377,7 +413,17 @@ class AssetRAGStore:
                 self.collection.delete(ids=stale_ids)
         except Exception as exc:  # noqa: BLE001
             log.warning("reindex_profile: profile sweep failed: %s", exc)
-        return self.ingest_profile(conn=conn, profile_name=profile_name, kinds=kinds)
+        if force:
+            # PR-D: clear the last_embedded_hash so the follow-up
+            # ingest_profile re-embeds every row regardless of
+            # current content hash.
+            _clear_last_embedded_hashes(conn, profile_name)
+        return self.ingest_profile(
+            conn=conn,
+            profile_name=profile_name,
+            kinds=kinds,
+            only_changed=not force,
+        )
 
     # ── reads ─────────────────────────────────────────────────────
 
@@ -461,6 +507,166 @@ class AssetRAGStore:
             return int(self.collection.count())
         except Exception:  # noqa: BLE001
             return 0
+
+
+# ── PR-D: incremental-embed helpers ───────────────────────────────────────
+
+# Per-kind config for the incremental-embed hash check. Each entry
+# is ``(table, hash_expr)``: a SQL expression that yields the current
+# canonical content hash for a row. notebooks + queries already store
+# a hash in a dedicated column; pipelines have no native hash so we
+# derive one from the content envelope at compare time. Other kinds
+# (jobs / streams / streamlit_apps) are absent on purpose — their
+# content is metadata-only and re-embedding them on every ingest is
+# cheap.
+_HASHABLE_KIND_SQL: dict[str, tuple[str, str]] = {
+    "notebook": ("remote_notebooks", "source_hash"),
+    "query": ("remote_queries", "sql_hash"),
+    "pipeline": (
+        "remote_pipelines",
+        "COALESCE(libraries_json, '') || '::' || COALESCE(latest_update_state, '')",
+    ),
+}
+
+
+def _hashable_for_pipeline(envelope: str) -> str:
+    """Return a stable sha256 over the pipeline content envelope.
+
+    Pipelines lack a per-row hash column; we compute one at compare
+    time from the same envelope the loader uses. Notebook + query
+    callers reuse their existing column values directly (already a
+    sha256 hex), so this helper is only used for pipelines.
+    """
+    return hashlib.sha256(envelope.encode("utf-8")).hexdigest()
+
+
+def _current_hashes_for_kinds(
+    conn: Any, profile_name: str, docs: list[AssetDocument]
+) -> dict[tuple[str, int], str]:
+    """Resolve current content hashes for the rows behind ``docs``.
+
+    Returns ``(kind, remote_id) -> hash`` for hashable kinds; other
+    kinds are absent so the caller treats them as "always re-embed".
+    """
+    out: dict[tuple[str, int], str] = {}
+    by_kind: dict[str, set[int]] = {}
+    for d in docs:
+        if d.kind not in _HASHABLE_KIND_SQL:
+            continue
+        by_kind.setdefault(d.kind, set()).add(int(d.remote_id))
+    for kind, ids in by_kind.items():
+        table, hash_expr = _HASHABLE_KIND_SQL[kind]
+        placeholders = ",".join("?" for _ in ids)
+        rows = conn.execute(
+            f"SELECT id, {hash_expr} FROM {table} "  # noqa: S608 — identifiers controlled above
+            f"WHERE profile_name = ? AND id IN ({placeholders})",
+            (profile_name, *ids),
+        ).fetchall()
+        for rid, raw in rows:
+            if raw is None:
+                continue
+            value = str(raw)
+            if kind == "pipeline":
+                value = _hashable_for_pipeline(value)
+            out[(kind, int(rid))] = value
+    return out
+
+
+def _last_embedded_hashes_for_kinds(
+    conn: Any, profile_name: str, docs: list[AssetDocument]
+) -> dict[tuple[str, int], str | None]:
+    """Read the most-recently-stamped embed hash per hashable row."""
+    out: dict[tuple[str, int], str | None] = {}
+    by_kind: dict[str, set[int]] = {}
+    for d in docs:
+        if d.kind not in _HASHABLE_KIND_SQL:
+            continue
+        by_kind.setdefault(d.kind, set()).add(int(d.remote_id))
+    for kind, ids in by_kind.items():
+        table = _HASHABLE_KIND_SQL[kind][0]
+        placeholders = ",".join("?" for _ in ids)
+        rows = conn.execute(
+            f"SELECT id, last_embedded_hash FROM {table} "  # noqa: S608 — identifiers controlled
+            f"WHERE profile_name = ? AND id IN ({placeholders})",
+            (profile_name, *ids),
+        ).fetchall()
+        for rid, value in rows:
+            out[(kind, int(rid))] = str(value) if value is not None else None
+    return out
+
+
+def _update_last_embedded_hashes(conn: Any, profile_name: str, docs: list[AssetDocument]) -> None:
+    """Stamp ``last_embedded_hash`` for every hashable row in ``docs``.
+
+    Called only after :meth:`AssetRAGStore.ingest_documents` succeeds,
+    so a crashed embed leaves the row eligible for retry on the next
+    ingest. The same set may be re-stamped on a re-run with identical
+    content — that's a no-op and cheap.
+    """
+    current = _current_hashes_for_kinds(conn, profile_name, docs)
+    if not current:
+        return
+    by_kind: dict[str, list[tuple[str, int]]] = {}
+    for (kind, rid), value in current.items():
+        by_kind.setdefault(kind, []).append((value, rid))
+    for kind, pairs in by_kind.items():
+        table = _HASHABLE_KIND_SQL[kind][0]
+        conn.executemany(
+            f"UPDATE {table} SET last_embedded_hash = ? "  # noqa: S608 — identifiers controlled
+            "WHERE profile_name = ? AND id = ?",
+            [(value, profile_name, rid) for value, rid in pairs],
+        )
+    if hasattr(conn, "commit"):
+        try:
+            conn.commit()
+        except Exception:  # noqa: BLE001 — best-effort autocommit
+            pass
+
+
+def _clear_last_embedded_hashes(conn: Any, profile_name: str) -> None:
+    """NULL out ``last_embedded_hash`` for every hashable row in a profile.
+
+    Used by ``reindex_profile(force=True)`` and by the per-asset
+    chunking-override PUT/DELETE so the next ingest re-embeds that
+    row even if its source_hash has not changed.
+    """
+    for kind in _HASHABLE_KIND_SQL:
+        table = _HASHABLE_KIND_SQL[kind][0]
+        conn.execute(
+            f"UPDATE {table} SET last_embedded_hash = NULL WHERE profile_name = ?",  # noqa: S608
+            (profile_name,),
+        )
+    if hasattr(conn, "commit"):
+        try:
+            conn.commit()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _clear_last_embedded_hash_for_row(
+    conn: Any, profile_name: str, kind: str, remote_id: int
+) -> None:
+    """NULL out a single row's ``last_embedded_hash``.
+
+    Used by the per-asset chunking-override PUT / DELETE: the user
+    asked for a different chunking strategy on this one asset, so
+    the next ingest must re-embed it under the new strategy even
+    when the source content is byte-identical.
+    """
+    spec = _HASHABLE_KIND_SQL.get(kind)
+    if spec is None:
+        return
+    table = spec[0]
+    conn.execute(
+        f"UPDATE {table} SET last_embedded_hash = NULL "  # noqa: S608 — identifiers controlled
+        "WHERE profile_name = ? AND id = ?",
+        (profile_name, int(remote_id)),
+    )
+    if hasattr(conn, "commit"):
+        try:
+            conn.commit()
+        except Exception:  # noqa: BLE001
+            pass
 
 
 __all__ = ["AssetRAGStore", "EmbeddingProviderMismatch"]

--- a/amx/cli_support/commands/db_assets.py
+++ b/amx/cli_support/commands/db_assets.py
@@ -232,8 +232,19 @@ def register_db_assets_commands(db_group: click.Group, *, pass_config) -> None:
         help="Re-chunk + re-embed all ingested assets for this DB profile.",
     )
     @click.option("-y", "--yes", is_flag=True, help="Skip the confirmation prompt.")
+    @click.option(
+        "--force",
+        is_flag=True,
+        help=(
+            "Re-embed every asset regardless of source_hash. PR-D: by "
+            "default the reindex respects last_embedded_hash so a "
+            "5,000-notebook profile only re-embeds the ones whose "
+            "content changed. --force is the explicit 'rebuild from "
+            "scratch' lever for embedding-model swaps."
+        ),
+    )
     @pass_config
-    def assets_reindex_cmd(cfg: AMXConfig, profile: str | None, yes: bool) -> None:
+    def assets_reindex_cmd(cfg: AMXConfig, profile: str | None, yes: bool, force: bool) -> None:
         """Re-embed every ingested asset under the active embedding model.
 
         Use after switching ``cfg.embedding_assets`` (e.g. MiniLM ->
@@ -244,7 +255,7 @@ def register_db_assets_commands(db_group: click.Group, *, pass_config) -> None:
         """
         from amx.cli_support.commands.db_assets_impl import run_reindex
 
-        run_reindex(cfg, profile=profile, skip_confirm=yes)
+        run_reindex(cfg, profile=profile, skip_confirm=yes, force=force)
 
     @assets.command("prune")
     @click.option(

--- a/amx/cli_support/commands/db_assets_impl.py
+++ b/amx/cli_support/commands/db_assets_impl.py
@@ -948,7 +948,7 @@ def _prompt_int(label, current, *, minimum):
     return value
 
 
-def run_reindex(cfg, *, profile, skip_confirm):
+def run_reindex(cfg, *, profile, skip_confirm, force: bool = False):
     """Drop the asset RAG collection and re-embed under the active model.
 
     Used after the user switches embedding providers (the
@@ -957,6 +957,12 @@ def run_reindex(cfg, *, profile, skip_confirm):
     :meth:`AssetRAGStore.reset_collection` + a fresh
     :meth:`ingest_profile` so the user sees one progress message
     rather than two separate calls.
+
+    PR-D: ``force=True`` re-embeds every asset regardless of
+    ``last_embedded_hash`` (the typical reason to run /reindex);
+    ``force=False`` calls the incremental path so re-running the
+    command after a partial failure only re-embeds what's still
+    stale.
     """
     from amx.assets.rag import AssetRAGStore
     from amx.storage.sqlite_store import history_store
@@ -981,7 +987,7 @@ def run_reindex(cfg, *, profile, skip_confirm):
         return
     store.reset_collection()
     with hs._connect() as conn:
-        indexed = store.ingest_profile(conn=conn, profile_name=profile_name)
+        indexed = store.reindex_profile(conn=conn, profile_name=profile_name, force=force)
     click.echo(f"Re-indexed {indexed} chunks for profile '{profile_name}'.")
 
 

--- a/amx/storage/schema_descriptions.py
+++ b/amx/storage/schema_descriptions.py
@@ -1888,6 +1888,7 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
         "last_modified_by": "User identifier of the last editor on the platform (NULL if unknown).",
         "owner": "Notebook owner per platform conventions (Snowflake OWNER role; Databricks creator). Distinct from last_modified_by.",
         "cell_count": "Number of cells parsed from the normalized .ipynb (NULL if parsing failed).",
+        "last_embedded_hash": "sha256 of source_text as of the most recent successful embed into the asset RAG store. PR-D: ingest_profile compares this against source_hash to skip re-embedding unchanged notebooks; NULL forces a fresh embed on next ingest (set on every new row and after per-asset chunking overrides change).",
         "ingested_at": "When AMX last ran ingestion for this row. Updated on every refresh.",
     },
     "remote_jobs": {
@@ -1946,6 +1947,7 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
         "libraries_json": "JSON array of library refs (notebook paths, files, jars) the pipeline executes.",
         "latest_update_state": "State of the most recent pipeline update (e.g. RUNNING, COMPLETED, FAILED).",
         "latest_update_creation_time": "Creation TIMESTAMP of the most recent update.",
+        "last_embedded_hash": "sha256 of the canonical libraries_json + latest_update_state pair as of the most recent successful embed. PR-D: lets ingest_profile skip pipelines whose content envelope is unchanged since the last embed; NULL forces a re-embed.",
         "ingested_at": "When AMX last refreshed this row.",
     },
     "remote_streamlit_apps": {
@@ -1992,6 +1994,7 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
         "user_name": "User who ran (history) or owns (saved) the query.",
         "executed_at": "Execution TIMESTAMP. NULL for kind='saved'.",
         "duration_ms": "Execution duration in milliseconds. NULL for kind='saved'.",
+        "last_embedded_hash": "sha256 of sql_text as of the most recent successful embed. PR-D: lets ingest_profile skip queries whose SQL hasn't changed; NULL forces re-embed.",
         "ingested_at": "When AMX last refreshed this row.",
     },
     "asset_chunking_overrides": {

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -1242,6 +1242,7 @@ class SQLiteHistoryStore:
                     last_modified_by TEXT,
                     owner TEXT,
                     cell_count INTEGER,
+                    last_embedded_hash TEXT,
                     ingested_at TIMESTAMP NOT NULL,
                     UNIQUE(profile_name, platform, external_id)
                 )
@@ -1340,6 +1341,7 @@ class SQLiteHistoryStore:
                     libraries_json TEXT NOT NULL,
                     latest_update_state TEXT,
                     latest_update_creation_time TIMESTAMP,
+                    last_embedded_hash TEXT,
                     ingested_at TIMESTAMP NOT NULL,
                     UNIQUE(profile_name, pipeline_id)
                 )
@@ -1420,6 +1422,7 @@ class SQLiteHistoryStore:
                     user_name TEXT,
                     executed_at TIMESTAMP,
                     duration_ms INTEGER,
+                    last_embedded_hash TEXT,
                     ingested_at TIMESTAMP NOT NULL,
                     UNIQUE(profile_name, platform, kind, external_id)
                 )
@@ -1453,6 +1456,14 @@ class SQLiteHistoryStore:
                 "CREATE INDEX IF NOT EXISTS idx_asset_chunking_overrides_profile "
                 "ON asset_chunking_overrides(profile_name, kind)"
             )
+
+            # PR-D (incremental embed): add ``last_embedded_hash`` to
+            # the three content-bearing remote_* tables on existing DBs
+            # that pre-date the column. ``CREATE TABLE IF NOT EXISTS``
+            # above is a no-op when the table already lives without
+            # the column, so the explicit migration below is the only
+            # path that gets it added to a pre-PR-D history.db.
+            self._ensure_remote_embed_columns(conn)
 
             # Seed the bundled default logos into ``lineage_logos`` if
             # they aren't there yet. Idempotent via the UNIQUE(key,
@@ -1644,6 +1655,39 @@ class SQLiteHistoryStore:
                 "CREATE INDEX IF NOT EXISTS idx_analysis_runs_shared_uuid "
                 "ON analysis_runs(shared_uuid)"
             )
+
+    def _ensure_remote_embed_columns(self, conn: Any) -> None:
+        """Idempotently add ``last_embedded_hash`` to content-bearing remote_* tables.
+
+        PR-D introduces incremental embedding: ingest_profile skips
+        re-embedding a row whose ``source_hash`` / ``sql_hash`` /
+        pipeline content hash still matches the value last written to
+        ``last_embedded_hash``. The new column is NULL on legacy rows
+        so the first post-migration ingest re-embeds everything once,
+        then stays incremental from there.
+        """
+        for table_name in ("remote_notebooks", "remote_queries", "remote_pipelines"):
+            try:
+                rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+                existing_cols = {str(r[1]) for r in rows}
+            except Exception as exc:
+                log.warning("Could not introspect %s schema: %s", table_name, exc)
+                continue
+            if "last_embedded_hash" in existing_cols:
+                continue
+            try:
+                conn.execute(f"ALTER TABLE {table_name} ADD COLUMN last_embedded_hash TEXT")
+                log.info(
+                    "Migrated %s: added column last_embedded_hash TEXT",
+                    table_name,
+                )
+            except Exception as exc:
+                log.warning(
+                    "Could not add %s.last_embedded_hash: %s  --  incremental "
+                    "embed will fall back to re-embedding every asset.",
+                    table_name,
+                    exc,
+                )
 
     def _ensure_scheduled_columns(self, conn: Any) -> None:
         """Idempotently add ``database`` / ``catalog`` to scheduled_runs.

--- a/amx/web/routers/assets.py
+++ b/amx/web/routers/assets.py
@@ -402,9 +402,16 @@ def _kind_defaults(cfg: AMXConfig, kind: str) -> dict[str, Any]:
 
 
 def _reindex_single_asset(cfg: AMXConfig, hs: Any, kind: str, profile: str, remote_id: int) -> bool:
-    """Drop + re-embed just one asset's chunks. Best-effort."""
+    """Drop + re-embed just one asset's chunks. Best-effort.
+
+    PR-D: the chunking-override PUT/DELETE that calls this needs the
+    next ingest to re-embed the row even when ``source_hash`` is
+    unchanged (the strategy changed, not the content). Clear
+    ``last_embedded_hash`` for the row before re-embedding so the
+    incremental gate inside ``ingest_profile`` doesn't skip it.
+    """
     try:
-        from amx.assets.rag import AssetRAGStore
+        from amx.assets.rag import AssetRAGStore, _clear_last_embedded_hash_for_row
     except Exception:  # noqa: BLE001
         return False
     try:
@@ -414,6 +421,7 @@ def _reindex_single_asset(cfg: AMXConfig, hs: Any, kind: str, profile: str, remo
     try:
         store.delete_asset(kind=kind, profile=profile, remote_id=remote_id)
         with hs._connect() as conn:  # noqa: SLF001
+            _clear_last_embedded_hash_for_row(conn, profile, kind, remote_id)
             store.ingest_profile(
                 conn=conn,
                 profile_name=profile,

--- a/tests/assets/test_incremental_embed.py
+++ b/tests/assets/test_incremental_embed.py
@@ -1,0 +1,358 @@
+"""PR-D: incremental-embed gate driven by ``last_embedded_hash``.
+
+The actual Chroma round-trip lives behind an optional dep
+(``sentence_transformers``), so these tests target the per-row hash
+helpers directly. They cover:
+
+* the migration adds ``last_embedded_hash`` to legacy DBs,
+* every schema-description entry is non-empty (CI schema gate),
+* ``_current_hashes_for_kinds`` reads the right column per kind,
+* ``_last_embedded_hashes_for_kinds`` reads the new column,
+* ``_update_last_embedded_hashes`` stamps the column after embed,
+* ``_clear_last_embedded_hashes`` NULLs the column on force-reindex,
+* ``_clear_last_embedded_hash_for_row`` NULLs a single row on the
+  chunking-override PUT/DELETE path.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from amx.assets.rag import (
+    _clear_last_embedded_hash_for_row,
+    _clear_last_embedded_hashes,
+    _current_hashes_for_kinds,
+    _hashable_for_pipeline,
+    _last_embedded_hashes_for_kinds,
+    _update_last_embedded_hashes,
+)
+from amx.assets.types import AssetDocument
+from amx.storage.schema_descriptions import SCHEMA_DESCRIPTIONS
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _make_store(tmp_path):
+    db_path = tmp_path / "history.db"
+    SQLiteHistoryStore(db_path).init()
+    return db_path
+
+
+def _seed_notebook(conn, *, name="nb1", source_hash="h-source", last_embedded_hash=None):
+    conn.execute(
+        """
+        INSERT INTO remote_notebooks
+            (profile_name, platform, external_id, name, workspace_path,
+             qualified_name, language, source_text, source_hash,
+             last_modified_at, last_modified_by, owner, cell_count,
+             last_embedded_hash, ingested_at)
+        VALUES ('prod', 'databricks', ?, ?, '/n', NULL, 'python',
+                '{}', ?, NULL, NULL, NULL, 1, ?, '2026-05-22')
+        """,
+        (f"ext-{name}", name, source_hash, last_embedded_hash),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+def _seed_query(conn, *, name="q1", sql_hash="h-sql", last_embedded_hash=None):
+    conn.execute(
+        """
+        INSERT INTO remote_queries
+            (profile_name, platform, kind, external_id, name, sql_text,
+             sql_hash, warehouse, user_name, executed_at, duration_ms,
+             last_embedded_hash, ingested_at)
+        VALUES ('prod', 'databricks', 'saved', ?, ?, 'SELECT 1', ?,
+                NULL, NULL, NULL, NULL, ?, '2026-05-22')
+        """,
+        (f"ext-{name}", name, sql_hash, last_embedded_hash),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+def _seed_pipeline(conn, *, name="p1", libraries='["a"]', state="RUNNING", last_embedded_hash=None):
+    conn.execute(
+        """
+        INSERT INTO remote_pipelines
+            (profile_name, pipeline_id, name, target_schema, edition,
+             continuous, photon, libraries_json, latest_update_state,
+             latest_update_creation_time, last_embedded_hash, ingested_at)
+        VALUES ('prod', ?, ?, 'analytics', 'CORE', 0, 0, ?, ?, NULL, ?, '2026-05-22')
+        """,
+        (f"ext-{name}", name, libraries, state, last_embedded_hash),
+    )
+    return conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+
+# ── schema migration + description coverage ──────────────────────────────
+
+
+def test_migration_adds_last_embedded_hash_to_legacy_db(tmp_path):
+    """A pre-PR-D history.db without the column gains it on init()."""
+    db_path = tmp_path / "history.db"
+    # Build a minimal legacy schema by hand — no last_embedded_hash columns.
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE remote_notebooks ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, profile_name TEXT NOT NULL, "
+            "platform TEXT NOT NULL, external_id TEXT NOT NULL, name TEXT NOT NULL, "
+            "workspace_path TEXT, qualified_name TEXT, language TEXT NOT NULL, "
+            "source_text TEXT NOT NULL, source_hash TEXT NOT NULL, "
+            "last_modified_at TIMESTAMP, last_modified_by TEXT, owner TEXT, "
+            "cell_count INTEGER, ingested_at TIMESTAMP NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE remote_queries ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, profile_name TEXT NOT NULL, "
+            "platform TEXT NOT NULL, kind TEXT NOT NULL, external_id TEXT NOT NULL, "
+            "name TEXT, sql_text TEXT NOT NULL, sql_hash TEXT NOT NULL, "
+            "warehouse TEXT, user_name TEXT, executed_at TIMESTAMP, "
+            "duration_ms INTEGER, ingested_at TIMESTAMP NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE remote_pipelines ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, profile_name TEXT NOT NULL, "
+            "pipeline_id TEXT NOT NULL, name TEXT NOT NULL, target_schema TEXT, "
+            "edition TEXT, continuous INTEGER NOT NULL, photon INTEGER NOT NULL, "
+            "libraries_json TEXT NOT NULL, latest_update_state TEXT, "
+            "latest_update_creation_time TIMESTAMP, ingested_at TIMESTAMP NOT NULL)"
+        )
+        conn.commit()
+    SQLiteHistoryStore(db_path).init()
+    with sqlite3.connect(db_path) as conn:
+        for table in ("remote_notebooks", "remote_queries", "remote_pipelines"):
+            cols = {r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+            assert "last_embedded_hash" in cols, f"{table} migration didn't add last_embedded_hash"
+
+
+def test_schema_descriptions_cover_last_embedded_hash():
+    """House rule §5: every internal column ships with a description."""
+    for table in ("remote_notebooks", "remote_queries", "remote_pipelines"):
+        desc = SCHEMA_DESCRIPTIONS.get(table, {})
+        assert desc.get("last_embedded_hash"), (
+            f"{table}.last_embedded_hash missing schema description"
+        )
+
+
+# ── hash helpers ──────────────────────────────────────────────────────────
+
+
+def test_current_hashes_reads_source_hash_for_notebooks(tmp_path):
+    db_path = _make_store(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        rid = _seed_notebook(conn, source_hash="abc123")
+        conn.commit()
+        docs = [
+            AssetDocument(
+                kind="notebook",
+                profile="prod",
+                remote_id=rid,
+                chunk_index=0,
+                text="...",
+            )
+        ]
+        hashes = _current_hashes_for_kinds(conn, "prod", docs)
+    assert hashes == {("notebook", rid): "abc123"}
+
+
+def test_current_hashes_reads_sql_hash_for_queries(tmp_path):
+    db_path = _make_store(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        rid = _seed_query(conn, sql_hash="def456")
+        conn.commit()
+        docs = [
+            AssetDocument(kind="query", profile="prod", remote_id=rid, chunk_index=0, text="...")
+        ]
+        hashes = _current_hashes_for_kinds(conn, "prod", docs)
+    assert hashes == {("query", rid): "def456"}
+
+
+def test_current_hashes_synthesizes_pipeline_hash(tmp_path):
+    """Pipelines have no native hash; the helper derives one from
+    the libraries_json + latest_update_state envelope.
+    """
+    db_path = _make_store(tmp_path)
+    expected = _hashable_for_pipeline('["a"]::RUNNING')
+    with sqlite3.connect(db_path) as conn:
+        rid = _seed_pipeline(conn, libraries='["a"]', state="RUNNING")
+        conn.commit()
+        docs = [
+            AssetDocument(
+                kind="pipeline",
+                profile="prod",
+                remote_id=rid,
+                chunk_index=0,
+                text="...",
+            )
+        ]
+        hashes = _current_hashes_for_kinds(conn, "prod", docs)
+    assert hashes == {("pipeline", rid): expected}
+
+
+def test_current_hashes_ignores_unhashable_kinds(tmp_path):
+    """Jobs / streams / streamlit_apps return no hash — they always
+    re-embed in the incremental path.
+    """
+    db_path = _make_store(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        docs = [
+            AssetDocument(kind="job", profile="prod", remote_id=99, chunk_index=0, text="..."),
+            AssetDocument(kind="stream", profile="prod", remote_id=99, chunk_index=0, text="..."),
+        ]
+        hashes = _current_hashes_for_kinds(conn, "prod", docs)
+    assert hashes == {}
+
+
+def test_last_embedded_returns_stored_value(tmp_path):
+    db_path = _make_store(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        rid = _seed_notebook(conn, source_hash="curr", last_embedded_hash="prev")
+        conn.commit()
+        docs = [
+            AssetDocument(
+                kind="notebook",
+                profile="prod",
+                remote_id=rid,
+                chunk_index=0,
+                text="...",
+            )
+        ]
+        out = _last_embedded_hashes_for_kinds(conn, "prod", docs)
+    assert out == {("notebook", rid): "prev"}
+
+
+def test_last_embedded_returns_none_for_fresh_row(tmp_path):
+    db_path = _make_store(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        rid = _seed_notebook(conn, source_hash="curr", last_embedded_hash=None)
+        conn.commit()
+        docs = [
+            AssetDocument(
+                kind="notebook",
+                profile="prod",
+                remote_id=rid,
+                chunk_index=0,
+                text="...",
+            )
+        ]
+        out = _last_embedded_hashes_for_kinds(conn, "prod", docs)
+    assert out == {("notebook", rid): None}
+
+
+def test_update_last_embedded_stamps_current_hash(tmp_path):
+    db_path = _make_store(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        rid = _seed_notebook(conn, source_hash="new-hash", last_embedded_hash=None)
+        conn.commit()
+        docs = [
+            AssetDocument(
+                kind="notebook",
+                profile="prod",
+                remote_id=rid,
+                chunk_index=0,
+                text="...",
+            )
+        ]
+        _update_last_embedded_hashes(conn, "prod", docs)
+        stored = conn.execute(
+            "SELECT last_embedded_hash FROM remote_notebooks WHERE id = ?", (rid,)
+        ).fetchone()[0]
+    assert stored == "new-hash"
+
+
+def test_clear_last_embedded_hashes_nulls_the_column(tmp_path):
+    db_path = _make_store(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        rid_nb = _seed_notebook(conn, last_embedded_hash="stamped")
+        rid_q = _seed_query(conn, last_embedded_hash="stamped")
+        rid_p = _seed_pipeline(conn, last_embedded_hash="stamped")
+        conn.commit()
+        _clear_last_embedded_hashes(conn, "prod")
+        nb_h = conn.execute(
+            "SELECT last_embedded_hash FROM remote_notebooks WHERE id = ?", (rid_nb,)
+        ).fetchone()[0]
+        q_h = conn.execute(
+            "SELECT last_embedded_hash FROM remote_queries WHERE id = ?", (rid_q,)
+        ).fetchone()[0]
+        p_h = conn.execute(
+            "SELECT last_embedded_hash FROM remote_pipelines WHERE id = ?", (rid_p,)
+        ).fetchone()[0]
+    assert nb_h is None and q_h is None and p_h is None
+
+
+def test_clear_last_embedded_hash_for_row_scoped(tmp_path):
+    """The single-row helper must not affect siblings — that's the
+    whole point of the per-asset chunking-override hook.
+    """
+    db_path = _make_store(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        rid_a = _seed_notebook(conn, name="a", last_embedded_hash="stamped")
+        rid_b = _seed_notebook(conn, name="b", last_embedded_hash="stamped")
+        conn.commit()
+        _clear_last_embedded_hash_for_row(conn, "prod", "notebook", rid_a)
+        a = conn.execute(
+            "SELECT last_embedded_hash FROM remote_notebooks WHERE id = ?", (rid_a,)
+        ).fetchone()[0]
+        b = conn.execute(
+            "SELECT last_embedded_hash FROM remote_notebooks WHERE id = ?", (rid_b,)
+        ).fetchone()[0]
+    assert a is None
+    assert b == "stamped"
+
+
+def test_clear_last_embedded_hash_for_row_ignores_unhashable_kind(tmp_path):
+    """Jobs aren't tracked; the helper is a no-op on them rather than
+    blowing up.
+    """
+    db_path = _make_store(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        # No remote_jobs table change — helper should silently noop.
+        _clear_last_embedded_hash_for_row(conn, "prod", "job", 1)
+
+
+# ── reindex --force CLI surface ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize("force_flag", [True, False])
+def test_reindex_command_accepts_force_flag(force_flag, monkeypatch):
+    """Ensure the new --force flag exists on /db assets reindex.
+
+    Doesn't exercise the embed path (no chromadb in CI); just
+    verifies argparse + the forward to ``run_reindex``.
+    """
+    from amx.cli_support.commands import db_assets_impl as impl
+
+    captured = {}
+
+    def fake_run_reindex(cfg, *, profile, skip_confirm, force=False):
+        captured["force"] = force
+        captured["profile"] = profile
+        captured["skip_confirm"] = skip_confirm
+
+    monkeypatch.setattr(impl, "run_reindex", fake_run_reindex)
+    import click
+    from click.testing import CliRunner
+
+    from amx.cli_support.commands.db_assets import register_db_assets_commands
+
+    pass_config = click.make_pass_decorator(object, ensure=True)
+
+    @click.group()
+    @click.pass_context
+    def root(ctx):
+        if ctx.obj is None:
+            from amx.config import AMXConfig
+
+            ctx.obj = AMXConfig()
+
+    @root.group()
+    def db():
+        pass
+
+    register_db_assets_commands(db, pass_config=pass_config)
+    args = ["db", "assets", "reindex", "--profile", "prod", "-y"]
+    if force_flag:
+        args.append("--force")
+    result = CliRunner().invoke(root, args, catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    assert captured["force"] is force_flag


### PR DESCRIPTION
## Summary

A profile with 5,000 notebooks used to re-embed every chunk on
every \`/db ingest-assets\` call, even when only one notebook
changed. On cell-strategy chunking that's ~150k chunks per ingest;
minutes on a local CPU. PR-D adds an incremental gate so the
steady state only embeds what actually changed.

* **Schema** — \`remote_notebooks\` / \`remote_queries\` /
  \`remote_pipelines\` gain a \`last_embedded_hash TEXT\` column.
  Migration is idempotent. Schema descriptions added per house
  rule §5.
* **Logic** — \`AssetRAGStore.ingest_profile\` gains \`only_changed\`
  (default True). Drops documents whose row's current content hash
  already matches \`last_embedded_hash\`. Notebooks reuse
  \`source_hash\`; queries reuse \`sql_hash\`; pipelines derive
  sha256(libraries_json + latest_update_state). Hash stamping
  happens after a successful embed so crashes stay retriable.
* **Reindex** — \`reindex_profile(force=True)\` (default) wipes
  the collection AND \`last_embedded_hash\`. \`force=False\` is
  the cheap repair path.
* **Wiring** — PUT/DELETE on /chunking nulls the row's
  \`last_embedded_hash\` so the override re-embeds even when source
  is byte-identical. \`/db assets reindex --force\` flag exposed.

Other kinds (jobs / streams / streamlit_apps) pass through the
gate unfiltered — their content is metadata-only and cheap to
re-embed.

## Test plan

- [x] \`test_incremental_embed.py\` (14 tests):
      migration adds column to legacy DBs, schema descriptions
      cover new column, current/last hash helpers per kind,
      unhashable kinds bypass the gate, update/clear semantics,
      \`--force\` flag wiring.
- [x] \`test_local_schema_comments\` schema-description gate green
      for the three new columns.
- [x] Adjacent suites (assets / cli / search / web/assets_router)
      138 passed / 4 sentence-transformers skips.
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [x] Deployed to remote Studio; \`/db assets reindex --force\` on a
      live profile re-embeds everything; subsequent
      \`/db ingest-assets\` skips unchanged notebooks.

Closes the four-PR sequence (PR-A #557, PR-B #558, PR-C #559).