### PR TITLE
fix(cache): close two leaks that re-issued live queries without /refresh

### DIFF
--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -1683,7 +1683,7 @@ def cmd_cache_stats(cfg: AMXConfig, rest: list[str]) -> None:
     """/db cache-stats — aggregate metrics per cache table."""
     if rest:
         warn("/db cache-stats takes no arguments; ignoring extras.")
-    from amx.storage.cache_ops import cache_stats
+    from amx.storage.cache_ops import cache_runtime_counters, cache_stats
 
     stats = cache_stats()
     if not stats:
@@ -1706,6 +1706,34 @@ def cmd_cache_stats(cfg: AMXConfig, rest: list[str]) -> None:
         else:
             rows.append(["TTL", "none — rewritten by /sync"])
         render_table(f"Cache: {key}", ["Metric", "Value"], rows)
+
+    # In-process counters: wizard picker memo + drift-probe gate. These
+    # complement the persistent stats above — they show whether the
+    # session-local caches are actually serving repeat requests.
+    runtime = cache_runtime_counters()
+    listing_memo = runtime.get("listing_memo") or {}
+    if listing_memo:
+        memo_rows: list[list[str]] = []
+        for kind in ("catalogs", "databases"):
+            counts = listing_memo.get(kind) or {}
+            hits = int(counts.get("hit", 0))
+            misses = int(counts.get("miss", 0))
+            memo_rows.append([kind, str(hits), str(misses)])
+        render_table(
+            "Wizard listing memo (in-process)",
+            ["Kind", "Hits", "Misses"],
+            memo_rows,
+        )
+    drift = runtime.get("drift_probe") or {}
+    if drift:
+        render_table(
+            "Drift probe (in-process)",
+            ["Metric", "Value"],
+            [
+                ["Skipped (cache fresh)", str(int(drift.get("skipped_cache_fresh", 0)))],
+                ["Ran", str(int(drift.get("ran", 0)))],
+            ],
+        )
 
 
 def cmd_cache_clear(cfg: AMXConfig, rest: list[str]) -> None:

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -53,6 +53,40 @@ from amx.utils.logging import get_logger
 log = get_logger("db.connector")
 
 
+# Process-wide hit / miss tallies for the in-memory wizard memo. Exposed
+# through ``/db cache stats`` so the user can verify the wizard fix is
+# serving repeat picker invocations from memo rather than the live DB.
+# Counters reset on process restart (no persistence).
+_LISTING_MEMO_COUNTERS: dict[str, dict[str, int]] = {
+    "catalogs": {"hit": 0, "miss": 0},
+    "databases": {"hit": 0, "miss": 0},
+}
+
+
+def _bump_listing_memo_counter(kind: str, outcome: str) -> None:
+    """Increment the wizard-memo counter for ``kind`` / ``outcome``.
+
+    ``kind`` is ``"catalogs"`` or ``"databases"``; ``outcome`` is
+    ``"hit"`` or ``"miss"``. The dict is initialized with both keys so
+    no thread-safety dance is needed for simple incremements — the GIL
+    serializes the read-modify-write of the int.
+    """
+    try:
+        _LISTING_MEMO_COUNTERS[kind][outcome] += 1
+    except KeyError:
+        pass
+
+
+def get_listing_memo_counters() -> dict[str, dict[str, int]]:
+    """Snapshot the wizard-memo hit / miss tallies.
+
+    Consumed by ``amx.storage.cache_ops.cache_stats`` so ``/db cache
+    stats`` can surface wizard cache effectiveness alongside the
+    persistent cache counters.
+    """
+    return {kind: dict(counts) for kind, counts in _LISTING_MEMO_COUNTERS.items()}
+
+
 class DatabaseConnector:
     """Unified database connector that delegates backend-specific work to adapters."""
 
@@ -110,6 +144,17 @@ class DatabaseConnector:
         from amx.db.adapters import get_adapter
 
         self._adapter = get_adapter(self.cfg)
+
+        # In-process memo for wizard-driven catalog / database pickers.
+        # These two listings have no persistent cache table (unlike
+        # schemas_cache / column_comments_cache) so without a memo the
+        # wizard fires a fresh ``SHOW CATALOGS`` / ``SHOW DATABASES`` on
+        # every /run, /edit, /search sync invocation. The memo lasts for
+        # ``_listing_memo_ttl_seconds`` and is cleared on ``reconnect()``
+        # and on explicit ``invalidate_listing_memo()`` calls.
+        self._catalogs_memo: tuple[float, list[str]] | None = None
+        self._databases_memo: tuple[float, list[str]] | None = None
+        self._listing_memo_ttl_seconds: float = 300.0
 
     @property
     def engine(self) -> Engine:
@@ -208,13 +253,28 @@ class DatabaseConnector:
         ran ``pip install amx-cli`` without ``[databricks]``) reaches
         the catalog picker as an actionable hint instead of
         masquerading as "empty workspace".
+
+        Reads from the in-process memo when fresh — wizards that fire
+        catalog pickers on every /run / /edit / /search sync used to
+        re-issue ``SHOW CATALOGS`` each time. The memo is cleared by
+        ``reconnect()`` and ``invalidate_listing_memo()``.
         """
+        now = time.time()
+        if self._catalogs_memo is not None:
+            ts, cached = self._catalogs_memo
+            if (now - ts) < self._listing_memo_ttl_seconds:
+                _bump_listing_memo_counter("catalogs", "hit")
+                return list(cached)
         try:
-            return list(self._adapter.list_catalogs(self.engine))
+            result = list(self._adapter.list_catalogs(self.engine))
         except ImportError:
             raise
         except Exception:
+            _bump_listing_memo_counter("catalogs", "miss")
             return []
+        self._catalogs_memo = (now, result)
+        _bump_listing_memo_counter("catalogs", "miss")
+        return result
 
     def supports_catalogs(self) -> bool:
         """True when ``list_catalogs`` is meaningful for this adapter."""
@@ -235,15 +295,37 @@ class DatabaseConnector:
         ``pip install amx-cli`` without the right extra) reaches the
         runtime database picker as an actionable hint instead of
         masquerading as "no databases visible". Mirrors the symmetric
-        behaviour of :meth:`list_catalogs`.
+        behaviour of :meth:`list_catalogs`, including the in-process
+        memo so picker re-prompts don't hit the server.
         """
+        now = time.time()
+        if self._databases_memo is not None:
+            ts, cached = self._databases_memo
+            if (now - ts) < self._listing_memo_ttl_seconds:
+                _bump_listing_memo_counter("databases", "hit")
+                return list(cached)
         try:
-            return list(self._adapter.list_databases(self.engine))
+            result = list(self._adapter.list_databases(self.engine))
         except ImportError:
             raise
         except Exception as exc:
             log.debug("list_databases failed: %s", exc)
+            _bump_listing_memo_counter("databases", "miss")
             return []
+        self._databases_memo = (now, result)
+        _bump_listing_memo_counter("databases", "miss")
+        return result
+
+    def invalidate_listing_memo(self) -> None:
+        """Drop the in-process catalog/database memo.
+
+        Called by reconnect-aware paths after a config edit so the next
+        picker sees the live server state. The persistent caches
+        (``schemas_cache``, ``column_comments_cache``) are unaffected —
+        their invalidations happen via the storage-layer helpers.
+        """
+        self._catalogs_memo = None
+        self._databases_memo = None
 
     def reconnect(self) -> None:
         """Dispose the active engine so the next ``self.engine`` access
@@ -253,6 +335,9 @@ class DatabaseConnector:
         in-memory; without a reconnect, ``self._engine`` would still be
         bound to the old database and every subsequent listing query
         would target the wrong DB.
+
+        Also drops the catalogs/databases memo — the picker just changed
+        the active scope, so the cached listing may not apply any more.
         """
         if self._engine is not None:
             try:
@@ -260,6 +345,7 @@ class DatabaseConnector:
             except Exception as exc:
                 log.debug("engine.dispose() raised during reconnect: %s", exc)
         self._engine = None
+        self.invalidate_listing_memo()
 
     def list_schemas(self) -> list[str]:
         # Cache fast path: the schemas_cache holds (schema, comment)

--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -50,9 +50,21 @@ log = get_logger("search.drift")
 #: quick succession. Memo lives in-process only.
 _PROBE_COOLDOWN_SEC = 60.0
 
+#: Skip the probe entirely when the persistent ``schemas_cache`` for
+#: the profile was refreshed within this many seconds. Rationale: the
+#: probe's `_live_table_count` reads through the connector's cache-first
+#: path, so a recently filled cache gives the same answer as a fresh
+#: round-trip. Override via ``AMX_DRIFT_PROBE_MIN_AGE_SEC``.
+_SCHEMAS_CACHE_FRESH_SEC = 300.0
+
 #: Last probe timestamp per profile.
 _LAST_PROBE: dict[str, float] = {}
 _LAST_PROBE_LOCK = threading.Lock()
+
+#: Per-process counters surfaced via ``/db cache stats`` so the user
+#: can verify the cache-age gate is doing its job. Keys: ``skipped``
+#: (cache fresh, no probe), ``ran`` (probe actually ran).
+_DRIFT_PROBE_COUNTERS: dict[str, int] = {"skipped_cache_fresh": 0, "ran": 0}
 
 
 @dataclass
@@ -92,6 +104,61 @@ def _cooldown_blocks(profile: str, now: float) -> bool:
             return True
         _LAST_PROBE[profile] = now
         return False
+
+
+def _resolve_min_age_seconds() -> float:
+    """Read ``AMX_DRIFT_PROBE_MIN_AGE_SEC`` if set, else return the default.
+
+    Invalid values (non-numeric, negative) fall back to the default so a
+    typo in the env never wedges the probe.
+    """
+    raw = os.environ.get("AMX_DRIFT_PROBE_MIN_AGE_SEC", "").strip()
+    if not raw:
+        return _SCHEMAS_CACHE_FRESH_SEC
+    try:
+        value = float(raw)
+    except ValueError:
+        return _SCHEMAS_CACHE_FRESH_SEC
+    return value if value >= 0 else _SCHEMAS_CACHE_FRESH_SEC
+
+
+def _schemas_cache_recently_refreshed(
+    hs: Any,
+    profile: str,
+    max_age_seconds: float,
+    now: float,
+) -> bool:
+    """``True`` when this profile's ``schemas_cache`` was refreshed within
+    ``max_age_seconds``.
+
+    The drift probe's live count is itself served through the connector's
+    cache-first ``list_schemas`` / ``list_assets`` path, so a hot cache
+    yields the same answer as a fresh round-trip. Skipping the probe in
+    that window cuts the every-/ask DB hit without losing freshness: an
+    older cache (or an explicit ``/refresh``) still falls through.
+    """
+    if max_age_seconds <= 0:
+        return False
+    try:
+        with hs._connect() as conn:
+            row = conn.execute(
+                "SELECT MAX(fetched_at) AS ts FROM schemas_cache WHERE db_profile = ?",
+                (profile,),
+            ).fetchone()
+    except Exception as exc:
+        log.debug("schemas_cache freshness lookup failed for %s: %s", profile, exc)
+        return False
+    if row is None:
+        return False
+    ts = row["ts"] if hasattr(row, "keys") else (row[0] if row else None)
+    if ts is None:
+        return False
+    return (now - float(ts)) < max_age_seconds
+
+
+def get_drift_probe_counters() -> dict[str, int]:
+    """Snapshot the drift-probe skipped / ran tallies for ``/db cache stats``."""
+    return dict(_DRIFT_PROBE_COUNTERS)
 
 
 def _catalog_table_count(catalog_db_path: str, profile: str) -> int:
@@ -631,11 +698,27 @@ def fire_drift_probe(cfg, profiles: Iterable[str], *, force: bool = False) -> No
         fresh = list(profile_list)
     else:
         fresh = [p for p in profile_list if not _cooldown_blocks(p, now)]
+        # Second gate: even outside the 60s cooldown, skip when the
+        # persistent schemas_cache for this profile was filled in the
+        # last ``min_age`` seconds. The probe reads through the same
+        # cache, so a hot row would yield the same result as a fresh
+        # round-trip. An explicit /refresh invalidates the cache row
+        # (see ``invalidate_schemas_cache``) and naturally falls through.
+        min_age = _resolve_min_age_seconds()
+        if min_age > 0 and fresh:
+            kept: list[str] = []
+            for p in fresh:
+                if _schemas_cache_recently_refreshed(hs, p, min_age, now):
+                    _DRIFT_PROBE_COUNTERS["skipped_cache_fresh"] += 1
+                else:
+                    kept.append(p)
+            fresh = kept
     if not fresh:
         return
 
     def _worker() -> None:
         for profile in fresh:
+            _DRIFT_PROBE_COUNTERS["ran"] += 1
             result = _probe_one(cfg, profile, catalog_db_path)
             if force or result.drifted:
                 _enqueue_sync(cfg, profile)
@@ -648,4 +731,4 @@ def fire_drift_probe(cfg, profiles: Iterable[str], *, force: bool = False) -> No
     thread.start()
 
 
-__all__ = ["fire_drift_probe", "DriftResult"]
+__all__ = ["fire_drift_probe", "DriftResult", "get_drift_probe_counters"]

--- a/amx/storage/cache_ops.py
+++ b/amx/storage/cache_ops.py
@@ -263,6 +263,37 @@ def cache_stats() -> dict[str, CacheStat]:
         conn.close()
 
 
+def cache_runtime_counters() -> dict[str, Any]:
+    """Snapshot the in-process counters that complement the persistent
+    cache stats.
+
+    Returns two sections:
+
+    * ``listing_memo`` — wizard-driven ``list_catalogs`` / ``list_databases``
+      hit/miss tallies from the connector's in-memory memo.
+    * ``drift_probe`` — how many handshakes the cache-age gate skipped
+      vs how many actually ran a live count.
+
+    Imports are deferred so this helper stays cheap to call when those
+    modules haven't been loaded yet (e.g. ``/db cache stats`` before
+    any DB connection has been opened).
+    """
+    out: dict[str, Any] = {"listing_memo": {}, "drift_probe": {}}
+    try:
+        from amx.db.connector import get_listing_memo_counters
+
+        out["listing_memo"] = get_listing_memo_counters()
+    except Exception:
+        pass
+    try:
+        from amx.search.drift import get_drift_probe_counters
+
+        out["drift_probe"] = get_drift_probe_counters()
+    except Exception:
+        pass
+    return out
+
+
 def _expand_types(types: list[str] | None) -> list[str]:
     if not types:
         return list(CACHE_TYPES)

--- a/amx/web/routers/db_cache.py
+++ b/amx/web/routers/db_cache.py
@@ -23,6 +23,7 @@ from amx.storage.cache_ops import (
     CACHE_TYPES,
     cache_clear,
     cache_inventory,
+    cache_runtime_counters,
     cache_stats,
 )
 
@@ -64,9 +65,14 @@ def show(
 
 @router.get("/stats")
 def stats() -> dict[str, Any]:
-    """Aggregate metrics per cache table."""
+    """Aggregate metrics per cache table.
+
+    Includes a ``runtime`` section that surfaces the in-process
+    counters added alongside the wizard memo and the cache-age-aware
+    drift probe so Studio can show how often each gate fired.
+    """
     raw = cache_stats()
-    return {
+    payload: dict[str, Any] = {
         key: {
             "table": stat.table,
             "total_rows": stat.total_rows,
@@ -79,6 +85,8 @@ def stats() -> dict[str, Any]:
         }
         for key, stat in raw.items()
     }
+    payload["runtime"] = cache_runtime_counters()
+    return payload
 
 
 @router.post("/clear")

--- a/tests/test_listing_memo_and_drift_gate.py
+++ b/tests/test_listing_memo_and_drift_gate.py
@@ -1,0 +1,353 @@
+"""Tests for the in-process wizard memo + the drift-probe cache-age gate.
+
+Two cache leaks the user reported as "tables aren't cached, the DB
+still gets a query even without /refresh":
+
+1. The wizard's ``list_catalogs`` / ``list_databases`` had no cache at
+   all. Every picker invocation fired a fresh ``SHOW CATALOGS`` /
+   ``SHOW DATABASES`` even when the same connector had just answered
+   the same question. ``DatabaseConnector`` now memos those listings
+   in-process for ``_listing_memo_ttl_seconds`` (default 5 minutes)
+   and clears the memo on ``reconnect()``.
+
+2. ``fire_drift_probe`` was rate-limited only by a 60-second per-profile
+   cooldown. Past the cooldown, every ``/ask`` handshake re-issued the
+   probe even when ``schemas_cache`` was minutes old and would give
+   the same answer. The probe now also skips when the persistent
+   schema cache for the profile was refreshed within
+   ``_resolve_min_age_seconds()`` (default 5 minutes).
+
+These tests pin both behaviors at the connector / drift module level
+without standing up a live database — the adapter is stubbed.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from amx.config import DBConfig
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@dataclass
+class _StubAdapter:
+    """Records every ``list_catalogs`` / ``list_databases`` call.
+
+    Returns canned data so the connector code under test never opens
+    a real engine. The connector's ``self.engine`` property is itself
+    monkey-patched to skip the SQLAlchemy round-trip.
+    """
+
+    name: str = "stub"
+    catalog_calls: int = 0
+    database_calls: int = 0
+    catalogs: list[str] | None = None
+    databases: list[str] | None = None
+
+    def list_catalogs(self, _engine: Any) -> list[str]:
+        self.catalog_calls += 1
+        return list(self.catalogs or ["main", "dev"])
+
+    def list_databases(self, _engine: Any) -> list[str]:
+        self.database_calls += 1
+        return list(self.databases or ["analytics", "raw"])
+
+
+def _stub_connector(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Build a ``DatabaseConnector`` with stubbed adapter + engine.
+
+    The connector lazy-imports ``ensure_backend_driver`` and
+    ``get_adapter`` inside ``__init__``; patch them at their source
+    modules so the real driver-install + adapter wiring is skipped.
+    """
+    from amx.db import connector as connector_mod
+
+    monkeypatch.setattr("amx.db.drivers.ensure_backend_driver", lambda _: None)
+    monkeypatch.setattr("amx.db.adapters.get_adapter", lambda _cfg: _StubAdapter())
+
+    db = connector_mod.DatabaseConnector(
+        DBConfig(backend="postgresql"),
+        profile_name="stub-profile",
+    )
+    # Bypass real engine construction — list_* never touches the engine
+    # except to pass it through to the adapter, and the stub ignores it.
+    db._engine = MagicMock(name="engine")
+    return db
+
+
+def test_list_catalogs_serves_repeat_calls_from_memo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two back-to-back wizard calls must hit the adapter once."""
+    from amx.db import connector as connector_mod
+
+    # Reset process-wide counters so prior tests don't pollute the count.
+    connector_mod._LISTING_MEMO_COUNTERS["catalogs"] = {"hit": 0, "miss": 0}
+
+    db = _stub_connector(monkeypatch)
+    first = db.list_catalogs()
+    second = db.list_catalogs()
+    assert first == second == ["main", "dev"]
+    assert db._adapter.catalog_calls == 1, "second call hit the adapter again"
+    snap = connector_mod.get_listing_memo_counters()
+    assert snap["catalogs"]["miss"] == 1
+    assert snap["catalogs"]["hit"] == 1
+
+
+def test_list_databases_serves_repeat_calls_from_memo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same contract as catalogs — wizard re-prompts don't re-list."""
+    from amx.db import connector as connector_mod
+
+    connector_mod._LISTING_MEMO_COUNTERS["databases"] = {"hit": 0, "miss": 0}
+
+    db = _stub_connector(monkeypatch)
+    db.list_databases()
+    db.list_databases()
+    db.list_databases()
+    assert db._adapter.database_calls == 1
+    snap = connector_mod.get_listing_memo_counters()
+    assert snap["databases"]["miss"] == 1
+    assert snap["databases"]["hit"] == 2
+
+
+def test_listing_memo_respects_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Past the TTL the memo expires and the adapter is hit again."""
+    db = _stub_connector(monkeypatch)
+    db._listing_memo_ttl_seconds = 0.01
+
+    db.list_catalogs()
+    time.sleep(0.02)
+    db.list_catalogs()
+    assert db._adapter.catalog_calls == 2
+
+
+def test_reconnect_clears_listing_memo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-pinning the database (the picker mutates ``cfg`` and calls
+    reconnect) must drop the memo — the listing for the new scope can
+    differ from the old one."""
+    db = _stub_connector(monkeypatch)
+    db.list_databases()
+    assert db._adapter.database_calls == 1
+
+    # ``reconnect`` disposes the engine; supply a mock that allows it.
+    db._engine = MagicMock()
+    db.reconnect()
+    db._engine = MagicMock(name="engine-after-reconnect")
+
+    db.list_databases()
+    assert db._adapter.database_calls == 2, "memo survived reconnect()"
+
+
+def test_invalidate_listing_memo_drops_both_kinds(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = _stub_connector(monkeypatch)
+    db.list_catalogs()
+    db.list_databases()
+    db.invalidate_listing_memo()
+    db.list_catalogs()
+    db.list_databases()
+    assert db._adapter.catalog_calls == 2
+    assert db._adapter.database_calls == 2
+
+
+def test_list_catalogs_import_error_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``ImportError`` from a missing optional driver must still reach the
+    catalog picker as the actionable hint — the memo path doesn't
+    swallow it."""
+    db = _stub_connector(monkeypatch)
+
+    def _raises(_engine: Any) -> list[str]:
+        raise ImportError("install the [databricks] extra")
+
+    db._adapter.list_catalogs = _raises  # type: ignore[assignment]
+
+    with pytest.raises(ImportError):
+        db.list_catalogs()
+
+
+# ── Drift probe cache-age gate ─────────────────────────────────────────
+
+
+def _make_history_store(tmp_path: Path) -> SQLiteHistoryStore:
+    store = SQLiteHistoryStore(tmp_path / "history.db")
+    store.init()
+    return store
+
+
+def test_schemas_cache_recently_refreshed_true_when_fresh(tmp_path: Path) -> None:
+    from amx.search import drift
+
+    store = _make_history_store(tmp_path)
+    # Stamp a row "now" so the freshness check passes.
+    store.save_schemas_cache(
+        db_profile="prof-a",
+        database="db1",
+        catalog="",
+        entries={"public": None},
+        bulk_filled=True,
+    )
+    now = time.time()
+    assert drift._schemas_cache_recently_refreshed(store, "prof-a", 300.0, now) is True
+
+
+def test_schemas_cache_recently_refreshed_false_when_stale(tmp_path: Path) -> None:
+    from amx.search import drift
+
+    store = _make_history_store(tmp_path)
+    store.save_schemas_cache(
+        db_profile="prof-a",
+        database="db1",
+        catalog="",
+        entries={"public": None},
+        bulk_filled=True,
+    )
+    # Pretend ten minutes elapsed since the stamp.
+    assert (
+        drift._schemas_cache_recently_refreshed(store, "prof-a", 60.0, time.time() + 600.0) is False
+    )
+
+
+def test_schemas_cache_recently_refreshed_false_when_missing(tmp_path: Path) -> None:
+    from amx.search import drift
+
+    store = _make_history_store(tmp_path)
+    assert (
+        drift._schemas_cache_recently_refreshed(store, "no-such-profile", 300.0, time.time())
+        is False
+    )
+
+
+def test_drift_probe_skipped_when_schemas_cache_fresh(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Past the 60s cooldown the cache-age gate is the new short-circuit.
+
+    Stamp a schemas_cache row "now" for the profile, then call
+    ``fire_drift_probe`` — the worker thread must not spawn and the
+    skipped counter must increment.
+    """
+    monkeypatch.delenv("AMX_SKIP_DRIFT_PROBE", raising=False)
+    monkeypatch.delenv("AMX_DRIFT_PROBE_MIN_AGE_SEC", raising=False)
+    from amx.search import drift
+
+    store = _make_history_store(tmp_path)
+    store.save_schemas_cache(
+        db_profile="prof-a",
+        database="db1",
+        catalog="",
+        entries={"public": None},
+        bulk_filled=True,
+    )
+    import amx.storage.sqlite_store as ss
+
+    monkeypatch.setattr(ss, "_store", store, raising=False)
+    monkeypatch.setattr(ss, "history_store", lambda: store)
+
+    drift._LAST_PROBE.clear()
+    drift._DRIFT_PROBE_COUNTERS["skipped_cache_fresh"] = 0
+    drift._DRIFT_PROBE_COUNTERS["ran"] = 0
+
+    spawned: list[str] = []
+
+    def _capture_thread(*args, **kwargs):
+        spawned.append(kwargs.get("name") or "")
+        return MagicMock()
+
+    monkeypatch.setattr(drift.threading, "Thread", _capture_thread)
+    drift.fire_drift_probe(None, ["prof-a"])
+
+    assert spawned == [], "probe ran despite a fresh schemas_cache row"
+    assert drift._DRIFT_PROBE_COUNTERS["skipped_cache_fresh"] == 1
+
+
+def test_drift_probe_runs_when_schemas_cache_stale(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When the cache is older than the gate window the probe must fire."""
+    monkeypatch.delenv("AMX_SKIP_DRIFT_PROBE", raising=False)
+    monkeypatch.setenv("AMX_DRIFT_PROBE_MIN_AGE_SEC", "1")
+    from amx.search import drift
+
+    store = _make_history_store(tmp_path)
+    store.save_schemas_cache(
+        db_profile="prof-b",
+        database="db1",
+        catalog="",
+        entries={"public": None},
+        bulk_filled=True,
+    )
+    import amx.storage.sqlite_store as ss
+
+    monkeypatch.setattr(ss, "history_store", lambda: store)
+
+    drift._LAST_PROBE.clear()
+    drift._DRIFT_PROBE_COUNTERS["skipped_cache_fresh"] = 0
+    drift._DRIFT_PROBE_COUNTERS["ran"] = 0
+
+    # Wait past the 1-second window so the cache is "stale" per the gate.
+    time.sleep(1.2)
+
+    spawned: list[str] = []
+
+    def _capture_thread(*args, **kwargs):
+        spawned.append(kwargs.get("name") or "")
+        m = MagicMock()
+        # Capture the worker so we can run it inline and observe the
+        # ran counter without spawning a real thread.
+        target = kwargs.get("target")
+        if callable(target):
+            target()
+        return m
+
+    monkeypatch.setattr(drift.threading, "Thread", _capture_thread)
+
+    # Stub the probe internals so the worker doesn't actually open
+    # a connector — we only care that the gate let it through.
+    monkeypatch.setattr(
+        drift, "_probe_one", lambda *a, **kw: drift.DriftResult("prof-b", 0, 0, False)
+    )
+    monkeypatch.setattr(drift, "_enqueue_sync", lambda *a, **kw: None)
+
+    drift.fire_drift_probe(None, ["prof-b"])
+
+    assert spawned, "probe was skipped despite a stale schemas_cache row"
+    assert drift._DRIFT_PROBE_COUNTERS["ran"] == 1
+    assert drift._DRIFT_PROBE_COUNTERS["skipped_cache_fresh"] == 0
+
+
+def test_resolve_min_age_seconds_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from amx.search import drift
+
+    monkeypatch.setenv("AMX_DRIFT_PROBE_MIN_AGE_SEC", "42")
+    assert drift._resolve_min_age_seconds() == 42.0
+
+    monkeypatch.setenv("AMX_DRIFT_PROBE_MIN_AGE_SEC", "not-a-number")
+    assert drift._resolve_min_age_seconds() == drift._SCHEMAS_CACHE_FRESH_SEC
+
+    monkeypatch.setenv("AMX_DRIFT_PROBE_MIN_AGE_SEC", "-5")
+    assert drift._resolve_min_age_seconds() == drift._SCHEMAS_CACHE_FRESH_SEC
+
+    monkeypatch.delenv("AMX_DRIFT_PROBE_MIN_AGE_SEC", raising=False)
+    assert drift._resolve_min_age_seconds() == drift._SCHEMAS_CACHE_FRESH_SEC
+
+
+def test_cache_runtime_counters_aggregates_both_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``cache_runtime_counters`` is what ``/db cache stats`` reads."""
+    from amx.db import connector as connector_mod
+    from amx.search import drift
+    from amx.storage.cache_ops import cache_runtime_counters
+
+    connector_mod._LISTING_MEMO_COUNTERS["catalogs"] = {"hit": 3, "miss": 1}
+    connector_mod._LISTING_MEMO_COUNTERS["databases"] = {"hit": 0, "miss": 2}
+    drift._DRIFT_PROBE_COUNTERS["skipped_cache_fresh"] = 5
+    drift._DRIFT_PROBE_COUNTERS["ran"] = 7
+
+    snap = cache_runtime_counters()
+    assert snap["listing_memo"]["catalogs"] == {"hit": 3, "miss": 1}
+    assert snap["listing_memo"]["databases"] == {"hit": 0, "miss": 2}
+    assert snap["drift_probe"] == {"skipped_cache_fresh": 5, "ran": 7}


### PR DESCRIPTION
## Summary

Two cache paths in AMX still hit the live DB on every invocation even
when no ``/refresh`` had been issued. Both are closed here.

- **Wizard pickers** — ``DatabaseConnector.list_catalogs`` and
  ``list_databases`` had no cache. Every ``/run`` / ``/edit`` /
  ``/search sync`` (and any other wizard that opens a picker) fired
  ``SHOW CATALOGS`` / ``SHOW DATABASES``. The connector now memos
  both listings in-process for 5 minutes and clears the memo on
  ``reconnect()``.
- **Drift probe** — ``fire_drift_probe`` was only rate-limited by a
  60-second cooldown. Past the cooldown, every ``/ask`` handshake
  re-issued the probe even when the persistent ``schemas_cache``
  was minutes old and would give the same answer. The probe now
  also skips when the cache for the profile was refreshed within
  ``AMX_DRIFT_PROBE_MIN_AGE_SEC`` (default 300s).
- **Observability** — ``/db cache stats`` and ``GET /api/db/cache/stats``
  now surface hit/miss counters for the wizard memo and the
  cache-age gate so the fix is verifiable without strace.

The Studio sidebar hydration loops the explore agent flagged as
"N+1" are NOT a real leak: ``get_table_comment`` and
``get_schema_comment`` already short-circuit through the
``_populate_*_metadata_cache`` bulk fill, so the loop is one bulk
query plus cache hits. Likewise the existing
``batch_get_table_comments`` adapter hook is already wired. Nothing
to change there.

## Test plan
- [x] ``pytest tests/test_listing_memo_and_drift_gate.py`` — 13 new tests covering memo TTL, ``reconnect()`` clearing, ``ImportError`` propagation, drift gate skipped/ran outcomes, and env-var override.
- [x] ``pytest tests/test_catalog_cache_hardening.py tests/test_runtime_pickers.py tests/test_bulk_schema_metadata_duckdb.py tests/test_db_cache_ops.py tests/test_live_db_cache_first.py tests/test_databricks_wizard_catalog_required.py tests/test_column_comments_cache.py`` — 63 adjacent tests still green.
- [x] ``ruff check`` + ``ruff format --check`` clean on all changed files.
- [x] ``mypy amx/...`` — no new errors introduced (5 pre-existing errors on ``main`` unchanged).
- [x] No ``paid`` literal, no Turkish text, no POSIX-only assumptions in the diff.
- [x] ``deploy.sh`` ran before this PR — Studio at studio.amxcli.com / 127.0.0.1:47821 reflects the new behavior.

## Verifying live
1. Open the catalog/database picker twice in one REPL session — only the first run hits the DB; ``/db cache-stats`` shows ``Wizard listing memo`` with hits incremented.
2. Run ``/ask`` twice within five minutes — the second handshake skips the drift probe; ``/db cache-stats`` shows ``Skipped (cache fresh)`` count incremented.
3. ``AMX_DRIFT_PROBE_MIN_AGE_SEC=0`` reverts to the old always-probe behavior; useful while sanity-checking against a warehouse that genuinely is drifting.