### PR TITLE
fix(cache): purge tombstones + Sync all warms every cache table

### DIFF
--- a/amx/config.py
+++ b/amx/config.py
@@ -2894,6 +2894,22 @@ class AMXConfig:
                 self.active_db_profiles = [self.active_db_profile]
             elif not self.active_db_profile:
                 self.active_db_profiles = []
+        # Cache tombstone purge — runs outside the config transaction
+        # so a sqlite hiccup on the cache side cannot block the config
+        # write. Without this, the just-removed profile's rows linger
+        # in catalog_entities / schemas_cache / column_comments_cache
+        # forever and the Studio Catalog cache page reports a phantom
+        # third profile.
+        try:
+            from amx.storage.cache_ops import cache_clear
+
+            cache_clear(profile=name)
+        except Exception:
+            # Best-effort cleanup; the startup sweep + read-side
+            # tombstone filter still hide the orphans even if this
+            # path fails (e.g. history store not yet initialised in
+            # an edge-case load order).
+            pass
 
     def apply_active_llm_profile(self) -> None:
         name = self.active_llm_profile or "default"

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -370,7 +370,7 @@ class DatabaseConnector:
         if live is None and self._is_cache_warm():
             cached = self._list_schemas_from_cache(catalog)
             log.info(
-                "list_schemas: cache-only mode for profile=%r catalog=%r — "
+                "list_schemas: cache-only mode for profile=%r catalog=%r - "
                 "served %d cached rows, no live DB query",
                 self.profile_name,
                 catalog,
@@ -760,7 +760,13 @@ class DatabaseConnector:
         as cold; we never starve a caller because the bookkeeping
         layer hiccuped.
         """
-        if not self.profile_name:
+        # Defensive ``getattr`` — some test paths build connector-like
+        # objects without going through ``__init__`` (subclasses,
+        # specced MagicMocks, the metadata-mode stub in
+        # tests/test_regressions.py). Treat a missing attribute the
+        # same as an unset profile name: legacy fallback path.
+        profile_name = getattr(self, "profile_name", "") or ""
+        if not profile_name:
             return False
         try:
             from amx.search.catalog import SearchCatalog
@@ -768,7 +774,7 @@ class DatabaseConnector:
             cat = SearchCatalog.from_history_store()
             if cat is None:
                 return False
-            return bool(cat.is_profile_fully_synced(self.profile_name))
+            return bool(cat.is_profile_fully_synced(profile_name))
         except Exception:
             return False
 
@@ -1109,7 +1115,7 @@ class DatabaseConnector:
         # gap with a live DB call.
         if self._is_cache_warm():
             log.info(
-                "get_table_comment: cache-only mode missed %s.%s for profile=%r — "
+                "get_table_comment: cache-only mode missed %s.%s for profile=%r - "
                 "returning None (re-sync the profile to populate)",
                 schema,
                 table,
@@ -1152,7 +1158,7 @@ class DatabaseConnector:
         # the cache; the warm flag now forces the empty result.
         if self._is_cache_warm():
             log.info(
-                "get_column_comments: cache-only mode missed %s.%s for profile=%r — "
+                "get_column_comments: cache-only mode missed %s.%s for profile=%r - "
                 "returning {} (re-sync the profile to populate)",
                 schema,
                 table,
@@ -1211,7 +1217,7 @@ class DatabaseConnector:
         if self._is_cache_warm():
             log.info(
                 "get_schema_comment: cache-only mode missed %s in catalog=%r for "
-                "profile=%r — returning None (re-sync to populate)",
+                "profile=%r - returning None (re-sync to populate)",
                 schema,
                 catalog,
                 self.profile_name,

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -376,9 +376,7 @@ class DatabaseConnector:
                 catalog,
                 len(cached),
             )
-            return self._apply_pinned_schema_filter(
-                [name for name, _ in cached]
-            )
+            return self._apply_pinned_schema_filter([name for name, _ in cached])
         if live is None and self._populate_catalogs_cache(catalog):
             cached = self._list_schemas_from_cache(catalog)
             if cached:

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -360,6 +360,25 @@ class DatabaseConnector:
             cached = self._list_schemas_from_cache(catalog)
             if cached:
                 live = [name for name, _ in cached]
+        # Cache-only gate: when a full ``Sync all`` has warmed this
+        # profile's caches, the schemas_cache is authoritative. Skip
+        # the live-DB fallthrough entirely — a missing row means the
+        # sync was incomplete and the caller should re-sync, not pay
+        # for a silent live round-trip. Anything outside this gate
+        # falls through to the original cache-first / live-fallback
+        # path so non-synced profiles behave exactly as before.
+        if live is None and self._is_cache_warm():
+            cached = self._list_schemas_from_cache(catalog)
+            log.info(
+                "list_schemas: cache-only mode for profile=%r catalog=%r — "
+                "served %d cached rows, no live DB query",
+                self.profile_name,
+                catalog,
+                len(cached),
+            )
+            return self._apply_pinned_schema_filter(
+                [name for name, _ in cached]
+            )
         if live is None and self._populate_catalogs_cache(catalog):
             cached = self._list_schemas_from_cache(catalog)
             if cached:
@@ -721,6 +740,40 @@ class DatabaseConnector:
         """Database scope the cache narrows on within a profile."""
         return str(getattr(self.cfg, "database", "") or getattr(self.cfg, "catalog", "") or "")
 
+    def _is_cache_warm(self) -> bool:
+        """Return ``True`` when the cached metadata for this connector's
+        profile can be trusted as complete — set by a finished
+        ``Sync all`` that warmed every cache table for the profile
+        (``catalog_entities``, ``schemas_cache``, and
+        ``column_comments_cache``). When True, the cache-aware read
+        paths (:meth:`list_schemas`, :meth:`get_table_comment`,
+        :meth:`get_column_comments`, :meth:`get_schema_comment`) MUST
+        NOT fall back to a live DB round-trip on a cache miss — they
+        serve the empty result instead and log a sync-gap warning so
+        a missing row surfaces as a bug to fix in the sync, not as a
+        silent latency spike.
+
+        Anonymous connectors (no ``profile_name``) always return
+        ``False`` so direct ``DBConfig`` constructions in tests keep
+        the legacy fallback behaviour.
+
+        Failures are swallowed and surface as ``False`` — a cache
+        without the new state columns (legacy database) is treated
+        as cold; we never starve a caller because the bookkeeping
+        layer hiccuped.
+        """
+        if not self.profile_name:
+            return False
+        try:
+            from amx.search.catalog import SearchCatalog
+
+            cat = SearchCatalog.from_history_store()
+            if cat is None:
+                return False
+            return bool(cat.is_profile_fully_synced(self.profile_name))
+        except Exception:
+            return False
+
     def _lookup_column_comments_cache(self, schema: str, table: str) -> dict[str, Any] | None:
         """Return a cached ``{table_comment, columns, kind, ...}`` or None."""
         try:
@@ -1052,6 +1105,19 @@ class DatabaseConnector:
         cached = self._lookup_column_comments_cache(schema, table)
         if cached is not None:
             return cached.get("table_comment")
+        # Cache-only gate: see :meth:`list_schemas` for the rationale.
+        # When a Sync all has warmed this profile, missing cache rows
+        # imply a sync gap — serve ``None`` rather than masking the
+        # gap with a live DB call.
+        if self._is_cache_warm():
+            log.info(
+                "get_table_comment: cache-only mode missed %s.%s for profile=%r — "
+                "returning None (re-sync the profile to populate)",
+                schema,
+                table,
+                self.profile_name,
+            )
+            return None
         # Try a single round-trip bulk source for the whole schema; on
         # success every sibling table is now warm in the cache too. If
         # the backend has no bulk source, drop to the per-table
@@ -1082,6 +1148,19 @@ class DatabaseConnector:
         cached = self._lookup_column_comments_cache(schema, table)
         if cached is not None and cached.get("columns"):
             return dict(cached["columns"])
+        # Cache-only gate — see :meth:`list_schemas`. The original
+        # Studio complaint was specifically this method silently
+        # hitting live DB after a Sync all had ostensibly populated
+        # the cache; the warm flag now forces the empty result.
+        if self._is_cache_warm():
+            log.info(
+                "get_column_comments: cache-only mode missed %s.%s for profile=%r — "
+                "returning {} (re-sync the profile to populate)",
+                schema,
+                table,
+                self.profile_name,
+            )
+            return {}
         if self._populate_schema_metadata_cache(schema):
             cached = self._lookup_column_comments_cache(schema, table)
             if cached is not None and cached.get("columns"):
@@ -1130,6 +1209,16 @@ class DatabaseConnector:
         cached = self._lookup_schemas_cache(catalog, schema)
         if cached is not None:
             return cached.get("schema_comment")
+        # Cache-only gate — see :meth:`list_schemas`.
+        if self._is_cache_warm():
+            log.info(
+                "get_schema_comment: cache-only mode missed %s in catalog=%r for "
+                "profile=%r — returning None (re-sync to populate)",
+                schema,
+                catalog,
+                self.profile_name,
+            )
+            return None
         # Cold path: bulk-fill the whole catalog in one shot so the
         # sidebar's per-schema loop becomes O(1) cache hits after the
         # first call. If the adapter has no bulk source, drop to the

--- a/amx/search/_catalog/entity_crud.py
+++ b/amx/search/_catalog/entity_crud.py
@@ -431,14 +431,24 @@ class EntityCrudMixin:
         }
 
     def is_profile_fully_synced(self, db_profile: str) -> bool:
-        """``True`` iff a full skeleton sync has ever finished for
-        *db_profile*. Reads ``catalog_profile_state``; requires
-        ``state='done'`` only. The cache NEVER auto-expires — pre-PR
-        the helper rejected snapshots older than 7 days, which forced
-        sidebar / Ask / drift surfaces to fall through to the live DB
-        on any week-old profile. The user's contract now: keep
-        cached data forever, surface a UI staleness pill instead of
-        invalidating.
+        """``True`` iff every cache surface for *db_profile* has been
+        warmed by a successful ``Sync all``. Tightened from "skeleton
+        done" to "skeleton + schemas + columns all stamped" so the
+        cache-only read mode in
+        :meth:`amx.db.connector.DatabaseConnector._is_cache_warm`
+        only kicks in when the next read can actually be served from
+        cache. Previously a profile with only the skeleton populated
+        (catalog_entities) would surface as fully synced and the
+        cache-only gate would route ``get_column_comments`` to an
+        empty cache row — starving the caller — because
+        ``column_comments_cache`` had never been warmed.
+
+        Reads ``catalog_profile_state``. The cache NEVER auto-expires
+        — pre-PR the helper rejected snapshots older than 7 days,
+        which forced sidebar / Ask / drift surfaces to fall through
+        to the live DB on any week-old profile. The user's contract
+        now: keep cached data forever, surface a UI staleness pill
+        instead of invalidating.
 
         Returns ``False`` when:
         - the table doesn't exist (legacy catalog from a pre-v0.15
@@ -446,16 +456,22 @@ class EntityCrudMixin:
           run a fresh skeleton sync)
         - the state row exists but `state != 'done'` (sync still
           running, failed, or never started)
+        - any of ``last_skeleton_sync_at`` / ``last_schemas_sync_at``
+          / ``last_columns_sync_at`` is NULL (a partial sync — the
+          caller must keep the live-DB fallback armed)
 
-        Use :meth:`get_profile_state` from ``SyncMixin`` to read
-        ``last_full_sync_at`` when a UI surface wants to render a
-        "synced N days ago" pill.
+        Use :meth:`get_profile_state` from ``SyncMixin`` to read the
+        individual timestamps when a UI surface wants to render a
+        "synced N days ago" pill or a per-surface staleness chip.
         """
         try:
             with self._connect() as conn:
                 row = conn.execute(
                     """
-                    SELECT state, last_full_sync_at
+                    SELECT state, last_full_sync_at,
+                           last_skeleton_sync_at,
+                           last_schemas_sync_at,
+                           last_columns_sync_at
                     FROM catalog_profile_state
                     WHERE db_profile = ?
                     """,
@@ -466,8 +482,21 @@ class EntityCrudMixin:
         if not row:
             return False
         state = str(row["state"] or "")
-        last = row["last_full_sync_at"]
-        return state == "done" and last is not None
+        if state != "done":
+            return False
+        # All four timestamps are required. ``last_full_sync_at``
+        # remains a hard gate for back-compat (any pre-existing logic
+        # that reads it directly stays consistent); the three
+        # per-surface stamps are the new contract.
+        return all(
+            row[col] is not None
+            for col in (
+                "last_full_sync_at",
+                "last_skeleton_sync_at",
+                "last_schemas_sync_at",
+                "last_columns_sync_at",
+            )
+        )
 
     def fetch_distinct_databases(self, db_profile: str) -> list[dict]:
         """Return distinct ``database_name`` rows for *db_profile* with

--- a/amx/search/_catalog/sync.py
+++ b/amx/search/_catalog/sync.py
@@ -260,19 +260,13 @@ class SyncMixin:
                 float(row["last_full_sync_at"]) if row["last_full_sync_at"] else None
             ),
             "last_skeleton_sync_at": (
-                float(row["last_skeleton_sync_at"])
-                if row["last_skeleton_sync_at"]
-                else None
+                float(row["last_skeleton_sync_at"]) if row["last_skeleton_sync_at"] else None
             ),
             "last_schemas_sync_at": (
-                float(row["last_schemas_sync_at"])
-                if row["last_schemas_sync_at"]
-                else None
+                float(row["last_schemas_sync_at"]) if row["last_schemas_sync_at"] else None
             ),
             "last_columns_sync_at": (
-                float(row["last_columns_sync_at"])
-                if row["last_columns_sync_at"]
-                else None
+                float(row["last_columns_sync_at"]) if row["last_columns_sync_at"] else None
             ),
             "last_error": str(row["last_error"] or ""),
         }

--- a/amx/search/_catalog/sync.py
+++ b/amx/search/_catalog/sync.py
@@ -153,21 +153,31 @@ class SyncMixin:
 
     def finish_skeleton_sync(self, db_profile: str, *, ok: bool, error: str = "") -> None:
         """Terminal state for a skeleton sync. ``ok=True`` flips
-        ``state='done'`` and stamps ``last_full_sync_at`` so the
-        cache-first gate trusts the catalog. ``ok=False`` flips to
-        ``state='failed'`` and records ``last_error`` for the
-        freshness pill's Retry surface — the catalog stays usable as
-        a fallback but readers know to treat it as partial."""
+        ``state='done'`` and stamps ``last_full_sync_at`` /
+        ``last_skeleton_sync_at`` so the cache-first gate trusts the
+        catalog. ``ok=False`` flips to ``state='failed'`` and records
+        ``last_error`` for the freshness pill's Retry surface — the
+        catalog stays usable as a fallback but readers know to treat
+        it as partial.
+
+        ``last_schemas_sync_at`` and ``last_columns_sync_at`` are not
+        touched here — they're stamped by
+        :meth:`mark_schemas_sync_done` /
+        :meth:`mark_columns_sync_done` as each cache surface is warmed
+        so the cache-only read gate can require all three to be
+        non-null before it suppresses the live-DB fallback.
+        """
         now = time.time()
         if ok:
             with self._connect() as conn:
                 conn.execute(
                     """
                     UPDATE catalog_profile_state
-                    SET state='done', finished_at=?, last_full_sync_at=?, last_error=''
+                    SET state='done', finished_at=?, last_full_sync_at=?,
+                        last_skeleton_sync_at=?, last_error=''
                     WHERE db_profile = ?
                     """,
-                    (now, now, db_profile),
+                    (now, now, now, db_profile),
                 )
         else:
             with self._connect() as conn:
@@ -180,6 +190,38 @@ class SyncMixin:
                     (now, str(error)[:4000], db_profile),
                 )
 
+    def mark_schemas_sync_done(self, db_profile: str) -> None:
+        """Stamp ``last_schemas_sync_at`` after a successful warm pass
+        through ``schemas_cache``. Caller's responsibility to ensure
+        the cache has actually been populated for the profile's
+        databases — this method just records the timestamp.
+        """
+        now = time.time()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO catalog_profile_state (db_profile, last_schemas_sync_at)
+                VALUES (?, ?)
+                ON CONFLICT(db_profile) DO UPDATE SET last_schemas_sync_at = excluded.last_schemas_sync_at
+                """,
+                (db_profile, now),
+            )
+
+    def mark_columns_sync_done(self, db_profile: str) -> None:
+        """Stamp ``last_columns_sync_at`` after a successful warm pass
+        through ``column_comments_cache``. Mirror of
+        :meth:`mark_schemas_sync_done`."""
+        now = time.time()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO catalog_profile_state (db_profile, last_columns_sync_at)
+                VALUES (?, ?)
+                ON CONFLICT(db_profile) DO UPDATE SET last_columns_sync_at = excluded.last_columns_sync_at
+                """,
+                (db_profile, now),
+            )
+
     def get_profile_state(self, db_profile: str) -> dict[str, Any]:
         """Read the current state row. Returns the default ``none``
         shape when the profile has never been synced."""
@@ -187,7 +229,9 @@ class SyncMixin:
             row = conn.execute(
                 """
                 SELECT state, total_tables, processed_tables,
-                       started_at, finished_at, last_full_sync_at, last_error
+                       started_at, finished_at, last_full_sync_at,
+                       last_skeleton_sync_at, last_schemas_sync_at,
+                       last_columns_sync_at, last_error
                 FROM catalog_profile_state
                 WHERE db_profile = ?
                 """,
@@ -201,6 +245,9 @@ class SyncMixin:
                 "started_at": None,
                 "finished_at": None,
                 "last_full_sync_at": None,
+                "last_skeleton_sync_at": None,
+                "last_schemas_sync_at": None,
+                "last_columns_sync_at": None,
                 "last_error": "",
             }
         return {
@@ -211,6 +258,21 @@ class SyncMixin:
             "finished_at": float(row["finished_at"]) if row["finished_at"] else None,
             "last_full_sync_at": (
                 float(row["last_full_sync_at"]) if row["last_full_sync_at"] else None
+            ),
+            "last_skeleton_sync_at": (
+                float(row["last_skeleton_sync_at"])
+                if row["last_skeleton_sync_at"]
+                else None
+            ),
+            "last_schemas_sync_at": (
+                float(row["last_schemas_sync_at"])
+                if row["last_schemas_sync_at"]
+                else None
+            ),
+            "last_columns_sync_at": (
+                float(row["last_columns_sync_at"])
+                if row["last_columns_sync_at"]
+                else None
             ),
             "last_error": str(row["last_error"] or ""),
         }

--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -638,9 +638,69 @@ def sync_profile_skeleton(
         _skeleton_jobs.unregister(profile)
         return summary
 
+    # Step 4: warm the per-table metadata caches so a post-sync read
+    # never falls back to live DB. ``schemas_cache`` was already
+    # populated as a side-effect of ``connector.list_schemas()`` in
+    # pass 1 (it routes through ``_populate_catalogs_cache``).
+    # ``column_comments_cache`` is NOT touched by the skeleton upsert
+    # pass, so the first sidebar drill or /ask read would otherwise
+    # hit live DB to fetch table + column comments. We walk per
+    # (container, schema) and let the connector's bulk helper fill
+    # the cache one round-trip at a time.
+    schemas_warmed_ok = reached_any
+    columns_warmed_ok = True
+    for container, schema_assets in per_container_plan:
+        if cancel_event.is_set():
+            break
+        try:
+            connector = _scoped_connector(cfg, profile, container or None, is_three_level)
+        except Exception as exc:
+            log.warning(
+                "Cache warm skipped, connector unavailable for %s/%s: %s",
+                profile,
+                container or "<default>",
+                exc,
+            )
+            columns_warmed_ok = False
+            continue
+        for schema, _assets in schema_assets:
+            if cancel_event.is_set():
+                break
+            try:
+                # Bulk-fill column_comments_cache for the whole schema
+                # in one round-trip when the adapter supports it.
+                connector._populate_schema_metadata_cache(schema)  # noqa: SLF001
+            except Exception as exc:
+                log.debug(
+                    "Cache warm raised for %s/%s/%s: %s",
+                    profile,
+                    container or "<default>",
+                    schema,
+                    exc,
+                )
+                columns_warmed_ok = False
+
     catalog.finish_skeleton_sync(profile, ok=True)
+    # Stamp the per-asset-type freshness timestamps only when the
+    # corresponding warm pass actually completed for this run.
+    # ``last_skeleton_sync_at`` is stamped inside finish_skeleton_sync;
+    # ``last_schemas_sync_at`` / ``last_columns_sync_at`` carry the
+    # "cache is hot for this profile" signal the cache-only read gate
+    # in connector.list_schemas / get_column_comments depends on.
+    if schemas_warmed_ok:
+        try:
+            catalog.mark_schemas_sync_done(profile)
+        except Exception as exc:
+            log.debug("mark_schemas_sync_done raised for %s: %s", profile, exc)
+    if columns_warmed_ok:
+        try:
+            catalog.mark_columns_sync_done(profile)
+        except Exception as exc:
+            log.debug("mark_columns_sync_done raised for %s: %s", profile, exc)
     summary["state"] = "done"
     summary["processed"] = processed
+    summary["schemas_warmed"] = bool(schemas_warmed_ok)
+    summary["columns_warmed"] = bool(columns_warmed_ok)
     _skeleton_jobs.unregister(profile)
     return summary
 

--- a/amx/storage/cache_ops.py
+++ b/amx/storage/cache_ops.py
@@ -462,10 +462,7 @@ def purge_orphan_profile_rows(
         if not names:
             # No configured profiles → every row is an orphan.
             ce_count = int(
-                conn.execute(
-                    "SELECT COUNT(*) AS n FROM catalog_entities"
-                ).fetchone()["n"]
-                or 0
+                conn.execute("SELECT COUNT(*) AS n FROM catalog_entities").fetchone()["n"] or 0
             )
             conn.execute("DELETE FROM catalog_descriptions")
             conn.execute("DELETE FROM catalog_entities")
@@ -474,9 +471,7 @@ def purge_orphan_profile_rows(
             except sqlite3.OperationalError:
                 pass
             sc = conn.execute("DELETE FROM schemas_cache").rowcount or 0
-            cc = conn.execute(
-                "DELETE FROM column_comments_cache"
-            ).rowcount or 0
+            cc = conn.execute("DELETE FROM column_comments_cache").rowcount or 0
             conn.commit()
             return {
                 "catalog_entities": ce_count,
@@ -516,14 +511,20 @@ def purge_orphan_profile_rows(
             )
         except sqlite3.OperationalError:
             pass
-        sc = conn.execute(
-            f"DELETE FROM schemas_cache WHERE {not_in}",
-            names,
-        ).rowcount or 0
-        cc = conn.execute(
-            f"DELETE FROM column_comments_cache WHERE {not_in}",
-            names,
-        ).rowcount or 0
+        sc = (
+            conn.execute(
+                f"DELETE FROM schemas_cache WHERE {not_in}",
+                names,
+            ).rowcount
+            or 0
+        )
+        cc = (
+            conn.execute(
+                f"DELETE FROM column_comments_cache WHERE {not_in}",
+                names,
+            ).rowcount
+            or 0
+        )
         conn.commit()
         deleted = {
             "catalog_entities": ce_count,

--- a/amx/storage/cache_ops.py
+++ b/amx/storage/cache_ops.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import sqlite3
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -199,13 +200,23 @@ def cache_inventory(
     )
 
 
-def cache_stats() -> dict[str, CacheStat]:
+def cache_stats(
+    *,
+    valid_profiles: Iterable[str] | None = None,
+) -> dict[str, CacheStat]:
     """Aggregate metrics per cache table.
 
     ``ttl_aware`` is True for ``schemas_cache`` + ``column_comments_cache``
     (they carry ``expires_at`` so a stale-row count is meaningful) and
     False for ``catalog_entities`` — the catalog is rewritten by
     ``/sync``, never sweeps itself.
+
+    When ``valid_profiles`` is set, every row in the underlying tables
+    whose ``db_profile`` is *not* a member is excluded from the
+    aggregate. The Studio Catalog cache page passes the configured
+    profile set so a deleted-profile tombstone never inflates the
+    headline numbers. Pass ``None`` (the default) to keep the legacy,
+    unfiltered shape — used by the REPL ``/db cache-stats`` view.
     """
     conn = _open()
     if conn is None:
@@ -213,6 +224,8 @@ def cache_stats() -> dict[str, CacheStat]:
     try:
         now = time.time()
         result: dict[str, CacheStat] = {}
+
+        valid_filter, valid_params = _profile_filter(valid_profiles)
 
         def _stat_ttl(table: str) -> CacheStat:
             row = conn.execute(
@@ -222,8 +235,9 @@ def cache_stats() -> dict[str, CacheStat]:
                           MIN(fetched_at) AS oldest,
                           MAX(fetched_at) AS newest,
                           SUM(CASE WHEN expires_at < ? THEN 1 ELSE 0 END) AS expired
-                     FROM {table}""",
-                (now,),
+                     FROM {table}
+                     WHERE 1 = 1{valid_filter}""",
+                (now, *valid_params),
             ).fetchone()
             return CacheStat(
                 table=table,
@@ -241,12 +255,14 @@ def cache_stats() -> dict[str, CacheStat]:
 
         # catalog_entities uses last_synced_at; never expires.
         row = conn.execute(
-            """SELECT COUNT(*) AS n,
+            f"""SELECT COUNT(*) AS n,
                       COUNT(DISTINCT db_profile) AS p,
                       COUNT(DISTINCT database_name) AS d,
                       MIN(last_synced_at) AS oldest,
                       MAX(last_synced_at) AS newest
-                 FROM catalog_entities"""
+                 FROM catalog_entities
+                 WHERE 1 = 1{valid_filter}""",
+            valid_params,
         ).fetchone()
         result["catalog"] = CacheStat(
             table="catalog_entities",
@@ -261,6 +277,26 @@ def cache_stats() -> dict[str, CacheStat]:
         return result
     finally:
         conn.close()
+
+
+def _profile_filter(
+    valid_profiles: Iterable[str] | None,
+) -> tuple[str, tuple[str, ...]]:
+    """Render an ``AND db_profile IN (...)`` clause + bind values.
+
+    Returns ``("", ())`` when ``valid_profiles`` is ``None`` so the
+    legacy (unfiltered) callers keep the same SQL shape. When the
+    caller supplies an empty iterable the clause becomes
+    ``AND 1 = 0`` — that's the "user has zero configured profiles"
+    state and matching no rows is the correct answer.
+    """
+    if valid_profiles is None:
+        return "", ()
+    names = tuple({str(p) for p in valid_profiles if p})
+    if not names:
+        return " AND 1 = 0", ()
+    placeholders = ",".join("?" for _ in names)
+    return f" AND db_profile IN ({placeholders})", names
 
 
 def cache_runtime_counters() -> dict[str, Any]:
@@ -394,6 +430,109 @@ def _delete_scoped(
         return int(cur.rowcount or 0)
     finally:
         conn.close()
+
+
+def purge_orphan_profile_rows(
+    valid_profiles: Iterable[str],
+) -> dict[str, int]:
+    """Delete every cache row whose ``db_profile`` is not in
+    ``valid_profiles``. Returns per-table delete counts.
+
+    Idempotent and safe to call at startup. Covers the three on-disk
+    cache tables (``schemas_cache``, ``column_comments_cache``,
+    ``catalog_entities``) plus the dependent rows in
+    ``catalog_descriptions`` and ``catalog_profile_state`` so the
+    state row that drives the Studio freshness pill disappears with
+    the rest of the profile's footprint.
+
+    Used by:
+
+    * the Studio app startup hook (one-time backfill sweep so the
+      Catalog cache page reflects only configured profiles), and
+    * :func:`amx.config.AMXConfig.remove_db_profile` (eager purge the
+      moment a profile is removed) — through the same helper so the
+      two paths can't drift.
+    """
+    names = tuple({str(p) for p in valid_profiles if p})
+    conn = _open(read_only=False)
+    if conn is None:
+        return {}
+    deleted: dict[str, int] = {}
+    try:
+        if not names:
+            # No configured profiles → every row is an orphan.
+            ce_count = int(
+                conn.execute(
+                    "SELECT COUNT(*) AS n FROM catalog_entities"
+                ).fetchone()["n"]
+                or 0
+            )
+            conn.execute("DELETE FROM catalog_descriptions")
+            conn.execute("DELETE FROM catalog_entities")
+            try:
+                conn.execute("DELETE FROM catalog_profile_state")
+            except sqlite3.OperationalError:
+                pass
+            sc = conn.execute("DELETE FROM schemas_cache").rowcount or 0
+            cc = conn.execute(
+                "DELETE FROM column_comments_cache"
+            ).rowcount or 0
+            conn.commit()
+            return {
+                "catalog_entities": ce_count,
+                "schemas_cache": int(sc),
+                "column_comments_cache": int(cc),
+            }
+
+        placeholders = ",".join("?" for _ in names)
+        not_in = f"db_profile NOT IN ({placeholders})"
+
+        # Count catalog_entities orphans BEFORE deleting; the
+        # post-delete rowcount is not portable across sqlite versions
+        # when a foreign key dependency was wiped in the same txn.
+        ce_count = int(
+            conn.execute(
+                f"SELECT COUNT(*) AS n FROM catalog_entities WHERE {not_in}",
+                names,
+            ).fetchone()["n"]
+            or 0
+        )
+        # Descriptions first so the FK isn't orphaned.
+        conn.execute(
+            f"""DELETE FROM catalog_descriptions
+                 WHERE entity_id IN (
+                     SELECT id FROM catalog_entities WHERE {not_in}
+                 )""",
+            names,
+        )
+        conn.execute(
+            f"DELETE FROM catalog_entities WHERE {not_in}",
+            names,
+        )
+        try:
+            conn.execute(
+                f"DELETE FROM catalog_profile_state WHERE {not_in}",
+                names,
+            )
+        except sqlite3.OperationalError:
+            pass
+        sc = conn.execute(
+            f"DELETE FROM schemas_cache WHERE {not_in}",
+            names,
+        ).rowcount or 0
+        cc = conn.execute(
+            f"DELETE FROM column_comments_cache WHERE {not_in}",
+            names,
+        ).rowcount or 0
+        conn.commit()
+        deleted = {
+            "catalog_entities": ce_count,
+            "schemas_cache": int(sc),
+            "column_comments_cache": int(cc),
+        }
+    finally:
+        conn.close()
+    return deleted
 
 
 def _clear_catalog_tables(

--- a/amx/storage/schema_descriptions.py
+++ b/amx/storage/schema_descriptions.py
@@ -884,6 +884,26 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
             "UTC epoch seconds of the last successful 'done' transition. "
             "Drives /sync recency hints."
         ),
+        "last_skeleton_sync_at": (
+            "UTC epoch seconds the last skeleton sync (catalog_entities "
+            "upsert) finished. Set alongside last_full_sync_at on a "
+            "successful sync; the cache-only read gate trusts it as "
+            "evidence the table-grain rows are populated."
+        ),
+        "last_schemas_sync_at": (
+            "UTC epoch seconds the last schemas_cache warm pass completed. "
+            "Stamped by sync_profile_skeleton when 'Sync all' fans out "
+            "into bulk schema reads, and by the granular 'Sync scope' "
+            "executor for mode='schemas'. The cache-only gate trusts a "
+            "non-null value as evidence the schemas cache is hot."
+        ),
+        "last_columns_sync_at": (
+            "UTC epoch seconds the last column_comments_cache warm pass "
+            "completed. Stamped by sync_profile_skeleton when 'Sync all' "
+            "fans out into bulk column reads, and by the granular 'Sync "
+            "scope' executor for mode='columns'. The cache-only gate "
+            "trusts a non-null value as evidence column metadata is hot."
+        ),
         "last_error": (
             "Error message captured when state='failed'. Empty string for successful syncs."
         ),

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -711,6 +711,23 @@ class SQLiteHistoryStore:
                 )
                 """
             )
+            # Per-asset-type freshness stamps for the catalog cache. The
+            # original ``last_full_sync_at`` only tracks whether the
+            # skeleton (catalog_entities) finished — but a profile can
+            # be "skeleton-done" while ``schemas_cache`` /
+            # ``column_comments_cache`` are still cold. These columns
+            # let the read-side cache-only gate require all three caches
+            # to be warm before suppressing the live-DB fallback.
+            # Added as additive ALTERs so existing databases upgrade in
+            # place; nullable so the legacy state row remains valid
+            # while the next sync stamps the new fields.
+            for _ddl in (
+                "ALTER TABLE catalog_profile_state ADD COLUMN last_skeleton_sync_at REAL",
+                "ALTER TABLE catalog_profile_state ADD COLUMN last_schemas_sync_at REAL",
+                "ALTER TABLE catalog_profile_state ADD COLUMN last_columns_sync_at REAL",
+            ):
+                with contextlib.suppress(sqlite3.OperationalError):
+                    conn.execute(_ddl)
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS catalog_relationships (

--- a/amx/web/routers/db_cache.py
+++ b/amx/web/routers/db_cache.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
+from amx.config import AMXConfig
 from amx.storage.cache_ops import (
     CACHE_TYPES,
     cache_clear,
@@ -26,6 +27,7 @@ from amx.storage.cache_ops import (
     cache_runtime_counters,
     cache_stats,
 )
+from amx.web.deps import get_cfg
 
 router = APIRouter(prefix="/api/db/cache", tags=["db-cache"])
 
@@ -64,14 +66,20 @@ def show(
 
 
 @router.get("/stats")
-def stats() -> dict[str, Any]:
+def stats(cfg: AMXConfig = Depends(get_cfg)) -> dict[str, Any]:
     """Aggregate metrics per cache table.
+
+    Counts are restricted to the profiles currently configured in
+    ``cfg.db_profiles``. Rows for a deleted/renamed profile remain on
+    disk until a startup sweep or eager purge removes them, but they
+    never inflate the headline numbers the Studio Catalog cache page
+    renders.
 
     Includes a ``runtime`` section that surfaces the in-process
     counters added alongside the wizard memo and the cache-age-aware
     drift probe so Studio can show how often each gate fired.
     """
-    raw = cache_stats()
+    raw = cache_stats(valid_profiles=tuple(cfg.db_profiles.keys()))
     payload: dict[str, Any] = {
         key: {
             "table": stat.table,

--- a/amx/web/server.py
+++ b/amx/web/server.py
@@ -175,6 +175,28 @@ def create_app(
         # cleanup keeps the table tidy regardless.
         pass
 
+    # Catalog cache tombstone sweep — drop catalog_entities /
+    # schemas_cache / column_comments_cache rows whose db_profile is
+    # not in cfg.db_profiles. Required because pre-fix
+    # ``/remove-db-profile`` runs left the cache rows behind, which
+    # then surfaced on the Studio Catalog cache page as a phantom
+    # extra "profile" in the catalog_entities count. Idempotent: once
+    # disk reflects only configured profiles, this is a no-op.
+    try:
+        import logging
+
+        from amx.storage.cache_ops import purge_orphan_profile_rows
+
+        configured = tuple(cfg.db_profiles.keys())
+        purged = purge_orphan_profile_rows(configured)
+        if any(purged.values()):
+            logging.getLogger("amx.web.startup").info(
+                "catalog cache tombstone sweep purged %s",
+                {k: v for k, v in purged.items() if v},
+            )
+    except Exception:
+        pass
+
     # Scheduler bootstrap pass: surface stale runs + missed schedules
     # for the catch-up banner. Pinned on the module object so the
     # ``/api/scheduler/bootstrap-report`` route can read it without

--- a/tests/lineage/test_sql_parse.py
+++ b/tests/lineage/test_sql_parse.py
@@ -32,7 +32,6 @@ from amx.lineage.extractors.sql_parse import (
 
 from .conftest import seed_table_entity
 
-
 # ── extract_reads_writes ─────────────────────────────────────────────
 
 

--- a/tests/test_catalog_skeleton_sync.py
+++ b/tests/test_catalog_skeleton_sync.py
@@ -40,6 +40,14 @@ class _StubConnector:
     def list_assets(self, schema: str) -> list[tuple[str, str]]:
         return list(self._assets.get(schema, []))
 
+    def _populate_schema_metadata_cache(self, schema: str) -> bool:
+        """No-op stand-in: the real connector bulk-fills
+        ``column_comments_cache`` here. The stub just signals "warm
+        pass completed" so the skeleton sync stamps
+        ``last_columns_sync_at`` and ``is_profile_fully_synced``
+        returns True under the post-tightening contract."""
+        return True
+
 
 class _StubCfg:
     """Stand-in for ``AMXConfig`` carrying just the fields the
@@ -321,6 +329,9 @@ class _PerDBConnector:
 
     def list_assets(self, schema: str) -> list[tuple[str, str]]:
         return list(self._schemas.get(schema, []))
+
+    def _populate_schema_metadata_cache(self, schema: str) -> bool:
+        return True
 
 
 class _UnpinnedStubCfg:

--- a/tests/test_connector_cache_only_mode.py
+++ b/tests/test_connector_cache_only_mode.py
@@ -1,0 +1,162 @@
+"""Cache-only read mode for connector cache-aware methods.
+
+Reported: Studio's ``Sync all`` button populated the catalog but
+subsequent reads still hit live DB. Root cause — even after
+``catalog_entities`` / ``schemas_cache`` / ``column_comments_cache``
+were warm, ``list_schemas`` / ``get_column_comments`` /
+``get_table_comment`` / ``get_schema_comment`` all fell through to
+live DB on a cache miss.
+
+This test pins the cache-only contract: when ``is_profile_fully_synced``
+returns True (the tightened post-sync state), those four methods
+return the empty result on a cache miss instead of running the
+live-DB fallback. When the profile is not fully synced, the
+fallback path is exercised as before.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amx.config import DBConfig
+from amx.db.connector import DatabaseConnector
+from amx.storage import sqlite_store as ss
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SQLiteHistoryStore:
+    db_path = tmp_path / "history.db"
+    s = SQLiteHistoryStore(db_path)
+    s.init()
+    monkeypatch.setattr(ss, "_store", s, raising=False)  # noqa: SLF001
+    yield s
+    monkeypatch.setattr(ss, "_store", None, raising=False)  # noqa: SLF001
+
+
+def _mark_profile_fully_synced(s: SQLiteHistoryStore, profile: str) -> None:
+    """Mirror what a successful Sync all stamps onto
+    catalog_profile_state. All four timestamp columns must be set
+    for the new is_profile_fully_synced contract."""
+    import time
+
+    now = time.time()
+    with s._connect() as conn:  # noqa: SLF001
+        conn.execute(
+            """INSERT OR REPLACE INTO catalog_profile_state (
+                   db_profile, state, last_full_sync_at,
+                   last_skeleton_sync_at, last_schemas_sync_at,
+                   last_columns_sync_at
+               ) VALUES (?, 'done', ?, ?, ?, ?)""",
+            (profile, now, now, now, now),
+        )
+
+
+def test_is_cache_warm_requires_all_four_timestamps(
+    store: SQLiteHistoryStore,
+) -> None:
+    """``_is_cache_warm`` returns True only when every per-surface
+    timestamp is set. A pre-PR catalog with only ``last_full_sync_at``
+    populated keeps the live-DB fallback armed."""
+    import time
+
+    now = time.time()
+    with store._connect() as conn:  # noqa: SLF001
+        # Old-shape state row: skeleton timestamps missing.
+        conn.execute(
+            """INSERT OR REPLACE INTO catalog_profile_state (
+                   db_profile, state, last_full_sync_at
+               ) VALUES ('legacy', 'done', ?)""",
+            (now,),
+        )
+    conn = DatabaseConnector(
+        DBConfig(backend="duckdb", database=":memory:"),
+        profile_name="legacy",
+    )
+    assert conn._is_cache_warm() is False  # noqa: SLF001
+
+    _mark_profile_fully_synced(store, "fresh")
+    conn_fresh = DatabaseConnector(
+        DBConfig(backend="duckdb", database=":memory:"),
+        profile_name="fresh",
+    )
+    assert conn_fresh._is_cache_warm() is True  # noqa: SLF001
+
+
+def test_anonymous_connector_is_never_cache_warm(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Connectors built without a profile_name (e.g. an ad-hoc
+    DBConfig in a test) must never enter cache-only mode, no matter
+    what state rows exist."""
+    _mark_profile_fully_synced(store, "any")
+    conn = DatabaseConnector(DBConfig(backend="duckdb", database=":memory:"))
+    assert conn._is_cache_warm() is False  # noqa: SLF001
+
+
+class _RaisingConnector(DatabaseConnector):
+    """Subclass whose live-DB fallbacks all raise. The cache-only gate
+    must short-circuit BEFORE any fallback runs — if the gate is
+    broken, the test sees the raising side."""
+
+    def _populate_catalogs_cache(self, catalog: str) -> bool:
+        raise AssertionError("live DB fallback was reached")
+
+    def _populate_schema_metadata_cache(self, schema: str) -> bool:
+        raise AssertionError("live DB fallback was reached")
+
+    @property
+    def engine(self) -> Any:  # type: ignore[override]
+        raise AssertionError("live DB engine was opened")
+
+
+def test_list_schemas_cache_only_when_warm(store: SQLiteHistoryStore) -> None:
+    """Empty schemas_cache + warm profile = return [], no live DB."""
+    _mark_profile_fully_synced(store, "warm")
+    conn = _RaisingConnector(
+        DBConfig(backend="duckdb", database=":memory:"),
+        profile_name="warm",
+    )
+    assert conn.list_schemas() == []
+
+
+def test_get_column_comments_cache_only_when_warm(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Cache miss + warm profile = return {}, no live DB."""
+    _mark_profile_fully_synced(store, "warm")
+    conn = _RaisingConnector(
+        DBConfig(backend="duckdb", database=":memory:"),
+        profile_name="warm",
+    )
+    # column_comments capability defaults True for the sqlite stub;
+    # the gate fires before the capability check anyway.
+    out = conn.get_column_comments("public", "users")
+    assert out == {}
+
+
+def test_get_table_comment_cache_only_when_warm(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Cache miss + warm profile = return None, no live DB."""
+    _mark_profile_fully_synced(store, "warm")
+    conn = _RaisingConnector(
+        DBConfig(backend="duckdb", database=":memory:"),
+        profile_name="warm",
+    )
+    assert conn.get_table_comment("public", "users") is None
+
+
+def test_get_schema_comment_cache_only_when_warm(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Cache miss + warm profile = return None, no live DB."""
+    _mark_profile_fully_synced(store, "warm")
+    conn = _RaisingConnector(
+        DBConfig(backend="duckdb", database=":memory:"),
+        profile_name="warm",
+    )
+    assert conn.get_schema_comment("public") is None

--- a/tests/test_db_cache_ops.py
+++ b/tests/test_db_cache_ops.py
@@ -21,6 +21,7 @@ from amx.storage.cache_ops import (
     cache_clear,
     cache_inventory,
     cache_stats,
+    purge_orphan_profile_rows,
 )
 from amx.storage.sqlite_store import SQLiteHistoryStore
 
@@ -193,3 +194,92 @@ def test_clear_global_flush_when_no_filters(store: SQLiteHistoryStore) -> None:
 def test_clear_unknown_type_raises(store: SQLiteHistoryStore) -> None:
     with pytest.raises(ValueError, match="Unknown cache types"):
         cache_clear(types=["foo"])
+
+
+def test_stats_valid_profiles_filter_excludes_tombstones(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Rows for a profile not in ``valid_profiles`` are excluded from
+    every aggregate — distinct counts AND total_rows. The Studio
+    Catalog cache page passes the configured profile set so a
+    deleted-profile tombstone never inflates the headline numbers.
+    """
+    _seed(store)
+    # Pretend the user just removed prof-b; prof-a is the only
+    # configured profile but prof-b's catalog rows are still on disk.
+    s = cache_stats(valid_profiles=("prof-a",))
+    assert s["schemas"].distinct_profiles == 1
+    assert s["schemas"].total_rows == 3  # 4 seeded rows - 1 for prof-b
+    assert s["catalog"].distinct_profiles == 1
+    assert s["catalog"].total_rows == 3  # 4 catalog rows - 1 for prof-b
+
+
+def test_stats_legacy_unfiltered_call_keeps_old_shape(
+    store: SQLiteHistoryStore,
+) -> None:
+    """``valid_profiles=None`` (the default) preserves the unfiltered
+    aggregate the REPL ``/db cache-stats`` view depends on."""
+    _seed(store)
+    s = cache_stats()
+    assert s["schemas"].distinct_profiles == 2
+    assert s["catalog"].distinct_profiles == 2
+
+
+def test_purge_orphan_profile_rows_deletes_tombstones(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Eager + startup paths both call this helper; rows for any
+    profile outside ``valid_profiles`` are deleted across all three
+    cache tables, descriptions, and the per-profile state row."""
+    _seed(store)
+    # Seed a catalog_profile_state row for prof-b so the helper can
+    # prove it cleans up the state table alongside the data tables.
+    with store._connect() as conn:  # noqa: SLF001
+        conn.execute(
+            """INSERT OR REPLACE INTO catalog_profile_state
+                   (db_profile, state, last_full_sync_at)
+               VALUES ('prof-b', 'done', ?)""",
+            (time.time(),),
+        )
+    counts = purge_orphan_profile_rows(("prof-a",))
+    assert counts["catalog_entities"] == 1
+    assert counts["schemas_cache"] == 1
+    assert counts["column_comments_cache"] == 0
+    # prof-b should be gone from every cache surface.
+    rows = cache_inventory(profile="prof-b")
+    assert rows == []
+    with store._connect() as conn:  # noqa: SLF001
+        n = conn.execute(
+            "SELECT COUNT(*) AS n FROM catalog_profile_state WHERE db_profile = 'prof-b'"
+        ).fetchone()
+    assert int(n["n"]) == 0
+    # prof-a left intact.
+    a = cache_inventory(profile="prof-a")
+    assert {(r.profile, r.database) for r in a} == {
+        ("prof-a", "db1"),
+        ("prof-a", "db2"),
+    }
+
+
+def test_purge_orphan_profile_rows_empty_valid_set_clears_everything(
+    store: SQLiteHistoryStore,
+) -> None:
+    """When the user has no configured DB profiles every cached row
+    is an orphan. The helper walks every table."""
+    _seed(store)
+    counts = purge_orphan_profile_rows(())
+    assert counts["catalog_entities"] == 4
+    assert cache_inventory() == []
+
+
+def test_purge_orphan_profile_rows_idempotent(store: SQLiteHistoryStore) -> None:
+    """Second call returns zeros — the startup sweep can run on every
+    boot without flicker."""
+    _seed(store)
+    purge_orphan_profile_rows(("prof-a",))
+    counts = purge_orphan_profile_rows(("prof-a",))
+    assert counts == {
+        "catalog_entities": 0,
+        "schemas_cache": 0,
+        "column_comments_cache": 0,
+    }

--- a/tests/test_db_cache_search.py
+++ b/tests/test_db_cache_search.py
@@ -85,14 +85,20 @@ def _seed(
                     ),
                 )
         if fully_synced:
+            # is_profile_fully_synced now requires all four sync
+            # timestamps to be non-null. Stamp every per-surface
+            # timestamp here so the seed mimics a true completed
+            # ``Sync all`` run.
             conn.execute(
                 """
                 INSERT INTO catalog_profile_state (
                     db_profile, state, total_tables, processed_tables,
-                    started_at, finished_at, last_full_sync_at, last_error
-                ) VALUES (?, 'done', 1, 1, ?, ?, ?, '')
+                    started_at, finished_at, last_full_sync_at,
+                    last_skeleton_sync_at, last_schemas_sync_at,
+                    last_columns_sync_at, last_error
+                ) VALUES (?, 'done', 1, 1, ?, ?, ?, ?, ?, ?, '')
                 """,
-                (profile, now, now, now),
+                (profile, now, now, now, now, now, now),
             )
 
 

--- a/tests/test_remove_db_profile_purges_cache.py
+++ b/tests/test_remove_db_profile_purges_cache.py
@@ -1,0 +1,96 @@
+"""``/remove-db-profile`` purges the catalog cache.
+
+Reported: Studio's Catalog cache page showed ``catalog_entities``
+with 3 profile(s) while only 2 DB profiles were configured. Root
+cause — ``AMXConfig.remove_db_profile`` deleted the profile entry
+from the config but left every ``catalog_entities`` /
+``schemas_cache`` / ``column_comments_cache`` row keyed by the
+removed profile name on disk. The next ``/stats`` call surfaced the
+tombstone as a phantom third profile.
+
+This test pins the contract: removing a DB profile clears every
+cache row keyed by that profile in the same call. The startup
+sweep + the read-side ``valid_profiles`` filter are belt-and-braces
+for older databases that already have tombstones; this test is
+specifically for the eager path.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from amx.config import AMXConfig, DBConfig
+from amx.storage import sqlite_store as ss
+from amx.storage.cache_ops import cache_inventory
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SQLiteHistoryStore:
+    db_path = tmp_path / "history.db"
+    s = SQLiteHistoryStore(db_path)
+    s.init()
+    monkeypatch.setattr(ss, "_store", s, raising=False)  # noqa: SLF001
+    yield s
+    monkeypatch.setattr(ss, "_store", None, raising=False)  # noqa: SLF001
+
+
+def _seed_cache_rows(s: SQLiteHistoryStore, profile: str) -> None:
+    s.save_schemas_cache(
+        db_profile=profile,
+        database="db1",
+        catalog="",
+        entries={"public": None},
+        ttl_seconds=3600.0,
+    )
+    s.save_column_comments_cache(
+        db_profile=profile,
+        database="db1",
+        schema="public",
+        entries={
+            "users": {
+                "table_comment": None,
+                "columns": {"id": None},
+                "kind": "TABLE",
+            },
+        },
+        ttl_seconds=3600.0,
+    )
+    with s._connect() as conn:  # noqa: SLF001
+        conn.execute(
+            """INSERT INTO catalog_entities (
+                   db_profile, db_backend, database_name, schema_name,
+                   table_name, column_name, entity_kind, asset_kind,
+                   last_synced_at
+               ) VALUES (?, 'postgresql', 'db1', 'public', 'users', NULL,
+                          'table', 'table', ?)""",
+            (profile, time.time()),
+        )
+
+
+def test_remove_db_profile_evicts_cache_rows(store: SQLiteHistoryStore) -> None:
+    cfg = AMXConfig()
+    cfg.db_profiles = {
+        "keeper": DBConfig(backend="postgresql", host="k"),
+        "doomed": DBConfig(backend="postgresql", host="d"),
+    }
+    cfg.active_db_profile = "keeper"
+    cfg.active_db_profiles = ["keeper", "doomed"]
+
+    _seed_cache_rows(store, "keeper")
+    _seed_cache_rows(store, "doomed")
+    pre = cache_inventory()
+    assert {(r.profile, r.database) for r in pre} == {
+        ("keeper", "db1"),
+        ("doomed", "db1"),
+    }
+
+    cfg.remove_db_profile("doomed")
+
+    post = cache_inventory()
+    # Only the surviving profile still has cache rows; the doomed
+    # profile's footprint is fully removed.
+    assert {(r.profile, r.database) for r in post} == {("keeper", "db1")}

--- a/tests/web/test_db_cache_router.py
+++ b/tests/web/test_db_cache_router.py
@@ -60,8 +60,14 @@ def stub_ops(monkeypatch):
         state["inventory_args"] = (profile, database)
         return [_Row("prof-a", "db1", 2, 1, 4, 1700000000.0)]
 
-    def fake_stats():
+    def fake_stats(*, valid_profiles=None):
+        # ``valid_profiles`` is the configured profile set the
+        # /api/db/cache/stats endpoint forwards from cfg.db_profiles so
+        # tombstones (rows for deleted profiles) never inflate the
+        # headline counts. Tests don't exercise the filter — they just
+        # accept the kwarg so the router can pass it through.
         state["stats_called"] = True
+        state["stats_valid_profiles"] = valid_profiles
         return {
             "schemas": _Stat("schemas_cache", 4, 1, 2, 1.0, 2.0, 0, True),
         }


### PR DESCRIPTION
## Summary

- **Stale profile/database counts on `/db-cache`**. `catalog_entities` reported 3 profile(s) / 8 databases while only 2 DB profiles were configured — a previously-removed profile's rows lived on forever because `remove_db_profile` did not clean the cache and `cache_stats()` ran `COUNT(DISTINCT db_profile)` with no filter. Eager purge on remove + read-side `valid_profiles` filter on `/api/db/cache/stats` + a startup orphan sweep close the gap (defense in depth).
- **Sync all did not actually warm every cache**. `sync_profile_skeleton` only wrote `catalog_entities`; `schemas_cache` / `column_comments_cache` stayed cold, so the next sidebar drill or `/ask` read still hit the live DB. The skeleton sync now bulk-fills `column_comments_cache` for every walked schema and stamps the three new per-asset-type freshness timestamps on `catalog_profile_state` (`last_skeleton_sync_at` / `last_schemas_sync_at` / `last_columns_sync_at`).
- **Reads can no longer fall back to the live DB once a profile is fully synced**. `is_profile_fully_synced` is tightened to require all three timestamps; the connector's `list_schemas` / `get_table_comment` / `get_column_comments` / `get_schema_comment` consult `_is_cache_warm()` and return the cached value (or empty) instead of the legacy live-DB fallthrough. Cache miss is logged as a sync gap — not silently masked.

## Test plan

- [x] `pytest tests/test_db_cache_ops.py tests/test_remove_db_profile_purges_cache.py tests/test_connector_cache_only_mode.py tests/test_catalog_skeleton_sync.py tests/test_skeleton_sync_cancellation.py tests/test_skeleton_sync_pinned_default.py tests/test_tool_freshness_contract.py tests/test_ask_cache_only.py tests/test_db_cache_search.py tests/test_local_schema_comments.py tests/test_remove_last_profile.py tests/test_column_comments_cache.py tests/test_live_db_cache_first.py` — 129 passing
- [x] Studio Catalog cache page reports the configured-profile count (2), not the orphaned 3.
- [x] Clicking **Sync all** on `dbr-oyk` warms `catalog_entities` + `schemas_cache` + `column_comments_cache` in the same pass.
- [x] After a Sync all, subsequent sidebar drills / `/ask` reads hit cache only — no `SELECT … FROM system.information_schema.*` round-trips on Databricks.