### PR TITLE
fix(ask): safety net on tool loop — token budget, structured tool errors, visible warnings

### DIFF
--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import threading
 import time as _llm_time
 from collections.abc import Callable
@@ -32,11 +33,14 @@ from amx.llm.provider import LLMProvider
 from amx.search._tool_agent_prompts import agent_system_prompt as _agent_system_prompt
 from amx.search.agent_tools import ToolBox
 from amx.search.catalog import SearchCatalog
+from amx.utils.logging import get_logger
 from amx.utils.token_tracker import estimate_tokens
 from amx.utils.token_tracker import tracker as token_tracker
 
 if TYPE_CHECKING:
     from amx.utils.live_display import LiveDisplay
+
+log = get_logger("search.tool_agent")
 
 # Maximum number of tool-call iterations before we force the LLM to answer.
 # A typical question takes 1–3 tool calls; 6 gives headroom for chained
@@ -47,6 +51,47 @@ _MAX_ITERATIONS = 6
 # Cap on tokens per LLM round in the agent loop. Tool answers are JSON
 # blobs; we trim them in agent_tools._safe_json so the prompt stays bounded.
 _AGENT_MAX_TOKENS = 1500
+
+# Cumulative input-token cap on the agent's `messages` list. Override
+# per-deployment via AMX_ASK_INPUT_TOKEN_BUDGET (lower for 32K-context
+# providers). When the next iteration's prompt would exceed this, the
+# oldest tool results are progressively replaced with a "context budget
+# reached" placeholder until the prompt fits — prevents silent model
+# choke on multi-turn sessions that accumulate 10–15 k tokens of tool
+# output. 100 000 leaves headroom for system prompt, tools schema, and
+# the configured output cap on the 200K Claude / GPT-4-turbo window.
+_AGENT_INPUT_TOKEN_BUDGET = int(os.environ.get("AMX_ASK_INPUT_TOKEN_BUDGET", "100000"))
+
+# Sentinel content that replaces a truncated tool result. Plain JSON so
+# the model parses it the same way as a normal result envelope.
+_TRUNCATED_TOOL_PAYLOAD = '{"truncated": true, "reason": "context budget reached"}'
+
+
+def _enforce_input_token_budget(
+    messages: list[dict[str, Any]],
+    *,
+    budget: int,
+) -> bool:
+    """Truncate oldest tool-result contents in-place until the estimated
+    token cost of `messages` falls under `budget`. Returns True when
+    any truncation occurred.
+
+    Tool results are mutated in iteration order so the model still sees
+    the most recent results in full — older results decay first.
+    """
+    if estimate_tokens(messages) <= budget:
+        return False
+    truncated_any = False
+    for msg in messages:
+        if msg.get("role") != "tool":
+            continue
+        if msg.get("content") == _TRUNCATED_TOOL_PAYLOAD:
+            continue
+        msg["content"] = _TRUNCATED_TOOL_PAYLOAD
+        truncated_any = True
+        if estimate_tokens(messages) <= budget:
+            return True
+    return truncated_any
 
 
 class ToolAgentResult:
@@ -653,7 +698,8 @@ def _run_tool_loop(
     schemas_hint: list[str] = []
     try:
         schemas_hint = [str(s) for s in toolbox._live_db().list_schemas()]  # noqa: SLF001
-    except Exception:
+    except Exception as exc:
+        log.warning("schemas_hint pre-fetch failed: %s", exc)
         schemas_hint = []
 
     # Multi-profile system-prompt enrichment: scope (which profiles the
@@ -721,9 +767,11 @@ def _run_tool_loop(
         if on_thinking_delta is not None:
             try:
                 on_thinking_delta(text)
-            except Exception:
-                # Never let a UI hook crash the agent loop.
-                pass
+            except Exception as exc:
+                # Never let a UI hook crash the agent loop; log so the
+                # silent UI failure is at least diagnosable in service
+                # logs.
+                log.warning("on_thinking_delta hook failed: %s", exc)
 
     on_thinking = (
         _forward_thinking if (display is not None or on_thinking_delta is not None) else None
@@ -735,6 +783,17 @@ def _run_tool_loop(
             from amx.agents.orchestrator import RunCancelled
 
             raise RunCancelled(f"Cancelled before iteration {iteration}")
+        # Defensive truncation BEFORE building the LiteLLM payload so a
+        # model with a smaller context window never gets a silently
+        # over-budget prompt. Mutates `messages` in place; subsequent
+        # iterations see the truncated tool results too.
+        if _enforce_input_token_budget(messages, budget=_AGENT_INPUT_TOKEN_BUDGET):
+            log.warning(
+                "tool_agent iter %d: input budget %d tokens exceeded; "
+                "truncated oldest tool results",
+                iterations,
+                _AGENT_INPUT_TOKEN_BUDGET,
+            )
         chat_messages = [_convert_message_for_litellm(m) for m in messages]
         # Pre-call token estimate so the tracker can label this step's
         # input cost. Falls back to 0 silently when tiktoken can't
@@ -754,9 +813,10 @@ def _run_tool_loop(
                 return
             try:
                 on_content_delta(chunk)
-            except Exception:
-                # Never let a UI hook crash the agent loop.
-                pass
+            except Exception as exc:
+                # Never let a UI hook crash the agent loop; log so the
+                # silent UI failure is at least diagnosable.
+                log.warning("on_content_delta hook failed: %s", exc)
 
         with _llm_round_heartbeat(
             on_llm_round=on_llm_round,
@@ -854,10 +914,38 @@ def _run_tool_loop(
                             "scope_profiles": list(toolbox.db_profiles),
                         }
                     )
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log.warning("on_tool_start hook failed: %s", exc)
             tool_t0 = _time.monotonic()
-            tool_result = toolbox.invoke(tc.name, tc.arguments or "{}")
+            try:
+                tool_result = toolbox.invoke(tc.name, tc.arguments or "{}")
+            except Exception as exc:
+                # Loop must NEVER crash on a tool exception — surface a
+                # structured error to the LLM so it can recover (try a
+                # different tool, or compose an answer that admits the
+                # failure). Without this, a transient DB blip kills the
+                # whole /ask turn.
+                log.warning(
+                    "tool %s raised during invoke: %s",
+                    tc.name,
+                    exc,
+                    exc_info=True,
+                )
+                # Argument-shape errors the LLM can fix by re-prompting
+                # are "permanent" (don't retry); everything else is
+                # treated as "transient" (retry-eligible).
+                category = (
+                    "permanent"
+                    if isinstance(exc, (ValueError, KeyError, TypeError))
+                    else "transient"
+                )
+                tool_result = json.dumps(
+                    {
+                        "error": f"Tool {tc.name} failed: {exc}",
+                        "category": category,
+                        "tool_name": tc.name,
+                    }
+                )
             tool_elapsed_ms = int((_time.monotonic() - tool_t0) * 1000)
             per_tool_latency_ms[tc.name] = per_tool_latency_ms.get(tc.name, 0) + tool_elapsed_ms
             summary = _summarise_tool_call(tc, tool_result)
@@ -900,14 +988,18 @@ def _run_tool_loop(
                         else:
                             summary["source"] = "mixed"
                     summary["elapsed_ms"] = tool_elapsed_ms
-            except Exception:
-                pass
+            except Exception as exc:
+                log.warning(
+                    "failed to parse tool %s result for source detection: %s",
+                    tc.name,
+                    exc,
+                )
             tool_call_log.append(summary)
             if on_tool_call is not None:
                 try:
                     on_tool_call(summary)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log.warning("on_tool_call hook failed: %s", exc)
             messages.append(
                 {
                     "role": "tool",
@@ -996,11 +1088,15 @@ def _run_tool_loop(
                                     }
                                 )
                                 _lineage_pages_appendix_injected = True
-            except Exception:
+            except Exception as exc:
                 # Best-effort enrichment — a failure here must never
-                # break the answer path. The legacy CLI path applies
-                # the same swallow-and-log policy.
-                pass
+                # break the answer path. Logged for diagnosis (the
+                # legacy CLI path's "swallow-and-log policy" referenced
+                # in earlier comments was actually swallow-only; this
+                # fixes the missing log without changing recovery).
+                log.warning(
+                    "lineage/pages enrichment failed: %s", exc, exc_info=True
+                )
     else:
         # Hit the iteration cap without a final answer — force a closing call
         # without ``tools`` so the LLM returns plain text from whatever it

--- a/tests/search/test_tool_loop_safety.py
+++ b/tests/search/test_tool_loop_safety.py
@@ -1,0 +1,233 @@
+"""Defensive guardrails on the /ask tool loop.
+
+Two failure modes used to bring the loop down without graceful
+degradation:
+
+1. The `messages` list accumulated unbounded across iterations and
+   eventually exceeded the LLM's context window; the failure surfaced
+   as an opaque provider error mid-stream rather than a clear
+   truncation event.
+2. A single tool raising during `ToolBox.invoke` crashed the whole
+   loop because the call site had no `try`/`except`. A transient DB
+   blip would kill the `/ask` turn for the user.
+
+This module pins the safety net in place: budget enforcement truncates
+oldest tool results in place, and tool exceptions surface to the LLM
+as structured error envelopes so it can recover (try a different
+tool, or compose an answer that admits the failure).
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_enforce_input_token_budget_no_op_when_under_budget() -> None:
+    """A small `messages` list passes through untouched — the safety
+    guard must add zero overhead on the happy path."""
+    import amx.search.tool_agent as ta
+
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "hi"},
+        {"role": "tool", "tool_call_id": "c1", "content": '{"matches": []}'},
+    ]
+    snapshot = [dict(m) for m in messages]
+
+    truncated = ta._enforce_input_token_budget(messages, budget=1_000_000)
+
+    assert truncated is False
+    assert messages == snapshot
+
+
+def test_enforce_input_token_budget_truncates_oldest_tool_first() -> None:
+    """When over budget, oldest tool result is replaced first; newer
+    tool results stay intact so the model still sees its latest
+    evidence."""
+    import amx.search.tool_agent as ta
+
+    big_payload = json.dumps({"rows": ["x" * 100 for _ in range(2000)]})
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "question"},
+        {"role": "tool", "tool_call_id": "c1", "content": big_payload},
+        {"role": "tool", "tool_call_id": "c2", "content": '{"small": true}'},
+    ]
+
+    truncated = ta._enforce_input_token_budget(messages, budget=100)
+
+    assert truncated is True
+    # Oldest tool result was truncated.
+    assert messages[2]["content"] == ta._TRUNCATED_TOOL_PAYLOAD
+    # Non-tool messages untouched.
+    assert messages[0]["content"] == "system prompt"
+    assert messages[1]["content"] == "question"
+
+
+def test_enforce_input_token_budget_idempotent_on_already_truncated() -> None:
+    """Calling the guard again after truncation must not re-mutate
+    placeholders or report a fresh truncation — protects callers that
+    invoke it every iteration."""
+    import amx.search.tool_agent as ta
+
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": "system"},
+        {"role": "tool", "tool_call_id": "c1", "content": ta._TRUNCATED_TOOL_PAYLOAD},
+    ]
+
+    first = ta._enforce_input_token_budget(messages, budget=1_000_000)
+    second = ta._enforce_input_token_budget(messages, budget=1_000_000)
+
+    assert first is False
+    assert second is False
+
+
+def _stub_llm_response(content: str, tool_calls: list[Any] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls or [],
+        finish_reason="stop",
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        thinking_content="",
+    )
+
+
+class _RaisingToolbox:
+    """Stand-in `ToolBox` whose `invoke` always raises.
+
+    Mirrors the minimal surface :mod:`amx.search.tool_agent` reads
+    (`db_profiles`, `available_schemas`, `_live_db`, the context-
+    manager protocol, and `invoke`) without pulling in a real catalog
+    or DB connector.
+    """
+
+    @staticmethod
+    def schemas() -> list[Any]:
+        return []
+
+    def available_schemas(self) -> list[Any]:
+        return self.schemas()
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.db_profiles: list[str] = ["p1"]
+        self.db_profile: str = "p1"
+
+    def __enter__(self) -> _RaisingToolbox:
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+    def _live_db(self) -> MagicMock:
+        return MagicMock(list_schemas=lambda: [])
+
+    def invoke(self, name: str, args: str) -> str:
+        raise RuntimeError(f"synthetic failure in {name}")
+
+
+def _build_cfg() -> MagicMock:
+    return MagicMock(
+        db=SimpleNamespace(catalog="", backend="postgresql", database="", project=""),
+        llm=SimpleNamespace(language="english", model="x"),
+        active_db_profile="p1",
+        active_llm_profile="default",
+        current_schema=None,
+        current_table=None,
+        db_profiles={},
+    )
+
+
+def test_tool_invoke_exception_surfaces_as_structured_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool raising during invoke must not crash the loop. The
+    error reaches the LLM as a JSON envelope on the tool result
+    message, the next iteration produces the final answer, and the
+    public result includes the failed tool call's metadata."""
+    import amx.search.tool_agent as ta
+
+    monkeypatch.setattr(ta, "ToolBox", _RaisingToolbox)
+
+    tool_call = SimpleNamespace(id="c1", name="search_tables_by_concept", arguments="{}")
+    chat_calls: list[list[dict[str, Any]]] = []
+    responses = [
+        _stub_llm_response("", tool_calls=[tool_call]),
+        _stub_llm_response("recovered answer"),
+    ]
+    fake_llm = MagicMock()
+
+    def _fake_chat(messages: list[dict[str, Any]], **kwargs: Any) -> SimpleNamespace:
+        chat_calls.append([dict(m) for m in messages])
+        return responses[len(chat_calls) - 1]
+
+    fake_llm.chat.side_effect = _fake_chat
+
+    result = ta.run_tool_agent(
+        cfg=_build_cfg(),
+        catalog=MagicMock(),
+        llm=fake_llm,
+        question="anything",
+        answer_language="english",
+        session_memory=None,
+    )
+
+    # The loop survived the synthetic exception.
+    assert result.answer == "recovered answer"
+
+    # The synthesis round saw a tool message carrying the structured
+    # error envelope — the LLM has enough context to choose recovery
+    # behavior rather than being told nothing.
+    second_round = chat_calls[1]
+    tool_msgs = [m for m in second_round if m.get("role") == "tool"]
+    assert len(tool_msgs) == 1
+    envelope = json.loads(tool_msgs[0]["content"])
+    assert envelope["tool_name"] == "search_tables_by_concept"
+    assert envelope["category"] == "transient"
+    assert "synthetic failure" in envelope["error"]
+
+    # The tool-call log records the call so observability stays honest;
+    # the result_preview reflects the error envelope, not a missing
+    # entry.
+    assert len(result.tool_calls) == 1
+    assert "synthetic failure" in result.tool_calls[0]["result_preview"]
+
+
+class _ValueErrorToolbox(_RaisingToolbox):
+    def invoke(self, name: str, args: str) -> str:
+        raise ValueError("bad arguments")
+
+
+def test_tool_invoke_value_error_marked_permanent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Argument-shape errors are tagged `permanent` so the LLM doesn't
+    waste an iteration retrying the same call."""
+    import amx.search.tool_agent as ta
+
+    monkeypatch.setattr(ta, "ToolBox", _ValueErrorToolbox)
+
+    tool_call = SimpleNamespace(id="c1", name="describe_table", arguments="{}")
+    responses = [
+        _stub_llm_response("", tool_calls=[tool_call]),
+        _stub_llm_response("admitted failure"),
+    ]
+    fake_llm = MagicMock()
+    fake_llm.chat.side_effect = responses
+
+    result = ta.run_tool_agent(
+        cfg=_build_cfg(),
+        catalog=MagicMock(),
+        llm=fake_llm,
+        question="describe x",
+        answer_language="english",
+        session_memory=None,
+    )
+
+    assert result.answer == "admitted failure"
+    envelope = json.loads(result.tool_calls[0]["result_preview"].rstrip("…"))
+    assert envelope["category"] == "permanent"


### PR DESCRIPTION
## Summary

PR 1 of the /ask agent refactor — minimum defensive code to stop three production hazards in `amx/search/tool_agent.py:_run_tool_loop` without changing happy-path behavior.

1. **Unbounded message growth** → silent context overflow. New `_enforce_input_token_budget` runs at every iteration top: when the cumulative `messages` token estimate exceeds the budget (default 100k, override via `AMX_ASK_INPUT_TOKEN_BUDGET`), oldest tool result contents are progressively replaced with a `{"truncated": true}` placeholder until the prompt fits. Newer tool results stay intact.
2. **`ToolBox.invoke` crashes the whole loop** on any exception. Wrapped in try/except: argument-shape errors (`ValueError`/`KeyError`/`TypeError`) become `{"category": "permanent"}` envelopes; everything else is `transient`. LLM sees the failure and recovers.
3. **Seven `except Exception: pass`** blocks swallowed UI-hook failures, JSON parse errors, lineage-enrichment crashes, and schemas_hint prefetch silently. Replaced with `log.warning`.

## Test plan

- [x] `tests/search/test_tool_loop_safety.py` — 5 new tests covering budget helper in isolation + end-to-end recovery from synthetic `RuntimeError` and `ValueError` in `ToolBox.invoke`.
- [x] Full `tests/search/` suite: 53 passed.
- [x] `ruff check amx/search/tool_agent.py`: passed.
- [x] `mypy amx/search/tool_agent.py`: passed.