### PR TITLE
refactor(ask): explicit tool registry — kill implicit getattr dispatch

### DIFF
--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -820,9 +820,30 @@ class ToolBox(
                 cache_key = None  # un-cacheable args; just dispatch normally
 
         try:
-            handler = getattr(self, f"_tool_{name}", None)
-            if handler is None:
+            from amx.search.tools.registry import get_binding
+
+            binding = get_binding(name)
+            if binding is None:
+                # Tool name not declared in the registry → either an
+                # unknown name or a schema/registry sync issue. The
+                # registry-vs-schemas drift test catches the second
+                # case at import time; this branch covers genuinely
+                # bad tool names from the LLM.
                 return _safe_json({"error": f"Unknown tool: {name}"})
+            handler = getattr(self, binding.handler_method, None)
+            if handler is None:
+                # Registry knows the tool but ToolBox lacks the handler
+                # method — same drift signal as the import-time test;
+                # treated as a server error envelope rather than a
+                # silent fall-through.
+                return _safe_json(
+                    {
+                        "error": (
+                            f"Tool {name} declared in registry but handler "
+                            f"{binding.handler_method!r} not found on ToolBox"
+                        )
+                    }
+                )
             payload = handler(**args)
             result = _safe_json(payload)
         except _ToolError as exc:

--- a/amx/search/tools/__init__.py
+++ b/amx/search/tools/__init__.py
@@ -1,0 +1,10 @@
+"""Tool registry + helpers for the /ask tool-calling loop.
+
+Split from `amx/search/agent_tools.py` so the schema↔implementation
+binding has a single declared source of truth instead of relying on
+implicit `getattr` dispatch on a god-object.
+"""
+
+from amx.search.tools.registry import TOOLS, ToolBinding, get_binding
+
+__all__ = ["TOOLS", "ToolBinding", "get_binding"]

--- a/amx/search/tools/registry.py
+++ b/amx/search/tools/registry.py
@@ -1,0 +1,78 @@
+"""Explicit registry binding LLM tool schemas to ToolBox methods.
+
+Replaces the implicit ``getattr(self, f"_tool_{name}")`` dispatch in
+:meth:`amx.search.agent_tools.ToolBox.invoke` with a declared mapping
+so schema↔implementation drift surfaces as a deterministic test
+failure (``test_tool_registry.py``) instead of a runtime
+``{"error": "Unknown tool: …"}`` envelope the LLM has to puzzle out.
+
+The registry also carries a ``side_effect`` flag per tool — the only
+non-pure tool today is ``describe_table`` (writes table metadata to
+the history cache with a 24-hour TTL). Future PRs in the /ask refactor
+(see ``moonlit-snacking-quokka.md`` plan) thread this flag through the
+agent prompt so the LLM knows when calling a tool has consequences
+beyond returning data.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class ToolBinding(NamedTuple):
+    """One tool's schema/handler binding.
+
+    ``handler_method`` is the attribute name looked up on
+    :class:`amx.search.agent_tools.ToolBox` (or one of its mixins).
+    Today every tool follows the ``_tool_{schema_name}`` convention;
+    storing the resolved name lets a future PR rename either side
+    independently without breaking the dispatch.
+    """
+
+    handler_method: str
+    side_effect: bool = False
+
+
+# Tools that mutate persistent state. Everything else is read-only
+# and defaults to ``side_effect=False``. Keep this set small — when
+# in doubt, audit the implementation and add a regression test before
+# flipping the flag.
+_SIDE_EFFECT_TOOLS: frozenset[str] = frozenset(
+    {
+        # `_tool_describe_table` calls `_writeback_table_metadata`
+        # which persists the live-probe result into the history store
+        # with a 24h TTL (see agent_tools.py:482-530).
+        "describe_table",
+    }
+)
+
+
+def _build_tools() -> dict[str, ToolBinding]:
+    """Build the registry from the canonical schema list.
+
+    Iterating ``tool_schemas()`` means every schema entry
+    automatically participates; missing or renamed schemas are caught
+    by ``test_every_schema_is_registered``.
+    """
+    from amx.search._tool_schemas import tool_schemas
+
+    out: dict[str, ToolBinding] = {}
+    for entry in tool_schemas():
+        name = str(entry.get("function", {}).get("name") or "")
+        if not name:
+            continue
+        out[name] = ToolBinding(
+            handler_method=f"_tool_{name}",
+            side_effect=name in _SIDE_EFFECT_TOOLS,
+        )
+    return out
+
+
+TOOLS: dict[str, ToolBinding] = _build_tools()
+
+
+def get_binding(name: str) -> ToolBinding | None:
+    """Look up a tool's binding by schema name; returns ``None`` for
+    unknown names so the caller can return its own structured error
+    envelope rather than raising."""
+    return TOOLS.get(name)

--- a/tests/search/test_tool_registry.py
+++ b/tests/search/test_tool_registry.py
@@ -1,0 +1,99 @@
+"""Registry-vs-schemas integrity for the /ask tool catalog.
+
+Locks in three contracts the implicit ``getattr`` dispatch never
+enforced:
+
+1. Every schema entry in ``amx/search/_tool_schemas.py`` has a binding
+   in ``amx/search/tools/registry.py:TOOLS`` — a new tool added to the
+   schema list but missed by the registry fails immediately rather
+   than at runtime when the LLM picks it.
+2. Every registered tool has a matching handler method on
+   ``ToolBox`` (or one of its mixins) — drift in the other direction
+   surfaces as a clean assertion instead of an
+   ``{"error": "handler not found"}`` envelope.
+3. The ``side_effect`` flag is declared correctly: ``describe_table``
+   (writes to history cache) is True; representative pure tools
+   stay False.
+"""
+
+from __future__ import annotations
+
+from amx.search._tool_schemas import tool_schemas
+from amx.search.agent_tools import ToolBox
+from amx.search.tools.registry import TOOLS, ToolBinding, get_binding
+
+
+def test_every_schema_has_a_registry_binding() -> None:
+    """Schemas drive the LLM's tool menu; every entry must have a
+    binding so dispatch never falls through to ``Unknown tool``."""
+    schema_names = {entry["function"]["name"] for entry in tool_schemas()}
+    missing = schema_names - set(TOOLS)
+    assert not missing, (
+        f"Tools declared in schemas but missing from registry: {sorted(missing)}"
+    )
+
+
+def test_registry_only_contains_real_schemas() -> None:
+    """A binding without a backing schema would never be invoked by
+    the LLM — flag the stale entry rather than carry dead weight."""
+    schema_names = {entry["function"]["name"] for entry in tool_schemas()}
+    stale = set(TOOLS) - schema_names
+    assert not stale, (
+        f"Tools in registry but no schema declares them: {sorted(stale)}"
+    )
+
+
+def test_every_registered_tool_has_handler_method() -> None:
+    """The dispatch path in ``ToolBox.invoke`` does
+    ``getattr(self, binding.handler_method)``; a missing method would
+    return an error envelope rather than execute. Lock the binding in
+    place at import time."""
+    missing: list[tuple[str, str]] = []
+    for name, binding in TOOLS.items():
+        if not hasattr(ToolBox, binding.handler_method):
+            missing.append((name, binding.handler_method))
+    assert not missing, (
+        "Tools in registry with no handler on ToolBox: "
+        + ", ".join(f"{n}→{m}" for n, m in missing)
+    )
+
+
+def test_describe_table_declared_side_effect() -> None:
+    """``_tool_describe_table`` writes the live-probe result into the
+    history cache (24h TTL). The registry must surface this so future
+    PRs can warn the LLM before invocation."""
+    binding = get_binding("describe_table")
+    assert binding is not None
+    assert binding.side_effect is True
+
+
+def test_pure_read_tools_default_to_no_side_effect() -> None:
+    """Representative read-only tools must not be flagged side-effect
+    — a false positive would force the LLM to surface a misleading
+    'this tool mutates state' notice on every catalog lookup."""
+    for name in ("list_schemas", "find_table_by_name", "search_assets", "describe_column"):
+        binding = get_binding(name)
+        assert binding is not None, f"{name} missing from registry"
+        assert binding.side_effect is False, (
+            f"Pure read tool {name} should default to side_effect=False"
+        )
+
+
+def test_get_binding_returns_none_for_unknown_tool() -> None:
+    """The dispatch path treats ``None`` from ``get_binding`` as a
+    clean 'unknown tool' signal — exercise it directly so refactors
+    that change the lookup contract are caught."""
+    assert get_binding("__definitely_not_a_real_tool__") is None
+
+
+def test_tool_binding_handler_method_follows_convention() -> None:
+    """Today every binding follows the ``_tool_{name}`` convention;
+    storing the resolved string is what lets a future PR rename the
+    method without changing the schema. Exercise the invariant so
+    accidental departures are spotted."""
+    for name, binding in TOOLS.items():
+        assert isinstance(binding, ToolBinding)
+        assert binding.handler_method == f"_tool_{name}", (
+            f"{name}: handler_method {binding.handler_method!r} does not "
+            f"match _tool_{{name}} convention"
+        )


### PR DESCRIPTION
## Summary

PR 2 of the /ask agent refactor. Replaces the implicit `getattr(self, f"_tool_{name}", None)` dispatch in `ToolBox.invoke` with an explicit `TOOLS: dict[str, ToolBinding]` registry built from the canonical `tool_schemas()` list at import time.

- New module `amx/search/tools/registry.py`: declared bindings + `side_effect` flag (today `describe_table` is the only True — it persists to history cache with 24h TTL).
- `ToolBox.invoke` resolves through registry; unknown-tool error envelope unchanged.

## Test plan

- [x] `tests/search/test_tool_registry.py` — 7 new tests: every schema has a binding, every binding has a handler method, side-effect flags correct, lookup contract preserved.
- [x] Full `tests/search/` suite: 60 passed.
- [x] `ruff check`: passed. `mypy amx/search/tools/`: passed.