### PR TITLE
refactor(ask): consolidated find_table dispatcher (internal, schema-gated)

### DIFF
--- a/amx/search/tools/consolidated.py
+++ b/amx/search/tools/consolidated.py
@@ -1,0 +1,100 @@
+"""Consolidated table-discovery functions for the /ask agent.
+
+Today the LLM sees four overlapping tools when it wants to find a
+table:
+
+* ``find_table_by_name`` — exact name match across catalog + live DB.
+* ``search_tables_by_concept`` — semantic search over table descriptions.
+* ``list_tables_in_schema`` — exhaustive enumeration in a single schema.
+* ``search_assets`` — keyword search across the whole asset catalog.
+
+Each call has its own argument shape and result envelope. The
+decision overhead bloats the LLM's tool menu (verbose schema
+descriptions explaining when to prefer which) and forces the prompt
+to carry ~50 lines of routing rules.
+
+This module is the **internal target** for consolidation. The
+public-LLM-facing unified tool (``find_table(name, strategy, scope)``)
+is intentionally NOT yet registered in
+``amx/search/_tool_schemas.py`` — wiring it would change the LLM's
+menu and routing in production, which the per-PR smoke-test gate
+cannot verify in the current refactor pass. Once the gate is back
+(or the unified tool is verified end-to-end), a follow-on PR flips
+the schema list and removes the legacy tools.
+
+For now the function below exists so:
+
+1. Parity tests (``test_consolidated_find_table.py``) prove the
+   dispatch produces byte-identical output to the legacy tools given
+   matching arguments — the contract the future schema flip needs.
+2. Internal callers (future pipeline stages, debug tooling) can use
+   one entry point instead of branching on strategy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from amx.search.agent_tools import ToolBox
+
+
+Strategy = Literal["exact", "semantic", "list_in_schema"]
+
+
+def find_table(
+    toolbox: ToolBox,
+    *,
+    name: str,
+    strategy: Strategy = "exact",
+    scope: str = "catalog",
+    limit: int = 10,
+    force_fresh: bool = False,
+) -> dict[str, Any]:
+    """Unified table discovery — dispatches to the legacy tool that
+    owns the requested strategy.
+
+    Arguments mirror the union of the legacy tools' kwargs so a future
+    schema flip is a one-line description swap rather than a
+    parameter-shape migration:
+
+    * ``strategy="exact"`` → :meth:`ToolBox._tool_find_table_by_name`.
+      ``name`` is the table name to look up; ``force_fresh`` skips
+      the cache layer. ``scope`` is currently advisory (legacy tool
+      always sweeps both catalog and live DB).
+    * ``strategy="semantic"`` →
+      :meth:`ToolBox._tool_search_tables_by_concept`. ``name`` is
+      treated as the concept query; ``limit`` caps results.
+    * ``strategy="list_in_schema"`` →
+      :meth:`ToolBox._tool_list_tables_in_schema`. ``name`` is the
+      schema name; ``scope`` may carry the catalog/database hint.
+
+    Behaviour parity is enforced by
+    ``tests/search/test_consolidated_find_table.py`` so the dispatch
+    can be swapped for a direct LLM-callable entry point without
+    surprising the legacy callers.
+    """
+    target = (name or "").strip()
+    if not target:
+        return {"error": "Argument 'name' is required."}
+
+    if strategy == "exact":
+        return toolbox._tool_find_table_by_name(  # noqa: SLF001
+            name=target, force_fresh=force_fresh
+        )
+    if strategy == "semantic":
+        return toolbox._tool_search_tables_by_concept(  # noqa: SLF001
+            concept=target, limit=limit
+        )
+    if strategy == "list_in_schema":
+        return toolbox._tool_list_tables_in_schema(  # noqa: SLF001
+            schema=target,
+            catalog=scope or "",
+            force_fresh=force_fresh,
+        )
+    return {
+        "error": (
+            f"Unknown strategy {strategy!r}. "
+            "Use 'exact', 'semantic', or 'list_in_schema'."
+        ),
+    }

--- a/tests/search/test_consolidated_find_table.py
+++ b/tests/search/test_consolidated_find_table.py
@@ -1,0 +1,145 @@
+"""Parity contract for the consolidated `find_table` dispatcher.
+
+The dispatcher in ``amx/search/tools/consolidated.py`` is not yet
+LLM-visible; the schema swap happens in a later PR. Until then this
+suite proves the dispatcher produces byte-identical output to the
+legacy tools given matching arguments — that's the contract the
+future schema flip relies on.
+
+Tests use a stubbed ToolBox whose legacy methods are recorded so the
+assertion targets the dispatch shape (which method was called with
+which kwargs) and the pass-through of the return value.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from amx.search.tools.consolidated import find_table
+
+
+class _RecordingToolbox:
+    """Stub ToolBox capturing legacy-method calls.
+
+    Mirrors only the three methods the dispatcher delegates to; any
+    other access raises AttributeError so an accidental new branch
+    in ``find_table`` is caught immediately.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _tool_find_table_by_name(self, *, name: str, force_fresh: bool) -> dict[str, Any]:
+        self.calls.append(
+            ("find_table_by_name", {"name": name, "force_fresh": force_fresh})
+        )
+        return {"found": True, "name": name, "via": "find_table_by_name"}
+
+    def _tool_search_tables_by_concept(self, *, concept: str, limit: int) -> dict[str, Any]:
+        self.calls.append(
+            ("search_tables_by_concept", {"concept": concept, "limit": limit})
+        )
+        return {"concept": concept, "limit": limit, "via": "search_tables_by_concept"}
+
+    def _tool_list_tables_in_schema(
+        self, *, schema: str, catalog: str, force_fresh: bool
+    ) -> dict[str, Any]:
+        self.calls.append(
+            (
+                "list_tables_in_schema",
+                {"schema": schema, "catalog": catalog, "force_fresh": force_fresh},
+            )
+        )
+        return {"schema": schema, "via": "list_tables_in_schema"}
+
+
+def test_exact_strategy_routes_to_find_table_by_name() -> None:
+    """`strategy='exact'` must call the legacy exact-match tool with
+    the same `name` + `force_fresh` it received."""
+    tb = _RecordingToolbox()
+
+    result = find_table(tb, name="customers", strategy="exact", force_fresh=True)  # type: ignore[arg-type]
+
+    assert tb.calls == [
+        ("find_table_by_name", {"name": "customers", "force_fresh": True})
+    ]
+    # Pass-through: the dispatcher must not modify the legacy result.
+    assert result == {"found": True, "name": "customers", "via": "find_table_by_name"}
+
+
+def test_semantic_strategy_routes_to_search_tables_by_concept() -> None:
+    """`strategy='semantic'` treats `name` as the concept query and
+    forwards `limit` verbatim."""
+    tb = _RecordingToolbox()
+
+    result = find_table(tb, name="customer activity", strategy="semantic", limit=5)  # type: ignore[arg-type]
+
+    assert tb.calls == [
+        ("search_tables_by_concept", {"concept": "customer activity", "limit": 5})
+    ]
+    assert result["via"] == "search_tables_by_concept"
+
+
+def test_list_in_schema_strategy_routes_to_list_tables_in_schema() -> None:
+    """`strategy='list_in_schema'` uses `name` as the schema and
+    threads `scope` into the legacy tool's `catalog` parameter."""
+    tb = _RecordingToolbox()
+
+    result = find_table(  # type: ignore[arg-type]
+        tb,
+        name="public",
+        strategy="list_in_schema",
+        scope="my_db",
+    )
+
+    assert tb.calls == [
+        (
+            "list_tables_in_schema",
+            {"schema": "public", "catalog": "my_db", "force_fresh": False},
+        )
+    ]
+    assert result["via"] == "list_tables_in_schema"
+
+
+def test_default_strategy_is_exact() -> None:
+    """Calling without `strategy=` must default to exact match — keeps
+    the dispatcher's call site obvious for the common path."""
+    tb = _RecordingToolbox()
+
+    find_table(tb, name="orders")  # type: ignore[arg-type]
+
+    assert tb.calls[0][0] == "find_table_by_name"
+
+
+def test_empty_name_returns_error_envelope_without_calling_legacy() -> None:
+    """Empty `name` is rejected up front — no legacy call, structured
+    error envelope. Matches the legacy tools' own validation."""
+    tb = _RecordingToolbox()
+
+    result = find_table(tb, name="", strategy="exact")  # type: ignore[arg-type]
+
+    assert tb.calls == []
+    assert "required" in result["error"]
+
+
+def test_whitespace_only_name_treated_as_empty() -> None:
+    """Whitespace-only `name` is the same as empty — legacy tools
+    strip and reject, the dispatcher does the same up front."""
+    tb = _RecordingToolbox()
+
+    result = find_table(tb, name="   ", strategy="exact")  # type: ignore[arg-type]
+
+    assert tb.calls == []
+    assert "required" in result["error"]
+
+
+def test_unknown_strategy_returns_error_envelope() -> None:
+    """An unknown strategy must surface a clear error envelope —
+    callers should never silently get the wrong tool's output."""
+    tb = _RecordingToolbox()
+
+    result = find_table(tb, name="x", strategy="fuzzy")  # type: ignore[arg-type]
+
+    assert tb.calls == []
+    assert "Unknown strategy" in result["error"]
+    assert "fuzzy" in result["error"]


### PR DESCRIPTION
## Summary

PR 3 of the /ask agent refactor — adds the internal entry point for the table-discovery consolidation without changing what the LLM sees.

- New `amx/search/tools/consolidated.py:find_table(toolbox, name, strategy, scope)` dispatches to legacy tools based on `strategy` (`exact` | `semantic` | `list_in_schema`).
- Function is **not yet wired into `_tool_schemas.py`** — wiring would change the LLM's tool menu in production. A follow-on PR (with smoke test) does the schema flip.
- Goal: parity contract proven, infrastructure in place, zero LLM behavior change.

## Test plan

- [x] `tests/search/test_consolidated_find_table.py` — 7 new tests: each strategy routes to the correct legacy tool with verbatim kwargs and pass-through return, default strategy is `exact`, empty/whitespace name → error envelope, unknown strategy → error envelope.
- [x] `ruff check`: passed. `mypy`: passed.