### PR TITLE
refactor(ask): extract token-budget helpers into pipeline module

### DIFF
--- a/amx/search/pipeline/__init__.py
+++ b/amx/search/pipeline/__init__.py
@@ -1,0 +1,23 @@
+"""Pure-function pipeline stages for the /ask agent.
+
+The /ask refactor (see ``moonlit-snacking-quokka.md`` plan) replaces
+the mixin-based ``SearchAgent`` with a pipeline:
+
+    ask(q) = synthesize(retrieve(plan(interpret(q))))
+
+Each stage owns one concern and takes its dependencies explicitly so
+it can be unit-tested without instantiating the whole SearchAgent.
+This module is the incremental landing point — stages migrate here
+one at a time, then ``SearchAgent`` mixins become thin shims that
+delegate to the pure functions.
+"""
+
+from amx.search.pipeline.budget import (
+    TRUNCATED_TOOL_PAYLOAD,
+    enforce_input_token_budget,
+)
+
+__all__ = [
+    "TRUNCATED_TOOL_PAYLOAD",
+    "enforce_input_token_budget",
+]

--- a/amx/search/pipeline/budget.py
+++ b/amx/search/pipeline/budget.py
@@ -1,0 +1,53 @@
+"""Token-budget enforcement for the /ask tool loop.
+
+Lives in its own module so future pipeline stages
+(``plan.py``, ``retrieve.py``, ``synthesize.py``) can call the same
+helpers without importing the entire ``tool_agent.py`` module.
+
+The truncation policy is: replace the oldest tool-result message
+contents in place with a fixed JSON sentinel until the estimated
+token cost falls under the budget. Newer tool results stay intact so
+the model still sees its latest evidence.
+
+The sentinel (``TRUNCATED_TOOL_PAYLOAD``) is plain JSON so the model
+parses it identically to any normal result envelope — no special
+handling required at the model side.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from amx.utils.token_tracker import estimate_tokens
+
+# Sentinel content that replaces a truncated tool result. Plain JSON
+# so the model parses it identically to any normal result envelope.
+TRUNCATED_TOOL_PAYLOAD = '{"truncated": true, "reason": "context budget reached"}'
+
+
+def enforce_input_token_budget(
+    messages: list[dict[str, Any]],
+    *,
+    budget: int,
+) -> bool:
+    """Truncate oldest tool-result contents in-place until the estimated
+    token cost of ``messages`` falls under ``budget``. Returns ``True``
+    when any truncation occurred, ``False`` when the prompt already fit.
+
+    Iteration order is oldest-first so the model retains its most
+    recent evidence. Re-running on an already-truncated message list
+    is a no-op (the sentinel content is recognised and skipped).
+    """
+    if estimate_tokens(messages) <= budget:
+        return False
+    truncated_any = False
+    for msg in messages:
+        if msg.get("role") != "tool":
+            continue
+        if msg.get("content") == TRUNCATED_TOOL_PAYLOAD:
+            continue
+        msg["content"] = TRUNCATED_TOOL_PAYLOAD
+        truncated_any = True
+        if estimate_tokens(messages) <= budget:
+            return True
+    return truncated_any

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -33,12 +33,19 @@ from amx.llm.provider import LLMProvider
 from amx.search._tool_agent_prompts import agent_system_prompt as _agent_system_prompt
 from amx.search.agent_tools import ToolBox
 from amx.search.catalog import SearchCatalog
+from amx.search.pipeline import budget as _budget
 from amx.utils.logging import get_logger
 from amx.utils.token_tracker import estimate_tokens
 from amx.utils.token_tracker import tracker as token_tracker
 
 if TYPE_CHECKING:
     from amx.utils.live_display import LiveDisplay
+
+# Backward-compat re-exports — older callers and tests reference these
+# private names directly. PR 7 removes the aliases; until then keep
+# them so the move is a pure relocation.
+_TRUNCATED_TOOL_PAYLOAD = _budget.TRUNCATED_TOOL_PAYLOAD
+_enforce_input_token_budget = _budget.enforce_input_token_budget
 
 log = get_logger("search.tool_agent")
 
@@ -61,38 +68,6 @@ _AGENT_MAX_TOKENS = 1500
 # output. 100 000 leaves headroom for system prompt, tools schema, and
 # the configured output cap on the 200K Claude / GPT-4-turbo window.
 _AGENT_INPUT_TOKEN_BUDGET = int(os.environ.get("AMX_ASK_INPUT_TOKEN_BUDGET", "100000"))
-
-# Sentinel content that replaces a truncated tool result. Plain JSON so
-# the model parses it the same way as a normal result envelope.
-_TRUNCATED_TOOL_PAYLOAD = '{"truncated": true, "reason": "context budget reached"}'
-
-
-def _enforce_input_token_budget(
-    messages: list[dict[str, Any]],
-    *,
-    budget: int,
-) -> bool:
-    """Truncate oldest tool-result contents in-place until the estimated
-    token cost of `messages` falls under `budget`. Returns True when
-    any truncation occurred.
-
-    Tool results are mutated in iteration order so the model still sees
-    the most recent results in full — older results decay first.
-    """
-    if estimate_tokens(messages) <= budget:
-        return False
-    truncated_any = False
-    for msg in messages:
-        if msg.get("role") != "tool":
-            continue
-        if msg.get("content") == _TRUNCATED_TOOL_PAYLOAD:
-            continue
-        msg["content"] = _TRUNCATED_TOOL_PAYLOAD
-        truncated_any = True
-        if estimate_tokens(messages) <= budget:
-            return True
-    return truncated_any
-
 
 class ToolAgentResult:
     """Container for what the agent loop produced."""

--- a/tests/search/test_pipeline_budget.py
+++ b/tests/search/test_pipeline_budget.py
@@ -1,0 +1,59 @@
+"""Canonical home for token-budget enforcement.
+
+The helper used to live in ``amx/search/tool_agent.py`` so other
+modules importing it had to pull in the entire tool-loop. PR 4 of the
+/ask refactor moves it to ``amx/search/pipeline/budget.py`` and
+re-exports it from ``tool_agent`` for backward compatibility. This
+suite exercises the new canonical location directly so a future
+removal of the re-export (planned for PR 7) does not silently lose
+coverage.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from amx.search.pipeline.budget import (
+    TRUNCATED_TOOL_PAYLOAD,
+    enforce_input_token_budget,
+)
+
+
+def test_truncated_payload_is_parseable_json() -> None:
+    """The model treats the sentinel like any other tool result, so
+    it must parse as JSON without special handling."""
+    parsed = json.loads(TRUNCATED_TOOL_PAYLOAD)
+    assert parsed == {"truncated": True, "reason": "context budget reached"}
+
+
+def test_enforce_no_op_when_under_budget() -> None:
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "hi"},
+        {"role": "tool", "tool_call_id": "c1", "content": '{"matches": []}'},
+    ]
+    snapshot = [dict(m) for m in messages]
+    assert enforce_input_token_budget(messages, budget=1_000_000) is False
+    assert messages == snapshot
+
+
+def test_enforce_truncates_oldest_first() -> None:
+    big = json.dumps({"rows": ["x" * 100 for _ in range(2000)]})
+    messages: list[dict[str, Any]] = [
+        {"role": "tool", "tool_call_id": "c1", "content": big},
+        {"role": "tool", "tool_call_id": "c2", "content": '{"small": true}'},
+    ]
+    assert enforce_input_token_budget(messages, budget=100) is True
+    assert messages[0]["content"] == TRUNCATED_TOOL_PAYLOAD
+
+
+def test_tool_agent_reexports_keep_back_compat() -> None:
+    """The module-level aliases in `tool_agent.py` are still exposed
+    so call sites (and existing tests) that read them via the
+    ``amx.search.tool_agent`` namespace keep working until the
+    re-export is removed in PR 7."""
+    import amx.search.tool_agent as ta
+
+    assert ta._TRUNCATED_TOOL_PAYLOAD == TRUNCATED_TOOL_PAYLOAD
+    assert ta._enforce_input_token_budget is enforce_input_token_budget


### PR DESCRIPTION
## Summary

PR 4 of the /ask agent refactor — pure relocation of token-budget enforcement.

- New `amx/search/pipeline/budget.py` owns `TRUNCATED_TOOL_PAYLOAD` and `enforce_input_token_budget`.
- `tool_agent.py` imports them through a module alias and re-exports as private names so existing callers keep working.
- A future PR removes the back-compat aliases once mixins are gone.

## Test plan

- [x] `tests/search/test_pipeline_budget.py` — 4 new tests anchor canonical location, payload parses as JSON, no-op + truncate paths, back-compat aliases still work.
- [x] `tests/search/test_tool_loop_safety.py` — 5 existing tests still pass via re-export.
- [x] Full `tests/search/` suite: 71 passed.
- [x] `ruff check`: passed. `mypy`: passed.
- [x] deploy.sh executed; Studio live.