### PR TITLE
refactor(ask): extract chitchat detector into pure pipeline function

### DIFF
--- a/amx/search/_agent/short_circuits.py
+++ b/amx/search/_agent/short_circuits.py
@@ -41,21 +41,17 @@ class ShortCircuitsMixin:
         as ``needs_clarification=True``, yielding "Could you clarify the
         exact scope (database/schema/table)?" — a confusing reply when the
         user just typed "hi".
+
+        Detection is delegated to the pure
+        :func:`amx.search.pipeline.short_circuits.is_chitchat`; the
+        mixin keeps ownership of the side-effect glue (session-store
+        recording, ``SearchAnswer`` construction).
         """
-        sample = (question or "").strip().lower()
-        if not sample:
+        from amx.search.pipeline.short_circuits import chitchat_summary, is_chitchat
+
+        if not is_chitchat(question, self._CHITCHAT_TOKENS):
             return None
-        # Must be short and contain only chitchat tokens — punctuation aside.
-        words = [tok for tok in re.split(r"[\s\?!.,;:]+", sample) if tok]
-        if not words or len(words) > 4:
-            return None
-        if not all(word in self._CHITCHAT_TOKENS for word in words):
-            return None
-        summary = (
-            "Hi! I'm AMX's metadata search assistant — I'm built to answer questions about "
-            "your database schemas, tables, and columns rather than chat. "
-            "Try: `what is the vbrk table?`, `which tables relate to pricing?`."
-        )
+        summary = chitchat_summary()
         self._record_short_circuit_assistant(summary=summary, intent="chitchat")
         return SearchAnswer(
             intent="chitchat",

--- a/amx/search/pipeline/short_circuits.py
+++ b/amx/search/pipeline/short_circuits.py
@@ -1,0 +1,74 @@
+"""Pure short-circuit detectors for the /ask flow.
+
+The mixin-based ``SearchAgent`` has a family of methods named
+``_handle_*`` that recognise question patterns and reply directly
+without driving the full plan/retrieve/synthesize loop. The
+recognition logic in each handler is pure — it inspects the question
+string + a small set of constants — but it's currently entangled with
+side effects (session-store writes, ``SearchAnswer`` construction).
+
+This module extracts the **pure detection step** so each short
+circuit becomes unit-testable in isolation. The mixin retains the
+side-effect glue (record assistant turn, construct the answer) and
+delegates the detection here.
+
+PR 5 of the /ask agent refactor migrates one short circuit at a time
+(``chitchat`` first); future PRs extract ``meta_query`` and
+``followup_reaffirmation`` under the same shape.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+# The canned reply for chitchat — kept as a constant exposed via the
+# ``chitchat_summary`` function so callers can't accidentally mutate
+# it. The wording matches the legacy mixin verbatim so behaviour
+# parity is provable.
+_CHITCHAT_SUMMARY = (
+    "Hi! I'm AMX's metadata search assistant — I'm built to answer questions about "
+    "your database schemas, tables, and columns rather than chat. "
+    "Try: `what is the vbrk table?`, `which tables relate to pricing?`."
+)
+
+# Pre-compiled splitter for tokenising chitchat candidates. Strips
+# whitespace and common punctuation in one pass so ``is_chitchat``
+# stays allocation-light on every ``/ask`` turn.
+_CHITCHAT_SPLIT_RE = re.compile(r"[\s\?!.,;:]+")
+
+
+def is_chitchat(question: str, chitchat_tokens: Iterable[str]) -> bool:
+    """Detect conversational filler (greetings, thanks, single-word
+    politeness).
+
+    Returns ``True`` when the question is short (≤4 words after
+    splitting on whitespace + common punctuation) AND every word is
+    in ``chitchat_tokens``. Mirrors the legacy
+    :meth:`amx.search._agent.short_circuits.ShortCircuitsMixin._handle_chitchat`
+    detection step byte-for-byte.
+
+    The token set is parameterised (not a module-level constant)
+    because ``SearchAgent`` owns the canonical
+    ``_CHITCHAT_TOKENS`` frozen set and may extend it per
+    deployment.
+    """
+    sample = (question or "").strip().lower()
+    if not sample:
+        return False
+    words = [tok for tok in _CHITCHAT_SPLIT_RE.split(sample) if tok]
+    if not words or len(words) > 4:
+        return False
+    token_set = (
+        chitchat_tokens
+        if isinstance(chitchat_tokens, (set, frozenset))
+        else frozenset(chitchat_tokens)
+    )
+    return all(word in token_set for word in words)
+
+
+def chitchat_summary() -> str:
+    """The canned reply text the mixin returns when chitchat is
+    detected. Exposed as a function so the constant cannot be
+    mutated in place by accident."""
+    return _CHITCHAT_SUMMARY

--- a/tests/search/test_pipeline_short_circuits.py
+++ b/tests/search/test_pipeline_short_circuits.py
@@ -1,0 +1,74 @@
+"""Pure detection tests for /ask short circuits.
+
+The chitchat detector lives in
+``amx/search/pipeline/short_circuits.py`` as a pure function so it
+can be exercised without instantiating ``SearchAgent``. This suite
+locks in the behaviour the legacy mixin used to inline; it also
+guards against accidental drift between the two until the mixin's
+side-effect shell is migrated in a later PR.
+"""
+
+from __future__ import annotations
+
+from amx.search.pipeline.short_circuits import (
+    chitchat_summary,
+    is_chitchat,
+)
+
+# Subset of ``SearchAgent._CHITCHAT_TOKENS`` — kept small and
+# explicit so the test reads as a spec for the rule.
+TOKENS = frozenset({"hi", "hello", "hey", "thanks", "ok", "good", "morning"})
+
+
+def test_short_pure_chitchat_recognised() -> None:
+    for q in ("hi", "Hello", "Hey!", "thanks", "ok"):
+        assert is_chitchat(q, TOKENS) is True, q
+
+
+def test_two_word_chitchat_recognised() -> None:
+    """Up to 4 words counts as chitchat when every token matches —
+    'good morning', 'hi there' style salutations."""
+    assert is_chitchat("good morning", TOKENS) is True
+    assert is_chitchat("hello!", TOKENS) is True
+
+
+def test_too_many_words_rejected() -> None:
+    """Long greetings are NOT short-circuited; the planner gets
+    them so a real follow-up question after a greeting still
+    flows through normally."""
+    assert is_chitchat("hi how are you doing today", TOKENS) is False
+
+
+def test_non_chitchat_word_rejected() -> None:
+    """A single off-token word in an otherwise short input means
+    the user is asking something — must fall through to planning."""
+    assert is_chitchat("hi customers", TOKENS) is False
+    assert is_chitchat("show me tables", TOKENS) is False
+
+
+def test_empty_question_rejected() -> None:
+    assert is_chitchat("", TOKENS) is False
+    assert is_chitchat("   ", TOKENS) is False
+
+
+def test_punctuation_only_rejected() -> None:
+    """After stripping ``?!.,;:`` the input has no words at all —
+    nothing to classify."""
+    assert is_chitchat("?", TOKENS) is False
+    assert is_chitchat("!!", TOKENS) is False
+
+
+def test_token_set_can_be_iterable_not_frozenset() -> None:
+    """SearchAgent currently passes a ``frozenset`` but the
+    contract should accept any iterable — converting once inside
+    the function keeps callers honest."""
+    assert is_chitchat("hi", ["hi", "hello"]) is True
+    assert is_chitchat("hi", ("hi", "hello")) is True
+
+
+def test_chitchat_summary_is_stable() -> None:
+    """The canned reply is a constant; tests pin the wording so
+    accidental edits surface as test failures."""
+    s = chitchat_summary()
+    assert "AMX's metadata search assistant" in s
+    assert "vbrk" in s


### PR DESCRIPTION
## Summary

PR 5 of the /ask agent refactor — first short-circuit handler migration to the pure-function + thin-shim pattern.

- New `amx/search/pipeline/short_circuits.py` owns `is_chitchat()` (pure detection) and `chitchat_summary()` (canned reply).
- `ShortCircuitsMixin._handle_chitchat` keeps the side-effect glue (session-store recording, `SearchAnswer` construction) and delegates detection to the pure helper.
- Byte-identical behavior; integration tests pass.

## Test plan

- [x] `tests/search/test_pipeline_short_circuits.py` — 8 new tests: short pure chitchat, multi-word, rejection paths (too long, off-token, empty, whitespace, punctuation), token-set iterable acceptance, summary wording.
- [x] Full `tests/search/` suite: 79 passed.
- [x] `ruff check`: passed. `mypy`: 16 pre-existing cross-mixin errors (not introduced).
- [x] deploy.sh executed; Studio live.