### PR TITLE
refactor(ask): extract meta_query detector into pure pipeline function

### DIFF
--- a/amx/search/_agent/short_circuits.py
+++ b/amx/search/_agent/short_circuits.py
@@ -99,16 +99,20 @@ class ShortCircuitsMixin:
         Patterns: "what was my previous question?", "what did I ask?".
         Resolves against ``ChatSessionStore.recent_turns`` so the user gets
         the literal prior question text rather than a clarification prompt.
+
+        Detection delegated to the pure
+        :func:`amx.search.pipeline.short_circuits.is_meta_query`;
+        reply composition uses
+        :func:`amx.search.pipeline.short_circuits.meta_query_summary`.
+        The mixin retains the side-effect glue (session-store lookup,
+        assistant-turn recording, ``SearchAnswer`` construction).
         """
-        sample = (question or "").strip().lower()
-        if not sample:
-            return None
-        meta_patterns = (
-            r"\b(?:previous|prior|last)\s+question\b",
-            r"\bwhat\s+(?:did|was)\s+(?:i|my)\s+(?:last\s+|previous\s+|prior\s+)?(?:question|ask)\b",
-            r"\bwhat\s+have\s+i\s+(?:asked|been\s+asking)\b",
+        from amx.search.pipeline.short_circuits import (
+            is_meta_query,
+            meta_query_summary,
         )
-        if not any(re.search(p, sample) for p in meta_patterns):
+
+        if not is_meta_query(question):
             return None
         prior_question = ""
         store = self._ensure_session_store()
@@ -123,10 +127,7 @@ class ShortCircuitsMixin:
             # we want the one BEFORE it.
             if len(user_turns) >= 2:
                 prior_question = str(user_turns[-2].get("question") or "").strip()
-        if not prior_question:
-            summary = "This is the first question in this session; no prior question is on record."
-        else:
-            summary = f'Your previous question was: "{prior_question}"'
+        summary = meta_query_summary(prior_question)
         self._record_short_circuit_assistant(summary=summary, intent="meta_query")
         return SearchAnswer(
             intent="meta_query",

--- a/amx/search/pipeline/short_circuits.py
+++ b/amx/search/pipeline/short_circuits.py
@@ -72,3 +72,43 @@ def chitchat_summary() -> str:
     detected. Exposed as a function so the constant cannot be
     mutated in place by accident."""
     return _CHITCHAT_SUMMARY
+
+
+# Meta-query patterns: questions about the conversation itself
+# ("what was my previous question?"). The patterns come from the
+# legacy mixin verbatim so the regression suite passes unchanged.
+_META_PATTERNS: tuple[str, ...] = (
+    r"\b(?:previous|prior|last)\s+question\b",
+    r"\bwhat\s+(?:did|was)\s+(?:i|my)\s+(?:last\s+|previous\s+|prior\s+)?(?:question|ask)\b",
+    r"\bwhat\s+have\s+i\s+(?:asked|been\s+asking)\b",
+)
+
+_META_COMPILED: tuple[re.Pattern[str], ...] = tuple(re.compile(p) for p in _META_PATTERNS)
+
+
+def is_meta_query(question: str) -> bool:
+    """Detect questions about the conversation itself.
+
+    Returns ``True`` for ``"what was my previous question?"`` and
+    close variants. Mirrors
+    :meth:`amx.search._agent.short_circuits.ShortCircuitsMixin._handle_meta_query`
+    detection step. Empty input is rejected up front so callers
+    don't have to guard.
+    """
+    sample = (question or "").strip().lower()
+    if not sample:
+        return False
+    return any(pat.search(sample) for pat in _META_COMPILED)
+
+
+def meta_query_summary(prior_question: str) -> str:
+    """Compose the canned reply for a meta-query short circuit.
+
+    When ``prior_question`` is empty the reply admits this is the
+    first turn in the session; otherwise it quotes the user's prior
+    question verbatim. Wording matches the legacy mixin.
+    """
+    cleaned = (prior_question or "").strip()
+    if not cleaned:
+        return "This is the first question in this session; no prior question is on record."
+    return f'Your previous question was: "{cleaned}"'

--- a/tests/search/test_pipeline_short_circuits.py
+++ b/tests/search/test_pipeline_short_circuits.py
@@ -72,3 +72,55 @@ def test_chitchat_summary_is_stable() -> None:
     s = chitchat_summary()
     assert "AMX's metadata search assistant" in s
     assert "vbrk" in s
+
+
+# --------------------------------------------------------------------- meta_query
+
+from amx.search.pipeline.short_circuits import (  # noqa: E402
+    is_meta_query,
+    meta_query_summary,
+)
+
+
+def test_meta_query_recognises_previous_question_phrasings() -> None:
+    """The three legacy regex patterns each match at least one
+    natural phrasing of "what was my last question?"."""
+    for q in (
+        "what was my previous question",
+        "what was my last question?",
+        "what is my prior question",
+        "what did I ask?",
+        "what have I asked so far",
+        "what have I been asking",
+    ):
+        assert is_meta_query(q) is True, q
+
+
+def test_meta_query_rejects_normal_questions() -> None:
+    """Questions about data, not about the conversation itself,
+    must fall through to planning."""
+    for q in (
+        "what is the customers table",
+        "list all schemas",
+        "describe the vbrk table",
+        "",
+        "   ",
+    ):
+        assert is_meta_query(q) is False, q
+
+
+def test_meta_query_summary_uses_canonical_first_turn_wording_when_empty() -> None:
+    s = meta_query_summary("")
+    assert "first question in this session" in s
+
+
+def test_meta_query_summary_quotes_prior_question_verbatim() -> None:
+    s = meta_query_summary("what is the customers table?")
+    assert 'Your previous question was: "what is the customers table?"' == s
+
+
+def test_meta_query_summary_strips_whitespace_around_prior() -> None:
+    """Leading/trailing whitespace on the stored prior question is
+    cleaned before quoting."""
+    s = meta_query_summary("   list schemas   ")
+    assert 'Your previous question was: "list schemas"' == s


### PR DESCRIPTION
## Summary

PR 6 of the /ask agent refactor — meta_query short-circuit migrated to pure-function + thin-shim pattern.

- `amx/search/pipeline/short_circuits.py` gains `is_meta_query()` (regex match against legacy patterns) and `meta_query_summary(prior_question)` (reply composition).
- `ShortCircuitsMixin._handle_meta_query` delegates detection + summary, retains side-effect glue (ChatSessionStore lookup, assistant-turn recording, SearchAnswer construction).
- Byte-identical behavior.

## Test plan

- [x] 5 new pinning tests: legacy regex variants recognised, normal questions rejected, first-turn vs prior-turn summary wording, whitespace stripping.
- [x] Full `tests/search/` suite: 84 passed.
- [x] `ruff`: passed.
- [x] deploy.sh executed; Studio live.