### PR TITLE
refactor(ask): extract followup_reaffirmation detector into pure pipeline function

### DIFF
--- a/amx/search/_agent/short_circuits.py
+++ b/amx/search/_agent/short_circuits.py
@@ -154,11 +154,18 @@ class ShortCircuitsMixin:
         the planner to map to anything meaningful and we don't want to fall
         through to "Could you clarify the exact scope?". Pull the last
         assistant turn out of the session store and re-confirm it verbatim.
+
+        Detection + summary composition delegated to pure helpers in
+        :mod:`amx.search.pipeline.short_circuits`; the mixin retains
+        ownership of the session-store lookup and ``SearchAnswer``
+        construction.
         """
-        sample = (question or "").strip().lower()
-        if not sample:
-            return None
-        if not any(re.match(pattern, sample) for pattern in self._AFFIRM_FOLLOWUP_RE):
+        from amx.search.pipeline.short_circuits import (
+            is_followup_reaffirmation,
+            reaffirmation_summary,
+        )
+
+        if not is_followup_reaffirmation(question):
             return None
         store = self._ensure_session_store()
         sid = self.cfg.active_chat_session_id
@@ -179,10 +186,7 @@ class ShortCircuitsMixin:
                     break
         if not prior_assistant:
             return None
-        summary = (
-            "Yes, I'm sure — the previous answer came from live database metadata. To restate: "
-            + prior_assistant
-        )
+        summary = reaffirmation_summary(prior_assistant)
         self._record_short_circuit_assistant(summary=summary, intent="reaffirmation")
         return SearchAnswer(
             intent="reaffirmation",

--- a/amx/search/pipeline/short_circuits.py
+++ b/amx/search/pipeline/short_circuits.py
@@ -112,3 +112,48 @@ def meta_query_summary(prior_question: str) -> str:
     if not cleaned:
         return "This is the first question in this session; no prior question is on record."
     return f'Your previous question was: "{cleaned}"'
+
+
+# Followup reaffirmation patterns: short pushback phrasings ("are
+# you sure?", "really?", "why?"). Each is anchored with ^/$ to
+# require the whole input is just the pushback — a fresh question
+# that happens to contain "sure" must NOT short-circuit.
+_AFFIRM_PATTERNS: tuple[str, ...] = (
+    r"^\s*(?:are\s+you\s+sure|you\s+sure|really|seriously|sure\?+)\s*[\.\?\!]*\s*$",
+    r"^\s*(?:is\s+that\s+(?:right|correct|true)|you\s+positive|positive\?+)\s*[\.\?\!]*\s*$",
+    r"^\s*(?:why|why\??|how\s+come|how)\s*[\.\?\!]*\s*$",
+)
+
+_AFFIRM_COMPILED: tuple[re.Pattern[str], ...] = tuple(re.compile(p) for p in _AFFIRM_PATTERNS)
+
+
+def is_followup_reaffirmation(question: str) -> bool:
+    """Detect short pushback phrasings on the prior answer.
+
+    Returns ``True`` for ``"are you sure?"``, ``"really"``, ``"why?"``
+    and close variants. Patterns are anchored with ``^/$`` so a fresh
+    question that happens to contain ``"sure"`` does not match.
+
+    Mirrors
+    :meth:`amx.search._agent.short_circuits.ShortCircuitsMixin._handle_followup_reaffirmation`
+    detection step byte-for-byte; the mixin keeps ownership of the
+    session-store lookup and ``SearchAnswer`` construction.
+    """
+    sample = (question or "").strip().lower()
+    if not sample:
+        return False
+    return any(pat.match(sample) for pat in _AFFIRM_COMPILED)
+
+
+def reaffirmation_summary(prior_assistant: str) -> str:
+    """Compose the canned reply for a reaffirmation short circuit.
+
+    Quotes the prior assistant answer verbatim so the user sees the
+    confirmation came from the same source they originally received.
+    Wording matches the legacy mixin.
+    """
+    cleaned = (prior_assistant or "").strip()
+    return (
+        "Yes, I'm sure — the previous answer came from live database metadata. To restate: "
+        + cleaned
+    )

--- a/tests/search/test_pipeline_short_circuits.py
+++ b/tests/search/test_pipeline_short_circuits.py
@@ -124,3 +124,58 @@ def test_meta_query_summary_strips_whitespace_around_prior() -> None:
     cleaned before quoting."""
     s = meta_query_summary("   list schemas   ")
     assert 'Your previous question was: "list schemas"' == s
+
+
+# --------------------------------------------------------------------- followup_reaffirmation
+
+from amx.search.pipeline.short_circuits import (  # noqa: E402
+    is_followup_reaffirmation,
+    reaffirmation_summary,
+)
+
+
+def test_reaffirmation_recognises_short_pushbacks() -> None:
+    """Each legacy pattern matches at least one natural pushback."""
+    for q in (
+        "are you sure",
+        "are you sure?",
+        "you sure?",
+        "really",
+        "seriously",
+        "sure?",
+        "is that right",
+        "is that correct?",
+        "is that true",
+        "you positive",
+        "positive?",
+        "why",
+        "why?",
+        "how come",
+        "how",
+    ):
+        assert is_followup_reaffirmation(q) is True, q
+
+
+def test_reaffirmation_rejects_fresh_questions_containing_trigger_words() -> None:
+    """Patterns are anchored with ^/$ — a fresh question that
+    happens to contain 'sure' or 'why' must NOT short-circuit."""
+    for q in (
+        "are you sure the customers table exists",
+        "why does this table have no rows",
+        "is that correct in the schema",
+        "what was the reason",
+        "",
+    ):
+        assert is_followup_reaffirmation(q) is False, q
+
+
+def test_reaffirmation_summary_quotes_prior_assistant_verbatim() -> None:
+    s = reaffirmation_summary("The customers table has 42 rows.")
+    assert "Yes, I'm sure" in s
+    assert "live database metadata" in s
+    assert "The customers table has 42 rows." in s
+
+
+def test_reaffirmation_summary_strips_whitespace_around_prior() -> None:
+    s = reaffirmation_summary("   42 rows.   ")
+    assert s.endswith("To restate: 42 rows.")


### PR DESCRIPTION
## Summary

PR 7 of the /ask agent refactor — third short-circuit handler migrated. All three deterministic handlers (chitchat, meta_query, followup_reaffirmation) now follow the pure-function + thin-shim pattern.

- `amx/search/pipeline/short_circuits.py` gains `is_followup_reaffirmation()` (pre-compiled regex, anchored with `^/$`) and `reaffirmation_summary(prior_assistant)`.
- `ShortCircuitsMixin._handle_followup_reaffirmation` delegates detection + summary; retains side-effect glue.

## Test plan

- [x] 4 new tests: pattern variants recognised, fresh questions with trigger words rejected, summary wording stable, whitespace stripping.
- [x] Full `tests/search/` suite: 88 passed.
- [x] deploy.sh executed; Studio live.