### PR TITLE
refactor(ask): extract looks_partial check to pipeline/tool_results.py

### DIFF
--- a/amx/search/pipeline/tool_results.py
+++ b/amx/search/pipeline/tool_results.py
@@ -1,0 +1,29 @@
+"""Tool-result inspection helpers for the /ask agent.
+
+Pure functions that examine the raw string a tool returned and pull
+out flags the loop needs (e.g. ``"partial": true`` from the catalog
+tools' envelope). Lives here so future pipeline stages and tests can
+reach the helpers without importing the entire ``tool_agent`` module.
+"""
+
+from __future__ import annotations
+
+
+def looks_partial(tool_result: str | None) -> bool:
+    """Cheap textual check for the ``"partial": true`` marker on a
+    tool result.
+
+    The result is the JSON string the catalog tools return; parsing
+    every result would be wasteful when only a minority carry the
+    flag. ``"partial": true`` (with single or double quotes, with or
+    without internal whitespace) is unambiguous enough that a
+    substring match is sufficient.
+
+    Returns ``False`` for ``None`` and empty strings so callers don't
+    have to guard.
+    """
+    if not tool_result:
+        return False
+    if '"partial": true' in tool_result or '"partial":true' in tool_result:
+        return True
+    return "'partial': True" in tool_result or "'partial':True" in tool_result

--- a/amx/search/tool_agent.py
+++ b/amx/search/tool_agent.py
@@ -35,6 +35,7 @@ from amx.search.agent_tools import ToolBox
 from amx.search.catalog import SearchCatalog
 from amx.search.pipeline import budget as _budget
 from amx.search.pipeline.focus import compute_focus_profile as _compute_focus_profile
+from amx.search.pipeline.tool_results import looks_partial as _looks_partial_impl
 from amx.utils.logging import get_logger
 from amx.utils.token_tracker import estimate_tokens
 from amx.utils.token_tracker import tracker as token_tracker
@@ -121,17 +122,12 @@ def _convert_message_for_litellm(message: dict[str, Any]) -> dict[str, Any]:
     return msg
 
 
-def _looks_partial(tool_result: str) -> bool:
-    """Cheap textual check for the ``"partial": true`` marker on a
-    tool result. The result is the JSON string the catalog tools
-    return; parsing every result would be wasteful when only a
-    minority carry the flag. ``"partial": true`` (with single or
-    double quotes) is unambiguous enough."""
-    if not tool_result:
-        return False
-    if '"partial": true' in tool_result or '"partial":true' in tool_result:
-        return True
-    return "'partial': True" in tool_result or "'partial':True" in tool_result
+def _looks_partial(tool_result: str | None) -> bool:
+    """Backward-compatible re-export of
+    :func:`amx.search.pipeline.tool_results.looks_partial`.
+    Kept until PR 7 of the plan removes the alias along with the
+    other backward-compat shims in this module."""
+    return _looks_partial_impl(tool_result)
 
 
 def _summarise_tool_call(tool_call: Any, result: str) -> dict[str, Any]:

--- a/tests/search/test_pipeline_tool_results.py
+++ b/tests/search/test_pipeline_tool_results.py
@@ -1,0 +1,57 @@
+"""Coverage for the tool-result inspection helpers.
+
+`looks_partial` was inlined in ``amx/search/tool_agent.py`` before
+PR 9 moved it to the pipeline package. The textual heuristic gets
+direct coverage here so the future removal of the back-compat
+re-export does not lose its test.
+"""
+
+from __future__ import annotations
+
+from amx.search.pipeline.tool_results import looks_partial
+
+
+def test_returns_false_for_none_and_empty() -> None:
+    assert looks_partial(None) is False
+    assert looks_partial("") is False
+
+
+def test_detects_canonical_double_quoted_form_with_space() -> None:
+    assert looks_partial('{"partial": true, "rows": []}') is True
+
+
+def test_detects_canonical_double_quoted_form_no_space() -> None:
+    """Some JSON serializers compact the colon — both shapes are
+    canonical so the heuristic must match either."""
+    assert looks_partial('{"partial":true,"rows":[]}') is True
+
+
+def test_detects_python_repr_single_quoted_form_with_space() -> None:
+    """Some logging paths log a `dict` repr instead of JSON — both
+    quote styles need to match for the loop's partial-catalog
+    detection to fire."""
+    assert looks_partial("{'partial': True, 'rows': []}") is True
+
+
+def test_detects_python_repr_single_quoted_form_no_space() -> None:
+    assert looks_partial("{'partial':True}") is True
+
+
+def test_returns_false_when_flag_absent() -> None:
+    assert looks_partial('{"partial": false, "rows": []}') is False
+    assert looks_partial('{"rows": []}') is False
+
+
+def test_returns_false_for_unrelated_text_containing_word_partial() -> None:
+    """Mentioning 'partial' in prose must not trigger — the marker
+    is the JSON KEY, not the literal word."""
+    assert looks_partial("the rows are partial but complete") is False
+
+
+def test_tool_agent_backcompat_reexport_still_works() -> None:
+    """The legacy `_looks_partial` name on `tool_agent` still
+    routes to the new implementation."""
+    import amx.search.tool_agent as ta
+
+    assert ta._looks_partial('{"partial": true}') is True
+    assert ta._looks_partial(None) is False


### PR DESCRIPTION
## Summary

PR 9 of the /ask agent refactor — moves the partial-catalog textual heuristic to its own pipeline module so future stages can call it without importing the tool-loop module.

- `amx/search/pipeline/tool_results.py` owns `looks_partial`.
- `tool_agent.py` keeps a one-line back-compat shim.

## Test plan

- [x] `tests/search/test_pipeline_tool_results.py` — 8 new tests cover None/empty input, 4 canonical quoting variants (JSON with/without space, Python repr with/without space), prose false-positive guard, back-compat re-export.
- [x] Full `tests/search/` suite: 105 passed.
- [x] `ruff`: passed.
- [x] deploy.sh executed; Studio live.