### PR TITLE
fix(ask): don't report unsynced-column tables as empty in describe_table

### DIFF
--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -2319,24 +2319,63 @@ class ToolBox(
             force_fresh=force_fresh,
         )
 
+        # A cache payload that carries the table but ZERO columns means
+        # the catalog has only a table-level entry — column entities were
+        # never synced for this table. That is NOT the same as a
+        # genuinely empty table. Trusting it makes describe_table report
+        # "0 columns" and the assistant confidently claim the table is an
+        # empty stub — a misleading answer when the table actually has
+        # columns the catalog simply never indexed. Demote the payload to
+        # a miss so we either probe live (when allowed) or return an
+        # honest "columns not cached" envelope below.
+        columns_unsynced = bool(
+            cache_payload is not None and not (cache_payload.get("columns") or [])
+        )
+        if columns_unsynced:
+            cache_payload = None
+            # Mirror a real cache miss: ``_resolve_table_metadata``
+            # returns ``source="live"`` on miss, and the final response
+            # echoes ``source`` verbatim. Without resetting it here the
+            # live-probe result would mislabel itself as a catalog hit.
+            source = "live"
+
         # Cache miss + cache-only mode: do not spin up a live connector.
         # Return a structured "not in cache" payload that the LLM can
         # surface back to the user; the assistant should then suggest
         # enabling Live refresh + re-asking (or running /search sync).
         if cache_payload is None and not self._allow_live_refresh and not force_fresh:
-            return {
-                "schema": schema_name,
-                "table": table_name,
-                "found": False,
-                "source": "catalog",
-                "cache_only": True,
-                "possibly_partial": True,
-                "hint": (
+            if columns_unsynced:
+                # The table EXISTS in the catalog; only its columns are
+                # missing. The hint explicitly tells the LLM not to
+                # infer emptiness so the user doesn't get told their
+                # populated table is a stub.
+                hint = (
+                    f"Column metadata for '{schema_name}.{table_name}' is not cached "
+                    f"for profile {target_profile}: the table is in the catalog but "
+                    f"its columns were never synced. Enable 'Live refresh' in the "
+                    f"composer and ask again to fetch the columns live, or run "
+                    f"/search sync first. Do NOT tell the user the table is empty or "
+                    f"has no columns — the column list is simply not cached."
+                )
+            else:
+                hint = (
                     f"Table '{schema_name}.{table_name}' is not in the "
                     f"catalog for profile {target_profile}. Enable "
                     f"'Live refresh' in the composer and ask again "
                     f"to fetch it live, or run /search sync first."
-                ),
+                )
+            return {
+                "schema": schema_name,
+                "table": table_name,
+                # When only the columns are unsynced the table itself
+                # is known to exist — report found=True so the LLM
+                # confirms existence while deferring on the columns.
+                "found": columns_unsynced,
+                "source": "catalog",
+                "cache_only": True,
+                "possibly_partial": True,
+                "columns_not_cached": columns_unsynced,
+                "hint": hint,
             }
 
         # Defer the live-connector + cat_arg resolution to the live

--- a/tests/test_toolbox_cache_first_metadata.py
+++ b/tests/test_toolbox_cache_first_metadata.py
@@ -334,6 +334,96 @@ def test_databases_to_sweep_memoises_per_profile(monkeypatch):
     assert live_calls["n"] == 1
 
 
+def test_describe_table_zero_column_catalog_hit_not_reported_as_empty(monkeypatch):
+    """Regression: a catalog entry that carries the TABLE but ZERO
+    columns (column entities never synced) must NOT be reported as an
+    empty table.
+
+    Before the fix, ``describe_table`` trusted the zero-column cache
+    payload and returned ``column_count=0``, leading the assistant to
+    tell the user their populated table was an empty stub. In
+    cache-only mode the tool now returns ``columns_not_cached=True``
+    with a hint that explicitly forbids claiming emptiness.
+    """
+    tb = _bare_toolbox()
+    tb._allow_live_refresh = False  # cache-only mode — the /ask default
+
+    # Resolver returns a payload (table exists) but with NO columns.
+    monkeypatch.setattr(
+        tb,
+        "_resolve_table_metadata",
+        lambda **_kw: ({"columns": [], "table_comment": "", "row_count": 0}, "catalog", 100.0),
+    )
+    # profile_table must never run in cache-only mode.
+    fake_db = MagicMock()
+    fake_db.profile_table.side_effect = AssertionError("live probe in cache-only mode")
+    fake_db.cfg = SimpleNamespace(database="", catalog="", project="")
+    tb._db = fake_db
+
+    out = tb._tool_describe_table(schema="airline", table="Airports")
+
+    assert out["columns_not_cached"] is True
+    # The table itself is known to exist — only its columns are missing.
+    assert out["found"] is True
+    assert out["cache_only"] is True
+    # The hint must steer the assistant away from claiming emptiness.
+    hint = out["hint"].lower()
+    assert "not cached" in hint
+    assert "empty" in hint  # "do NOT tell the user the table is empty"
+    fake_db.profile_table.assert_not_called()
+
+
+def test_describe_table_zero_column_catalog_hit_falls_through_to_live(monkeypatch):
+    """When live refresh is allowed, a zero-column catalog hit is
+    demoted to a miss so ``describe_table`` probes the live DB and
+    returns the real columns instead of trusting the empty catalog
+    entry.
+    """
+    tb = _bare_toolbox()  # fixture sets _allow_live_refresh = True
+
+    monkeypatch.setattr(
+        tb,
+        "_resolve_table_metadata",
+        lambda **_kw: ({"columns": [], "table_comment": "", "row_count": 0}, "catalog", 100.0),
+    )
+
+    fake_profile = SimpleNamespace(
+        columns=[
+            SimpleNamespace(name="Code", dtype="varchar", nullable=False, existing_comment=""),
+            SimpleNamespace(
+                name="Description", dtype="varchar", nullable=True, existing_comment=""
+            ),
+        ],
+        row_count=100,
+        existing_comment="",
+        analytics=None,
+    )
+    fake_db = MagicMock()
+    fake_db.profile_table.return_value = fake_profile
+    fake_db.cfg = SimpleNamespace(database="", catalog="", project="")
+    tb._db = fake_db
+
+    class _Store:
+        def lookup_run_context_cache(self, **_kw):
+            return None
+
+        def save_run_context_cache(self, **_kw):
+            return None
+
+    monkeypatch.setattr(tb, "_history_store", lambda: _Store())
+    monkeypatch.setattr(tb, "_databases_to_sweep", lambda: [None])
+    monkeypatch.setattr(tb, "_connector_for_database", lambda _d: fake_db)
+    monkeypatch.setattr(tb, "_resolve_catalog_or_autopick", lambda *_a, **_kw: ("", [], []))
+    monkeypatch.setattr(tb, "_scoped_catalog", lambda *_a, **_kw: _NullCtx())
+    monkeypatch.setattr(tb, "_now", lambda: 1_700_000_000.0)
+
+    out = tb._tool_describe_table(schema="airline", table="Airports")
+
+    assert out["source"] == "live"
+    assert out["column_count"] == 2
+    fake_db.profile_table.assert_called()
+
+
 def test_list_schemas_serves_from_catalog_when_synced(monkeypatch):
     """``list_schemas`` reads from ``catalog_entities`` first; only
     falls back to a live ``db.list_schemas`` call when the catalog is


### PR DESCRIPTION
## Summary

A real `/ask` answer was actively wrong. Asked *"what columns does the Airports table have?"*, the assistant said `airline.Airports` "reports 0 columns and 0 rows... an empty stub." The table actually has 2 columns (`Code`, `Description`) — they were never synced into `catalog_entities` (the catalog held only a table-level entry).

**Root cause:** `_tool_describe_table` treated a catalog hit with zero column entities as authoritative and returned `column_count=0`. The LLM then told the user their populated table was empty. The `force_fresh=true` retry didn't help — cache-only Ask mode silently coerces it to False.

**Fix:** a cache payload that carries the table but ZERO columns is demoted to a miss. Downstream then does the right thing:
- Live refresh enabled → probe the live DB, return real columns (verified: returns `Code` + `Description`).
- Cache-only mode → honest envelope with `columns_not_cached=true`, `found=true`, and a hint that forbids claiming emptiness.

## Test plan

- [x] 2 new tests in `tests/test_toolbox_cache_first_metadata.py`: cache-only honest envelope (no live probe), live fallthrough returns real columns.
- [x] 142 search + toolbox tests pass.
- [x] Verified end-to-end against the live `local-postgre` profile: cache-only answer changed from "empty stub" to "columns not cached, enable Live refresh"; live mode returns the 2 real columns.
- [x] `ruff`: passed. No new mypy errors (11 pre-existing in agent_tools.py unchanged).
- [x] deploy.sh executed; Studio live.