### PR TITLE
fix(ask): _safe_json truncation must always emit valid JSON

### DIFF
--- a/amx/search/_agent_tools_helpers.py
+++ b/amx/search/_agent_tools_helpers.py
@@ -129,14 +129,66 @@ def _description_proximity(left: str, right: str) -> float:
 
 
 def _safe_json(value: Any, *, max_len: int = 6000) -> str:
-    """Serialize a tool result; truncate so the prompt stays manageable."""
+    """Serialize a tool result; truncate so the prompt stays manageable.
+
+    Truncation ALWAYS yields valid JSON. The previous implementation
+    chopped the serialized string at a fixed offset and appended
+    ``...<truncated>`` — which produced invalid JSON whenever the cut
+    landed mid-string or mid-object (e.g. a wide ``describe_table``
+    result). That corrupted payload was then handed straight to the
+    LLM as the tool result, so for tables with many columns / long
+    descriptions the model received an unparseable blob and could
+    silently miss the columns that got cut off.
+
+    When the serialized form exceeds ``max_len`` we instead emit a
+    valid JSON envelope: a ``_truncated`` flag, a short instruction
+    the LLM can act on, and a readable text prefix of the original
+    payload so the model still sees the leading fields verbatim.
+    """
     try:
         text = json.dumps(value, ensure_ascii=False, default=str)
     except Exception:  # pragma: no cover - JSON of catalog rows always works
         text = str(value)
-    if len(text) > max_len:
-        text = text[: max_len - 18] + "...<truncated>"
-    return text
+    if len(text) <= max_len:
+        return text
+
+    note = (
+        f"Result exceeded {max_len} characters and was truncated. "
+        "Some fields below may be cut off. If you need the missing "
+        "detail, ask a narrower question (e.g. specific columns) or "
+        "request the next part."
+    )
+
+    def _envelope(prefix: str) -> str:
+        return json.dumps(
+            {"_truncated": True, "_note": note, "_partial_prefix": prefix},
+            ensure_ascii=False,
+            default=str,
+        )
+
+    # When the budget is so small that even the empty-prefix envelope
+    # (its fixed ``_note`` text) overflows, fall back to a minimal but
+    # still-valid JSON marker. Realistic budgets (default 6000) never
+    # hit this; it keeps the "always valid JSON, always within budget"
+    # contract honest for pathologically small ``max_len`` values.
+    if len(_envelope("")) > max_len:
+        return '{"_truncated": true}'
+
+    # Start from a budget-aware prefix length (subtract the empty
+    # envelope's own size) then shrink until the serialized envelope —
+    # JSON-escaping of the prefix included — fits under ``max_len``.
+    # This keeps as much readable payload as possible for the LLM
+    # while guaranteeing valid JSON, rather than capping the prefix at
+    # a fixed fraction of the budget.
+    budget = max(0, max_len - len(_envelope("")) - 8)
+    prefix = text[:budget]
+    result = _envelope(prefix)
+    while len(result) > max_len and prefix:
+        # Trim 10% at a time; escaping overhead is the only reason a
+        # within-budget prefix can overflow, and it's bounded.
+        prefix = prefix[: int(len(prefix) * 0.9)]
+        result = _envelope(prefix)
+    return result
 
 
 def _sample_distinct_values(

--- a/tests/test_agent_tools_helpers.py
+++ b/tests/test_agent_tools_helpers.py
@@ -88,7 +88,62 @@ def test_safe_json_truncates_long_payloads() -> None:
     big = {"rows": ["x" * 100 for _ in range(200)]}
     out = _safe_json(big, max_len=200)
     assert len(out) <= 200
-    assert out.endswith("...<truncated>")
+
+
+def test_safe_json_truncation_is_always_valid_json() -> None:
+    """Regression: the old char-chop truncation produced INVALID JSON
+    (unterminated strings) when the cut landed mid-value, corrupting
+    the tool result handed to the LLM. Truncation must now always
+    round-trip through ``json.loads``."""
+    import json
+
+    from amx.search._agent_tools_helpers import _safe_json
+
+    # A wide describe_table-shaped payload that comfortably exceeds the
+    # default 6000-char budget.
+    big = {
+        "schema": "airline",
+        "table": "wide",
+        "columns": [
+            {"name": f"col_{i}", "type": "varchar", "comment": "x" * 80}
+            for i in range(300)
+        ],
+    }
+    out = _safe_json(big)
+    parsed = json.loads(out)  # must not raise
+    assert parsed["_truncated"] is True
+    assert "_note" in parsed
+    # The readable prefix preserves the leading fields so the LLM still
+    # sees the schema/table and the first columns verbatim.
+    assert "airline" in parsed["_partial_prefix"]
+    assert len(out) <= 6000
+
+
+def test_safe_json_small_payload_round_trips_unchanged() -> None:
+    """Below the budget, the output is the plain serialized value —
+    no envelope wrapping on the happy path."""
+    import json
+
+    from amx.search._agent_tools_helpers import _safe_json
+
+    payload = {"schema": "s", "table": "t", "columns": [{"name": "id"}]}
+    out = _safe_json(payload)
+    assert json.loads(out) == payload
+    assert "_truncated" not in out
+
+
+def test_safe_json_respects_custom_max_len_and_stays_valid() -> None:
+    """A tiny custom budget still yields valid JSON (the envelope is
+    trimmed until it fits)."""
+    import json
+
+    from amx.search._agent_tools_helpers import _safe_json
+
+    big = {"rows": ["y" * 50 for _ in range(100)]}
+    out = _safe_json(big, max_len=400)
+    assert len(out) <= 400
+    parsed = json.loads(out)  # must not raise
+    assert parsed["_truncated"] is True
 
 
 def test_safe_json_returns_str_for_unserialisable() -> None:


### PR DESCRIPTION
## Summary

Surfaced by the `log.warning` added in the safety-net PR: a real `/ask` turn logged *"failed to parse tool describe_table result... Unterminated string at char 5981"*.

**Root cause:** `_safe_json` truncated tool results with a crude character chop (`text[:max_len-18] + "...<truncated>"`). When the cut landed mid-value, the result was **invalid JSON** — handed straight to the LLM, which could silently miss every column after the cut. Affects any tool whose result exceeds the 6000-char budget (wide `describe_table` especially).

**Fix:** truncation now emits a **valid JSON envelope** — `_truncated` flag, actionable `_note`, and a `_partial_prefix` with as much original payload as the budget allows (measured-and-trimmed so the escaped envelope stays under `max_len`). Minimal `{"_truncated": true}` fallback for pathologically small budgets.

Generic correctness fix — protects every tool, not just describe_table.

## Test plan

- [x] `tests/test_agent_tools_helpers.py`: updated legacy test + 3 new (valid-JSON round-trip on wide payload, small-payload pass-through, custom max_len validity).
- [x] 128 search + toolbox + helper tests pass.
- [x] Verified end-to-end: beer_factory.customers query no longer logs the parse warning, still returns all 12 columns.
- [x] `ruff`: passed. `mypy`: passed.
- [x] deploy.sh executed; Studio live.