### PR TITLE
fix(ask): don't report cached row_count=0 as an empty table

### DIFF
--- a/amx/search/agent_tools.py
+++ b/amx/search/agent_tools.py
@@ -2554,8 +2554,19 @@ class ToolBox(
         # already assembled — zero extra cost.
         nullable_count = sum(1 for c in all_cols if c.get("nullable"))
         documented_count = sum(1 for c in all_cols if str(c.get("comment") or "").strip())
+        # The catalog cache does NOT capture row counts — /search sync
+        # records 0 for every table. So a cached row_count of 0 means
+        # "unknown", not "empty table"; presenting it as 0 would let the
+        # LLM falsely report an empty table (the same failure mode the
+        # zero-column guard fixes). Only the live profile_table path
+        # yields a trustworthy count. When unknown we emit ``null`` +
+        # ``row_count_known: false`` so the model defers instead of
+        # claiming 0.
+        row_count_known = source == "live" or int(profile.row_count or 0) > 0
+        row_count_value: int | None = int(profile.row_count or 0) if row_count_known else None
         stats = {
-            "row_count": int(profile.row_count or 0),
+            "row_count": row_count_value,
+            "row_count_known": row_count_known,
             "column_count": len(all_cols),
             "nullable_columns": nullable_count,
             "non_nullable_columns": max(0, len(all_cols) - nullable_count),
@@ -2571,7 +2582,8 @@ class ToolBox(
             "catalog": cat_arg or None,
             "found": True,
             "table_comment": str(profile.existing_comment or ""),
-            "row_count": int(profile.row_count or 0),
+            "row_count": row_count_value,
+            "row_count_known": row_count_known,
             "column_count": len(all_cols),
             "stats": stats,
             "dtype_summary": dtype_summary,

--- a/tests/test_toolbox_cache_first_metadata.py
+++ b/tests/test_toolbox_cache_first_metadata.py
@@ -424,6 +424,79 @@ def test_describe_table_zero_column_catalog_hit_falls_through_to_live(monkeypatc
     fake_db.profile_table.assert_called()
 
 
+def test_describe_table_cached_zero_row_count_reported_as_unknown(monkeypatch):
+    """Regression: /search sync never captures row counts (every
+    catalog row stores row_count=0), so a cached row_count of 0 means
+    "unknown", NOT "empty table". describe_table must surface it as
+    ``row_count=None`` + ``row_count_known=False`` so the assistant
+    doesn't tell the user a populated table has zero rows.
+    """
+    tb = _bare_toolbox()
+    tb._allow_live_refresh = False  # cache-only mode — the /ask default
+
+    # Catalog hit WITH columns (so we stay on the cache branch) but
+    # row_count 0 — exactly what /search sync produces.
+    monkeypatch.setattr(
+        tb,
+        "_resolve_table_metadata",
+        lambda **_kw: (
+            {
+                "columns": [
+                    {"name": "id", "dtype": "int", "nullable": False, "comment": "pk"},
+                    {"name": "name", "dtype": "varchar", "nullable": True, "comment": ""},
+                ],
+                "table_comment": "customer rows",
+                "row_count": 0,
+            },
+            "catalog",
+            100.0,
+        ),
+    )
+    fake_db = MagicMock()
+    fake_db.cfg = SimpleNamespace(database="", catalog="", project="")
+    tb._db = fake_db
+
+    out = tb._tool_describe_table(schema="beer_factory", table="customers")
+
+    # The table + its columns ARE known; only the row count is not.
+    assert out["found"] is True
+    assert out["column_count"] == 2
+    assert out["row_count_known"] is False
+    assert out["row_count"] is None
+    assert out["stats"]["row_count"] is None
+    assert out["stats"]["row_count_known"] is False
+
+
+def test_describe_table_cached_positive_row_count_is_trusted(monkeypatch):
+    """A cached row_count > 0 is real data worth surfacing — it must
+    stay an int and be marked known, so the guard above doesn't blank
+    out legitimately-captured counts."""
+    tb = _bare_toolbox()
+    tb._allow_live_refresh = False
+
+    monkeypatch.setattr(
+        tb,
+        "_resolve_table_metadata",
+        lambda **_kw: (
+            {
+                "columns": [{"name": "id", "dtype": "int", "nullable": False, "comment": ""}],
+                "table_comment": "",
+                "row_count": 4242,
+            },
+            "catalog",
+            100.0,
+        ),
+    )
+    fake_db = MagicMock()
+    fake_db.cfg = SimpleNamespace(database="", catalog="", project="")
+    tb._db = fake_db
+
+    out = tb._tool_describe_table(schema="s", table="t")
+
+    assert out["row_count"] == 4242
+    assert out["row_count_known"] is True
+
+
 def test_list_schemas_serves_from_catalog_when_synced(monkeypatch):
     """``list_schemas`` reads from ``catalog_entities`` first; only
     falls back to a live ``db.list_schemas`` call when the catalog is


### PR DESCRIPTION
## Summary

Same failure class as the zero-column guard (#580). `/search sync` never captures row counts — every `catalog_entities` table row stores `row_count=0` (verified: 0 of 1140 local-postgre tables have `row_count>0`). So a cached `row_count` of 0 means **unknown**, not **empty table**. `describe_table` presented it as a factual 0, so "how many rows does X have?" could make the assistant claim a populated table is empty.

**Fix:** when serving from the catalog cache and the cached `row_count` is 0, surface `row_count=null` + `row_count_known=false`. A live `profile_table` result, or a cached count > 0, is trusted as-is.

## Test plan

- [x] 2 new tests: cached zero row_count → unknown (null + known=false); cached positive row_count → trusted (int + known=true).
- [x] 233 search + toolbox tests pass.
- [x] Verified end-to-end: beer_factory.customers cache-only describe now returns row_count=None, known=False.
- [x] `ruff`: passed. No new mypy errors.
- [x] deploy.sh executed; Studio live.