### PR TITLE
fix(search): vector index failure must not block catalog metadata sync

### DIFF
--- a/amx/cli_support/commands/search.py
+++ b/amx/cli_support/commands/search.py
@@ -482,6 +482,10 @@ def _sync_db_scope(
     database_name = cfg.db.database or cfg.db.catalog or cfg.db.project or ""
     inserted = 0
     updated = 0
+    # Clear any stale degradation flag from a previous catalog reuse so
+    # the post-sync hint reflects THIS run's indexing outcome only.
+    if hasattr(catalog, "_index_degraded"):
+        catalog._index_degraded = False
     total_assets = sum(len(asset_names) for asset_names in scope.values())
     display = get_display()
     activity_idx: int | None = None
@@ -547,6 +551,16 @@ def _sync_db_scope(
             display.fail_activity(activity_idx, summary)
         else:
             display.complete_activity(activity_idx, summary)
+    # Structured metadata always lands now even when semantic indexing
+    # was skipped (embedding profile drifted from the vector
+    # collection). Surface that once so the user knows columns/row
+    # counts are synced but semantic search needs a rebuild.
+    if getattr(catalog, "_index_degraded", False):
+        warn(
+            "Columns and row counts were synced, but semantic search indexing "
+            "was skipped because the embedding profile no longer matches the "
+            "vector collection. Run `/search rebuild` to restore semantic search."
+        )
     return inserted, updated
 
 

--- a/amx/search/_catalog/entity_crud.py
+++ b/amx/search/_catalog/entity_crud.py
@@ -29,6 +29,7 @@ import json
 import sqlite3
 import time
 
+from amx.rag_core.collection_identity import CollectionIdentityMismatch
 from amx.search._catalog._constants import SOURCE_PRIORITY, _json_loads
 from amx.utils.logging import get_logger
 
@@ -1078,11 +1079,45 @@ class EntityCrudMixin:
         )
         return results[:limit], truncated
 
+    def _note_index_degraded(self, exc: Exception) -> None:
+        """Record that semantic indexing was skipped, logging once.
+
+        Writing the structured catalog metadata (columns, dtypes, row
+        counts, FKs) lives in SQLite and is independent of the
+        embedding model — only semantic search needs the vector index.
+        When the embedding profile drifts away from the identity the
+        collection was built with, indexing raises
+        :class:`CollectionIdentityMismatch`; that must degrade semantic
+        search, NOT abort the metadata write. The flag lets the sync
+        caller surface a single "run /search rebuild" hint instead of
+        spamming one warning per column.
+        """
+        if not getattr(self, "_index_degraded", False):
+            log.warning(
+                "Semantic indexing skipped during catalog write — the embedding "
+                "identity no longer matches the vector collection (%s). Structured "
+                "metadata (columns, row counts, types) is still written; run "
+                "/search rebuild to restore semantic search.",
+                exc,
+            )
+        self._index_degraded = True
+        self._index_degraded_reason = str(exc)
+
     def _index_entity(self, conn: sqlite3.Connection, entity_id: int) -> None:
         row = conn.execute("SELECT * FROM catalog_entities WHERE id = ?", (entity_id,)).fetchone()
         if not row:
             return
-        self.index.upsert_entities([dict(row)])
+        try:
+            self.index.upsert_entities([dict(row)])
+        except CollectionIdentityMismatch as exc:
+            # Embedding profile drifted from the collection's stamped
+            # identity. Skip the vector upsert (and the indexed=1 stamp
+            # below) so the entity stays unindexed until /search rebuild,
+            # but let the structured metadata commit. ``rebuild_profile``
+            # resets the collection identity first, so it never reaches
+            # this branch — only drifted sync/usage writes do.
+            self._note_index_degraded(exc)
+            return
         conn.execute(
             """
             UPDATE catalog_descriptions

--- a/tests/test_sync_decouple_vector_index.py
+++ b/tests/test_sync_decouple_vector_index.py
@@ -1,0 +1,174 @@
+"""Vector indexing must never block catalog metadata writes.
+
+A user changed their catalog embedding profile (minilm → gte-small)
+after the vector collection was built. Every subsequent `/search sync`
+crashed at the indexing step with `CollectionIdentityMismatch`, and
+because the structured-metadata write shared the call path, NO columns
+or row counts were persisted for the affected tables — the catalog was
+stuck at table-level skeleton data.
+
+The structured metadata (columns, dtypes, row counts, FKs) lives in
+SQLite and is independent of the embedding model; only semantic search
+needs the vector index. These tests pin the decoupling: a vector
+identity mismatch degrades semantic search (skips the index, sets a
+flag) but the metadata still commits.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amx.db.connector import AssetKind, ColumnProfile, TableProfile
+from amx.rag_core.collection_identity import (
+    CollectionIdentity,
+    CollectionIdentityMismatch,
+)
+from amx.search.catalog import SearchCatalog
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _identity_mismatch() -> CollectionIdentityMismatch:
+    """Build a realistic mismatch (minilm → gte-small) like the one a
+    user hits after swapping the catalog embedding profile."""
+    return CollectionIdentityMismatch(
+        recorded=CollectionIdentity(
+            embedding_provider="minilm", embedding_model="minilm-l6-v2"
+        ),
+        active=CollectionIdentity(
+            embedding_provider="sentence_transformers",
+            embedding_model="thenlper/gte-small",
+        ),
+        recovery_hint="Run /search rebuild.",
+    )
+
+
+@pytest.fixture()
+def fresh_catalog(tmp_path: Path) -> SearchCatalog:
+    db = tmp_path / "history.db"
+    store = SQLiteHistoryStore(db)
+    store.init()
+    return SearchCatalog(db)
+
+
+def _profile() -> TableProfile:
+    return TableProfile(
+        schema="airline",
+        name="Airports",
+        asset_kind=AssetKind.TABLE,
+        row_count=6510,
+        existing_comment="Airport reference data",
+        columns=[
+            ColumnProfile(name="Code", dtype="TEXT", nullable=False, existing_comment="IATA code"),
+            ColumnProfile(
+                name="Description", dtype="TEXT", nullable=True, existing_comment="Airport name"
+            ),
+        ],
+    )
+
+
+def _column_names(catalog: SearchCatalog) -> list[str]:
+    with catalog._connect() as conn:  # noqa: SLF001
+        return [
+            str(r["column_name"])
+            for r in conn.execute(
+                "SELECT column_name FROM catalog_entities "
+                "WHERE entity_kind = 'column' ORDER BY column_name"
+            )
+        ]
+
+
+def _table_row_count(catalog: SearchCatalog) -> int | None:
+    with catalog._connect() as conn:  # noqa: SLF001
+        row = conn.execute(
+            "SELECT row_count FROM catalog_entities WHERE entity_kind = 'table' LIMIT 1"
+        ).fetchone()
+        return None if row is None else row["row_count"]
+
+
+def test_sync_persists_metadata_when_indexing_identity_mismatch(
+    fresh_catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The headline regression: a CollectionIdentityMismatch during
+    indexing must NOT abort the metadata write. Columns + row count
+    land; the degradation flag is set so the caller can prompt a
+    rebuild."""
+
+    def _boom(_entities: list[dict[str, object]]) -> int:
+        raise _identity_mismatch()
+
+    monkeypatch.setattr(fresh_catalog.index, "upsert_entities", _boom)
+
+    # Must NOT raise.
+    fresh_catalog.sync_table_profile(
+        db_profile="local-postgre",
+        db_backend="postgresql",
+        database_name="bird_train",
+        profile=_profile(),
+        query_usage={},
+    )
+
+    # Structured metadata persisted despite the indexing failure.
+    assert _column_names(fresh_catalog) == ["Code", "Description"]
+    assert _table_row_count(fresh_catalog) == 6510
+    # The degradation flag is set so /search sync can tell the user to
+    # run /search rebuild.
+    assert getattr(fresh_catalog, "_index_degraded", False) is True
+
+
+def test_sync_indexes_normally_when_no_mismatch(
+    fresh_catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: when indexing succeeds, the degradation flag stays
+    unset and the indexed=1 stamp is written (no silent degradation)."""
+    calls: list[int] = []
+
+    def _ok(entities: list[dict[str, object]]) -> int:
+        calls.append(len(entities))
+        return len(entities)
+
+    monkeypatch.setattr(fresh_catalog.index, "upsert_entities", _ok)
+
+    fresh_catalog.sync_table_profile(
+        db_profile="local-postgre",
+        db_backend="postgresql",
+        database_name="bird_train",
+        profile=_profile(),
+        query_usage={},
+    )
+
+    assert _column_names(fresh_catalog) == ["Code", "Description"]
+    assert getattr(fresh_catalog, "_index_degraded", False) is False
+    # Indexing actually ran (table + 2 columns → at least one upsert).
+    assert calls
+
+
+def test_indexing_warning_logged_once_not_per_entity(
+    fresh_catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A wide table must not spam one warning per column — the
+    degradation hint logs at most once per sync run via the flag."""
+
+    def _boom(_entities: list[dict[str, object]]) -> int:
+        raise _identity_mismatch()
+
+    monkeypatch.setattr(fresh_catalog.index, "upsert_entities", _boom)
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="search.catalog.entity_crud"):
+        fresh_catalog.sync_table_profile(
+            db_profile="p",
+            db_backend="postgresql",
+            database_name="d",
+            profile=_profile(),
+            query_usage={},
+        )
+
+    skip_warnings = [
+        r for r in caplog.records if "Semantic indexing skipped" in r.getMessage()
+    ]
+    # One sync_table_profile call → exactly one degradation warning,
+    # even though the table has multiple column entities to index.
+    assert len(skip_warnings) == 1


### PR DESCRIPTION
## Summary

**THE root cause of "sync gives incomplete info."** A user swapped the catalog embedding profile (minilm → gte-small) after the vector collection was built. Every `/search sync` then crashed at the indexing step with `CollectionIdentityMismatch`, and because the structured-metadata write shared the call path/transaction, the whole sync rolled back — **no columns or row counts were persisted** for any affected table. The catalog stayed at table-level skeleton data, which is why most column/row questions returned "enable Live refresh".

The structured metadata (columns, dtypes, row counts, FKs) lives in SQLite and is independent of the embedding model — only semantic search needs the vector index. An embedding drift should never block metadata cataloging.

**Fix:**
- `_index_entity` catches `CollectionIdentityMismatch`, records a one-shot degradation flag, and returns without the `indexed=1` stamp — entity stays unindexed until `/search rebuild`, but metadata commits. `rebuild_profile` resets the collection identity first, so it never hits this branch.
- `_sync_db_scope` surfaces a single "columns and row counts were synced, but semantic indexing was skipped — run /search rebuild" warning.

## Test plan

- [x] `tests/test_sync_decouple_vector_index.py` — 3 tests: metadata persists on mismatch + flag set, happy-path indexing unaffected, warning logged once not per-column.
- [x] 169 catalog/search tests pass.
- [x] Verified end-to-end on live local-postgre: syncing `airline` now persists all columns + real row counts (Air Carriers 1656, Airlines 701352, Airports 6510) even with the mismatch present, instead of crashing.
- [x] `ruff`: passed. No new mypy errors.
- [x] deploy.sh executed; Studio live.