### PR TITLE
feat(studio): show synced row count on the Table detail page

### DIFF
--- a/amx/web/routers/live_db.py
+++ b/amx/web/routers/live_db.py
@@ -316,6 +316,70 @@ def _cached_table_comment(
     return str(row["table_comment"] or "")
 
 
+def _cached_row_count(
+    profile: str,
+    schema: str,
+    table: str,
+    *,
+    database_scope: str | None,
+) -> int | None:
+    """Return the synced row count from ``catalog_entities``, or ``None``
+    when unknown.
+
+    A stored ``row_count`` of 0 means "not captured" — ``/search sync``
+    records 0 for tables it never counted — so it is reported as
+    ``None`` (unknown) rather than a misleading "0 rows", matching the
+    describe_table guard. The table-level entity carries the count;
+    ``database_scope`` disambiguates same-named tables across databases.
+    """
+    try:
+        from amx.storage.sqlite_store import history_store as _history_store
+
+        hs = _history_store()
+    except Exception:
+        hs = None
+    if hs is None:
+        return None
+    row = None
+    try:
+        with hs._connect() as conn:  # noqa: SLF001 — same access as sibling helpers
+            if database_scope:
+                row = conn.execute(
+                    """
+                    SELECT row_count FROM catalog_entities
+                    WHERE db_profile = ? AND database_name = ?
+                      AND schema_name = ? AND table_name = ?
+                      AND entity_kind = 'table'
+                    ORDER BY row_count DESC, last_synced_at DESC LIMIT 1
+                    """,
+                    (profile, database_scope, schema, table),
+                ).fetchone()
+            if row is None:
+                # No database scope (or no scoped hit): the same
+                # schema.table can exist in multiple databases, one
+                # counted and one skeleton-only (row_count 0). Prefer
+                # the counted copy so an ambiguous lookup surfaces the
+                # real number rather than a stale 0.
+                row = conn.execute(
+                    """
+                    SELECT row_count FROM catalog_entities
+                    WHERE db_profile = ? AND schema_name = ? AND table_name = ?
+                      AND entity_kind = 'table'
+                    ORDER BY row_count DESC, last_synced_at DESC LIMIT 1
+                    """,
+                    (profile, schema, table),
+                ).fetchone()
+    except Exception:
+        return None
+    if row is None:
+        return None
+    try:
+        count = int(row["row_count"] or 0)
+    except (TypeError, ValueError):
+        return None
+    return count if count > 0 else None
+
+
 def _cached_column_structure(
     profile: str,
     schema: str,
@@ -1282,6 +1346,9 @@ def table_snapshot(
                     for c in salvage
                 ],
                 "source": "cache-fallback",
+                "row_count": _cached_row_count(
+                    name, schema, table, database_scope=cache_scope
+                ),
             },
             schema,
             table,
@@ -1315,8 +1382,16 @@ def table_snapshot(
                         for c in salvage
                     ],
                     "source": "cache-fallback",
+                    "row_count": _cached_row_count(
+                        name, schema, table, database_scope=cache_scope
+                    ),
                 },
                 schema,
                 table,
             )
+    # Surface the synced row count (from the catalog) so the Table page
+    # can show "N rows" — the live snapshot itself is profiling-free and
+    # carries no count. ``None`` when unknown (never counted), so the UI
+    # shows nothing rather than a misleading 0.
+    snapshot["row_count"] = _cached_row_count(name, schema, table, database_scope=cache_scope)
     return _merge_pending(snapshot, schema, table)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -366,6 +366,11 @@ export interface SnapshotResponse {
   pending_description?: string | null;
   pending_column_descriptions?: Record<string, string>;
   pending_run_id?: number | null;
+  /** Synced row count from the catalog (``/search sync``). ``null`` when
+   *  unknown — sync records 0 for tables it never counted, which is
+   *  surfaced as ``null`` rather than a misleading "0 rows". Absent on
+   *  older servers. */
+  row_count?: number | null;
 }
 
 export interface RunRow {

--- a/frontend/src/routes/Table.tsx
+++ b/frontend/src/routes/Table.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router-dom";
-import { AlignLeft, Columns, Sparkles, Database, Workflow } from "lucide-react";
+import { AlignLeft, Columns, Hash, Sparkles, Database, Workflow } from "lucide-react";
 
 import { api, assetsForTable, lineageArtifactsForTable } from "../lib/api";
 import type { LineageArtifact, LinkedAssetRow } from "../lib/api";
@@ -82,6 +82,10 @@ export default function Table() {
   });
 
   const totalCols = snapshot.data?.columns?.length ?? columns.data?.count ?? 0;
+  // Synced row count from the catalog. ``null``/undefined means the
+  // count was never captured by /search sync — show "—" rather than a
+  // misleading "0".
+  const rowCount = snapshot.data?.row_count ?? null;
   const commented =
     snapshot.data?.columns?.filter((c) => (c.comment || "").trim().length > 0).length ?? 0;
   const tableComment = snapshot.data?.table_comment ?? "";
@@ -374,8 +378,13 @@ export default function Table() {
         }
       />
 
-      <div className="grid gap-4 md:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-4">
         <SummaryCard label="Columns" value={String(totalCols)} icon={Columns} />
+        <SummaryCard
+          label="Rows"
+          value={rowCount != null ? rowCount.toLocaleString() : "—"}
+          icon={Hash}
+        />
         <SummaryCard
           label="With comments"
           value={totalCols ? `${commented}/${totalCols}` : "—"}

--- a/tests/test_live_db_row_count.py
+++ b/tests/test_live_db_row_count.py
@@ -1,0 +1,123 @@
+"""The Table page surfaces the synced row count.
+
+The live metadata snapshot is profiling-free (no COUNT(*)), so the
+Studio Table page never had a row count to show — even though
+``/search sync`` records one in ``catalog_entities``. ``_cached_row_count``
+reads that synced value so ``table_snapshot`` can include it.
+
+Contract:
+* a stored ``row_count`` > 0 is returned,
+* a stored 0 means "never counted" → ``None`` (not a misleading 0),
+* when the same schema.table exists in two databases (one counted,
+  one skeleton-only), the counted copy wins on an unscoped lookup.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+import amx.web.routers.live_db as live_db
+from amx.storage import sqlite_store as ss
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture()
+def seeded_history_store(tmp_path: Path):
+    db_path = tmp_path / "history.db"
+    SQLiteHistoryStore(db_path).init()
+    ss._store = SQLiteHistoryStore(db_path)  # noqa: SLF001
+    yield db_path
+    ss._store = None  # noqa: SLF001
+
+
+def _seed_table(
+    db_path: Path,
+    *,
+    profile: str,
+    database: str,
+    schema: str,
+    table: str,
+    row_count: int,
+) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO catalog_entities (
+                db_profile, db_backend, database_name, schema_name,
+                table_name, column_name, entity_kind, asset_kind,
+                row_count, search_text, updated_at, last_synced_at
+            ) VALUES (?, 'postgresql', ?, ?, ?, NULL, 'table', 'table', ?, '', ?, ?)
+            """,
+            (profile, database, schema, table, row_count, time.time(), time.time()),
+        )
+
+
+def test_returns_synced_positive_count(seeded_history_store: Path) -> None:
+    _seed_table(
+        seeded_history_store,
+        profile="p",
+        database="bird_train",
+        schema="app_store",
+        table="playstore",
+        row_count=10840,
+    )
+    assert (
+        live_db._cached_row_count("p", "app_store", "playstore", database_scope="bird_train")
+        == 10840
+    )
+
+
+def test_zero_count_reported_as_unknown(seeded_history_store: Path) -> None:
+    """Sync records 0 for tables it never counted — surface None, not 0."""
+    _seed_table(
+        seeded_history_store,
+        profile="p",
+        database="bird_train",
+        schema="airline",
+        table="Airports",
+        row_count=0,
+    )
+    assert (
+        live_db._cached_row_count("p", "airline", "Airports", database_scope="bird_train")
+        is None
+    )
+
+
+def test_unscoped_lookup_prefers_counted_copy(seeded_history_store: Path) -> None:
+    """Same schema.table in two databases — one counted, one
+    skeleton-only (0). An unscoped lookup must return the real count,
+    not the stale 0."""
+    _seed_table(
+        seeded_history_store,
+        profile="p",
+        database="bird_train",
+        schema="beer_factory",
+        table="customers",
+        row_count=554,
+    )
+    _seed_table(
+        seeded_history_store,
+        profile="p",
+        database="bird_train_desc",
+        schema="beer_factory",
+        table="customers",
+        row_count=0,
+    )
+    assert (
+        live_db._cached_row_count("p", "beer_factory", "customers", database_scope=None) == 554
+    )
+
+
+def test_missing_table_returns_none(seeded_history_store: Path) -> None:
+    assert live_db._cached_row_count("p", "nope", "nope", database_scope=None) is None
+
+
+def test_no_history_store_returns_none(tmp_path: Path) -> None:
+    """When the history store singleton isn't initialised, the helper
+    degrades to None rather than raising."""
+    ss._store = None  # noqa: SLF001
+    assert live_db._cached_row_count("p", "s", "t", database_scope=None) is None


### PR DESCRIPTION
## Summary

The captured row counts were invisible in Studio. The live metadata snapshot that feeds the Table page is profiling-free (no COUNT(*)), and the catalog `/inventory` + `/explain` endpoints that carry `row_count` aren't consumed by the SPA — so a table's row count never appeared in the UI even after `/search sync` recorded it.

- **Backend:** `table_snapshot` now includes `row_count` via the new `_cached_row_count` helper (reuses the value sync already stored — no extra live COUNT(*)). A stored 0 ("never counted") is surfaced as `null`, matching the describe_table guard, so the UI shows "—" not a misleading 0. Unscoped lookups prefer the counted copy when a table exists in two databases.
- **Frontend:** Table page gains a "Rows" summary card (thousands-separated, "—" when unknown). Stats grid goes 3→4 cards, responsive (stack on mobile, 2-up sm, 4-up md+).

## Test plan

- [x] `tests/test_live_db_row_count.py` — 5 tests: positive count returned, zero → None, unscoped prefers counted copy, missing → None, no-store → None.
- [x] 64 live_db tests pass; frontend `tsc --noEmit` clean; `ruff` clean.
- [x] Verified against live catalog: playstore 10840, customers 554, Airlines 701352, state 62.
- [x] deploy.sh executed; Studio live. (Visual check of the Rows card pending in Studio.)