### PR TITLE
feat(studio): Deep sync — opt-in full profile (columns + row counts)

### DIFF
--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -715,6 +715,144 @@ def sync_profile_skeleton(
     return summary
 
 
+def deep_sync_profile(
+    cfg,
+    profile: str,
+    catalog,
+    *,
+    databases: list[str] | None = None,
+) -> dict:
+    """Full-profile sync: profile every table the skeleton already
+    catalogued and write its columns + row count.
+
+    The skeleton sync (:func:`sync_profile_skeleton`) is deliberately
+    fast — it writes table-level rows only, no columns or counts. This
+    is the opt-in "Deep sync": for every table already in
+    ``catalog_entities`` it runs ``profile_table`` (which issues a
+    ``COUNT(*)``) and ``sync_table_profile`` so the Studio Table page
+    shows real column lists + row counts. It reuses the skeleton's
+    inventory rather than re-walking the live DB, the skeleton state
+    machine for progress (so the freshness pill renders), and the
+    cooperative cancel registry. Never raises — terminal failures land
+    on ``finish_skeleton_sync(ok=False)``.
+
+    ``databases`` (optional) restricts the pass to those container
+    names; ``None`` covers every database the skeleton recorded.
+    """
+    from amx.search import _skeleton_jobs
+
+    cancel_event = _skeleton_jobs.register(profile)
+    summary: dict[str, Any] = {"profile": profile, "state": "syncing", "processed": 0, "failed": 0}
+
+    profile_map = getattr(cfg, "db_profiles", {}) or {}
+    target_db = profile_map.get((profile or "").strip()) if hasattr(profile_map, "get") else None
+    if target_db is None and cfg is not None:
+        target_db = getattr(cfg, "db", None)
+    db_backend = str(getattr(target_db, "backend", "") or "") if target_db is not None else ""
+    is_three_level = db_backend in _THREE_LEVEL_BACKENDS
+
+    # Pull the table inventory the skeleton already populated. Reusing
+    # it avoids a second live-DB enumeration; the skeleton is a
+    # prerequisite (the Studio "Deep sync" button is only offered once
+    # a profile has rows).
+    inventory: list[tuple[str, str, str]] = []
+    try:
+        with catalog._connect() as conn:  # noqa: SLF001 — same access as catalog methods
+            if databases:
+                placeholders = ",".join("?" for _ in databases)
+                rows = conn.execute(
+                    f"""
+                    SELECT DISTINCT database_name, schema_name, table_name
+                    FROM catalog_entities
+                    WHERE db_profile = ? AND entity_kind = 'table'
+                      AND database_name IN ({placeholders})
+                    ORDER BY database_name, schema_name, table_name
+                    """,
+                    (profile, *databases),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """
+                    SELECT DISTINCT database_name, schema_name, table_name
+                    FROM catalog_entities
+                    WHERE db_profile = ? AND entity_kind = 'table'
+                    ORDER BY database_name, schema_name, table_name
+                    """,
+                    (profile,),
+                ).fetchall()
+        inventory = [
+            (str(r["database_name"] or ""), str(r["schema_name"] or ""), str(r["table_name"] or ""))
+            for r in rows
+            if r["schema_name"] and r["table_name"]
+        ]
+    except Exception as exc:
+        log.warning("Deep sync inventory read failed for %s: %s", profile, exc)
+        catalog.finish_skeleton_sync(profile, ok=False, error=str(exc))
+        summary["state"] = "failed"
+        summary["error"] = str(exc)
+        _skeleton_jobs.unregister(profile)
+        return summary
+
+    total = len(inventory)
+    catalog.start_skeleton_sync(profile, total_tables=total)
+    if total == 0:
+        catalog.finish_skeleton_sync(profile, ok=True)
+        summary["state"] = "done"
+        summary["note"] = "no tables in catalog — run a skeleton sync first"
+        _skeleton_jobs.unregister(profile)
+        return summary
+
+    processed = 0
+    failed = 0
+    # Group consecutive tables by container so one scoped connector
+    # serves every table in a database.
+    connector = None
+    current_container: str | None = None
+    for container, schema, table in inventory:
+        if cancel_event.is_set():
+            break
+        if connector is None or container != current_container:
+            try:
+                connector = _scoped_connector(cfg, profile, container or None, is_three_level)
+                current_container = container
+            except Exception as exc:
+                log.warning(
+                    "Deep sync connector failed for %s/%s: %s", profile, container or "<default>", exc
+                )
+                connector = None
+                failed += 1
+                continue
+        try:
+            prof = connector.profile_table(schema, table, sample_size=0)
+            catalog.sync_table_profile(
+                db_profile=profile,
+                db_backend=db_backend,
+                database_name=container,
+                profile=prof,
+                query_usage={},
+            )
+            processed += 1
+        except Exception as exc:
+            failed += 1
+            log.warning("Deep sync profile failed for %s.%s: %s", schema, table, exc)
+        # Progress on its own short-lived connection — never hold a
+        # catalog connection open across sync_table_profile (which
+        # opens its own), or SQLite WAL deadlocks.
+        catalog.record_skeleton_progress(profile, processed)
+
+    if cancel_event.is_set():
+        catalog.finish_skeleton_sync(profile, ok=False, error="cancelled")
+        summary["state"] = "cancelled"
+    else:
+        catalog.finish_skeleton_sync(profile, ok=True)
+        summary["state"] = "done"
+    summary["processed"] = processed
+    summary["failed"] = failed
+    summary["total"] = total
+    _skeleton_jobs.unregister(profile)
+    return summary
+
+
 def _asset_name_and_kind(asset: Any) -> tuple[str, str]:
     """Connectors return ``list_assets`` rows in two shapes — a tuple
     ``(name, kind)`` or a single string ``name``. Normalize so the

--- a/amx/web/routers/catalog.py
+++ b/amx/web/routers/catalog.py
@@ -478,6 +478,96 @@ def trigger_catalog_sync(
     }
 
 
+@router.post("/deep-sync")
+def trigger_deep_sync(
+    profile: str | None = Query(default=None),
+    database: str | None = Query(default=None, alias="database"),
+    cfg: AMXConfig = Depends(get_cfg),
+) -> dict[str, Any]:
+    """Kick off a deep (full-profile) sync for the requested profile.
+
+    Unlike ``POST /sync`` (skeleton — table-level rows only), this
+    profiles every catalogued table (``profile_table`` + ``COUNT(*)``)
+    and writes columns + row counts so the Table page renders real
+    structure and counts. Slower by design, so it is a separate
+    opt-in action. Runs in a daemon thread and reuses the skeleton
+    state machine, so the freshness pill and ``POST /sync/cancel``
+    work unchanged.
+
+    A skeleton sync must have run first (it populates the table
+    inventory this pass profiles); on an empty catalog the job
+    finishes immediately with a note.
+    """
+    import threading
+
+    from amx.search.catalog import SearchCatalog
+    from amx.search.drift import deep_sync_profile
+
+    if profile:
+        targets = [profile.strip()]
+    else:
+        if database:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="?database= requires ?profile= to scope the deep sync.",
+            )
+        profile_map = getattr(cfg, "db_profiles", None)
+        targets = list(profile_map.keys()) if hasattr(profile_map, "keys") else []
+    targets = [p for p in targets if p]
+    if not targets:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No DB profile to deep-sync. Pass ?profile=<name> or save a profile first.",
+        )
+    catalog = SearchCatalog.from_history_store()
+    if catalog is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="History store not initialised — cannot deep-sync catalog yet.",
+        )
+    for target in targets:
+        try:
+            catalog.start_skeleton_sync(target, total_tables=0)
+        except Exception:
+            try:
+                catalog.finish_skeleton_sync(target, ok=False, error="bootstrap failed")
+            except Exception:
+                pass
+
+    databases_arg: list[str] | None = [database.strip()] if database else None
+
+    from amx.search import _skeleton_jobs
+
+    def _spawn(target_profile: str) -> None:
+        _skeleton_jobs.register(target_profile)
+
+        def _runner() -> None:
+            try:
+                deep_sync_profile(cfg, target_profile, catalog, databases=databases_arg)
+            except Exception as exc:  # pragma: no cover - best-effort
+                try:
+                    catalog.finish_skeleton_sync(target_profile, ok=False, error=str(exc))
+                except Exception:
+                    pass
+                finally:
+                    _skeleton_jobs.unregister(target_profile)
+
+        threading.Thread(
+            target=_runner,
+            name=f"amx-catalog-deep-sync-{target_profile}",
+            daemon=True,
+        ).start()
+
+    for target in targets:
+        _spawn(target)
+    return {
+        "profiles": targets,
+        "database": database or None,
+        "status": "queued",
+        "mode": "deep",
+    }
+
+
 @router.post("/sync/cancel")
 def cancel_catalog_sync(body: CatalogSyncCancelRequest) -> dict[str, Any]:
     """Cooperatively cancel an in-flight skeleton sync for ``profile``.

--- a/frontend/src/routes/DbCache.tsx
+++ b/frontend/src/routes/DbCache.tsx
@@ -325,6 +325,34 @@ export default function DbCache() {
         title: e instanceof Error ? e.message : "Sync failed",
       }),
   });
+  // Deep sync — full profile (columns + row counts), opt-in because it
+  // runs profile_table + COUNT(*) per table. The plain Sync above is
+  // skeleton-only (fast table inventory). Reuses the same freshness
+  // state machine, so the pill + invalidations are identical.
+  const deepSyncMut = useMutation({
+    mutationFn: (target: string | null) =>
+      apiFetch(
+        target
+          ? `/api/catalog/deep-sync?profile=${encodeURIComponent(target)}`
+          : "/api/catalog/deep-sync",
+        { method: "POST" },
+      ),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["catalog-freshness"] });
+      qc.invalidateQueries({ queryKey: ["db-cache", "show"] });
+      qc.invalidateQueries({ queryKey: ["db-cache", "stats"] });
+      qc.invalidateQueries({ queryKey: ["live-schemas"] });
+      window.setTimeout(() => {
+        qc.invalidateQueries({ queryKey: ["catalog-freshness"] });
+        qc.invalidateQueries({ queryKey: ["db-cache", "show"] });
+      }, 3000);
+    },
+    onError: (e) =>
+      toast.push({
+        tone: "error",
+        title: e instanceof Error ? e.message : "Deep sync failed",
+      }),
+  });
   const freshness = freshnessQ.data;
   const freshnessProfiles = freshness?.profiles ?? [];
   const anySyncing = (freshness?.syncing_profile_count ?? 0) > 0;
@@ -687,22 +715,41 @@ export default function DbCache() {
           title="Profile freshness"
           description="Per-profile last sync timestamp and manual refresh controls."
           actions={
-            <Button
-              variant="primary"
-              size="sm"
-              leadingIcon={
-                <RefreshCw
-                  size={12}
-                  className={
-                    anySyncing || syncMut.isPending ? "animate-spin" : ""
-                  }
-                />
-              }
-              onClick={() => syncMut.mutate(null)}
-              disabled={syncMut.isPending || anySyncing}
-            >
-              {anySyncing || syncMut.isPending ? "Syncing…" : "Sync all"}
-            </Button>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="primary"
+                size="sm"
+                leadingIcon={
+                  <RefreshCw
+                    size={12}
+                    className={
+                      anySyncing || syncMut.isPending ? "animate-spin" : ""
+                    }
+                  />
+                }
+                onClick={() => syncMut.mutate(null)}
+                disabled={syncMut.isPending || deepSyncMut.isPending || anySyncing}
+              >
+                {anySyncing || syncMut.isPending ? "Syncing…" : "Sync all"}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                leadingIcon={
+                  <RefreshCw
+                    size={12}
+                    className={
+                      anySyncing || deepSyncMut.isPending ? "animate-spin" : ""
+                    }
+                  />
+                }
+                onClick={() => deepSyncMut.mutate(null)}
+                disabled={syncMut.isPending || deepSyncMut.isPending || anySyncing}
+                title="Full profile: fetches columns + row counts for every table (slower)."
+              >
+                {deepSyncMut.isPending ? "Deep syncing…" : "Deep sync all"}
+              </Button>
+            </div>
           }
         />
         <CardBody>

--- a/tests/test_deep_sync_profile.py
+++ b/tests/test_deep_sync_profile.py
@@ -1,0 +1,166 @@
+"""Deep sync profiles every catalogued table (columns + row counts).
+
+The Studio "Sync" button runs a skeleton sync — table-level rows only,
+no columns or counts. "Deep sync" is the opt-in full-profile pass:
+for every table the skeleton already catalogued, it runs
+``profile_table`` + ``sync_table_profile`` so the Table page shows
+real structure and row counts.
+
+These tests pin the orchestration: it reads the skeleton inventory,
+profiles each table, writes columns + counts, tracks progress, and
+honours cancellation. The per-table write itself is covered by
+``test_sync_decouple_vector_index.py`` / ``test_search_catalog.py``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import amx.search.drift as drift
+from amx.db.connector import AssetKind, ColumnProfile, TableProfile
+from amx.search.catalog import SearchCatalog
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _seed_skeleton(db_path: Path, profile: str, tables: list[tuple[str, str, str]]) -> None:
+    """Insert table-level (skeleton) rows — no columns, row_count 0."""
+    with sqlite3.connect(db_path) as conn:
+        for database, schema, table in tables:
+            conn.execute(
+                """
+                INSERT INTO catalog_entities (
+                    db_profile, db_backend, database_name, schema_name,
+                    table_name, column_name, entity_kind, asset_kind,
+                    row_count, search_text, updated_at, last_synced_at
+                ) VALUES (?, 'postgresql', ?, ?, ?, NULL, 'table', 'table', 0, '', ?, ?)
+                """,
+                (profile, database, schema, table, time.time(), time.time()),
+            )
+
+
+def _cfg_stub() -> SimpleNamespace:
+    db = SimpleNamespace(backend="postgresql", database="bird_train", catalog="", project="")
+    return SimpleNamespace(db_profiles={"p": db}, db=db)
+
+
+@pytest.fixture()
+def catalog(tmp_path: Path) -> SearchCatalog:
+    db_path = tmp_path / "history.db"
+    SQLiteHistoryStore(db_path).init()
+    cat = SearchCatalog(db_path)
+    # Keep the vector index out of the test — the decouple fix already
+    # guarantees metadata writes survive index failures; here we just
+    # want to assert the orchestration + column/count writes.
+    cat._index_entity = lambda *a, **k: None  # type: ignore[method-assign]  # noqa: SLF001
+    return cat
+
+
+def _fake_connector(row_count: int = 999):
+    class _Conn:
+        def profile_table(self, schema: str, table: str, sample_size: int = 0) -> TableProfile:
+            return TableProfile(
+                schema=schema,
+                name=table,
+                asset_kind=AssetKind.TABLE,
+                row_count=row_count,
+                columns=[
+                    ColumnProfile(name="id", dtype="int", nullable=False, existing_comment=""),
+                    ColumnProfile(name="name", dtype="text", nullable=True, existing_comment=""),
+                ],
+            )
+
+    return _Conn()
+
+
+def _column_count(catalog: SearchCatalog) -> int:
+    with catalog._connect() as conn:  # noqa: SLF001
+        return int(
+            conn.execute(
+                "SELECT COUNT(*) FROM catalog_entities WHERE entity_kind = 'column'"
+            ).fetchone()[0]
+        )
+
+
+def test_deep_sync_profiles_every_catalogued_table(
+    catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_skeleton(
+        catalog.db_path,
+        "p",
+        [("bird_train", "app_store", "playstore"), ("bird_train", "airline", "Airports")],
+    )
+    monkeypatch.setattr(drift, "_scoped_connector", lambda *a, **k: _fake_connector(10840))
+
+    summary = drift.deep_sync_profile(_cfg_stub(), "p", catalog)
+
+    assert summary["state"] == "done"
+    assert summary["processed"] == 2
+    assert summary["failed"] == 0
+    # Each table now has its 2 columns written (skeleton had none).
+    assert _column_count(catalog) == 4
+    # Row counts landed on the table entities.
+    with catalog._connect() as conn:  # noqa: SLF001
+        counts = [
+            r["row_count"]
+            for r in conn.execute(
+                "SELECT row_count FROM catalog_entities WHERE entity_kind = 'table'"
+            )
+        ]
+    assert all(c == 10840 for c in counts)
+
+
+def test_deep_sync_empty_catalog_finishes_with_note(
+    catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No skeleton rows → nothing to profile; finish cleanly with a
+    note rather than erroring."""
+    called = {"n": 0}
+
+    def _conn(*_a, **_k):
+        called["n"] += 1
+        return _fake_connector()
+
+    monkeypatch.setattr(drift, "_scoped_connector", _conn)
+
+    summary = drift.deep_sync_profile(_cfg_stub(), "p", catalog)
+
+    assert summary["state"] == "done"
+    assert summary.get("note")
+    assert called["n"] == 0  # no connector opened
+
+
+def test_deep_sync_continues_past_a_failing_table(
+    catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One table that raises during profiling must not abort the rest
+    — it's counted as failed and the others still sync."""
+    _seed_skeleton(
+        catalog.db_path,
+        "p",
+        [("bird_train", "s", "good"), ("bird_train", "s", "bad")],
+    )
+
+    class _Conn:
+        def profile_table(self, schema: str, table: str, sample_size: int = 0) -> TableProfile:
+            if table == "bad":
+                raise RuntimeError("permission denied")
+            return TableProfile(
+                schema=schema,
+                name=table,
+                asset_kind=AssetKind.TABLE,
+                row_count=5,
+                columns=[ColumnProfile(name="c", dtype="int", nullable=True, existing_comment="")],
+            )
+
+    monkeypatch.setattr(drift, "_scoped_connector", lambda *a, **k: _Conn())
+
+    summary = drift.deep_sync_profile(_cfg_stub(), "p", catalog)
+
+    assert summary["state"] == "done"
+    assert summary["processed"] == 1
+    assert summary["failed"] == 1


### PR DESCRIPTION
## Summary

The Studio "Sync" button runs a **skeleton** sync — fast, table-level inventory only, no columns or row counts. That's why clicking Sync never populated per-table structure/counts; the full-profile path only ran via the CLI `/search sync`.

This adds an explicit **"Deep sync all"** action:
- `amx/search/drift.py:deep_sync_profile` — reuses the skeleton's table inventory from `catalog_entities` (no second live enumeration), profiles each table (`profile_table` → columns + `COUNT(*)`), writes via `sync_table_profile`. Reuses the skeleton state machine (freshness pill) + cancel registry. Per-table failures are counted and skipped, not fatal.
- `POST /api/catalog/deep-sync` — mirrors `/sync` but runs the deep pass in a daemon thread; `/sync/cancel` works unchanged.
- DbCache page: "Deep sync all" button beside "Sync all", labelled as the slower full-profile pass.

Kept separate (opt-in) because it issues `profile_table` + `COUNT(*)` per table — slow on large catalogs. The fast skeleton stays the default.

## Test plan

- [x] `tests/test_deep_sync_profile.py` — 3 tests: profiles every catalogued table (columns + counts written), empty catalog finishes with a note, a failing table is skipped not fatal.
- [x] `ruff` + `mypy` clean; frontend `tsc --noEmit` clean.
- [x] deploy.sh executed; Studio live. (Click "Deep sync all" on the DB Cache page to populate columns + counts, then the Table page Rows card fills in.)