### PR TITLE
feat(storage): add shared catalog_entities table (schema foundation)

### DIFF
--- a/amx/storage/schema_descriptions.py
+++ b/amx/storage/schema_descriptions.py
@@ -783,6 +783,20 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
             "UTC epoch seconds of the last code-context sync (lineage usage, "
             "test references). NULL on entities never touched by /code."
         ),
+        # Attribution columns — present on the SHARED catalog_entities table
+        # (team-wide structural catalog) so /history-store list-team can show
+        # who profiled what. Absent from the local SQLite table.
+        "created_by": (
+            "User who ran the deep sync that produced this row. Shared-store "
+            "only — for team attribution."
+        ),
+        "hostname": (
+            "Machine that ran the deep sync. Shared-store only — for team "
+            "attribution."
+        ),
+        "client_version": (
+            "AMX client version that wrote the row. Shared-store only."
+        ),
     },
     # ── catalog_descriptions (local only) ─────────────────────────────────
     "catalog_descriptions": {

--- a/amx/storage/shared_schema.py
+++ b/amx/storage/shared_schema.py
@@ -130,7 +130,7 @@ DEFAULT_HISTORY_SCHEMA_COMMENT = SHARED_SCHEMA_COMMENT
 # All client versions writing into a shared store record this as their
 # ``schema_version`` so an older client refuses to write into a schema
 # bumped by a newer client (avoids losing columns the new client added).
-SHARED_SCHEMA_VERSION = 5
+SHARED_SCHEMA_VERSION = 6
 
 
 def _desc(table: str, column: str | None = None) -> str:
@@ -1866,6 +1866,90 @@ def build_metadata(schema: str | None = None) -> MetaData:
         ),
         Index("idx_remote_queries_profile_platform", "profile_name", "platform"),
         comment=_desc("remote_queries"),
+    )
+
+    # ── catalog_entities: shared structural table/column metadata ─────────
+    # Mirrors the LOCAL catalog_entities structural columns so a deep
+    # sync's expensive COUNT(*) pass runs once per team and propagates.
+    # Descriptions are NOT shared here — they flow via run_results /
+    # analysis_runs; only structure (columns, dtypes, row counts, key
+    # flags) lives in this table. The natural key
+    # (db_profile, database_name, schema_name, table_name, column_name)
+    # plus last_synced_at drives last-write-wins upserts in both
+    # directions (push + pull).
+    Table(
+        "catalog_entities",
+        md,
+        Column("id", String(36), primary_key=True, comment=_desc("catalog_entities", "id")),
+        Column(
+            "db_profile",
+            String(120),
+            nullable=False,
+            comment=_desc("catalog_entities", "db_profile"),
+        ),
+        Column("db_backend", String(40), comment=_desc("catalog_entities", "db_backend")),
+        Column(
+            "database_name",
+            String(255),
+            nullable=False,
+            default="",
+            comment=_desc("catalog_entities", "database_name"),
+        ),
+        Column(
+            "schema_name",
+            String(255),
+            nullable=False,
+            comment=_desc("catalog_entities", "schema_name"),
+        ),
+        Column(
+            "table_name",
+            String(255),
+            nullable=False,
+            comment=_desc("catalog_entities", "table_name"),
+        ),
+        Column(
+            "column_name",
+            String(255),
+            nullable=False,
+            default="",
+            comment=_desc("catalog_entities", "column_name"),
+        ),
+        Column(
+            "entity_kind",
+            String(20),
+            nullable=False,
+            comment=_desc("catalog_entities", "entity_kind"),
+        ),
+        Column("asset_kind", String(40), comment=_desc("catalog_entities", "asset_kind")),
+        Column("dtype", String(255), comment=_desc("catalog_entities", "dtype")),
+        Column("nullable", Integer, comment=_desc("catalog_entities", "nullable")),
+        Column("pk_flag", Integer, comment=_desc("catalog_entities", "pk_flag")),
+        Column("fk_flag", Integer, comment=_desc("catalog_entities", "fk_flag")),
+        Column("row_count", BigInteger, comment=_desc("catalog_entities", "row_count")),
+        Column(
+            "last_synced_at",
+            DateTime(timezone=True),
+            index=True,
+            comment=_desc("catalog_entities", "last_synced_at"),
+        ),
+        Column("created_by", String(120), comment=_desc("catalog_entities", "created_by")),
+        Column("hostname", String(255), comment=_desc("catalog_entities", "hostname")),
+        Column("client_version", String(40), comment=_desc("catalog_entities", "client_version")),
+        UniqueConstraint(
+            "db_profile",
+            "database_name",
+            "schema_name",
+            "table_name",
+            "column_name",
+            name="uq_catalog_entities_natural_key",
+        ),
+        Index(
+            "ix_catalog_entities_profile_schema",
+            "db_profile",
+            "database_name",
+            "schema_name",
+        ),
+        comment=_desc("catalog_entities"),
     )
 
     return md

--- a/tests/test_shared_schema_comments.py
+++ b/tests/test_shared_schema_comments.py
@@ -54,14 +54,15 @@ def test_create_history_tables_ddl_emits_comments_on_postgres() -> None:
     )
     ddl = PostgreSQLAdapter(cfg).create_history_tables_ddl("AMX")
 
-    assert ddl.count("CREATE TABLE") == 26, "expected 26 CREATE TABLE statements"
-    assert ddl.count("COMMENT ON TABLE") == 26, "expected 26 COMMENT ON TABLE statements"
-    # 321 columns (275 pre-Phase-A-Task-6 + 46 new remote-asset columns:
+    assert ddl.count("CREATE TABLE") == 27, "expected 27 CREATE TABLE statements"
+    assert ddl.count("COMMENT ON TABLE") == 27, "expected 27 COMMENT ON TABLE statements"
+    # 339 columns (275 pre-Phase-A-Task-6 + 46 remote-asset columns:
     #              remote_pipelines (12), remote_streamlit_apps (9),
     #              remote_streams (9), remote_task_dependencies (3),
-    #              remote_queries (13) = 46 added)
-    assert ddl.count("COMMENT ON COLUMN") == 321, (
-        f"expected 321 COMMENT ON COLUMN statements, got {ddl.count('COMMENT ON COLUMN')}"
+    #              remote_queries (13) = 46; + catalog_entities (18) for
+    #              the shared structural catalog = 339)
+    assert ddl.count("COMMENT ON COLUMN") == 339, (
+        f"expected 339 COMMENT ON COLUMN statements, got {ddl.count('COMMENT ON COLUMN')}"
     )
 
 


### PR DESCRIPTION
## Summary

First step of team-wide catalog sharing (spec: `docs/superpowers/specs/2026-05-25-shared-catalog-design.md`). Adds the shared-store table for structural catalog metadata so one member's deep sync propagates to the team.

- `shared_schema.py`: new `catalog_entities` table (mirrors local structural columns + `created_by`/`hostname`/`client_version`). Natural key `(db_profile, database_name, schema_name, table_name, column_name)` + indexed `last_synced_at` for last-write-wins. `SHARED_SCHEMA_VERSION` 5→6.
- `schema_descriptions.py`: descriptions for the 3 new attribution columns on the existing `catalog_entities` entry.
- `test_shared_schema_comments.py`: table count 26→27, column count 321→339.

**No behavior change** — nothing reads/writes the shared table yet. Push/backfill/pull land in the follow-up PR.

## Test plan

- [x] `tests/test_shared_schema_comments.py` + `tests/test_local_schema_comments.py`: 14 passed.
- [x] `ruff` + `mypy` clean. Metadata builds; every column has a comment.
- Storage-layer only, no Studio surface → no deploy.