### PR TITLE
feat(storage): wire shared-catalog push/backfill/pull

### DIFF
--- a/amx/cli_support/commands/history_store.py
+++ b/amx/cli_support/commands/history_store.py
@@ -312,6 +312,26 @@ def _run_pull_from_shared(shared_store) -> None:
     else:
         info("Nothing new to pull (already in sync).")
 
+    # Shared structural catalog: backfill local deep-sync results UP
+    # (covers rows produced while the store was off), then pull the
+    # team's catalog DOWN so columns + row counts arrive without a local
+    # COUNT(*) pass. Best-effort — never blocks the enable/pull flow.
+    try:
+        from amx.storage.migration import (
+            pull_catalog_to_local,
+            push_catalog_to_shared,
+        )
+
+        pushed = push_catalog_to_shared(local, shared_store)
+        pulled = pull_catalog_to_local(local, shared_store)
+        if pushed or pulled:
+            info(
+                f"Catalog sync: pushed {pushed} local row(s) up, "
+                f"pulled {pulled} team row(s) down."
+            )
+    except Exception as exc:
+        info(f"Catalog sync skipped (runs still synced): {exc}")
+
 
 def _pick_history_database(cfg: AMXConfig, db_cfg, adapter) -> str:
     """Ask the user which database / catalog should host the AMX schema.

--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -849,8 +849,34 @@ def deep_sync_profile(
     summary["processed"] = processed
     summary["failed"] = failed
     summary["total"] = total
+    # Team sharing: when the shared history store is active, push this
+    # profile's freshly-profiled structural rows up so teammates inherit
+    # the COUNT(*) work. Best-effort — a shared-store failure must never
+    # turn a successful local deep sync into a failure. When the store is
+    # OFF the active history store has no ``.shared`` handle, so this is
+    # a silent no-op (the gating the user asked for).
+    if summary["state"] == "done":
+        summary["shared_pushed"] = _push_catalog_if_shared(profile)
     _skeleton_jobs.unregister(profile)
     return summary
+
+
+def _push_catalog_if_shared(profile: str) -> int:
+    """Push a profile's local catalog rows to the shared store when one
+    is active. Returns the number of rows pushed (0 when no shared store
+    / on any failure). Never raises."""
+    try:
+        from amx.storage.sqlite_store import history_store
+
+        hs = history_store()
+        if hs is None or not hasattr(hs, "shared") or not hasattr(hs, "local"):
+            return 0  # store disabled → local-only, no push
+        from amx.storage.migration import push_catalog_to_shared
+
+        return push_catalog_to_shared(hs.local, hs.shared, db_profile=profile)
+    except Exception as exc:  # pragma: no cover - best-effort
+        log.warning("Catalog push to shared store skipped for %s: %s", profile, exc)
+        return 0
 
 
 def _asset_name_and_kind(asset: Any) -> tuple[str, str]:

--- a/amx/storage/migration.py
+++ b/amx/storage/migration.py
@@ -602,4 +602,180 @@ def ensure_column_exists(
             )
 
 
-__all__ = ["ensure_column_exists", "migrate_local_to_shared", "pull_shared_to_local"]
+_CATALOG_STRUCTURAL_COLS = (
+    "db_profile",
+    "db_backend",
+    "database_name",
+    "schema_name",
+    "table_name",
+    "column_name",
+    "entity_kind",
+    "asset_kind",
+    "dtype",
+    "nullable",
+    "pk_flag",
+    "fk_flag",
+    "row_count",
+    "last_synced_at",
+)
+
+
+def push_catalog_to_shared(
+    local: SQLiteHistoryStore,
+    shared: SQLAlchemyHistoryStore,
+    *,
+    db_profile: str | None = None,
+) -> int:
+    """Push local structural catalog rows UP to the shared store.
+
+    Reads ``catalog_entities`` from local SQLite (optionally scoped to
+    one ``db_profile``) and upserts them into the shared store, where
+    last-write-wins on ``last_synced_at`` dedupes against teammates'
+    rows. Used both by the deep-sync push (one profile) and the
+    enable-time backfill (all profiles).
+
+    Local ``last_synced_at`` is epoch seconds; the shared store wants a
+    tz-aware datetime, so it is converted here. Table-level rows store
+    ``column_name`` as NULL locally and ``''`` in the shared natural
+    key, so the value is normalised on the way up.
+
+    Best-effort and read-only against local: returns the number of rows
+    the shared store reported written. A shared outage is swallowed by
+    ``upsert_catalog_entities`` (returns a partial count).
+    """
+    where = "WHERE db_profile = ?" if db_profile else ""
+    params: tuple[Any, ...] = (db_profile,) if db_profile else ()
+    with local._connect() as conn:  # noqa: SLF001
+        local_rows = conn.execute(
+            f"SELECT {', '.join(_CATALOG_STRUCTURAL_COLS)} "
+            f"FROM catalog_entities {where}",
+            params,
+        ).fetchall()
+    if not local_rows:
+        return 0
+    rows: list[dict[str, Any]] = []
+    for r in local_rows:
+        d = {col: r[col] for col in _CATALOG_STRUCTURAL_COLS}
+        d["column_name"] = d.get("column_name") or ""
+        ts = d.get("last_synced_at")
+        d["last_synced_at"] = (
+            datetime.fromtimestamp(float(ts), tz=timezone.utc) if ts else None
+        )
+        rows.append(d)
+    return shared.upsert_catalog_entities(rows)
+
+
+def pull_catalog_to_local(
+    local: SQLiteHistoryStore,
+    shared: SQLAlchemyHistoryStore,
+) -> int:
+    """Pull shared structural catalog rows DOWN into local SQLite.
+
+    Upserts by the natural key
+    (db_profile, database_name, schema_name, table_name, column_name)
+    with last-write-wins on ``last_synced_at``. Only the structural
+    columns are touched; a newly inserted row gets
+    ``effective_description_id = NULL`` (descriptions resolve from the
+    puller's own local state, populated by the run-sharing path), and
+    an existing local row keeps its description link untouched — only
+    its structural columns refresh when the shared snapshot is newer.
+
+    Returns the number of local rows inserted or updated. Degrades to 0
+    when the shared store is unreachable.
+    """
+    shared_rows = shared.fetch_catalog_entities()
+    if not shared_rows:
+        return 0
+    written = 0
+    with local._lock:  # noqa: SLF001
+        with local._connect() as conn:  # noqa: SLF001
+            for row in shared_rows:
+                # Normalise the shared '' table-level marker back to the
+                # local NULL convention so the natural-key match works.
+                col_name = row.get("column_name") or None
+                incoming_ts = _dt_to_ts(row.get("last_synced_at"))
+                existing = conn.execute(
+                    """
+                    SELECT id, last_synced_at FROM catalog_entities
+                    WHERE db_profile = ? AND database_name = ?
+                      AND schema_name = ? AND table_name = ?
+                      AND ((column_name IS NULL AND ? IS NULL) OR column_name = ?)
+                    LIMIT 1
+                    """,
+                    (
+                        row.get("db_profile"),
+                        row.get("database_name") or "",
+                        row.get("schema_name"),
+                        row.get("table_name"),
+                        col_name,
+                        col_name,
+                    ),
+                ).fetchone()
+                if existing is None:
+                    conn.execute(
+                        """
+                        INSERT INTO catalog_entities (
+                            db_profile, db_backend, database_name, schema_name,
+                            table_name, column_name, entity_kind, asset_kind,
+                            dtype, nullable, pk_flag, fk_flag, row_count,
+                            search_text, effective_description_id,
+                            updated_at, last_synced_at
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '', NULL, ?, ?)
+                        """,
+                        (
+                            row.get("db_profile"),
+                            row.get("db_backend"),
+                            row.get("database_name") or "",
+                            row.get("schema_name"),
+                            row.get("table_name"),
+                            col_name,
+                            row.get("entity_kind"),
+                            row.get("asset_kind"),
+                            row.get("dtype"),
+                            row.get("nullable"),
+                            row.get("pk_flag"),
+                            row.get("fk_flag"),
+                            row.get("row_count"),
+                            time.time(),
+                            incoming_ts,
+                        ),
+                    )
+                    written += 1
+                else:
+                    stored_ts = existing["last_synced_at"]
+                    if incoming_ts is not None and (
+                        stored_ts is None or incoming_ts > float(stored_ts)
+                    ):
+                        conn.execute(
+                            """
+                            UPDATE catalog_entities
+                            SET db_backend = ?, entity_kind = ?, asset_kind = ?,
+                                dtype = ?, nullable = ?, pk_flag = ?, fk_flag = ?,
+                                row_count = ?, updated_at = ?, last_synced_at = ?
+                            WHERE id = ?
+                            """,
+                            (
+                                row.get("db_backend"),
+                                row.get("entity_kind"),
+                                row.get("asset_kind"),
+                                row.get("dtype"),
+                                row.get("nullable"),
+                                row.get("pk_flag"),
+                                row.get("fk_flag"),
+                                row.get("row_count"),
+                                time.time(),
+                                incoming_ts,
+                                existing["id"],
+                            ),
+                        )
+                        written += 1
+    return written
+
+
+__all__ = [
+    "ensure_column_exists",
+    "migrate_local_to_shared",
+    "pull_shared_to_local",
+    "push_catalog_to_shared",
+    "pull_catalog_to_local",
+]

--- a/amx/storage/sqlalchemy_store.py
+++ b/amx/storage/sqlalchemy_store.py
@@ -160,6 +160,19 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _as_utc(value: Any) -> datetime | None:
+    """Coerce a datetime to aware-UTC for safe comparison.
+
+    SQLite round-trips ``DateTime`` columns as naive; warehouse backends
+    return aware. Comparing the two raises ``TypeError``, so normalise a
+    naive value to UTC before any ``>`` comparison. Non-datetimes and
+    ``None`` pass through as ``None``.
+    """
+    if not isinstance(value, datetime):
+        return None
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+
+
 def _jsonable(value: Any) -> Any:
     """Recursively convert a value to a JSON-serializable form.
 
@@ -240,6 +253,7 @@ class SQLAlchemyHistoryStore:
         self._t_lineage_comments = self._md.tables[f"{schema}.lineage_comments"]
         self._t_pages = self._md.tables[f"{schema}.documentation_pages"]
         self._t_documentation_pages = self._t_pages  # alias used by backfill code
+        self._t_catalog = self._md.tables[f"{schema}.catalog_entities"]
         self._hostname = _hostname()
         self._username = _username()
         self._client_version = _client_version()
@@ -894,6 +908,107 @@ class SQLAlchemyHistoryStore:
         for row in rows:
             host = row.get("hostname") or ""
             if exclude_hostname and host == exclude_hostname:
+                continue
+            out.append(dict(row))
+        return out
+
+    # ── shared catalog (structural metadata) ──────────────────────────────
+
+    def upsert_catalog_entities(self, rows: list[dict[str, Any]]) -> int:
+        """Upsert structural catalog rows into the shared store.
+
+        Each row is keyed by the natural tuple
+        (db_profile, database_name, schema_name, table_name, column_name).
+        Last-write-wins: an incoming row only overwrites the stored one
+        when its ``last_synced_at`` is strictly newer (so an older
+        snapshot from a lagging teammate never clobbers a fresher count).
+
+        Portable across backends — a per-row SELECT then conditional
+        INSERT/UPDATE rather than dialect-specific ``ON CONFLICT``.
+        Returns the number of rows inserted or updated. Best-effort:
+        a backend error is logged and the count so far is returned, so
+        a partial shared outage never raises into the caller.
+        """
+        if not rows:
+            return 0
+        t = self._t_catalog
+        written = 0
+        try:
+            with self.engine.begin() as conn:
+                for row in rows:
+                    key = and_(
+                        t.c.db_profile == row["db_profile"],
+                        t.c.database_name == (row.get("database_name") or ""),
+                        t.c.schema_name == row["schema_name"],
+                        t.c.table_name == row["table_name"],
+                        t.c.column_name == (row.get("column_name") or ""),
+                    )
+                    existing = conn.execute(
+                        select(t.c.id, t.c.last_synced_at).where(key)
+                    ).mappings().first()
+                    payload = {
+                        "db_profile": row["db_profile"],
+                        "db_backend": row.get("db_backend"),
+                        "database_name": row.get("database_name") or "",
+                        "schema_name": row["schema_name"],
+                        "table_name": row["table_name"],
+                        "column_name": row.get("column_name") or "",
+                        "entity_kind": row["entity_kind"],
+                        "asset_kind": row.get("asset_kind"),
+                        "dtype": row.get("dtype"),
+                        "nullable": row.get("nullable"),
+                        "pk_flag": row.get("pk_flag"),
+                        "fk_flag": row.get("fk_flag"),
+                        "row_count": row.get("row_count"),
+                        "last_synced_at": row.get("last_synced_at"),
+                        "created_by": row.get("created_by") or self._username,
+                        "hostname": row.get("hostname") or self._hostname,
+                        "client_version": row.get("client_version") or self._client_version,
+                    }
+                    if existing is None:
+                        payload["id"] = str(uuid.uuid4())
+                        conn.execute(insert(t).values(**payload))
+                        written += 1
+                    else:
+                        # Normalise to aware-UTC before comparing: SQLite
+                        # round-trips DateTime as naive, so a naive stored
+                        # value and an aware incoming one would raise
+                        # "can't compare offset-naive and offset-aware".
+                        incoming_ts = _as_utc(row.get("last_synced_at"))
+                        stored_ts = _as_utc(existing.get("last_synced_at"))
+                        # Last-write-wins: only overwrite with a strictly
+                        # newer snapshot. Missing timestamps never win.
+                        if incoming_ts is not None and (
+                            stored_ts is None or incoming_ts > stored_ts
+                        ):
+                            conn.execute(
+                                update(t).where(t.c.id == existing["id"]).values(**payload)
+                            )
+                            written += 1
+        except SQLAlchemyError as exc:
+            log.warning("upsert_catalog_entities failed after %d rows: %s", written, exc)
+        return written
+
+    def fetch_catalog_entities(
+        self, *, exclude_hostname: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Return shared catalog rows for pull-to-local.
+
+        Unlike runs, catalog rows are NOT filtered to other hosts —
+        the freshest structural snapshot is wanted regardless of who
+        produced it (last-write-wins already deduped on push). The
+        ``exclude_hostname`` arg is accepted for symmetry with
+        :meth:`iter_runs_by_other_hosts` but defaults to including all.
+        """
+        try:
+            with self.engine.begin() as conn:
+                rows = conn.execute(select(self._t_catalog)).mappings().all()
+        except SQLAlchemyError as exc:
+            log.debug("fetch_catalog_entities failed: %s", exc)
+            return []
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            if exclude_hostname and (row.get("hostname") or "") == exclude_hostname:
                 continue
             out.append(dict(row))
         return out

--- a/tests/test_shared_catalog_sync.py
+++ b/tests/test_shared_catalog_sync.py
@@ -1,0 +1,183 @@
+"""Push/pull of the structural catalog between local and shared stores.
+
+One team member's deep sync (the expensive COUNT(*) pass) should
+propagate to teammates through the shared store instead of each member
+re-running it. These tests exercise the two halves against a real local
+SQLite store and a SQLite-backed shared SQLAlchemy store:
+
+* ``push_catalog_to_shared`` — local structural rows go up, deduped by
+  the natural key with last-write-wins on ``last_synced_at``.
+* ``pull_catalog_to_local`` — shared rows come down, table-level
+  ``column_name`` normalised back to NULL, description link left NULL.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+
+from amx.search.catalog import SearchCatalog
+from amx.storage.migration import pull_catalog_to_local, push_catalog_to_shared
+from amx.storage.shared_schema import build_metadata
+from amx.storage.sqlalchemy_store import SQLAlchemyHistoryStore
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+def _make_shared(tmp_path: Path, name: str = "shared") -> SQLAlchemyHistoryStore:
+    engine = create_engine(f"sqlite:///{tmp_path / f'{name}.db'}")
+    build_metadata(schema="main").create_all(engine)
+    return SQLAlchemyHistoryStore(engine, "main")
+
+
+def _make_local(tmp_path: Path, name: str) -> SQLiteHistoryStore:
+    store = SQLiteHistoryStore(tmp_path / f"{name}.db")
+    store.init()
+    # Ensure the catalog_entities table exists (created by the catalog layer).
+    SearchCatalog(tmp_path / f"{name}.db")
+    return store
+
+
+def _seed_local_table(
+    store: SQLiteHistoryStore,
+    *,
+    profile: str,
+    database: str,
+    schema: str,
+    table: str,
+    columns: list[tuple[str, str]],
+    row_count: int,
+    synced_at: float,
+) -> None:
+    """Insert a table-level row (column_name NULL) + its column rows."""
+    with store._connect() as conn:  # noqa: SLF001
+        conn.execute(
+            """
+            INSERT INTO catalog_entities (
+                db_profile, db_backend, database_name, schema_name, table_name,
+                column_name, entity_kind, asset_kind, row_count, search_text,
+                updated_at, last_synced_at
+            ) VALUES (?, 'postgresql', ?, ?, ?, NULL, 'table', 'table', ?, '', ?, ?)
+            """,
+            (profile, database, schema, table, row_count, time.time(), synced_at),
+        )
+        for col, dtype in columns:
+            conn.execute(
+                """
+                INSERT INTO catalog_entities (
+                    db_profile, db_backend, database_name, schema_name, table_name,
+                    column_name, entity_kind, asset_kind, dtype, row_count,
+                    search_text, updated_at, last_synced_at
+                ) VALUES (?, 'postgresql', ?, ?, ?, ?, 'column', 'table', ?, ?, '', ?, ?)
+                """,
+                (profile, database, schema, table, col, dtype, row_count,
+                 time.time(), synced_at),
+            )
+
+
+def _local_rows(store: SQLiteHistoryStore, schema: str, table: str) -> list[dict]:
+    with store._connect() as conn:  # noqa: SLF001
+        return [
+            dict(r)
+            for r in conn.execute(
+                "SELECT column_name, entity_kind, row_count, dtype, "
+                "effective_description_id, last_synced_at "
+                "FROM catalog_entities WHERE schema_name = ? AND table_name = ? "
+                "ORDER BY entity_kind, column_name",
+                (schema, table),
+            )
+        ]
+
+
+def test_push_then_pull_round_trips_structure(tmp_path: Path) -> None:
+    """A deep-synced table on machine A reaches machine B's local
+    catalog through the shared store — columns + row count intact."""
+    shared = _make_shared(tmp_path)
+    local_a = _make_local(tmp_path, "a")
+    _seed_local_table(
+        local_a,
+        profile="p",
+        database="bird_train",
+        schema="app_store",
+        table="playstore",
+        columns=[("App", "text"), ("Rating", "double")],
+        row_count=10840,
+        synced_at=1_700_000_000.0,
+    )
+
+    pushed = push_catalog_to_shared(local_a, shared)
+    assert pushed == 3  # 1 table + 2 columns
+
+    # Fresh machine B pulls.
+    local_b = _make_local(tmp_path, "b")
+    pulled = pull_catalog_to_local(local_b, shared)
+    assert pulled == 3
+
+    rows = _local_rows(local_b, "app_store", "playstore")
+    assert len(rows) == 3
+    table_row = next(r for r in rows if r["entity_kind"] == "table")
+    assert table_row["row_count"] == 10840
+    # Table-level column_name normalised back to NULL on the pull.
+    assert table_row["column_name"] is None
+    # Description link left NULL — descriptions flow via the run path.
+    assert table_row["effective_description_id"] is None
+    col_names = {r["column_name"] for r in rows if r["entity_kind"] == "column"}
+    assert col_names == {"App", "Rating"}
+
+
+def test_pull_last_write_wins(tmp_path: Path) -> None:
+    """A newer shared snapshot overwrites an older local row; an older
+    shared snapshot does not clobber a newer local one."""
+    shared = _make_shared(tmp_path)
+    local_a = _make_local(tmp_path, "a")
+
+    # A pushes an OLD snapshot (row_count 100).
+    _seed_local_table(
+        local_a, profile="p", database="d", schema="s", table="t",
+        columns=[("c", "int")], row_count=100, synced_at=1_000.0,
+    )
+    push_catalog_to_shared(local_a, shared)
+
+    local_b = _make_local(tmp_path, "b")
+    pull_catalog_to_local(local_b, shared)
+    assert next(r for r in _local_rows(local_b, "s", "t")
+                if r["entity_kind"] == "table")["row_count"] == 100
+
+    # A re-syncs with a NEWER snapshot (row_count 999).
+    with local_a._connect() as conn:  # noqa: SLF001
+        conn.execute(
+            "UPDATE catalog_entities SET row_count = 999, last_synced_at = 2000.0 "
+            "WHERE schema_name = 's' AND table_name = 't'"
+        )
+    push_catalog_to_shared(local_a, shared)
+
+    # B pulls again — the newer count wins.
+    pull_catalog_to_local(local_b, shared)
+    assert next(r for r in _local_rows(local_b, "s", "t")
+                if r["entity_kind"] == "table")["row_count"] == 999
+
+
+def test_push_empty_local_is_noop(tmp_path: Path) -> None:
+    shared = _make_shared(tmp_path)
+    local = _make_local(tmp_path, "empty")
+    assert push_catalog_to_shared(local, shared) == 0
+
+
+def test_push_scoped_to_profile(tmp_path: Path) -> None:
+    """Pushing with a db_profile filter only sends that profile's rows."""
+    shared = _make_shared(tmp_path)
+    local = _make_local(tmp_path, "a")
+    _seed_local_table(
+        local, profile="p1", database="d", schema="s", table="t1",
+        columns=[("c", "int")], row_count=5, synced_at=1_000.0,
+    )
+    _seed_local_table(
+        local, profile="p2", database="d", schema="s", table="t2",
+        columns=[("c", "int")], row_count=5, synced_at=1_000.0,
+    )
+    pushed = push_catalog_to_shared(local, shared, db_profile="p1")
+    assert pushed == 2  # only p1's table + column
+    fetched = shared.fetch_catalog_entities()
+    assert {r["db_profile"] for r in fetched} == {"p1"}


### PR DESCRIPTION
## Summary

Second step of team-wide catalog sharing (spec: `docs/superpowers/specs/2026-05-25-shared-catalog-design.md`). With the shared `catalog_entities` table in place (#587), this wires the sharing so one member's deep sync (COUNT(*) per table) reaches the team.

**Shared store methods** (`sqlalchemy_store.py`):
- `upsert_catalog_entities` — portable natural-key upsert with last-write-wins on `last_synced_at`; best-effort.
- `fetch_catalog_entities` — read for pull.
- `_as_utc` — normalises naive/aware datetimes for safe comparison.

**Push/pull** (`migration.py`):
- `push_catalog_to_shared` — local → shared (epoch→datetime, NULL→'' column_name). Optional `db_profile` scope.
- `pull_catalog_to_local` — shared → local ('' → NULL, last-write-wins, `effective_description_id` left NULL).

**Triggers/gating:**
- `deep_sync_profile`: pushes the profile's rows after a successful sync IFF the active store is dual-write (shared enabled). Store OFF → no `.shared` → silent no-op. Best-effort.
- `/history-store` enable/pull: backfills local catalog UP then pulls the team's DOWN, alongside the existing run/lineage/pages pull.

## Test plan

- [x] `tests/test_shared_catalog_sync.py` — 4 tests vs real local SQLite + SQLite-backed shared store: round-trip structure, last-write-wins, empty no-op, profile-scoped push.
- [x] 27 storage/catalog tests pass. `ruff` clean. No new mypy errors.
- [x] deploy.sh executed; Studio live.
- Note: e2e against a real warehouse shared store is unverified in this dev env (`history_store_enabled=false`); covered by SQLite-backed unit tests.