### PR TITLE
fix(studio): cache-first table snapshot + exact row counts on Databricks

### DIFF
--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -824,6 +824,16 @@ def deep_sync_profile(
                 continue
         try:
             prof = connector.profile_table(schema, table, sample_size=0)
+            # Backends that block the profiler's COUNT(*) when no cheap
+            # stat is available (Databricks sets
+            # full_scan_when_row_count_unknown=False to avoid surprise
+            # full scans) leave row_count at 0. Deep sync is the opt-in
+            # "pay the cost" path, so fetch an exact count here when the
+            # profiler couldn't — that's the whole reason the user ran it.
+            if not getattr(prof, "row_count", 0):
+                exact = _exact_row_count(connector, schema, table)
+                if exact is not None:
+                    prof.row_count = exact
             catalog.sync_table_profile(
                 db_profile=profile,
                 db_backend=db_backend,
@@ -859,6 +869,29 @@ def deep_sync_profile(
         summary["shared_pushed"] = _push_catalog_if_shared(profile)
     _skeleton_jobs.unregister(profile)
     return summary
+
+
+def _exact_row_count(connector: Any, schema: str, table: str) -> int | None:
+    """Run an exact ``SELECT COUNT(*)`` for one table, best-effort.
+
+    Used by deep sync to fill the row count on backends whose profiler
+    skips the COUNT(*) (e.g. Databricks, where
+    full_scan_when_row_count_unknown is False). On Delta the count is
+    usually answered from file metadata, so it is cheap in practice.
+    Returns ``None`` on any failure so a single uncountable table never
+    aborts the deep sync.
+    """
+    try:
+        from sqlalchemy import text as _text
+
+        adapter = connector._adapter  # noqa: SLF001
+        fqn = adapter.fully_qualified_name(schema, table)
+        with connector.engine.connect() as conn:
+            value = conn.execute(_text(f"SELECT COUNT(*) FROM {fqn}")).scalar()
+        return int(value) if value is not None else None
+    except Exception as exc:  # pragma: no cover - best-effort
+        log.debug("Exact row count failed for %s.%s: %s", schema, table, exc)
+        return None
 
 
 def _push_catalog_if_shared(profile: str) -> int:

--- a/amx/web/routers/live_db.py
+++ b/amx/web/routers/live_db.py
@@ -1293,26 +1293,62 @@ def table_snapshot(
     profile: str = Query(...),
     database: str | None = Query(default=None),
     catalog: str | None = Query(default=None),
+    force_live: bool = Query(default=False),
     cfg: AMXConfig = Depends(get_cfg),
 ) -> dict[str, Any]:
     """Return the lightweight metadata snapshot the orchestrator uses:
-    column names + dtypes + comments + table comment. No profiling.
+    column names + dtypes + comments + table comment + cached row count.
 
-    Resilient against partial introspection: when the live snapshot
-    comes back with zero columns (the table was removed from the live
-    DB after a code-RAG ingest, the user lacks ``USAGE`` on the
-    schema, or the connector swallowed a ``NoSuchTableError``), we
-    fall back to the cached column list so the Studio Table page
-    still renders something useful instead of an empty card.
+    **Cache-first.** When the catalog already has this table's columns
+    (from a deep sync or /search sync), the snapshot is served straight
+    from the local cache with NO live database round-trip — the whole
+    point of syncing is to avoid slow live metadata reads (especially on
+    Databricks). ``?force_live=true`` bypasses the cache for an explicit
+    refresh.
 
-    Pending-review entries for the asset (Browse → AI Generate output
-    that has not been approved yet) are merged onto the response under
+    On a cache miss the live snapshot is read, and that path is itself
+    resilient: when the live read comes back with zero columns (table
+    dropped, missing ``USAGE``, a swallowed ``NoSuchTableError``) it
+    falls back to whatever the caches hold so the Table page still
+    renders something useful.
+
+    Pending-review entries for the asset are merged under
     ``pending_description`` / ``pending_column_descriptions`` /
-    ``pending_run_id`` so the Table page can surface them with a pill
-    instead of losing them on refresh.
+    ``pending_run_id`` so the Table page can surface them with a pill.
     """
     name = _require_profile(profile)
     cache_scope = database or catalog
+
+    # ── Cache-first read ──────────────────────────────────────────────
+    if not force_live:
+        cached_cols = _columns_from_cache(name, schema, table, database_scope=cache_scope)
+        if cached_cols:
+            comments = _cached_column_comments(name, schema, table, database_scope=cache_scope)
+            return _merge_pending(
+                {
+                    "schema": schema,
+                    "table": table,
+                    "table_comment": _cached_table_comment(
+                        name, schema, table, database_scope=cache_scope
+                    ),
+                    "columns": [
+                        {
+                            "name": c["name"],
+                            "dtype": c.get("dtype") or "",
+                            "nullable": bool(c.get("nullable", True)),
+                            "comment": comments.get(c["name"], ""),
+                        }
+                        for c in cached_cols
+                    ],
+                    "source": "cache",
+                    "row_count": _cached_row_count(
+                        name, schema, table, database_scope=cache_scope
+                    ),
+                },
+                schema,
+                table,
+            )
+
     db = _connector_for_scope(cfg, name, database=database, catalog=catalog)
     try:
         snapshot = db.get_table_metadata_snapshot(schema, table)

--- a/tests/test_deep_sync_profile.py
+++ b/tests/test_deep_sync_profile.py
@@ -134,6 +134,40 @@ def test_deep_sync_empty_catalog_finishes_with_note(
     assert called["n"] == 0  # no connector opened
 
 
+def test_deep_sync_fills_row_count_when_profiler_returns_zero(
+    catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On backends that block the profiler's COUNT(*) (e.g. Databricks),
+    profile_table returns row_count=0. Deep sync then runs an exact
+    count via _exact_row_count and persists THAT, so Databricks tables
+    get real counts instead of a misleading 0."""
+    _seed_skeleton(catalog.db_path, "p", [("dbx", "amx_test_schema", "adrc")])
+
+    class _ZeroCountConn:
+        def profile_table(self, schema: str, table: str, sample_size: int = 0) -> TableProfile:
+            return TableProfile(
+                schema=schema,
+                name=table,
+                asset_kind=AssetKind.TABLE,
+                row_count=0,  # profiler blocked the COUNT(*)
+                columns=[ColumnProfile(name="id", dtype="int", nullable=True, existing_comment="")],
+            )
+
+    monkeypatch.setattr(drift, "_scoped_connector", lambda *a, **k: _ZeroCountConn())
+    # Stand in for the exact COUNT(*) the connector would run.
+    monkeypatch.setattr(drift, "_exact_row_count", lambda *a, **k: 123456)
+
+    summary = drift.deep_sync_profile(_cfg_stub(), "p", catalog)
+
+    assert summary["state"] == "done"
+    with catalog._connect() as conn:  # noqa: SLF001
+        row_count = conn.execute(
+            "SELECT row_count FROM catalog_entities "
+            "WHERE entity_kind = 'table' AND table_name = 'adrc'"
+        ).fetchone()[0]
+    assert row_count == 123456
+
+
 def test_deep_sync_continues_past_a_failing_table(
     catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Two reported problems, both on the Databricks profile (`/cat/dbr-oyk/...`):

**1. Row counts never came from Databricks.** The profiler skips `COUNT(*)` when no cheap stat exists and the backend sets `full_scan_when_row_count_unknown=False` (Databricks does, to avoid surprise full scans), so `profile_table` returned 0 and deep sync stored 0.
→ `deep_sync_profile` now runs an exact `SELECT COUNT(*)` via `_exact_row_count` when the profiler returned 0. Deep sync is the opt-in "pay the cost" path; on Delta the count is metadata-fast. Best-effort per table.

**2. The Table page hit the live DB on every open** instead of serving synced metadata from cache. `table_snapshot` read live FIRST, cache only on failure.
→ `table_snapshot` is now **cache-first**: when the catalog has the table's columns (from deep/search sync) it builds the snapshot from cache (columns + comments + row count) with NO live round-trip. `?force_live=true` bypasses; cache miss falls through to the resilient live path.

## Test plan

- [x] `tests/test_deep_sync_profile.py` + test: profiler-zero count is replaced by the exact count.
- [x] 18 live_db/catalog/deep-sync tests pass. `ruff` + frontend `tsc` clean.
- [x] deploy.sh executed; Studio live.
- Verify on Studio: open `/cat/dbr-oyk/amx_test/amx_test_schema/adrc` after a Deep sync — should load from cache (fast) and show a row count.