### PR TITLE
feat(studio): per-table Deep sync button on the Table page

### DIFF
--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -871,6 +871,65 @@ def deep_sync_profile(
     return summary
 
 
+def deep_sync_one_table(
+    cfg,
+    profile: str,
+    *,
+    schema: str,
+    table: str,
+    database: str | None = None,
+) -> dict:
+    """Deep-sync a SINGLE table: profile it (columns + exact COUNT(*))
+    and write the structural row to the local catalog (and shared store
+    when active).
+
+    Powers the per-asset "Deep sync" button on the Table page so a user
+    can refresh one table's columns + row count without re-profiling the
+    whole profile. Synchronous (one table is quick) and returns the
+    outcome for the caller to render. Never raises — failures land in
+    the returned dict.
+    """
+    profile_map = getattr(cfg, "db_profiles", {}) or {}
+    target_db = profile_map.get((profile or "").strip()) if hasattr(profile_map, "get") else None
+    if target_db is None and cfg is not None:
+        target_db = getattr(cfg, "db", None)
+    db_backend = str(getattr(target_db, "backend", "") or "") if target_db is not None else ""
+    is_three_level = db_backend in _THREE_LEVEL_BACKENDS
+
+    from amx.search.catalog import SearchCatalog
+
+    catalog = SearchCatalog.from_history_store()
+    if catalog is None:
+        return {"ok": False, "error": "history store not initialised"}
+    try:
+        connector = _scoped_connector(cfg, profile, database or None, is_three_level)
+    except Exception as exc:
+        return {"ok": False, "error": f"connector unavailable: {exc}"}
+    try:
+        prof = connector.profile_table(schema, table, sample_size=0)
+        if not getattr(prof, "row_count", 0):
+            exact = _exact_row_count(connector, schema, table)
+            if exact is not None:
+                prof.row_count = exact
+        catalog.sync_table_profile(
+            db_profile=profile,
+            db_backend=db_backend,
+            database_name=database or "",
+            profile=prof,
+            query_usage={},
+        )
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+    _push_catalog_if_shared(profile)
+    return {
+        "ok": True,
+        "schema": schema,
+        "table": table,
+        "row_count": int(getattr(prof, "row_count", 0) or 0),
+        "column_count": len(getattr(prof, "columns", []) or []),
+    }
+
+
 def _exact_row_count(connector: Any, schema: str, table: str) -> int | None:
     """Run an exact ``SELECT COUNT(*)`` for one table, best-effort.
 

--- a/amx/web/routers/catalog.py
+++ b/amx/web/routers/catalog.py
@@ -568,6 +568,46 @@ def trigger_deep_sync(
     }
 
 
+@router.post("/deep-sync-table")
+def trigger_deep_sync_table(
+    schema: str = Query(...),
+    table: str = Query(...),
+    profile: str | None = Query(default=None),
+    database: str | None = Query(default=None),
+    catalog: str | None = Query(default=None),
+    cfg: AMXConfig = Depends(get_cfg),
+) -> dict[str, Any]:
+    """Deep-sync a SINGLE table: profile its columns + exact row count
+    and write them to the catalog (and shared store when active).
+
+    Powers the per-asset "Deep sync" button on the Table page so a user
+    can refresh one table without re-profiling the whole profile. Runs
+    synchronously (one table) and returns the row/column counts so the
+    SPA can refresh the Table card immediately.
+    """
+    from amx.search.drift import deep_sync_one_table
+
+    target = (profile or cfg.active_db_profile or "").strip()
+    if not target:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No DB profile resolved for deep-sync-table.",
+        )
+    result = deep_sync_one_table(
+        cfg,
+        target,
+        schema=schema,
+        table=table,
+        database=database or catalog,
+    )
+    if not result.get("ok"):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Deep sync of {schema}.{table} failed: {result.get('error', 'unknown')}",
+        )
+    return result
+
+
 @router.post("/sync/cancel")
 def cancel_catalog_sync(body: CatalogSyncCancelRequest) -> dict[str, Any]:
     """Cooperatively cancel an in-flight skeleton sync for ``profile``.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -373,6 +373,15 @@ export interface SnapshotResponse {
   row_count?: number | null;
 }
 
+/** Result of a per-table deep sync (POST /api/catalog/deep-sync-table). */
+export interface DeepSyncTableResponse {
+  ok: boolean;
+  schema: string;
+  table: string;
+  row_count: number;
+  column_count: number;
+}
+
 export interface RunRow {
   id: number;
   command: string;
@@ -690,6 +699,18 @@ export const api = {
         `/api/live/schemas/${encodeURIComponent(schema)}/tables/${encodeURIComponent(table)}/snapshot`,
         scope,
       ),
+    ),
+  /** Deep-sync ONE table: profile its columns + exact row count into the
+   *  catalog (and shared store when active). Powers the per-table "Deep
+   *  sync" button so the user can refresh one table's count without
+   *  re-profiling the whole profile. */
+  deepSyncTable: (scope: Scope, schema: string, table: string) =>
+    apiFetch<DeepSyncTableResponse>(
+      withScope(
+        `/api/catalog/deep-sync-table?schema=${encodeURIComponent(schema)}&table=${encodeURIComponent(table)}`,
+        scope,
+      ),
+      { method: "POST" },
     ),
   recentRuns: (limit = 20, command: string | null = "analyze.run") => {
     const params = new URLSearchParams({ limit: String(limit) });

--- a/frontend/src/routes/Table.tsx
+++ b/frontend/src/routes/Table.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router-dom";
-import { AlignLeft, Columns, Hash, Sparkles, Database, Workflow } from "lucide-react";
+import {
+  AlignLeft,
+  Columns,
+  Database,
+  Hash,
+  RefreshCw,
+  Sparkles,
+  Workflow,
+} from "lucide-react";
 
 import { api, assetsForTable, lineageArtifactsForTable } from "../lib/api";
 import type { LineageArtifact, LinkedAssetRow } from "../lib/api";
@@ -308,6 +316,29 @@ export default function Table() {
     },
   });
 
+  // Per-table deep sync: profile THIS table (columns + exact row count)
+  // into the catalog without re-profiling the whole profile. On success
+  // the snapshot query is invalidated so the Rows card refreshes.
+  const deepSync = useMutation({
+    mutationFn: () => api.deepSyncTable(scope!, schema, table),
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ["live-snapshot"] });
+      qc.invalidateQueries({ queryKey: ["live-columns"] });
+      toast.push({
+        title: "Deep sync complete",
+        description: `${table}: ${res.row_count.toLocaleString()} rows, ${res.column_count} columns.`,
+        tone: "success",
+      });
+    },
+    onError: (e: Error) => {
+      toast.push({
+        title: "Deep sync failed",
+        description: e.message,
+        tone: "error",
+      });
+    },
+  });
+
   if (!scope || !schema || !table) {
     return (
       <EmptyState
@@ -355,6 +386,16 @@ export default function Table() {
         }
         actions={
           <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              size="md"
+              leadingIcon={<RefreshCw size={14} />}
+              loading={deepSync.isPending}
+              onClick={() => deepSync.mutate()}
+              title="Profile this table from the database — fetches columns and the exact row count, then caches them"
+            >
+              Deep sync
+            </Button>
             <Button
               variant="secondary"
               size="md"

--- a/tests/test_deep_sync_profile.py
+++ b/tests/test_deep_sync_profile.py
@@ -168,6 +168,61 @@ def test_deep_sync_fills_row_count_when_profiler_returns_zero(
     assert row_count == 123456
 
 
+def test_deep_sync_one_table_profiles_and_persists(
+    catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The per-table deep sync (Table-page button) profiles one table
+    and writes its columns + row count to the catalog, without needing
+    a prior skeleton row for it."""
+    import amx.search.catalog as catalog_mod
+
+    monkeypatch.setattr(
+        catalog_mod.SearchCatalog, "from_history_store", classmethod(lambda cls: catalog)
+    )
+    monkeypatch.setattr(drift, "_scoped_connector", lambda *a, **k: _fake_connector(42))
+
+    result = drift.deep_sync_one_table(
+        _cfg_stub(), "p", schema="amx_test_schema", table="adr_6", database="amx_test"
+    )
+
+    assert result["ok"] is True
+    assert result["row_count"] == 42
+    assert result["column_count"] == 2
+    with catalog._connect() as conn:  # noqa: SLF001
+        cols = conn.execute(
+            "SELECT COUNT(*) FROM catalog_entities "
+            "WHERE entity_kind = 'column' AND table_name = 'adr_6'"
+        ).fetchone()[0]
+    assert cols == 2
+
+
+def test_deep_sync_one_table_count_fallback(
+    catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the profiler returns row_count=0 (Databricks), the per-table
+    deep sync fills it with an exact COUNT(*)."""
+    import amx.search.catalog as catalog_mod
+
+    class _ZeroConn:
+        def profile_table(self, schema: str, table: str, sample_size: int = 0) -> TableProfile:
+            return TableProfile(
+                schema=schema, name=table, asset_kind=AssetKind.TABLE, row_count=0,
+                columns=[ColumnProfile(name="c", dtype="int", nullable=True, existing_comment="")],
+            )
+
+    monkeypatch.setattr(
+        catalog_mod.SearchCatalog, "from_history_store", classmethod(lambda cls: catalog)
+    )
+    monkeypatch.setattr(drift, "_scoped_connector", lambda *a, **k: _ZeroConn())
+    monkeypatch.setattr(drift, "_exact_row_count", lambda *a, **k: 98765)
+
+    result = drift.deep_sync_one_table(
+        _cfg_stub(), "p", schema="s", table="t", database="d"
+    )
+    assert result["ok"] is True
+    assert result["row_count"] == 98765
+
+
 def test_deep_sync_continues_past_a_failing_table(
     catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Previously the only way to capture a table's columns + row count was a whole-profile deep sync. This adds a per-asset **Deep sync** button on the Table page so the user can refresh one table (e.g. when its Rows card shows "—").

- `drift.deep_sync_one_table`: profiles ONE table (columns + exact `COUNT(*)` fallback for Databricks), writes to catalog + shared store. Synchronous, never raises.
- `POST /api/catalog/deep-sync-table`: thin endpoint, returns row/column counts.
- `api.deepSyncTable` + a "Deep sync" button on the Table header. On success invalidates the snapshot query → cache-first read repaints the Rows card.

## Test plan

- [x] `tests/test_deep_sync_profile.py` +2 tests: per-table persist, Databricks count fallback. 6 pass.
- [x] `ruff` + `mypy` + frontend `tsc` clean.
- [x] deploy.sh executed; Studio live.
- Verify: open the `adr_6` Table page → click "Deep sync" → Rows fills in.