### PR TITLE
feat: deep option for scheduled cache refresh (CLI + Studio)

### DIFF
--- a/amx/cli_support/commands/schedule.py
+++ b/amx/cli_support/commands/schedule.py
@@ -294,7 +294,28 @@ def register_schedule_commands(
         "review_strategy",
         default=None,
         type=click.Choice(["auto", "manual"]),
-        help="Review strategy. Prompts if omitted.",
+        help="Review strategy. Prompts if omitted (analyze schedules only).",
+    )
+    @click.option(
+        "--kind",
+        default="analyze",
+        type=click.Choice(["analyze", "cache_refresh"]),
+        help="Schedule kind: 'analyze' (LLM generation) or 'cache_refresh' (catalog sync).",
+    )
+    @click.option(
+        "--deep",
+        is_flag=True,
+        default=False,
+        help=(
+            "cache_refresh only: profile columns + exact row counts each run "
+            "(deep sync) instead of the shallow inventory/comment warm."
+        ),
+    )
+    @click.option(
+        "--cron",
+        "cron_expr",
+        default=None,
+        help="Recurring cron expression (e.g. '0 */6 * * *'). One-shot when omitted.",
     )
     @pc
     def schedule_add(
@@ -306,13 +327,25 @@ def register_schedule_commands(
         scope: str | None,
         llm_profile: str | None,
         review_strategy: str | None,
+        kind: str,
+        deep: bool,
+        cron_expr: str | None,
     ) -> None:
         """Create a new scheduled run.
 
         Run without flags for a guided wizard with picker-based selection
         of DB / LLM profiles and live-DB scope, OR supply every flag for
         a non-interactive create.
+
+        ``--kind cache_refresh`` schedules a catalog sync instead of an
+        LLM analyze run; add ``--deep`` to profile columns + row counts
+        each run. Example:
+
+            /schedule add --kind cache_refresh --deep \\
+                --db dbr-oyk --scope all --cron '0 */6 * * *' \\
+                --at '2026-01-01 02:00'
         """
+        is_cache_refresh = kind == "cache_refresh"
         hs = _require_store()
 
         # Resolve each field: use the flag if given, otherwise prompt.
@@ -343,7 +376,9 @@ def register_schedule_commands(
                 default=cfg.active_db_profile,
             )
 
-        if not llm_profile:
+        # cache_refresh schedules have no LLM step or review strategy —
+        # they sync the catalog, not generate descriptions.
+        if not llm_profile and not is_cache_refresh:
             llm_names = sorted((cfg.llm_profiles or {}).keys())
             llm_profile = _pick_from_list(
                 llm_names,
@@ -354,7 +389,7 @@ def register_schedule_commands(
         if not scope:
             scope = _pick_scope_spec(cfg, db_profile)
 
-        if not review_strategy:
+        if not review_strategy and not is_cache_refresh:
             review_strategy = click.prompt(
                 "Review strategy",
                 type=click.Choice(["auto", "manual"]),
@@ -362,16 +397,26 @@ def register_schedule_commands(
                 show_default=True,
             )
 
-        fire_at_utc, fire_at_tz = _parse_at(at, tz_name)
-        scope_json = _parse_scope(scope)
+        # at / tz_name / scope are guaranteed set by the prompts above;
+        # coerce for the type checker (and as a runtime safety net).
+        fire_at_utc, fire_at_tz = _parse_at(str(at), str(tz_name))
+        scope_json = _parse_scope(str(scope))
+        # Thread the deep flag into scope_json — the cache_refresh
+        # executor reads scope.deep to choose deep_sync vs skeleton.
+        if deep:
+            _scope_obj = json.loads(scope_json)
+            _scope_obj["deep"] = True
+            scope_json = json.dumps(_scope_obj)
         sid = hs.create_scheduled_run(
             name=name,
             fire_at_utc=fire_at_utc,
             fire_at_tz=fire_at_tz,
             db_profile=db_profile,
             scope_json=scope_json,
-            llm_profile=llm_profile,
-            review_strategy=review_strategy,
+            llm_profile=llm_profile or "",
+            review_strategy=review_strategy or "auto",
+            kind=kind,
+            cron_expr=cron_expr,
         )
         row = hs.get_scheduled_run(sid)
         local = _render_at_local(row)

--- a/amx/runtime/worker.py
+++ b/amx/runtime/worker.py
@@ -438,12 +438,20 @@ def cache_refresh_executor(run_id: int, payload: dict[str, Any]) -> None:
     except (TypeError, ValueError):
         scope_obj = {}
     mode = str(scope_obj.get("mode") or "all")
+    # ``deep`` opts the schedule into full profiling (columns + exact
+    # row counts via deep_sync) instead of the shallow skeleton/comment
+    # warm. Off by default so existing schedules keep their fast,
+    # inventory-only behaviour; on, a recurring schedule keeps row
+    # counts fresh and (when the shared store is enabled) propagates
+    # them to the team automatically.
+    deep = bool(scope_obj.get("deep"))
 
     log.info(
-        "cache_refresh_executor: schedule #%s firing on profile=%s mode=%s",
+        "cache_refresh_executor: schedule #%s firing on profile=%s mode=%s deep=%s",
         schedule_id,
         profile_name,
         mode,
+        deep,
     )
 
     if mode == "all":
@@ -451,7 +459,12 @@ def cache_refresh_executor(run_id: int, payload: dict[str, Any]) -> None:
         if catalog is None:
             raise RuntimeError("History store unavailable; cache refresh aborted.")
         databases_arg = [str(database_overlay)] if database_overlay else None
-        sync_profile_skeleton(cfg, profile_name, catalog, databases=databases_arg)
+        if deep:
+            from amx.search.drift import deep_sync_profile
+
+            deep_sync_profile(cfg, profile_name, catalog, databases=databases_arg)
+        else:
+            sync_profile_skeleton(cfg, profile_name, catalog, databases=databases_arg)
         return
 
     # Collect (schema, table | None) work units. schemas → whole-schema.
@@ -536,6 +549,41 @@ def cache_refresh_executor(run_id: int, payload: dict[str, Any]) -> None:
                         schema,
                         asset_name,
                         exc,
+                    )
+
+    # Deep scoped refresh: profile each resolved table (columns + exact
+    # row count) so a scoped deep schedule keeps counts fresh, not just
+    # comments. Schema-level units expand to their tables. Best-effort
+    # per table — a single failure never aborts the schedule.
+    if deep and work:
+        from amx.search.drift import deep_sync_one_table
+
+        deep_db = database_overlay or catalog_overlay
+        for schema, table in work:
+            tables_to_sync: list[str] = []
+            if table:
+                tables_to_sync = [table]
+            else:
+                try:
+                    tables_to_sync = [name for name, _kind in connector.list_assets(schema)]
+                except Exception as exc:
+                    log.debug(
+                        "cache_refresh_executor: deep list_assets(%s) failed: %s", schema, exc
+                    )
+            for asset_name in tables_to_sync:
+                res = deep_sync_one_table(
+                    cfg,
+                    profile_name,
+                    schema=schema,
+                    table=asset_name,
+                    database=str(deep_db) if deep_db else None,
+                )
+                if not res.get("ok"):
+                    log.debug(
+                        "cache_refresh_executor: deep sync %s.%s skipped: %s",
+                        schema,
+                        asset_name,
+                        res.get("error"),
                     )
 
 

--- a/frontend/src/components/ScheduleCacheRefreshDialog.tsx
+++ b/frontend/src/components/ScheduleCacheRefreshDialog.tsx
@@ -206,6 +206,12 @@ export default function ScheduleCacheRefreshDialog({
   });
   const [showCron, setShowCron] = useState(false);
   const [customCron, setCustomCron] = useState(editing?.cron_expr ?? "0 */6 * * *");
+  // Deep schedules profile columns + exact row counts (deep_sync) instead
+  // of the shallow skeleton/comment warm. Preserved across edits via the
+  // ``deep`` flag stored inside scope_json.
+  const [deepSync, setDeepSync] = useState<boolean>(
+    Boolean((editing?.scope_json as Record<string, unknown> | null | undefined)?.deep),
+  );
   const [error, setError] = useState<string | null>(null);
 
   const dbProfilesQ = useQuery({
@@ -303,7 +309,7 @@ export default function ScheduleCacheRefreshDialog({
       db_profile: dbProfile,
       database: isCatalogBackend ? null : database || null,
       catalog: isCatalogBackend ? database || null : null,
-      scope: picksToScopeJson(scopePicks),
+      scope: { ...picksToScopeJson(scopePicks), deep: deepSync },
       cron_expr: cron,
     };
     // Only set ``kind`` on create — PATCH never changes a row's kind.
@@ -436,6 +442,24 @@ export default function ScheduleCacheRefreshDialog({
               onChange={setScopePicks}
             />
           </Field>
+          <div className="md:col-span-2">
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={deepSync}
+                onChange={(e) => setDeepSync(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span className="text-sm">
+                <span className="font-medium">Deep sync</span>
+                <span className="block text-xs text-ink-dim">
+                  Profile columns + exact row counts each run (slower —
+                  issues a COUNT(*) per table). Leave off for a fast
+                  inventory-only refresh.
+                </span>
+              </span>
+            </label>
+          </div>
         </div>
         <div className="rounded-md border border-border bg-surface-muted px-3 py-2 text-xs">
           <button

--- a/tests/test_worker_cache_warm.py
+++ b/tests/test_worker_cache_warm.py
@@ -89,3 +89,61 @@ def test_run_warm_columns_mode_collapses_to_table(monkeypatch: pytest.MonkeyPatc
     calls = built[0].bulk_warm_calls
     # Two column picks on the same table collapse to a single schema warm.
     assert calls.count(("sap_s6p", DURABLE_COMMENT_CACHE_TTL_SECONDS)) == 1
+
+
+def test_deep_all_calls_deep_sync_not_skeleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cache_refresh schedule with scope.deep=True and mode='all'
+    runs deep_sync_profile (columns + row counts), NOT the shallow
+    skeleton sync."""
+    _patch(monkeypatch)
+
+    import amx.search.catalog as catalog_mod
+    import amx.search.drift as drift_mod
+
+    monkeypatch.setattr(
+        catalog_mod.SearchCatalog, "from_history_store", classmethod(lambda cls: object())
+    )
+    calls = {"deep": 0, "skeleton": 0}
+    monkeypatch.setattr(
+        drift_mod, "deep_sync_profile", lambda *a, **k: calls.__setitem__("deep", calls["deep"] + 1)
+    )
+    monkeypatch.setattr(
+        drift_mod,
+        "sync_profile_skeleton",
+        lambda *a, **k: calls.__setitem__("skeleton", calls["skeleton"] + 1),
+    )
+
+    worker.cache_refresh_executor(
+        9, {"id": 9, "db_profile": "prof", "scope_json": json.dumps({"mode": "all", "deep": True})}
+    )
+
+    assert calls["deep"] == 1
+    assert calls["skeleton"] == 0
+
+
+def test_shallow_all_calls_skeleton_not_deep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without deep, mode='all' keeps the fast skeleton sync."""
+    _patch(monkeypatch)
+
+    import amx.search.catalog as catalog_mod
+    import amx.search.drift as drift_mod
+
+    monkeypatch.setattr(
+        catalog_mod.SearchCatalog, "from_history_store", classmethod(lambda cls: object())
+    )
+    calls = {"deep": 0, "skeleton": 0}
+    monkeypatch.setattr(
+        drift_mod, "deep_sync_profile", lambda *a, **k: calls.__setitem__("deep", calls["deep"] + 1)
+    )
+    monkeypatch.setattr(
+        drift_mod,
+        "sync_profile_skeleton",
+        lambda *a, **k: calls.__setitem__("skeleton", calls["skeleton"] + 1),
+    )
+
+    worker.cache_refresh_executor(
+        10, {"id": 10, "db_profile": "prof", "scope_json": json.dumps({"mode": "all"})}
+    )
+
+    assert calls["skeleton"] == 1
+    assert calls["deep"] == 0


### PR DESCRIPTION
## Summary

Scheduled cache refresh only did a shallow sync (skeleton + comment warm) — never columns or row counts. Adds a **deep** option, threaded through `scope_json` (no migration):

- **worker**: `scope.deep` → `mode='all'` runs `deep_sync_profile` (columns + exact counts) instead of skeleton; scoped modes `deep_sync_one_table` each resolved table. Off by default.
- **CLI** `/schedule add`: new `--kind {analyze,cache_refresh}`, `--deep`, `--cron`. cache_refresh skips LLM/strategy prompts; `--deep` injects into scope_json.
- **Studio** ScheduleCacheRefreshDialog: a "Deep sync" checkbox, preserved across edits via scope_json.

When deep + shared store enabled, the scheduled run auto-pushes fresh counts to the team (deep_sync's existing shared-push path).

## Test plan

- [x] `tests/test_worker_cache_warm.py` +2: deep+all → deep_sync_profile not skeleton; shallow+all → skeleton. 10 tests pass.
- [x] `ruff` clean; `mypy` net -1 error; frontend `tsc` clean.
- [x] deploy.sh executed; Studio live.
- Verify: Studio → Schedule cache refresh → "Deep sync" checkbox; or `/schedule add --kind cache_refresh --deep ...`.