### PR TITLE
feat: auto-generation — scheduled missing-only description generation

### DIFF
--- a/amx/cli_support/commands/schedule.py
+++ b/amx/cli_support/commands/schedule.py
@@ -317,6 +317,26 @@ def register_schedule_commands(
         default=None,
         help="Recurring cron expression (e.g. '0 */6 * * *'). One-shot when omitted.",
     )
+    @click.option(
+        "--missing-only",
+        is_flag=True,
+        default=False,
+        help=(
+            "analyze only: describe just the columns that lack a "
+            "description. Combine with --strategy auto for unattended "
+            "auto-generation of new columns."
+        ),
+    )
+    @click.option(
+        "--deep-first",
+        is_flag=True,
+        default=False,
+        help=(
+            "analyze only: deep-sync the catalog (columns + row counts) "
+            "before generating, so newly added columns are discovered "
+            "and described in the same run."
+        ),
+    )
     @pc
     def schedule_add(
         cfg: AMXConfig,
@@ -330,6 +350,8 @@ def register_schedule_commands(
         kind: str,
         deep: bool,
         cron_expr: str | None,
+        missing_only: bool,
+        deep_first: bool,
     ) -> None:
         """Create a new scheduled run.
 
@@ -401,11 +423,17 @@ def register_schedule_commands(
         # coerce for the type checker (and as a runtime safety net).
         fire_at_utc, fire_at_tz = _parse_at(str(at), str(tz_name))
         scope_json = _parse_scope(str(scope))
-        # Thread the deep flag into scope_json — the cache_refresh
-        # executor reads scope.deep to choose deep_sync vs skeleton.
-        if deep:
+        # Thread the auto-generation flags into scope_json — executors
+        # read scope.deep (cache_refresh: deep_sync vs skeleton),
+        # scope.missing_only + scope.deep_first (analyze: auto-gen).
+        if deep or missing_only or deep_first:
             _scope_obj = json.loads(scope_json)
-            _scope_obj["deep"] = True
+            if deep:
+                _scope_obj["deep"] = True
+            if missing_only:
+                _scope_obj["missing_only"] = True
+            if deep_first:
+                _scope_obj["deep_first"] = True
             scope_json = json.dumps(_scope_obj)
         sid = hs.create_scheduled_run(
             name=name,

--- a/amx/runtime/worker.py
+++ b/amx/runtime/worker.py
@@ -180,6 +180,39 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
         overlay["catalog"] = str(overlay_catalog)
     scoped_cfg = replace(db_cfg, **overlay) if overlay else db_cfg
 
+    # Auto-generation knobs carried in scope_json:
+    #   missing_only  → only describe columns that lack a description
+    #   deep_first    → deep-sync the catalog before generating so newly
+    #                   added columns are discovered and described
+    # review_strategy (on the payload) decides apply policy: 'auto'
+    # writes COMMENT ON to the DB after generation; 'manual' leaves the
+    # results in pending review.
+    scope_flags: dict[str, Any] = {}
+    try:
+        _sj = payload.get("scope_json")
+        scope_flags = json.loads(_sj) if isinstance(_sj, str) and _sj else {}
+    except (TypeError, ValueError):
+        scope_flags = {}
+    missing_only = bool(scope_flags.get("missing_only"))
+    deep_first = bool(scope_flags.get("deep_first"))
+    review_strategy = str(payload.get("review_strategy") or "auto")
+
+    if deep_first:
+        try:
+            from amx.search.catalog import SearchCatalog
+            from amx.search.drift import deep_sync_profile
+
+            _cat = SearchCatalog.from_history_store()
+            if _cat is not None:
+                _dbs = [str(overlay_database)] if overlay_database else None
+                deep_sync_profile(cfg, db_profile_name, _cat, databases=_dbs)
+        except Exception as exc:  # noqa: BLE001 - never block generation on a sync hiccup
+            log.warning(
+                "production_run_executor: deep_first sync skipped for schedule #%s: %s",
+                schedule_id,
+                exc,
+            )
+
     db = DatabaseConnector(scoped_cfg, profile_name=db_profile_name)
     llm = LLMProvider(llm_cfg)
     orchestrator = Orchestrator(
@@ -187,6 +220,7 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
         llm,
         run_id=run_id,
         search_profile=db_profile_name,
+        missing_only=missing_only,
     )
 
     # When the schedule was created with column-level picks, plumb the
@@ -276,6 +310,25 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
         if len(per_table_errors) > 5:
             summary += f"; (+{len(per_table_errors) - 5} more)"
         raise RuntimeError(f"All {processed} table(s) in scope failed. {summary}")
+
+    # Apply policy. 'auto' writes the generated descriptions to the DB
+    # (COMMENT ON) right after generation — the unattended path that
+    # makes a scheduled run a true auto-generation. 'manual' leaves the
+    # results in pending review for a human to approve later.
+    if review_strategy == "auto":
+        try:
+            applied = orchestrator.apply_results()
+            log.info(
+                "production_run_executor: schedule #%s auto-applied %s description(s).",
+                schedule_id,
+                applied,
+            )
+        except Exception:
+            log.exception(
+                "production_run_executor: auto-apply failed for schedule #%s; "
+                "results remain in pending review.",
+                schedule_id,
+            )
 
 
 def _scope_column_overrides(

--- a/frontend/src/routes/Schedules.tsx
+++ b/frontend/src/routes/Schedules.tsx
@@ -132,6 +132,15 @@ function NewScheduleDialog({
   const [reviewStrategy, setReviewStrategy] = useState<"auto" | "manual">(
     (editing?.review_strategy as "auto" | "manual" | undefined) ?? "auto",
   );
+  // Auto-generation knobs (stored in scope_json). missing_only →
+  // describe only columns lacking a description; deep_first → deep-sync
+  // the catalog before generating so new columns are discovered.
+  const [missingOnly, setMissingOnly] = useState<boolean>(
+    Boolean((editing?.scope_json as Record<string, unknown> | null | undefined)?.missing_only),
+  );
+  const [deepFirst, setDeepFirst] = useState<boolean>(
+    Boolean((editing?.scope_json as Record<string, unknown> | null | undefined)?.deep_first),
+  );
   const [error, setError] = useState<string | null>(null);
 
   const dbProfilesQ = useQuery({
@@ -208,7 +217,11 @@ function NewScheduleDialog({
   });
 
   function buildScope(): Record<string, unknown> {
-    return picksToScopeJson(scopePicks);
+    return {
+      ...picksToScopeJson(scopePicks),
+      missing_only: missingOnly,
+      deep_first: deepFirst,
+    };
   }
 
   function onSubmit(e: React.FormEvent) {
@@ -385,6 +398,40 @@ function NewScheduleDialog({
               onChange={setScopePicks}
             />
           </Field>
+          <div className="md:col-span-2 space-y-2">
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={missingOnly}
+                onChange={(e) => setMissingOnly(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span className="text-sm">
+                <span className="font-medium">Only missing descriptions</span>
+                <span className="block text-xs text-ink-dim">
+                  Describe just the columns that lack a description. With
+                  review strategy “auto”, this auto-generates descriptions
+                  for new/undocumented columns each run.
+                </span>
+              </span>
+            </label>
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={deepFirst}
+                onChange={(e) => setDeepFirst(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span className="text-sm">
+                <span className="font-medium">Refresh catalog first (deep)</span>
+                <span className="block text-xs text-ink-dim">
+                  Deep-sync columns + row counts before generating so
+                  newly added columns are discovered and described in the
+                  same run.
+                </span>
+              </span>
+            </label>
+          </div>
         </div>
         {error && (
           <p className="rounded-md border border-critical/40 bg-critical/10 px-3 py-2 text-sm text-critical">

--- a/tests/runtime/test_auto_generation_executor.py
+++ b/tests/runtime/test_auto_generation_executor.py
@@ -1,0 +1,130 @@
+"""Auto-generation knobs in ``production_run_executor``.
+
+A scheduled analyze run becomes "auto-generation" when:
+  * scope.missing_only → the Orchestrator only describes columns that
+    lack a description,
+  * scope.deep_first → a deep sync runs before generation so newly
+    added columns are discovered,
+  * review_strategy='auto' → results are applied to the DB after
+    generation (vs 'manual' which leaves them in pending review).
+
+These tests drive the executor past its setup with stubs and assert
+each knob is honoured.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+class _FakeOrchestrator:
+    last: _FakeOrchestrator | None = None
+
+    def __init__(self, *a: Any, **k: Any) -> None:
+        self.missing_only = k.get("missing_only")
+        self.process_calls: list[tuple[str, str]] = []
+        self.applied = 0
+        _FakeOrchestrator.last = self
+
+    def process_table(self, schema: str, table: str, **_k: Any) -> None:
+        self.process_calls.append((schema, table))
+
+    def apply_results(self, results: Any = None) -> int:
+        self.applied += 1
+        return 3
+
+
+def _patch_common(monkeypatch: pytest.MonkeyPatch) -> None:
+    import amx.agents.orchestrator as orch_mod
+    import amx.config as config_mod
+    import amx.db.connector as connector_mod
+    import amx.llm.provider as llm_mod
+    import amx.runtime.worker as worker
+
+    cfg = SimpleNamespace(
+        db_profiles={"prof": SimpleNamespace(backend="postgresql")},
+        llm_profiles={"llm": object()},
+    )
+    monkeypatch.setattr(config_mod.AMXConfig, "load", staticmethod(lambda *a, **k: cfg))
+    monkeypatch.setattr(connector_mod, "DatabaseConnector", lambda *a, **k: object())
+    monkeypatch.setattr(llm_mod, "LLMProvider", lambda *a, **k: object())
+    monkeypatch.setattr(orch_mod, "Orchestrator", _FakeOrchestrator)
+    # One table in scope so process_table fires once.
+    monkeypatch.setattr(worker, "_resolve_live_scope", lambda *a, **k: {"s": ["t"]})
+
+
+def _payload(**scope_extra: Any) -> dict[str, Any]:
+    review = scope_extra.pop("review_strategy", "manual")
+    return {
+        "id": 1,
+        "db_profile": "prof",
+        "llm_profile": "llm",
+        "review_strategy": review,
+        "scope_json": json.dumps({"mode": "all", **scope_extra}),
+    }
+
+
+def test_missing_only_flows_to_orchestrator(monkeypatch: pytest.MonkeyPatch) -> None:
+    from amx.runtime.worker import production_run_executor
+
+    _patch_common(monkeypatch)
+    production_run_executor(1, _payload(missing_only=True))
+
+    assert _FakeOrchestrator.last is not None
+    assert _FakeOrchestrator.last.missing_only is True
+
+
+def test_auto_strategy_applies_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    from amx.runtime.worker import production_run_executor
+
+    _patch_common(monkeypatch)
+    production_run_executor(1, _payload(missing_only=True, review_strategy="auto"))
+
+    assert _FakeOrchestrator.last.applied == 1  # apply_results called once
+
+
+def test_manual_strategy_does_not_apply(monkeypatch: pytest.MonkeyPatch) -> None:
+    from amx.runtime.worker import production_run_executor
+
+    _patch_common(monkeypatch)
+    production_run_executor(1, _payload(review_strategy="manual"))
+
+    assert _FakeOrchestrator.last.applied == 0  # left in pending review
+
+
+def test_deep_first_runs_deep_sync_before_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    import amx.search.catalog as catalog_mod
+    import amx.search.drift as drift_mod
+    from amx.runtime.worker import production_run_executor
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(
+        catalog_mod.SearchCatalog, "from_history_store", classmethod(lambda cls: object())
+    )
+    deep_calls = {"n": 0}
+    monkeypatch.setattr(
+        drift_mod, "deep_sync_profile", lambda *a, **k: deep_calls.__setitem__("n", 1)
+    )
+
+    production_run_executor(1, _payload(deep_first=True))
+
+    assert deep_calls["n"] == 1
+
+
+def test_no_deep_first_skips_deep_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    import amx.search.drift as drift_mod
+    from amx.runtime.worker import production_run_executor
+
+    _patch_common(monkeypatch)
+    deep_calls = {"n": 0}
+    monkeypatch.setattr(
+        drift_mod, "deep_sync_profile", lambda *a, **k: deep_calls.__setitem__("n", 1)
+    )
+
+    production_run_executor(1, _payload(missing_only=True))
+
+    assert deep_calls["n"] == 0


### PR DESCRIPTION
## Summary

Wires the second architectural gap: **auto-generation** of descriptions for new/undocumented columns, on a schedule, completing the detect-new-structure → document-it loop.

**Locked definition:** `kind=analyze` + `missing_only=true` scheduled run; `review_strategy` picks apply policy (manual → pending, auto → write `COMMENT ON`); optional `deep_first` deep-syncs the catalog first so new columns are discovered.

- **Engine** (`production_run_executor`): reads `scope.missing_only` → `Orchestrator(missing_only=True)`; `scope.deep_first` → `deep_sync_profile` before generation (best-effort); `review_strategy='auto'` → `apply_results()` (was stored but never acted on); `'manual'` → pending.
- **CLI** `/schedule add`: `--missing-only`, `--deep-first` flags.
- **Studio** analyze schedule dialog: "Only missing descriptions" + "Refresh catalog first (deep)" checkboxes, persisted via scope_json.

## Test plan

- [x] `tests/runtime/test_auto_generation_executor.py` — 5 tests: missing_only → Orchestrator, auto applies / manual doesn't, deep_first runs sync / absence skips it. 21 executor/worker tests pass.
- [x] `ruff` + frontend `tsc` clean; no new mypy errors.
- [x] deploy.sh executed; Studio live.
- Verify: Studio → analyze schedule → the two checkboxes; or `/schedule add --missing-only --deep-first --strategy auto --cron ...`.