### PR TITLE
feat(embeddings): single resolution authority with honest fallback signal

### DIFF
--- a/amx/assets/rag.py
+++ b/amx/assets/rag.py
@@ -82,34 +82,11 @@ def _resolve_assets_embedding(cfg: Any | None = None) -> tuple[str, str, Any | N
     (``embedding_function=None``) when no config is available or the
     user has the default kind selected.
     """
-    from amx.search.embeddings import make_embedding_function
+    from amx.rag_core.embedding_resolver import resolve_embedding
 
-    if cfg is None:
-        try:
-            from amx.config import AMXConfig
-
-            cfg = AMXConfig.load()
-        except Exception:  # noqa: BLE001 — config load may fail in tests
-            cfg = None
-
-    embedding = getattr(cfg, "embedding_assets", None) if cfg is not None else None
-    if embedding is None:
-        return ("minilm", "minilm-l6-v2", None)
-
-    kind = (getattr(embedding, "kind", "") or "minilm").lower().strip()
-    model = getattr(embedding, "model", "") or ""
-    api_key = getattr(embedding, "api_key", "") or ""
-    base_url = getattr(embedding, "base_url", "") or ""
-
-    if kind in {"", "minilm", "default", "minilm-l6-v2"}:
-        return ("minilm", "minilm-l6-v2", None)
-    if not model:
-        return ("minilm", "minilm-l6-v2", None)
-    try:
-        ef = make_embedding_function(kind, model=model, api_key=api_key, base_url=base_url)
-    except Exception:  # noqa: BLE001 — fall back to MiniLM on builder failure
-        return ("minilm", "minilm-l6-v2", None)
-    return (kind, model, ef)
+    return resolve_embedding(
+        "assets", cfg, default_resolver=lambda: ("minilm", "minilm-l6-v2", None)
+    ).as_tuple()
 
 
 class AssetRAGStore:

--- a/amx/codebase/code_rag.py
+++ b/amx/codebase/code_rag.py
@@ -164,42 +164,16 @@ def _resolve_code_embedding(
     (``amx.search.embeddings`` pulls Chroma which pulls this module on
     some platforms).
     """
-    from amx.search.embeddings import make_embedding_function
+    from amx.rag_core.embedding_resolver import resolve_embedding
 
-    if cfg is None:
-        try:
-            from amx.config import AMXConfig
-
-            cfg = AMXConfig.load()
-        except Exception:
-            cfg = None
-
-    embedding = getattr(cfg, "embedding_code", None) if cfg is not None else None
-    if embedding is None:
-        return _default_code_embedding()
-
-    kind = (getattr(embedding, "kind", "") or "minilm").lower().strip()
-    model = getattr(embedding, "model", "") or ""
-    api_key = getattr(embedding, "api_key", "") or ""
-    base_url = getattr(embedding, "base_url", "") or ""
-
-    if kind in {"", "minilm", "default", "minilm-l6-v2"}:
-        # User is on the default — opportunistically upgrade to the
-        # code-specialised embedder. An explicit ``/embeddings minilm``
-        # choice falls into this branch too (the cfg layer normalises
-        # both to ``minilm``), which is intentional: a code-trained
-        # encoder is the right floor for ``/code search`` regardless
-        # of what the user picked for prose RAG.
-        return _default_code_embedding()
-
-    if not model:
-        return _default_code_embedding()
-
-    try:
-        ef = make_embedding_function(kind, model=model, api_key=api_key, base_url=base_url)
-    except Exception:
-        return _default_code_embedding()
-    return (kind, model, ef)
+    # Code's default/fallback target is the opportunistic jina encoder
+    # (with its own MiniLM fallback + one-time warning), NOT plain
+    # MiniLM — so the explicit-provider path + the honest fallback
+    # signal are shared via resolve_embedding while the code-specialised
+    # default stays in ``_default_code_embedding``.
+    return resolve_embedding(
+        "code", cfg, default_resolver=_default_code_embedding
+    ).as_tuple()
 
 
 def _default_code_embedding() -> tuple[str, str, EmbeddingFunction | None]:

--- a/amx/docs/rag.py
+++ b/amx/docs/rag.py
@@ -107,43 +107,11 @@ def _resolve_docs_embedding(cfg: Any | None = None) -> tuple[str, str, Embedding
     what get persisted as collection metadata so a later reopen can
     detect mismatches.
     """
-    from amx.search.embeddings import make_embedding_function
+    from amx.rag_core.embedding_resolver import resolve_embedding
 
-    if cfg is None:
-        try:
-            from amx.config import AMXConfig
-
-            cfg = AMXConfig.load()
-        except Exception:
-            cfg = None
-
-    embedding = getattr(cfg, "embedding_docs", None) if cfg is not None else None
-    if embedding is None:
-        return ("minilm", "minilm-l6-v2", None)
-
-    kind = (getattr(embedding, "kind", "") or "minilm").lower().strip()
-    model = getattr(embedding, "model", "") or ""
-    api_key = getattr(embedding, "api_key", "") or ""
-    base_url = getattr(embedding, "base_url", "") or ""
-
-    if kind in {"", "minilm", "default", "minilm-l6-v2"}:
-        return ("minilm", "minilm-l6-v2", None)
-
-    # For non-default kinds the model id IS the unique identifier; if
-    # the user hasn't picked one yet fall back to MiniLM rather than
-    # error here (the embeddings module emits a themed warning at
-    # startup for that case).
-    if not model:
-        return ("minilm", "minilm-l6-v2", None)
-
-    try:
-        ef = make_embedding_function(kind, model=model, api_key=api_key, base_url=base_url)
-    except Exception:
-        # Builder failure (missing optional dep, bad model id) — fall
-        # back to MiniLM so retrieval still works; the mismatch check
-        # later will catch the wrong-provider case explicitly.
-        return ("minilm", "minilm-l6-v2", None)
-    return (kind, model, ef)
+    return resolve_embedding(
+        "docs", cfg, default_resolver=lambda: ("minilm", "minilm-l6-v2", None)
+    ).as_tuple()
 
 
 EXPLANATORY_TERMS = frozenset(

--- a/amx/rag_core/embedding_resolver.py
+++ b/amx/rag_core/embedding_resolver.py
@@ -1,0 +1,152 @@
+"""Single resolution authority for embedding models across all sides.
+
+AMX embeds text in several subsystems — docs (which also powers catalog
+search), code, and ingested assets — each with its own
+``embedding_{side}`` config field and its own Chroma collection. Before
+this module each side had its own ``_resolve_*_embedding`` function that
+independently read config, built the embedding function, and **silently**
+fell back to MiniLM when the configured model couldn't be built (e.g.
+``sentence-transformers`` not installed). That silent substitution meant
+a user could configure gte-small and unknowingly run MiniLM.
+
+``resolve_embedding`` centralises that logic and — crucially — reports
+whether a fallback happened (``fell_back`` + ``fallback_reason``) so
+callers and the UI can surface the truth instead of a silent swap. The
+per-side *default* target still differs (docs/assets fall back to plain
+MiniLM; code prefers a code-specialised encoder), so each side passes
+its own ``default_resolver``; the explicit-provider path and the
+fallback-signalling are shared here.
+
+The three legacy ``_resolve_*_embedding`` functions are thin wrappers
+that call this and return the historical ``(provider, model,
+embedding_function)`` tuple, so existing callers are unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+# A side's default/fallback resolver returns the legacy tuple
+# ``(provider, model, embedding_function)``. MiniLM is represented by
+# ``embedding_function=None`` (Chroma's bundled default).
+DefaultResolver = Callable[[], tuple[str, str, Any | None]]
+
+# config ``kind`` values that mean "the bundled MiniLM default".
+_DEFAULT_KINDS = {"", "minilm", "default", "minilm-l6-v2"}
+
+
+@dataclass(frozen=True)
+class ResolvedEmbedding:
+    """The outcome of resolving an embedding side, with honest provenance.
+
+    ``configured_*`` is what the config asked for; ``active_*`` is what
+    is actually used after any fallback. When they differ because the
+    configured model could not be built, ``fell_back`` is True and
+    ``fallback_reason`` explains why (so the UI can say "configured
+    gte-small but running minilm — sentence-transformers not installed"
+    instead of silently substituting).
+    """
+
+    side: str
+    configured_provider: str
+    configured_model: str
+    active_provider: str
+    active_model: str
+    embedding_function: Any | None
+    fell_back: bool
+    fallback_reason: str | None
+    dependency_available: bool
+
+    def as_tuple(self) -> tuple[str, str, Any | None]:
+        """Legacy ``(provider, model, embedding_function)`` shape that
+        the historical ``_resolve_*_embedding`` callers expect — always
+        the ACTIVE (post-fallback) identity, matching prior behaviour."""
+        return (self.active_provider, self.active_model, self.embedding_function)
+
+
+def _load_cfg(cfg: Any | None) -> Any | None:
+    if cfg is not None:
+        return cfg
+    try:
+        from amx.config import AMXConfig
+
+        return AMXConfig.load()
+    except Exception:
+        return None
+
+
+def resolve_embedding(
+    side: str,
+    cfg: Any | None,
+    *,
+    default_resolver: DefaultResolver,
+) -> ResolvedEmbedding:
+    """Resolve the embedding for ``side`` ("docs" | "code" | "assets").
+
+    The explicit-provider path (a non-default ``kind`` with a model id)
+    is built via ``make_embedding_function``; on a build failure it
+    falls back to ``default_resolver()`` AND records ``fell_back`` +
+    ``fallback_reason``. The default path (no config, default kind, or
+    no model id) delegates to ``default_resolver()`` and is NOT a
+    fallback — it's the configured intent.
+    """
+    from amx.search.embeddings import make_embedding_function
+
+    cfg = _load_cfg(cfg)
+    embedding = getattr(cfg, f"embedding_{side}", None) if cfg is not None else None
+
+    def _default(reason: str | None, dep_ok: bool) -> ResolvedEmbedding:
+        provider, model, ef = default_resolver()
+        configured_provider = (
+            (getattr(embedding, "kind", "") or "minilm").lower().strip()
+            if embedding is not None
+            else provider
+        )
+        configured_model = (getattr(embedding, "model", "") or "") if embedding is not None else model
+        fell = reason is not None
+        return ResolvedEmbedding(
+            side=side,
+            configured_provider=configured_provider or provider,
+            configured_model=configured_model or model,
+            active_provider=provider,
+            active_model=model,
+            embedding_function=ef,
+            fell_back=fell,
+            fallback_reason=reason,
+            dependency_available=dep_ok,
+        )
+
+    if embedding is None:
+        return _default(None, True)
+
+    kind = (getattr(embedding, "kind", "") or "minilm").lower().strip()
+    model = getattr(embedding, "model", "") or ""
+    api_key = getattr(embedding, "api_key", "") or ""
+    base_url = getattr(embedding, "base_url", "") or ""
+
+    # Default kind, or a non-default kind with no model id picked yet →
+    # the side's default. Not a fallback; this is the configured intent.
+    if kind in _DEFAULT_KINDS or not model:
+        return _default(None, True)
+
+    try:
+        ef = make_embedding_function(kind, model=model, api_key=api_key, base_url=base_url)
+    except Exception as exc:
+        # The configured model could not be built (missing optional
+        # dependency, bad model id, unreachable endpoint). Fall back so
+        # the feature still works, but record it loudly.
+        return _default(str(exc) or exc.__class__.__name__, False)
+
+    return ResolvedEmbedding(
+        side=side,
+        configured_provider=kind,
+        configured_model=model,
+        active_provider=kind,
+        active_model=model,
+        embedding_function=ef,
+        fell_back=False,
+        fallback_reason=None,
+        dependency_available=True,
+    )

--- a/tests/test_embedding_resolver.py
+++ b/tests/test_embedding_resolver.py
@@ -1,0 +1,147 @@
+"""Single-authority embedding resolution + honest fallback signal.
+
+Before this module each side (docs/code/assets) silently fell back to
+MiniLM when the configured model couldn't be built, so a user could
+configure gte-small and unknowingly run MiniLM. ``resolve_embedding``
+centralises the logic and reports ``fell_back`` + ``fallback_reason``
+so the substitution is never silent. These tests pin that contract and
+verify the three legacy wrappers still return the historical tuple.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from amx.rag_core.embedding_resolver import ResolvedEmbedding, resolve_embedding
+
+_MINILM = lambda: ("minilm", "minilm-l6-v2", None)  # noqa: E731
+
+
+def _cfg(side: str, *, kind: str, model: str = "") -> SimpleNamespace:
+    field = f"embedding_{side}"
+    return SimpleNamespace(
+        **{field: SimpleNamespace(kind=kind, model=model, api_key="", base_url="")}
+    )
+
+
+def test_default_kind_is_not_a_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg("docs", kind="minilm")
+    r = resolve_embedding("docs", cfg, default_resolver=_MINILM)
+    assert r.active_provider == "minilm"
+    assert r.fell_back is False
+    assert r.fallback_reason is None
+    assert r.dependency_available is True
+
+
+def test_none_config_is_not_a_fallback() -> None:
+    r = resolve_embedding("docs", SimpleNamespace(), default_resolver=_MINILM)
+    assert r.active_provider == "minilm"
+    assert r.fell_back is False
+
+
+def test_configured_model_that_loads(monkeypatch: pytest.MonkeyPatch) -> None:
+    import amx.search.embeddings as emb
+
+    sentinel = object()
+    monkeypatch.setattr(emb, "make_embedding_function", lambda *a, **k: sentinel)
+    cfg = _cfg("docs", kind="sentence_transformers", model="thenlper/gte-small")
+
+    r = resolve_embedding("docs", cfg, default_resolver=_MINILM)
+
+    assert r.configured_provider == "sentence_transformers"
+    assert r.configured_model == "thenlper/gte-small"
+    assert r.active_provider == "sentence_transformers"
+    assert r.active_model == "thenlper/gte-small"
+    assert r.embedding_function is sentinel
+    assert r.fell_back is False
+    assert r.dependency_available is True
+
+
+def test_configured_model_that_fails_falls_back_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    import amx.search.embeddings as emb
+
+    def _boom(*_a: Any, **_k: Any):
+        raise RuntimeError("sentence-transformers is not installed")
+
+    monkeypatch.setattr(emb, "make_embedding_function", _boom)
+    cfg = _cfg("docs", kind="sentence_transformers", model="thenlper/gte-small")
+
+    r = resolve_embedding("docs", cfg, default_resolver=_MINILM)
+
+    # Configured intent preserved, active reflects the fallback.
+    assert r.configured_provider == "sentence_transformers"
+    assert r.configured_model == "thenlper/gte-small"
+    assert r.active_provider == "minilm"
+    assert r.active_model == "minilm-l6-v2"
+    # The substitution is NOT silent.
+    assert r.fell_back is True
+    assert "sentence-transformers is not installed" in (r.fallback_reason or "")
+    assert r.dependency_available is False
+
+
+def test_explicit_kind_without_model_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = _cfg("assets", kind="openai_compatible", model="")
+    r = resolve_embedding("assets", cfg, default_resolver=_MINILM)
+    assert r.active_provider == "minilm"
+    assert r.fell_back is False
+
+
+def test_as_tuple_returns_active_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    import amx.search.embeddings as emb
+
+    monkeypatch.setattr(emb, "make_embedding_function", lambda *a, **k: "EF")
+    cfg = _cfg("code", kind="openai_compatible", model="text-embedding-3-small")
+    r = resolve_embedding("code", cfg, default_resolver=_MINILM)
+    assert r.as_tuple() == ("openai_compatible", "text-embedding-3-small", "EF")
+
+
+def test_code_default_resolver_is_used_for_default_kind() -> None:
+    """Code's default target is its own (jina/minilm) resolver, not the
+    plain MiniLM one — the side-specific default is honoured."""
+    called = {"n": 0}
+
+    def _code_default():
+        called["n"] += 1
+        return ("sentence_transformers", "jinaai/jina-embeddings-v2-base-code", "JINA_EF")
+
+    cfg = _cfg("code", kind="minilm")
+    r = resolve_embedding("code", cfg, default_resolver=_code_default)
+    assert called["n"] == 1
+    assert r.active_model == "jinaai/jina-embeddings-v2-base-code"
+    assert r.fell_back is False
+
+
+# ── back-compat: the three legacy wrappers return the historical tuple ──
+
+
+def test_docs_wrapper_back_compat(monkeypatch: pytest.MonkeyPatch) -> None:
+    from amx.docs.rag import _resolve_docs_embedding
+
+    out = _resolve_docs_embedding(SimpleNamespace())
+    assert out == ("minilm", "minilm-l6-v2", None)
+
+
+def test_assets_wrapper_back_compat() -> None:
+    from amx.assets.rag import _resolve_assets_embedding
+
+    out = _resolve_assets_embedding(SimpleNamespace())
+    assert out[0] == "minilm" and out[1] == "minilm-l6-v2"
+
+
+def test_resolved_embedding_is_frozen() -> None:
+    r = ResolvedEmbedding(
+        side="docs",
+        configured_provider="minilm",
+        configured_model="minilm-l6-v2",
+        active_provider="minilm",
+        active_model="minilm-l6-v2",
+        embedding_function=None,
+        fell_back=False,
+        fallback_reason=None,
+        dependency_available=True,
+    )
+    with pytest.raises(Exception):
+        r.fell_back = True  # type: ignore[misc]


### PR DESCRIPTION
## Summary

PR1 of unified embedding management (spec: `docs/superpowers/specs/2026-05-25-unified-embedding-management-design.md`).

Each side (docs/search, code, assets) had its own resolver that **silently** fell back to MiniLM when the configured model couldn't be built — so a user could configure gte-small and unknowingly run MiniLM.

- New `amx/rag_core/embedding_resolver.py`: `resolve_embedding(side, cfg, *, default_resolver) -> ResolvedEmbedding`, carrying `configured_*` vs `active_*` + `fell_back` / `fallback_reason` / `dependency_available`.
- The three `_resolve_*_embedding` functions become thin wrappers (`.as_tuple()`), behaviour-preserving. Per-side default target preserved (docs/assets → MiniLM; code → jina-or-MiniLM).
- The `fell_back` signal is consumed by the status endpoint + health panel in PR2/PR3.

## Test plan

- [x] `tests/test_embedding_resolver.py` — 10 tests: default-kind not a fallback, configured-loads, configured-fails-falls-back-loudly (reason + dep=False), code default, back-compat tuples.
- [x] 73 rag/embedding tests pass (6 skip: sentence-transformers absent in CI shell). `ruff` + `mypy` clean.
- [x] deploy.sh executed; Studio live.