### PR TITLE
feat(embeddings): status reports configured-vs-running + needs_rebuild

### DIFF
--- a/amx/rag_core/embedding_resolver.py
+++ b/amx/rag_core/embedding_resolver.py
@@ -150,3 +150,23 @@ def resolve_embedding(
         fallback_reason=None,
         dependency_available=True,
     )
+
+
+def _minilm_default() -> tuple[str, str, Any | None]:
+    return ("minilm", "minilm-l6-v2", None)
+
+
+def resolve_side(side: str, cfg: Any | None = None) -> ResolvedEmbedding:
+    """Resolve a side by name, applying that side's own default target.
+
+    A convenience dispatcher so callers (status endpoint, health panel,
+    CLI) get a full :class:`ResolvedEmbedding` — configured vs active +
+    fell_back — without knowing each side's default resolver. docs and
+    assets default to plain MiniLM; code defers to its jina-or-MiniLM
+    default. Unknown sides default to MiniLM.
+    """
+    if side == "code":
+        from amx.codebase.code_rag import _default_code_embedding
+
+        return resolve_embedding("code", cfg, default_resolver=_default_code_embedding)
+    return resolve_embedding(side, cfg, default_resolver=_minilm_default)

--- a/amx/web/routers/profiles.py
+++ b/amx/web/routers/profiles.py
@@ -658,21 +658,14 @@ def _collection_status_for_side(side: str, cfg: AMXConfig) -> dict[str, Any]:
     except Exception as exc:
         return {"collections": [], "stale": False, "error": f"{exc.__class__.__name__}: {exc}"}
 
-    if side == "docs":
-        from amx.docs.rag import _resolve_docs_embedding
+    from amx.rag_core.embedding_resolver import resolve_side
 
-        active_provider, active_model, _ = _resolve_docs_embedding(cfg)
-        prefix = "amx_search"
-    elif side == "assets":
-        from amx.assets.rag import _resolve_assets_embedding
-
-        active_provider, active_model, _ = _resolve_assets_embedding(cfg)
-        prefix = "amx_assets"
-    else:
-        from amx.codebase.code_rag import _resolve_code_embedding
-
-        active_provider, active_model, _ = _resolve_code_embedding(cfg)
-        prefix = "amx_code"
+    prefix = {"docs": "amx_search", "assets": "amx_assets", "code": "amx_code"}.get(
+        side, "amx_search"
+    )
+    resolved = resolve_side(side, cfg)
+    active_provider = resolved.active_provider
+    active_model = resolved.active_model
 
     collections: list[dict[str, Any]] = []
     stale = False
@@ -690,9 +683,15 @@ def _collection_status_for_side(side: str, cfg: AMXConfig) -> dict[str, Any]:
             count = int(coll.count())
         except Exception:
             count = 0
+        # An empty collection (count 0) has no vectors to be stale —
+        # flagging it produces a false "Vectors are stale" warning from
+        # leftover/legacy empty collections (e.g. the pre-per-profile
+        # ``amx_search`` shell). Only a populated collection whose
+        # recorded identity differs from the active one is truly stale.
         is_stale = bool(
             recorded_provider
             and recorded_model
+            and count > 0
             and (recorded_provider != active_provider or recorded_model != active_model)
         )
         if is_stale:
@@ -711,6 +710,16 @@ def _collection_status_for_side(side: str, cfg: AMXConfig) -> dict[str, Any]:
         "stale": stale,
         "current_provider": active_provider,
         "current_model": active_model,
+        # Enriched (unified embedding management): configured vs actually
+        # running, so the UI can show "configured X but running Y" instead
+        # of a silent substitution. ``needs_rebuild`` is the single verdict
+        # the panel/CTA act on: stale vectors OR a silent fallback.
+        "configured_provider": resolved.configured_provider,
+        "configured_model": resolved.configured_model,
+        "fell_back": resolved.fell_back,
+        "fallback_reason": resolved.fallback_reason,
+        "dependency_available": resolved.dependency_available,
+        "needs_rebuild": bool(stale or resolved.fell_back),
     }
 
 

--- a/tests/test_embedding_resolver.py
+++ b/tests/test_embedding_resolver.py
@@ -131,6 +131,35 @@ def test_assets_wrapper_back_compat() -> None:
     assert out[0] == "minilm" and out[1] == "minilm-l6-v2"
 
 
+def test_resolve_side_docs_uses_minilm_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The side dispatcher applies the right default without the caller
+    knowing it — docs/assets default to plain MiniLM."""
+    from amx.rag_core.embedding_resolver import resolve_side
+
+    r = resolve_side("docs", _cfg("docs", kind="minilm"))
+    assert r.active_provider == "minilm"
+    assert r.fell_back is False
+
+
+def test_resolve_side_reports_fallback_honestly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The headline contract: a configured model that can't build is
+    reported as fell_back with active != configured — never a silent
+    swap."""
+    import amx.search.embeddings as emb
+    from amx.rag_core.embedding_resolver import resolve_side
+
+    monkeypatch.setattr(
+        emb,
+        "make_embedding_function",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("dep missing")),
+    )
+    r = resolve_side("assets", _cfg("assets", kind="sentence_transformers", model="x/y"))
+    assert r.configured_model == "x/y"
+    assert r.active_provider == "minilm"
+    assert r.fell_back is True
+    assert r.dependency_available is False
+
+
 def test_resolved_embedding_is_frozen() -> None:
     r = ResolvedEmbedding(
         side="docs",


### PR DESCRIPTION
## Summary

PR2 of unified embedding management. Consumes PR1's honest fallback signal so `/api/profiles/embedding/status` reports CONFIGURED vs actually-RUNNING per side.

- `resolve_side(side, cfg)` dispatcher: applies each side's default (docs/assets → MiniLM; code → jina-or-MiniLM), returns full `ResolvedEmbedding`.
- `_collection_status_for_side` now returns `configured_provider/model`, `fell_back`, `fallback_reason`, `dependency_available`, `needs_rebuild` (stale OR silent fallback). Empty collections still excluded from staleness.

Verified on real config: in an env without `sentence-transformers`, docs reports configured=gte-small / active=minilm / fell_back=True with the reason — the silent swap is now visible.

## Test plan

- [x] `tests/test_embedding_resolver.py` +2 (resolve_side default + honest fallback). 12 resolver tests pass.
- [x] 67 embedding/profiles tests pass; `ruff` clean; no new mypy errors.
- [x] deploy.sh executed; Studio live.