### PR TITLE
feat(embeddings): /embeddings status + rebuild on a shared health authority

### DIFF
--- a/amx/cli_support/commands/embeddings.py
+++ b/amx/cli_support/commands/embeddings.py
@@ -25,6 +25,7 @@ from amx.utils.console import (
     ask,
     ask_choice,
     ask_password,
+    confirm,
     error,
     heading,
     info,
@@ -33,6 +34,19 @@ from amx.utils.console import (
 )
 
 Side = Literal["docs", "code"]
+
+#: Every embeddable side for the status/rebuild actions. The provider
+#: picker above still operates on docs/code only (assets follow the docs
+#: model in practice), but health + rebuild cover all three stores.
+_ALL_SIDES = ("docs", "code", "assets")
+_SIDE_ALIASES = {
+    "docs": "docs",
+    "doc": "docs",
+    "rag": "docs",
+    "code": "code",
+    "assets": "assets",
+    "asset": "assets",
+}
 
 # ``amx.search.embeddings`` pulls in chromadb at import time, which
 # we don't want to load on every CLI launch. Mirror the constant
@@ -292,12 +306,119 @@ def _apply_kind(cfg: AMXConfig, side: Side, head: str, rest: list[str]) -> None:
     )
 
 
+_SIDE_TITLE = {"docs": "Catalog / docs", "code": "Code", "assets": "Assets"}
+
+
+def _compact_label(provider: str, model: str) -> str:
+    """Table-friendly identity: the model id is what matters, so show it
+    when present and fall back to the provider (e.g. bare ``minilm``)."""
+    m = (model or "").strip()
+    p = (provider or "").strip()
+    label = m or p or "—"
+    return label if len(label) <= 26 else label[:25] + "…"
+
+
+def cmd_embeddings_status(cfg: AMXConfig) -> None:
+    """Print the health table: configured vs running model, vector count,
+    and the per-side verdict (OK / Stale / Fallback)."""
+    from amx.rag_core.embedding_health import all_status
+
+    statuses = all_status(cfg)
+    heading("Embedding health")
+    info(f"{'Store':<16}{'Configured':<28}{'Running':<28}{'Chunks':>8}  Status")
+    any_fallback = False
+    any_stale = False
+    for side in _ALL_SIDES:
+        s = statuses.get(side, {})
+        if s.get("error"):
+            info(f"{_SIDE_TITLE[side]:<16}{s['error']}")
+            continue
+        configured = _compact_label(
+            s.get("configured_provider", ""), s.get("configured_model", "")
+        )
+        running = _compact_label(s.get("current_provider", ""), s.get("current_model", ""))
+        chunks = sum(int(c.get("count") or 0) for c in s.get("collections", []))
+        if s.get("fell_back"):
+            verdict = "FALLBACK"
+            any_fallback = True
+        elif s.get("stale"):
+            verdict = "stale"
+            any_stale = True
+        else:
+            verdict = "ok"
+        info(f"{_SIDE_TITLE[side]:<16}{configured:<28}{running:<28}{chunks:>8}  {verdict}")
+
+    if any_fallback:
+        warn("")
+        warn(
+            "A configured model could not be loaded, so that store is running "
+            "the bundled default. Rebuilding won't help — install the dependency "
+            "or pick an available model first."
+        )
+        for side in _ALL_SIDES:
+            reason = statuses.get(side, {}).get("fallback_reason")
+            if reason:
+                warn(f"  {_SIDE_TITLE[side]}: {reason}")
+    if any_stale:
+        info("")
+        info("Some vectors are stale — run /embeddings rebuild to re-embed under the active model.")
+
+
+def cmd_embeddings_rebuild(cfg: AMXConfig, rest: list[str]) -> None:
+    """Clear vector collections so the next ingest/query re-embeds under
+    the active provider. ``rebuild`` or ``rebuild all`` does every store;
+    ``rebuild <side>`` does one."""
+    from amx.rag_core.embedding_health import (
+        EmbeddingBackendUnavailable,
+        rebuild_all,
+        rebuild_side,
+    )
+
+    target = (rest[0] if rest else "all").lower().strip()
+    if target in {"all", ""}:
+        if not confirm(
+            "Rebuild every RAG store (docs, code, assets)? Existing vectors are "
+            "dropped and must be re-ingested.",
+            default=False,
+        ):
+            info("Cancelled.")
+            return
+        result = rebuild_all(cfg)
+        for r in result.get("results", []):
+            if r.get("ok"):
+                success(f"{r['side']}: {r.get('message', 'rebuilt')}")
+            else:
+                error(f"{r['side']}: {r.get('error', 'failed')}")
+        (success if result.get("ok") else warn)(result.get("message", "done"))
+        return
+
+    side = _SIDE_ALIASES.get(target)
+    if side is None:
+        error(f"Unknown side {target!r}. Expected one of {_ALL_SIDES} or 'all'.")
+        return
+    if not confirm(
+        f"Rebuild the {_SIDE_TITLE[side]} store? Existing vectors are dropped "
+        "and must be re-ingested.",
+        default=False,
+    ):
+        info("Cancelled.")
+        return
+    try:
+        result = rebuild_side(side, cfg)
+    except EmbeddingBackendUnavailable as exc:
+        error(str(exc))
+        return
+    success(result.get("message", f"Rebuilt {side}."))
+
+
 def cmd_embeddings(cfg: AMXConfig, rest: list[str]) -> None:
     """Show or change the search-index embedding providers.
 
     Usage (inside /search namespace)::
 
         /embeddings                              # show both sides + interactive picker
+        /embeddings status                       # health table for every store
+        /embeddings rebuild [side|all]           # re-embed one store or all of them
         /embeddings docs                         # show docs side + interactive picker
         /embeddings code                         # show code side + interactive picker
         /embeddings docs minilm                  # switch docs to MiniLM (Chroma default)
@@ -315,6 +436,14 @@ def cmd_embeddings(cfg: AMXConfig, rest: list[str]) -> None:
     other provider that exposes the OpenAI ``/embeddings`` shape — the
     user just plugs in the matching ``base_url`` and ``api_key``.
     """
+    action = (rest[0] or "").lower().strip() if rest else ""
+    if action == "status":
+        cmd_embeddings_status(cfg)
+        return
+    if action == "rebuild":
+        cmd_embeddings_rebuild(cfg, rest[1:])
+        return
+
     side, rest = _pick_side(rest)
     if side is None:
         return

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -488,7 +488,7 @@ _SEARCH_COMMANDS: tuple[SlashCommand, ...] = (
     SlashCommand(
         "/embeddings",
         "search",
-        "Show or change the search-index embedding provider (/embeddings [minilm|openai|local] [model])",
+        "Embedding provider + health (/embeddings status | rebuild [side|all] | [minilm|openai|local] [model])",
     ),
     # Sync & rebuild
     SlashCommand(

--- a/amx/rag_core/embedding_health.py
+++ b/amx/rag_core/embedding_health.py
@@ -1,0 +1,244 @@
+"""Shared embedding health + rebuild logic for every surface.
+
+AMX embeds text in three subsystems — docs (which also powers catalog
+search), code, and ingested assets — each with its own Chroma collection
+and ``embedding_{side}`` config. This module is the single, transport-free
+authority for two questions the Studio panel, the cross-page CTAs, and the
+``/embeddings`` CLI all need to answer the same way:
+
+* **What is each store's health?** ``collection_status`` reports the
+  configured-vs-running model, whether a silent fallback happened, the
+  persisted vector identity, and the single ``needs_rebuild`` verdict.
+* **How do I rebuild a store?** ``rebuild_side`` / ``rebuild_all`` clear
+  the collections so the next ingest/query re-embeds under the active
+  provider.
+
+Kept free of FastAPI so the CLI can import it without dragging the web
+stack (and chromadb) onto the boot path — callers lazy-import the heavy
+backends inside the functions. The web router wraps
+:class:`EmbeddingBackendUnavailable` into an HTTP error; the CLI prints it.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+#: Every embeddable side, in display order. docs first because it powers
+#: catalog search and is the one users notice degrading first.
+EMBEDDING_SIDES: tuple[str, ...] = ("docs", "code", "assets")
+
+#: Chroma collection-name prefix per side.
+_COLLECTION_PREFIX = {"docs": "amx_search", "assets": "amx_assets", "code": "amx_code"}
+
+
+class EmbeddingBackendUnavailable(Exception):
+    """A side's RAG backend could not be reached to rebuild it.
+
+    ``status_code`` mirrors the HTTP status the web router should map to
+    (500 when the backend import/op failed, 503 when a prerequisite like
+    ``/sync`` has not run yet) so the API contract is preserved after the
+    logic moved out of the router.
+    """
+
+    def __init__(self, message: str, *, status_code: int = 500) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _chroma_persist_path() -> str:
+    return str(Path.home() / ".amx" / "chroma_db")
+
+
+def collection_status(side: str, cfg: Any) -> dict[str, Any]:
+    """Inspect a side's persisted collections and report its health.
+
+    Returns the per-collection ``provider``/``model``/``count`` plus the
+    configured-vs-running identity, the ``fell_back`` signal, and a single
+    ``needs_rebuild`` verdict (stale vectors OR a silent fallback). An
+    empty collection (count 0) is never "stale" — flagging it produces a
+    false alarm from leftover/legacy shells.
+    """
+    try:
+        import chromadb
+    except Exception:
+        return {"collections": [], "stale": False, "error": "chromadb not installed"}
+
+    try:
+        client = chromadb.PersistentClient(path=_chroma_persist_path())
+    except Exception as exc:
+        return {"collections": [], "stale": False, "error": f"{exc.__class__.__name__}: {exc}"}
+
+    from amx.rag_core.embedding_resolver import resolve_side
+
+    prefix = _COLLECTION_PREFIX.get(side, "amx_search")
+    resolved = resolve_side(side, cfg)
+    active_provider = resolved.active_provider
+    active_model = resolved.active_model
+
+    collections: list[dict[str, Any]] = []
+    stale = False
+    for coll in client.list_collections():
+        name = getattr(coll, "name", "")
+        if not name.startswith(prefix):
+            continue
+        try:
+            meta = dict(coll.metadata or {})
+        except Exception:
+            meta = {}
+        recorded_provider = str(meta.get("embedding_provider") or "")
+        recorded_model = str(meta.get("embedding_model") or "")
+        try:
+            count = int(coll.count())
+        except Exception:
+            count = 0
+        is_stale = bool(
+            recorded_provider
+            and recorded_model
+            and count > 0
+            and (recorded_provider != active_provider or recorded_model != active_model)
+        )
+        if is_stale:
+            stale = True
+        collections.append(
+            {
+                "name": name,
+                "count": count,
+                "embedding_provider": recorded_provider,
+                "embedding_model": recorded_model,
+                "stale": is_stale,
+            }
+        )
+    return {
+        "collections": collections,
+        "stale": stale,
+        "current_provider": active_provider,
+        "current_model": active_model,
+        "configured_provider": resolved.configured_provider,
+        "configured_model": resolved.configured_model,
+        "fell_back": resolved.fell_back,
+        "fallback_reason": resolved.fallback_reason,
+        "dependency_available": resolved.dependency_available,
+        "needs_rebuild": bool(stale or resolved.fell_back),
+    }
+
+
+def all_status(cfg: Any) -> dict[str, dict[str, Any]]:
+    """Health for every side, keyed by side name."""
+    return {side: collection_status(side, cfg) for side in EMBEDDING_SIDES}
+
+
+def rebuild_side(side: str, cfg: Any, profile_filter: str | None = None) -> dict[str, Any]:
+    """Clear one side's vector collections so the next query/ingest
+    re-embeds under the active provider.
+
+    Raises :class:`EmbeddingBackendUnavailable` when the side's RAG
+    backend is missing or not yet initialised. A rebuild re-embeds under
+    the *active* provider; if the side has silently fallen back it
+    re-embeds under the fallback — it does not restore the configured
+    model. Fix the dependency/config first (the ``fell_back`` flag from
+    :func:`collection_status` is the signal).
+    """
+    if side == "docs":
+        try:
+            from amx.search.catalog import SearchCatalog
+        except Exception as exc:
+            raise EmbeddingBackendUnavailable(
+                f"Docs catalog unavailable: {exc.__class__.__name__}: {exc}"
+            ) from exc
+        catalog = SearchCatalog.from_history_store()
+        if catalog is None:
+            raise EmbeddingBackendUnavailable(
+                "Docs catalog is not initialised; run /sync first.", status_code=503
+            )
+        rebuilt: list[str] = []
+        db_profiles = getattr(cfg, "db_profiles", {}) or {}
+        targets = [profile_filter] if profile_filter else sorted(db_profiles.keys()) or [""]
+        for db_profile in targets:
+            try:
+                catalog.rebuild_profile(db_profile or "")
+                rebuilt.append(db_profile or "(default)")
+            except Exception as exc:
+                log.warning("rebuild_profile failed for %r: %s", db_profile, exc)
+        return {
+            "ok": True,
+            "side": "docs",
+            "rebuilt": rebuilt,
+            "message": f"Rebuilt {len(rebuilt)} docs collection(s).",
+        }
+
+    if side == "assets":
+        try:
+            from amx.assets.rag import AssetRAGStore
+        except Exception as exc:
+            raise EmbeddingBackendUnavailable(
+                f"Asset RAG unavailable: {exc.__class__.__name__}: {exc}"
+            ) from exc
+        try:
+            store = AssetRAGStore(cfg=cfg)
+            store.reset_collection()
+        except Exception as exc:
+            raise EmbeddingBackendUnavailable(
+                f"Asset collection reset failed: {exc.__class__.__name__}: {exc}"
+            ) from exc
+        return {
+            "ok": True,
+            "side": "assets",
+            "cleared": True,
+            "message": (
+                "Cleared the assets collection; run /db assets reindex to "
+                "re-embed under the active provider."
+            ),
+        }
+
+    # side == "code"
+    try:
+        from amx.codebase.code_rag import delete_code_collection
+    except Exception as exc:
+        raise EmbeddingBackendUnavailable(
+            f"Code RAG unavailable: {exc.__class__.__name__}: {exc}"
+        ) from exc
+    cleared = bool(
+        delete_code_collection(source_filters=[profile_filter] if profile_filter else None)
+    )
+    return {
+        "ok": True,
+        "side": "code",
+        "cleared": cleared,
+        "message": (
+            "Cleared the code collection; the next /code query will re-embed "
+            "with the active provider."
+            if cleared
+            else "Code collection did not exist; nothing to clear."
+        ),
+    }
+
+
+def rebuild_all(cfg: Any, profile_filter: str | None = None) -> dict[str, Any]:
+    """Rebuild every side, recording per-side failures without aborting.
+
+    ``ok`` is True only when every side cleared. A side whose backend is
+    unavailable lands in ``failed`` with its error captured in
+    ``results`` so the caller can report a partial outcome.
+    """
+    results: list[dict[str, Any]] = []
+    failed: list[str] = []
+    for side in EMBEDDING_SIDES:
+        try:
+            results.append(rebuild_side(side, cfg, profile_filter))
+        except EmbeddingBackendUnavailable as exc:
+            failed.append(side)
+            results.append({"ok": False, "side": side, "error": str(exc)})
+    return {
+        "ok": not failed,
+        "results": results,
+        "failed": failed,
+        "message": (
+            f"Rebuilt {len(EMBEDDING_SIDES) - len(failed)}/{len(EMBEDDING_SIDES)} sides."
+            if failed
+            else "Rebuilt every RAG store; re-ingest/query to re-embed under the active provider."
+        ),
+    }

--- a/amx/web/routers/profiles.py
+++ b/amx/web/routers/profiles.py
@@ -637,180 +637,11 @@ def test_embedding(
     return {"ok": True, "message": f"OK — embedded one sample in {dim} dimensions.", "dim": dim}
 
 
-def _collection_status_for_side(side: str, cfg: AMXConfig) -> dict[str, Any]:
-    """Inspect persisted collections to detect stale-vector state.
-
-    Returns the per-collection ``provider``/``model``/``count`` plus a
-    ``stale`` flag. Stale means the collection's metadata recorded a
-    different provider/model than what ``cfg.embedding_{side}`` now
-    resolves to, so vectors must be re-embedded.
-    """
-    from pathlib import Path
-
-    try:
-        import chromadb
-    except Exception:
-        return {"collections": [], "stale": False, "error": "chromadb not installed"}
-
-    persist = str(Path.home() / ".amx" / "chroma_db")
-    try:
-        client = chromadb.PersistentClient(path=persist)
-    except Exception as exc:
-        return {"collections": [], "stale": False, "error": f"{exc.__class__.__name__}: {exc}"}
-
-    from amx.rag_core.embedding_resolver import resolve_side
-
-    prefix = {"docs": "amx_search", "assets": "amx_assets", "code": "amx_code"}.get(
-        side, "amx_search"
-    )
-    resolved = resolve_side(side, cfg)
-    active_provider = resolved.active_provider
-    active_model = resolved.active_model
-
-    collections: list[dict[str, Any]] = []
-    stale = False
-    for coll in client.list_collections():
-        name = getattr(coll, "name", "")
-        if not name.startswith(prefix):
-            continue
-        try:
-            meta = dict(coll.metadata or {})
-        except Exception:
-            meta = {}
-        recorded_provider = str(meta.get("embedding_provider") or "")
-        recorded_model = str(meta.get("embedding_model") or "")
-        try:
-            count = int(coll.count())
-        except Exception:
-            count = 0
-        # An empty collection (count 0) has no vectors to be stale —
-        # flagging it produces a false "Vectors are stale" warning from
-        # leftover/legacy empty collections (e.g. the pre-per-profile
-        # ``amx_search`` shell). Only a populated collection whose
-        # recorded identity differs from the active one is truly stale.
-        is_stale = bool(
-            recorded_provider
-            and recorded_model
-            and count > 0
-            and (recorded_provider != active_provider or recorded_model != active_model)
-        )
-        if is_stale:
-            stale = True
-        collections.append(
-            {
-                "name": name,
-                "count": count,
-                "embedding_provider": recorded_provider,
-                "embedding_model": recorded_model,
-                "stale": is_stale,
-            }
-        )
-    return {
-        "collections": collections,
-        "stale": stale,
-        "current_provider": active_provider,
-        "current_model": active_model,
-        # Enriched (unified embedding management): configured vs actually
-        # running, so the UI can show "configured X but running Y" instead
-        # of a silent substitution. ``needs_rebuild`` is the single verdict
-        # the panel/CTA act on: stale vectors OR a silent fallback.
-        "configured_provider": resolved.configured_provider,
-        "configured_model": resolved.configured_model,
-        "fell_back": resolved.fell_back,
-        "fallback_reason": resolved.fallback_reason,
-        "dependency_available": resolved.dependency_available,
-        "needs_rebuild": bool(stale or resolved.fell_back),
-    }
-
-
 @router.get("/embedding/status")
 def get_embedding_status(cfg: AMXConfig = Depends(get_cfg)) -> dict[str, Any]:
-    return {side: _collection_status_for_side(side, cfg) for side in _EMBEDDING_SIDES}
+    from amx.rag_core.embedding_health import all_status
 
-
-def _rebuild_one_side(side: str, cfg: AMXConfig, profile_filter: str | None) -> dict[str, Any]:
-    """Clear one side's vector collections so the next query/ingest
-    re-embeds under the active provider. Raises ``HTTPException`` when
-    the side's RAG backend is unavailable. Pulled out of the endpoint so
-    the rebuild-all endpoint can drive every side through one code path.
-    """
-    if side == "docs":
-        try:
-            from amx.search.catalog import SearchCatalog
-        except Exception as exc:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Docs catalog unavailable: {exc.__class__.__name__}: {exc}",
-            ) from exc
-        catalog = SearchCatalog.from_history_store()
-        if catalog is None:
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Docs catalog is not initialised; run /sync first.",
-            )
-        rebuilt: list[str] = []
-        targets = [profile_filter] if profile_filter else sorted(cfg.db_profiles.keys()) or [""]
-        for db_profile in targets:
-            try:
-                catalog.rebuild_profile(db_profile or "")
-                rebuilt.append(db_profile or "(default)")
-            except Exception as exc:
-                log.warning("rebuild_profile failed for %r: %s", db_profile, exc)
-        return {
-            "ok": True,
-            "side": "docs",
-            "rebuilt": rebuilt,
-            "message": f"Rebuilt {len(rebuilt)} docs collection(s).",
-        }
-
-    if side == "assets":
-        try:
-            from amx.assets.rag import AssetRAGStore
-        except Exception as exc:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Asset RAG unavailable: {exc.__class__.__name__}: {exc}",
-            ) from exc
-        try:
-            store = AssetRAGStore(cfg=cfg)
-            store.reset_collection()
-        except Exception as exc:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Asset collection reset failed: {exc.__class__.__name__}: {exc}",
-            ) from exc
-        return {
-            "ok": True,
-            "side": "assets",
-            "cleared": True,
-            "message": (
-                "Cleared the assets collection; run /db assets reindex to "
-                "re-embed under the active provider."
-            ),
-        }
-
-    # side == "code"
-    try:
-        from amx.codebase.code_rag import delete_code_collection
-    except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Code RAG unavailable: {exc.__class__.__name__}: {exc}",
-        ) from exc
-    cleared = bool(
-        delete_code_collection(source_filters=[profile_filter] if profile_filter else None)
-    )
-    return {
-        "ok": True,
-        "side": "code",
-        "cleared": cleared,
-        "message": (
-            "Cleared the code collection; the next /code query will re-embed "
-            "with the active provider."
-            if cleared
-            else "Code collection did not exist; nothing to clear."
-        ),
-    }
+    return all_status(cfg)
 
 
 @router.post("/embedding/rebuild")
@@ -823,33 +654,12 @@ def rebuild_all_embeddings(
     A per-side failure is recorded and the loop continues, so one
     unavailable backend doesn't abort the others — the response reports
     which sides succeeded. ``ok`` is True only when every side cleared.
-
-    Note: a rebuild re-embeds under the *active* provider. If a side has
-    silently fallen back (its configured model can't be built), rebuild
-    re-embeds under the fallback — it does not restore the configured
-    model. Fix the dependency/config first; the status endpoint's
-    ``fell_back`` flag is the signal for that.
     """
+    from amx.rag_core.embedding_health import rebuild_all
+
     body = body or {}
     profile_filter = (body.get("profile") or "").strip() or None
-    results: list[dict[str, Any]] = []
-    failed: list[str] = []
-    for side in _EMBEDDING_SIDES:
-        try:
-            results.append(_rebuild_one_side(side, cfg, profile_filter))
-        except HTTPException as exc:
-            failed.append(side)
-            results.append({"ok": False, "side": side, "error": str(exc.detail)})
-    return {
-        "ok": not failed,
-        "results": results,
-        "failed": failed,
-        "message": (
-            f"Rebuilt {len(_EMBEDDING_SIDES) - len(failed)}/{len(_EMBEDDING_SIDES)} sides."
-            if failed
-            else "Rebuilt every RAG store; re-ingest/query to re-embed under the active provider."
-        ),
-    }
+    return rebuild_all(cfg, profile_filter)
 
 
 @router.post("/embedding/{side}/rebuild")
@@ -864,10 +674,15 @@ def rebuild_embedding(
     Blocking — large catalogs take seconds to tens of seconds; jobs
     infrastructure is out of scope for the initial split.
     """
+    from amx.rag_core.embedding_health import EmbeddingBackendUnavailable, rebuild_side
+
     side = _check_side(side)
     body = body or {}
     profile_filter = (body.get("profile") or "").strip() or None
-    return _rebuild_one_side(side, cfg, profile_filter)
+    try:
+        return rebuild_side(side, cfg, profile_filter)
+    except EmbeddingBackendUnavailable as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
 # ── Doc + Code profiles (path lists) ───────────────────────────────────

--- a/tests/test_embedding_health.py
+++ b/tests/test_embedding_health.py
@@ -1,0 +1,81 @@
+"""Shared embedding health + rebuild authority.
+
+These pin the transport-free contract that both the web router and the
+``/embeddings`` CLI consume, so the two surfaces can never drift: the
+rebuild-all aggregate, the per-side failure capture, and the HTTP-status
+hint carried by :class:`EmbeddingBackendUnavailable`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import amx.rag_core.embedding_health as eh
+from amx.rag_core.embedding_health import (
+    EMBEDDING_SIDES,
+    EmbeddingBackendUnavailable,
+    rebuild_all,
+)
+
+
+def test_sides_cover_docs_code_assets() -> None:
+    assert set(EMBEDDING_SIDES) == {"docs", "code", "assets"}
+
+
+def test_backend_unavailable_carries_status_hint() -> None:
+    assert EmbeddingBackendUnavailable("x").status_code == 500
+    assert EmbeddingBackendUnavailable("y", status_code=503).status_code == 503
+
+
+def test_rebuild_all_runs_every_side_when_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    def _fake(side: str, cfg: Any, profile: str | None) -> dict[str, Any]:
+        seen.append(side)
+        return {"ok": True, "side": side, "message": f"rebuilt {side}"}
+
+    monkeypatch.setattr(eh, "rebuild_side", _fake)
+    out = rebuild_all(SimpleNamespace())
+    assert seen == list(EMBEDDING_SIDES)
+    assert out["ok"] is True
+    assert out["failed"] == []
+    assert {r["side"] for r in out["results"]} == set(EMBEDDING_SIDES)
+
+
+def test_rebuild_all_records_failure_and_keeps_going(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake(side: str, cfg: Any, profile: str | None) -> dict[str, Any]:
+        if side == "code":
+            raise EmbeddingBackendUnavailable("Code RAG unavailable")
+        return {"ok": True, "side": side}
+
+    monkeypatch.setattr(eh, "rebuild_side", _fake)
+    out = rebuild_all(SimpleNamespace())
+    # One side failed but the others still ran.
+    assert out["ok"] is False
+    assert out["failed"] == ["code"]
+    assert {r["side"] for r in out["results"]} == set(EMBEDDING_SIDES)
+    code_row = next(r for r in out["results"] if r["side"] == "code")
+    assert code_row["ok"] is False
+    assert "Code RAG unavailable" in code_row["error"]
+
+
+def test_collection_status_handles_missing_chromadb(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When chromadb can't be imported the status is reported as an error
+    # rather than raising — every surface must still render.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_chromadb(name: str, *a: Any, **k: Any):
+        if name == "chromadb":
+            raise ImportError("no chromadb")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_chromadb)
+    out = eh.collection_status("docs", SimpleNamespace())
+    assert out["stale"] is False
+    assert out["collections"] == []
+    assert "chromadb" in out["error"]


### PR DESCRIPTION
## Summary

PR4 of unified embedding management — CLI parity, built on a single transport-free authority both the web and CLI share.

- **`amx/rag_core/embedding_health.py`** (new): one place for "what is each store's health" (`collection_status`/`all_status`) and "rebuild a store" (`rebuild_side`/`rebuild_all`). FastAPI-free so the CLI imports it without the web stack; `rebuild_side` raises `EmbeddingBackendUnavailable` carrying an HTTP status hint.
- **Web router** delegates to it (status + per-side + rebuild-all). Behaviour identical — existing endpoint tests still pass; the logic just left the router.
- **CLI:** `/embeddings status` prints a health table (configured vs running, chunk count, OK/Stale/FALLBACK) and `/embeddings rebuild [side|all]` re-embeds with a destructive-action confirm. Both distinguish a silent fallback (rebuild won't help) from stale vectors (rebuild fixes).

Status, the Studio panel, the cross-page CTAs, and the CLI now read one authority — they can't drift.

## Test plan

- [x] `tests/test_embedding_health.py`: rebuild-all aggregate, per-side failure capture, graceful no-chromadb. 30 embedding tests pass.
- [x] `ruff` + `mypy` clean on all touched files.
- [x] deploy.sh → live: status endpoint through the new module reports configured=running=gte-small / fell_back=false in the Studio venv (has the dependency).
- [x] CLI `/embeddings status` honestly shows FALLBACK in a shell without sentence-transformers.