### PR TITLE
feat(catalog): record first_synced_at so new assets can be detected

### DIFF
--- a/amx/search/_catalog/entity_crud.py
+++ b/amx/search/_catalog/entity_crud.py
@@ -121,13 +121,18 @@ class EntityCrudMixin:
             )
             return int(row["id"])
 
+        # ``first_synced_at`` is stamped ONLY here (insert), never in the
+        # UPDATE branch above — it's the durable "this asset first appeared
+        # at T" fact that change-triggered schedules diff against their
+        # watermark. ``last_synced_at`` can't serve that role since it's
+        # bumped on every re-sync.
         cur = conn.execute(
             """
             INSERT INTO catalog_entities (
                 db_profile, db_backend, database_name, schema_name, table_name, column_name,
                 entity_kind, asset_kind, dtype, nullable, pk_flag, fk_flag, row_count,
-                updated_at, last_synced_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                updated_at, last_synced_at, first_synced_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 db_profile,
@@ -143,6 +148,7 @@ class EntityCrudMixin:
                 pk_flag,
                 fk_flag,
                 row_count,
+                now,
                 now,
                 now,
             ),

--- a/amx/storage/schema_descriptions.py
+++ b/amx/storage/schema_descriptions.py
@@ -783,6 +783,12 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
             "UTC epoch seconds of the last code-context sync (lineage usage, "
             "test references). NULL on entities never touched by /code."
         ),
+        "first_synced_at": (
+            "UTC epoch seconds when this asset FIRST appeared in the catalog. "
+            "Set only on insert, never bumped, so change-triggered schedules "
+            "can diff newly-appeared assets against their watermark. NULL on "
+            "rows that predate the column."
+        ),
         # Attribution columns — present on the SHARED catalog_entities table
         # (team-wide structural catalog) so /history-store list-team can show
         # who profiled what. Absent from the local SQLite table.

--- a/amx/storage/shared_schema.py
+++ b/amx/storage/shared_schema.py
@@ -130,7 +130,7 @@ DEFAULT_HISTORY_SCHEMA_COMMENT = SHARED_SCHEMA_COMMENT
 # All client versions writing into a shared store record this as their
 # ``schema_version`` so an older client refuses to write into a schema
 # bumped by a newer client (avoids losing columns the new client added).
-SHARED_SCHEMA_VERSION = 6
+SHARED_SCHEMA_VERSION = 7
 
 
 def _desc(table: str, column: str | None = None) -> str:
@@ -1931,6 +1931,11 @@ def build_metadata(schema: str | None = None) -> MetaData:
             DateTime(timezone=True),
             index=True,
             comment=_desc("catalog_entities", "last_synced_at"),
+        ),
+        Column(
+            "first_synced_at",
+            DateTime(timezone=True),
+            comment=_desc("catalog_entities", "first_synced_at"),
         ),
         Column("created_by", String(120), comment=_desc("catalog_entities", "created_by")),
         Column("hostname", String(255), comment=_desc("catalog_entities", "hostname")),

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -568,7 +568,8 @@ class SQLiteHistoryStore:
                     effective_description_id INTEGER,
                     updated_at REAL NOT NULL DEFAULT 0,
                     last_synced_at REAL NOT NULL DEFAULT 0,
-                    last_code_sync_at REAL
+                    last_code_sync_at REAL,
+                    first_synced_at REAL
                 )
                 """
             )
@@ -608,6 +609,13 @@ class SQLiteHistoryStore:
                 "ON catalog_entities(source_remote_id, entity_kind) "
                 "WHERE source_remote_id IS NOT NULL"
             )
+            # ``first_synced_at`` records when an asset FIRST appeared (set
+            # only on INSERT, never bumped), so change-triggered schedules
+            # can diff "what is new since I last looked" against their
+            # watermark. ``last_synced_at`` can't serve this — it moves on
+            # every re-sync. NULL on rows that predate the column.
+            with contextlib.suppress(sqlite3.OperationalError):
+                conn.execute("ALTER TABLE catalog_entities ADD COLUMN first_synced_at REAL")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS catalog_descriptions (

--- a/tests/test_catalog_skeleton_sync.py
+++ b/tests/test_catalog_skeleton_sync.py
@@ -532,3 +532,43 @@ def test_skeleton_sync_warms_comments_with_durable_ttl(
     sync_profile_skeleton(_StubCfg(), "prof-a", fresh_catalog)
 
     assert getattr(connector, "last_warm_ttl", None) == DURABLE_COMMENT_CACHE_TTL_SECONDS
+
+
+def _first_synced(cat: SearchCatalog, profile: str, table: str) -> float | None:
+    with cat._connect() as conn:  # noqa: SLF001
+        row = conn.execute(
+            "SELECT first_synced_at FROM catalog_entities "
+            "WHERE db_profile = ? AND table_name = ? AND entity_kind = 'table'",
+            (profile, table),
+        ).fetchone()
+    return None if row is None else row["first_synced_at"]
+
+
+def test_first_synced_at_set_on_insert_preserved_on_resync(
+    fresh_catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``first_synced_at`` is the change-trigger signal: stamped when an
+    asset first appears, never bumped on a re-sync (unlike
+    ``last_synced_at``). A newly-appeared table carries a strictly later
+    ``first_synced_at`` so a watermark diff can isolate it."""
+    connector = _StubConnector(schemas=["public"], assets={"public": [("users", "table")]})
+    _stub_build_connector(monkeypatch, connector)
+
+    sync_profile_skeleton(_StubCfg(), "prof-a", fresh_catalog)
+    first = _first_synced(fresh_catalog, "prof-a", "users")
+    assert first is not None and first > 0
+
+    # Re-sync the SAME table — first_synced_at must not move; last_synced_at must.
+    time.sleep(0.01)
+    sync_profile_skeleton(_StubCfg(), "prof-a", fresh_catalog)
+    assert _first_synced(fresh_catalog, "prof-a", "users") == first
+
+    # A brand-new table appears — its first_synced_at is strictly later,
+    # so "what is new since I last looked" is a simple watermark compare.
+    time.sleep(0.01)
+    connector._assets["public"] = [("users", "table"), ("orders", "table")]  # noqa: SLF001
+    sync_profile_skeleton(_StubCfg(), "prof-a", fresh_catalog)
+    new_first = _first_synced(fresh_catalog, "prof-a", "orders")
+    assert new_first is not None and new_first > first
+    # The pre-existing table's stamp is still untouched.
+    assert _first_synced(fresh_catalog, "prof-a", "users") == first

--- a/tests/test_shared_schema_comments.py
+++ b/tests/test_shared_schema_comments.py
@@ -56,13 +56,14 @@ def test_create_history_tables_ddl_emits_comments_on_postgres() -> None:
 
     assert ddl.count("CREATE TABLE") == 27, "expected 27 CREATE TABLE statements"
     assert ddl.count("COMMENT ON TABLE") == 27, "expected 27 COMMENT ON TABLE statements"
-    # 339 columns (275 pre-Phase-A-Task-6 + 46 remote-asset columns:
+    # 340 columns (275 pre-Phase-A-Task-6 + 46 remote-asset columns:
     #              remote_pipelines (12), remote_streamlit_apps (9),
     #              remote_streams (9), remote_task_dependencies (3),
-    #              remote_queries (13) = 46; + catalog_entities (18) for
-    #              the shared structural catalog = 339)
-    assert ddl.count("COMMENT ON COLUMN") == 339, (
-        f"expected 339 COMMENT ON COLUMN statements, got {ddl.count('COMMENT ON COLUMN')}"
+    #              remote_queries (13) = 46; + catalog_entities (19, incl.
+    #              first_synced_at for change-triggered schedules) for
+    #              the shared structural catalog = 340)
+    assert ddl.count("COMMENT ON COLUMN") == 340, (
+        f"expected 340 COMMENT ON COLUMN statements, got {ddl.count('COMMENT ON COLUMN')}"
     )
 
 


### PR DESCRIPTION
## Summary

Foundation (PR-A of 3) for **change-triggered schedules**. `catalog_entities` only tracked `last_synced_at`, which moves on every re-sync — so there was no way to distinguish a newly-appeared asset from a re-touched one.

- New `first_synced_at` column on `catalog_entities` (local + shared schema), stamped **only on insert** in `_upsert_entity`, never bumped on update.
- `SHARED_SCHEMA_VERSION` 6 → 7; `schema_descriptions` entry added; the ALTER migration is additive (pre-existing rows read NULL).
- No behaviour change yet — purely the signal the change-trigger dispatcher (PR-B) will diff against a per-schedule watermark.

## Test plan

- [x] `first_synced_at` set on insert, preserved across a re-sync, and a newly-appeared table carries a strictly later stamp.
- [x] Both schema-comment gates green (shared column count 339 → 340).
- [x] `ruff` clean; no net-new `mypy` errors; catalog/skeleton/deep-sync regression green.