### PR TITLE
feat(scheduler): change-triggered schedules fire when new assets appear

### DIFF
--- a/amx/runtime/worker.py
+++ b/amx/runtime/worker.py
@@ -205,7 +205,12 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
             _cat = SearchCatalog.from_history_store()
             if _cat is not None:
                 _dbs = [str(overlay_database)] if overlay_database else None
-                deep_sync_profile(cfg, db_profile_name, _cat, databases=_dbs)
+                # dispatch_changes=False: this deep-sync is part of a fired
+                # run, so it must not recursively re-trigger change schedules
+                # on the columns it stamps.
+                deep_sync_profile(
+                    cfg, db_profile_name, _cat, databases=_dbs, dispatch_changes=False
+                )
         except Exception as exc:  # noqa: BLE001 - never block generation on a sync hiccup
             log.warning(
                 "production_run_executor: deep_first sync skipped for schedule #%s: %s",
@@ -808,6 +813,8 @@ def _mark_completed(store: _HistoryStore, *, run_id: int, schedule_id: int) -> N
         log.exception("finish_run failed for run_id=%s", run_id)
     if _try_rearm_recurring(store, schedule_id):
         return
+    if _try_rearm_change(store, schedule_id):
+        return
     try:
         store.set_scheduled_run_status(
             schedule_id,
@@ -846,6 +853,8 @@ def _mark_failed(
     # the diagnostic detail.
     if _try_rearm_recurring(store, schedule_id):
         return
+    if _try_rearm_change(store, schedule_id):
+        return
     try:
         store.set_scheduled_run_status(
             schedule_id,
@@ -874,3 +883,20 @@ def _try_rearm_recurring(store: _HistoryStore, schedule_id: int) -> bool:
         log.exception("arm_next_fire raised for schedule_id=%s", schedule_id)
         return False
     return bool(next_at)
+
+
+def _try_rearm_change(store: _HistoryStore, schedule_id: int) -> bool:
+    """Return a change-triggered schedule to ``pending`` (watching).
+
+    Change schedules never go terminal on their own — they keep watching
+    until deleted. Returns True when the row was a change schedule (caller
+    skips the terminal transition); False otherwise.
+    """
+    helper = getattr(store, "rearm_change_schedule", None)
+    if helper is None:
+        return False
+    try:
+        return bool(helper(schedule_id))
+    except Exception:
+        log.exception("rearm_change_schedule raised for schedule_id=%s", schedule_id)
+        return False

--- a/amx/scheduler/change_trigger.py
+++ b/amx/scheduler/change_trigger.py
@@ -1,0 +1,176 @@
+"""Change-triggered schedule dispatcher.
+
+AMX has no push-based CDC; the lightweight, native way to notice a new
+asset is the thing the product does constantly — **sync**. So a
+change-triggered schedule (``scheduled_runs.trigger='change'``) has no
+fire time. Instead, every time a top-level sync completes
+(``sync_profile_skeleton`` / ``deep_sync_profile`` called from manual
+Sync, a ``cache_refresh`` schedule, or the drift probe), this module is
+invoked to:
+
+1. find active change schedules for the synced profile,
+2. diff ``catalog_entities`` for assets whose ``first_synced_at`` is newer
+   than the schedule's ``last_checked_at`` watermark, within its watched
+   scope,
+3. fire a ``missing_only`` analyze run narrowed to exactly the tables that
+   gained something, reusing :func:`spawn_scheduled_worker` +
+   ``production_run_executor`` (so generation, deep-sync-first, and
+   auto-apply all behave identically to a time schedule),
+4. advance the watermark so the same assets never re-fire.
+
+The fired run's *own* internal deep-sync passes ``dispatch_changes=False``
+so it can't recursively re-trigger detection; and a schedule that is
+currently ``running`` is excluded from selection, so a sync mid-run can't
+double-fire it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from amx.utils.logging import get_logger
+
+log = get_logger("scheduler.change_trigger")
+
+
+def _watched_schemas(scope_json: str | None) -> list[str] | None:
+    """Schema filter for a watcher's scope. ``None`` means "whole profile"
+    (mode ``all`` / database-level watch); a list restricts to those
+    schemas (mode ``schemas``)."""
+    if not scope_json:
+        return None
+    try:
+        obj = json.loads(scope_json)
+    except (TypeError, ValueError):
+        return None
+    if obj.get("mode") == "schemas":
+        return [str(s) for s in (obj.get("schemas") or []) if s]
+    return None
+
+
+def _narrowed_scope_json(watch_scope_json: str | None, tables: list[tuple[str, str]]) -> str:
+    """Build the run scope for the fired analyze run: exactly the tables
+    that gained a new asset, in ``missing_only`` mode so only the
+    description-less columns (the new ones, plus any pre-existing gaps) are
+    generated. ``deep_first`` is forced on so a brand-new table's columns
+    are profiled before generation."""
+    deep_first = True
+    if watch_scope_json:
+        try:
+            deep_first = bool(json.loads(watch_scope_json).get("deep_first", True))
+        except (TypeError, ValueError):
+            deep_first = True
+    return json.dumps(
+        {
+            "mode": "tables",
+            "tables": [{"schema": s, "table": t} for s, t in tables],
+            "missing_only": True,
+            "deep_first": deep_first,
+        }
+    )
+
+
+def dispatch_after_sync(
+    profile: str,
+    cfg: Any,
+    *,
+    databases: list[str] | None = None,
+) -> int:
+    """Evaluate change schedules for ``profile`` after a sync completed.
+
+    Returns the number of schedules fired. Never raises — a failure here
+    must not break the sync that triggered it; everything is logged.
+    """
+    try:
+        from amx.search.catalog import SearchCatalog
+        from amx.storage.sqlite_store import history_store
+
+        store = history_store()
+        catalog = SearchCatalog.from_history_store()
+        if store is None or catalog is None:
+            return 0
+        schedules = store.list_change_schedules(db_profile=profile)
+    except Exception:
+        log.exception("change-trigger: could not load schedules for profile=%s", profile)
+        return 0
+
+    fired = 0
+    for sched in schedules:
+        try:
+            fired += _evaluate_one(store, catalog, sched, databases=databases)
+        except Exception:
+            log.exception(
+                "change-trigger: evaluation failed for schedule #%s",
+                sched.get("id"),
+            )
+    return fired
+
+
+def _evaluate_one(
+    store: Any,
+    catalog: Any,
+    sched: dict[str, Any],
+    *,
+    databases: list[str] | None,
+) -> int:
+    schedule_id = int(sched["id"])
+    profile = str(sched.get("db_profile") or "")
+    watermark = sched.get("last_checked_at")
+    watch_scope_json = sched.get("scope_json")
+    schemas = _watched_schemas(watch_scope_json)
+    # The watcher's database overlay narrows detection to one database; a
+    # sync that touched other databases shouldn't fire it.
+    sched_db = sched.get("database") or None
+    if sched_db and databases is not None and sched_db not in databases:
+        return 0
+
+    # Capture the checkpoint BEFORE querying so assets inserted after this
+    # instant stay for the next sync rather than being silently skipped.
+    checkpoint = time.time()
+    new_rows = catalog.new_entities_since(
+        profile,
+        float(watermark) if watermark is not None else None,
+        database=sched_db,
+        schemas=schemas,
+    )
+
+    # Collapse new tables and new columns to the set of owning tables; the
+    # missing_only filter on the fired run handles per-column selection.
+    tables: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for r in new_rows:
+        key = (str(r["schema_name"]), str(r["table_name"]))
+        if key[1] and key not in seen:
+            seen.add(key)
+            tables.append(key)
+
+    if not tables:
+        store.advance_change_watermark(schedule_id, checkpoint)
+        return 0
+
+    payload = dict(sched)
+    payload["scope_json"] = _narrowed_scope_json(watch_scope_json, tables)
+    # Advance the watermark BEFORE firing: the fired run's own deep-sync
+    # will stamp new first_synced_at values, and advancing first (plus the
+    # running-guard in list_change_schedules) prevents this watcher from
+    # reacting to assets it created itself.
+    store.advance_change_watermark(schedule_id, checkpoint)
+
+    from amx.runtime.worker import production_run_executor, spawn_scheduled_worker
+
+    run_id = spawn_scheduled_worker(
+        payload,
+        store=store,
+        run_executor=production_run_executor,
+        background=True,
+    )
+    log.info(
+        "change-trigger: schedule #%s fired run #%s for %s new table(s) in profile %s",
+        schedule_id,
+        run_id,
+        len(tables),
+        profile,
+    )
+    return 1

--- a/amx/search/_catalog/entity_crud.py
+++ b/amx/search/_catalog/entity_crud.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import time
+from typing import Any
 
 from amx.rag_core.collection_identity import CollectionIdentityMismatch
 from amx.search._catalog._constants import SOURCE_PRIORITY, _json_loads
@@ -154,6 +155,46 @@ class EntityCrudMixin:
             ),
         )
         return int(cur.lastrowid)
+
+    def new_entities_since(
+        self,
+        db_profile: str,
+        since_ts: float | None,
+        *,
+        database: str | None = None,
+        schemas: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Catalog entities that FIRST appeared after ``since_ts``.
+
+        Drives change-triggered schedules: the dispatcher passes the
+        schedule's ``last_checked_at`` watermark and the watched scope, and
+        gets back the tables/columns newly discovered since then. Rows
+        predating ``first_synced_at`` (NULL) never match — only genuinely
+        new assets do. ``since_ts`` of None means "everything seen so far"
+        (a freshly-created watcher with no watermark yet).
+
+        Returns dicts with ``schema_name``, ``table_name``, ``column_name``,
+        ``entity_kind``, ``first_synced_at`` ordered oldest-first.
+        """
+        clauses = ["db_profile = ?", "first_synced_at IS NOT NULL"]
+        params: list[Any] = [db_profile]
+        if since_ts is not None:
+            clauses.append("first_synced_at > ?")
+            params.append(float(since_ts))
+        if database is not None:
+            clauses.append("database_name = ?")
+            params.append(database)
+        if schemas:
+            placeholders = ",".join("?" for _ in schemas)
+            clauses.append(f"schema_name IN ({placeholders})")
+            params.extend(schemas)
+        sql = (
+            "SELECT schema_name, table_name, column_name, entity_kind, first_synced_at "
+            "FROM catalog_entities WHERE " + " AND ".join(clauses) + " ORDER BY first_synced_at ASC"
+        )
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
 
     def _insert_description(
         self,

--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -362,6 +362,7 @@ def sync_profile_skeleton(
     catalog,
     *,
     databases: list[str] | None = None,
+    dispatch_changes: bool = True,
 ) -> dict:
     """Synchronous skeleton sync. Walks **every** reachable database
     (or catalog, on 3-level backends) under *profile* and upserts the
@@ -712,6 +713,11 @@ def sync_profile_skeleton(
     summary["schemas_warmed"] = bool(schemas_warmed_ok)
     summary["columns_warmed"] = bool(columns_warmed_ok)
     _skeleton_jobs.unregister(profile)
+    # A successful skeleton sync may have discovered new tables — let any
+    # change-triggered schedules react. Suppressed when this sync is itself
+    # part of a fired run (dispatch_changes=False) to avoid recursion.
+    if dispatch_changes:
+        _dispatch_change_schedules(profile, cfg, databases=databases)
     return summary
 
 
@@ -721,6 +727,7 @@ def deep_sync_profile(
     catalog,
     *,
     databases: list[str] | None = None,
+    dispatch_changes: bool = True,
 ) -> dict:
     """Full-profile sync: profile every table the skeleton already
     catalogued and write its columns + row count.
@@ -868,7 +875,23 @@ def deep_sync_profile(
     if summary["state"] == "done":
         summary["shared_pushed"] = _push_catalog_if_shared(profile)
     _skeleton_jobs.unregister(profile)
+    # A deep sync discovers new columns on existing tables (the skeleton
+    # only sees table names) — let change-triggered schedules react.
+    # Suppressed when this deep sync is itself part of a fired run.
+    if dispatch_changes and summary["state"] == "done":
+        _dispatch_change_schedules(profile, cfg, databases=databases)
     return summary
+
+
+def _dispatch_change_schedules(profile: str, cfg, *, databases: list[str] | None) -> None:
+    """Best-effort hook into the change-trigger dispatcher. Isolated here
+    so a dispatcher import/runtime error can never break a sync."""
+    try:
+        from amx.scheduler.change_trigger import dispatch_after_sync
+
+        dispatch_after_sync(profile, cfg, databases=databases)
+    except Exception:
+        log.exception("change-trigger dispatch failed for profile=%s", profile)
 
 
 def deep_sync_one_table(

--- a/amx/storage/_history_scheduled.py
+++ b/amx/storage/_history_scheduled.py
@@ -36,6 +36,7 @@ def create_scheduled_run(
     extra_args_json: str | None = None,
     kind: str = "analyze",
     cron_expr: str | None = None,
+    trigger: str = "time",
 ) -> int:
     """Insert a new scheduled_runs row in status='pending'.
 
@@ -51,8 +52,19 @@ def create_scheduled_run(
     ('cache_refresh'). ``cron_expr`` is NULL for one-shot fires and
     a valid croniter expression for recurring schedules — the tick
     engine re-arms the row from the cron after each fire.
+
+    ``trigger`` is 'time' (default — fired by the tick when
+    ``fire_at_utc`` elapses) or 'change' (fired by the post-sync
+    dispatcher when a new asset appears under the watched scope;
+    ``fire_at_utc`` carries a harmless placeholder and is never used).
     """
     now = time.time()
+    trigger = str(trigger or "time")
+    # A change watcher's watermark starts at creation time so it only fires
+    # for assets that appear AFTER it was set up — otherwise its first sync
+    # would treat the entire pre-existing catalog as "new". Time schedules
+    # leave it NULL.
+    last_checked_at = now if trigger == "change" else None
     with hs._lock, hs._connect() as conn:
         cur = conn.execute(
             """
@@ -60,9 +72,9 @@ def create_scheduled_run(
                 name, fire_at_utc, fire_at_tz, status,
                 db_profile, database, catalog,
                 scope_json, llm_profile, review_strategy,
-                extra_args_json, kind, cron_expr,
-                created_at, updated_at
-            ) VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                extra_args_json, kind, cron_expr, trigger,
+                created_at, updated_at, last_checked_at
+            ) VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 name,
@@ -77,8 +89,10 @@ def create_scheduled_run(
                 extra_args_json,
                 str(kind or "analyze"),
                 cron_expr,
+                trigger,
                 now,
                 now,
+                last_checked_at,
             ),
         )
         return int(cur.lastrowid or 0)
@@ -142,6 +156,72 @@ def list_due_pending_schedules(
             (now_utc, int(limit)),
         ).fetchall()
     return [dict(r) for r in rows]
+
+
+def list_change_schedules(
+    hs: SQLiteHistoryStore,
+    *,
+    db_profile: str | None = None,
+) -> list[dict[str, Any]]:
+    """Active change-triggered schedules (``trigger='change'``).
+
+    Only rows the dispatcher may fire are returned — ``status='pending'``
+    (watching). A row currently ``running`` is intentionally excluded so a
+    second sync mid-run can't double-fire it. Optionally scoped to one
+    ``db_profile``.
+    """
+    clauses = ["trigger = 'change'", "status = 'pending'"]
+    params: list[Any] = []
+    if db_profile is not None:
+        clauses.append("db_profile = ?")
+        params.append(db_profile)
+    sql = "SELECT * FROM scheduled_runs WHERE " + " AND ".join(clauses) + " ORDER BY id ASC"
+    with hs._connect() as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(sql, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+def rearm_change_schedule(hs: SQLiteHistoryStore, schedule_id: int) -> bool:
+    """Return a change schedule to ``pending`` (watching) after a fire.
+
+    A change-triggered schedule never reaches a terminal state on its own
+    — it keeps watching until the user deletes it. Like
+    :func:`arm_next_fire`, this writes ``status='pending'`` directly
+    (bypassing the time-based state machine, which has no running→pending
+    edge). Returns False for non-change schedules so the caller falls back
+    to the normal terminal transition.
+    """
+    with hs._lock, hs._connect() as conn:
+        row = conn.execute(
+            "SELECT trigger FROM scheduled_runs WHERE id = ?",
+            (schedule_id,),
+        ).fetchone()
+        if row is None or str(row[0]) != "change":
+            return False
+        conn.execute(
+            "UPDATE scheduled_runs SET status = 'pending', updated_at = ? WHERE id = ?",
+            (time.time(), schedule_id),
+        )
+        return True
+
+
+def advance_change_watermark(hs: SQLiteHistoryStore, schedule_id: int, ts: float) -> None:
+    """Move a change schedule's ``last_checked_at`` watermark forward.
+
+    Called after the dispatcher has evaluated (and possibly fired on) the
+    assets newer than the previous watermark, so the same assets are never
+    re-evaluated on a later sync. Never moves the watermark backwards.
+    """
+    with hs._lock, hs._connect() as conn:
+        conn.execute(
+            """
+            UPDATE scheduled_runs
+            SET last_checked_at = ?, updated_at = ?
+            WHERE id = ? AND (last_checked_at IS NULL OR last_checked_at < ?)
+            """,
+            (ts, time.time(), schedule_id, ts),
+        )
 
 
 def update_scheduled_run(
@@ -269,13 +349,17 @@ def claim_due_schedule(hs: SQLiteHistoryStore, *, now_utc: float) -> int | None:
     under concurrent calls from multiple threads -- the
     ``WHERE status='pending'`` predicate on the UPDATE turns a lost
     race into a return of None for the loser.
+
+    Change-triggered schedules (``trigger='change'``) are excluded: they
+    have no meaningful ``fire_at_utc`` and are fired only by the post-sync
+    dispatcher, never by the time loop.
     """
     now = time.time()
     with hs._lock, hs._connect() as conn:
         row = conn.execute(
             """
             SELECT id FROM scheduled_runs
-            WHERE status = 'pending' AND fire_at_utc <= ?
+            WHERE status = 'pending' AND trigger = 'time' AND fire_at_utc <= ?
             ORDER BY fire_at_utc ASC
             LIMIT 1
             """,

--- a/amx/storage/schema_descriptions.py
+++ b/amx/storage/schema_descriptions.py
@@ -1574,6 +1574,20 @@ SCHEMA_DESCRIPTIONS: dict[str, dict[str, str]] = {
             "Error message when status='failed'. NULL on success and on "
             "schedules that have not fired yet."
         ),
+        "trigger": (
+            "Firing mechanism: 'time' (default — the tick engine fires it "
+            "when fire_at_utc elapses) or 'change' (the post-sync dispatcher "
+            "fires it when a new asset appears under the watched scope). "
+            "Change schedules are excluded from the time-based claim and "
+            "carry a placeholder fire_at_utc that is never used."
+        ),
+        "last_checked_at": (
+            "Change-trigger watermark: UTC epoch up to which this schedule "
+            "has already evaluated new assets. The dispatcher fires only for "
+            "catalog_entities whose first_synced_at exceeds it, then advances "
+            "it, so a re-sync of the same assets never re-fires. NULL on "
+            "time-based schedules."
+        ),
     },
     # ── apply_events (local only) ─────────────────────────────────────────
     "apply_events": {

--- a/amx/storage/sqlite_store.py
+++ b/amx/storage/sqlite_store.py
@@ -1161,7 +1161,9 @@ class SQLiteHistoryStore:
                     updated_at REAL NOT NULL,
                     fired_at REAL,
                     triggered_run_id INTEGER,
-                    last_error TEXT
+                    last_error TEXT,
+                    trigger TEXT NOT NULL DEFAULT 'time',
+                    last_checked_at REAL
                 )
                 """
             )
@@ -2037,6 +2039,18 @@ class SQLiteHistoryStore:
             # to ``status='pending'`` with a fresh ``fire_at_utc`` every
             # time it fires.
             ("cron_expr", "TEXT"),
+            # ``trigger`` discriminates time-based schedules ('time',
+            # legacy default — fired by the tick when fire_at_utc elapses)
+            # from change-triggered ones ('change' — fired by the
+            # post-sync dispatcher when a new asset appears under the
+            # watched scope, never by the time loop).
+            ("trigger", "TEXT NOT NULL DEFAULT 'time'"),
+            # ``last_checked_at`` is the change-trigger watermark: the UTC
+            # epoch up to which this schedule has already evaluated new
+            # assets. The dispatcher fires only for catalog_entities whose
+            # first_synced_at exceeds it, then advances it — so a re-sync
+            # of the same assets never re-fires. NULL on time schedules.
+            ("last_checked_at", "REAL"),
         ):
             if col_name in existing_cols:
                 continue
@@ -2246,6 +2260,21 @@ class SQLiteHistoryStore:
         from amx.storage._history_scheduled import arm_next_fire
 
         return arm_next_fire(self, *args, **kwargs)
+
+    def list_change_schedules(self, *args, **kwargs):
+        from amx.storage._history_scheduled import list_change_schedules
+
+        return list_change_schedules(self, *args, **kwargs)
+
+    def advance_change_watermark(self, *args, **kwargs):
+        from amx.storage._history_scheduled import advance_change_watermark
+
+        return advance_change_watermark(self, *args, **kwargs)
+
+    def rearm_change_schedule(self, *args, **kwargs):
+        from amx.storage._history_scheduled import rearm_change_schedule
+
+        return rearm_change_schedule(self, *args, **kwargs)
 
     def profile_has_active_cache_refresh_schedule(self, *args, **kwargs):
         from amx.storage._history_scheduled import profile_has_active_cache_refresh_schedule

--- a/tests/test_change_trigger.py
+++ b/tests/test_change_trigger.py
@@ -1,0 +1,224 @@
+"""Change-triggered schedule dispatch + storage contracts.
+
+These pin the behaviour the user asked for: a schedule with no fire time
+that auto-runs when a new asset appears under its watched scope, fires
+narrowly for just the new tables, advances a watermark so the same assets
+never re-fire, and stays out of the time-based claim loop.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from amx.scheduler.change_trigger import _evaluate_one
+from amx.search.catalog import SearchCatalog
+from amx.storage import sqlite_store as ss
+from amx.storage.sqlite_store import SQLiteHistoryStore
+
+
+@pytest.fixture()
+def store_and_catalog(tmp_path: Path) -> tuple[SQLiteHistoryStore, SearchCatalog]:
+    db_path = tmp_path / "history.db"
+    store = SQLiteHistoryStore(db_path)
+    store.init()
+    ss._store = store  # noqa: SLF001
+    cat = SearchCatalog(db_path)
+    yield store, cat
+    ss._store = None  # noqa: SLF001
+
+
+def _insert_entity(
+    cat: SearchCatalog,
+    *,
+    profile: str,
+    schema: str,
+    table: str,
+    column: str | None,
+    kind: str,
+    first_synced_at: float,
+) -> None:
+    """Insert a catalog_entities row with an explicit first_synced_at so
+    tests control what counts as "new since the watermark"."""
+    with cat._connect() as conn:  # noqa: SLF001
+        conn.execute(
+            """
+            INSERT INTO catalog_entities (
+                db_profile, db_backend, database_name, schema_name, table_name,
+                column_name, entity_kind, asset_kind, updated_at, last_synced_at,
+                first_synced_at
+            ) VALUES (?, '', '', ?, ?, ?, ?, 'table', ?, ?, ?)
+            """,
+            (profile, schema, table, column, kind, first_synced_at, first_synced_at, first_synced_at),
+        )
+
+
+def _make_change_schedule(store: SQLiteHistoryStore, *, profile: str, watermark: float) -> int:
+    sid = store.create_scheduled_run(
+        name="watch public",
+        fire_at_utc=time.time(),  # placeholder; never used for change
+        fire_at_tz="UTC",
+        db_profile=profile,
+        scope_json=json.dumps({"mode": "schemas", "schemas": ["public"], "deep_first": True}),
+        llm_profile="default",
+        review_strategy="manual",
+        kind="analyze",
+        trigger="change",
+    )
+    # Pin the watermark deterministically. create_scheduled_run seeds it to
+    # "now"; we set it directly here (advance_change_watermark is
+    # forward-only and would refuse to move it back for the test).
+    with store._connect() as conn:  # noqa: SLF001
+        conn.execute(
+            "UPDATE scheduled_runs SET last_checked_at = ? WHERE id = ?",
+            (watermark, sid),
+        )
+    return sid
+
+
+# ── time-claim exclusion ───────────────────────────────────────────────
+
+
+def test_claim_due_schedule_skips_change_schedules(
+    store_and_catalog: tuple[SQLiteHistoryStore, SearchCatalog],
+) -> None:
+    store, _ = store_and_catalog
+    # A change schedule whose placeholder fire_at is in the past must NOT
+    # be claimed by the time loop.
+    store.create_scheduled_run(
+        name="watcher",
+        fire_at_utc=time.time() - 3600,
+        fire_at_tz="UTC",
+        db_profile="prof-a",
+        scope_json=json.dumps({"mode": "all"}),
+        llm_profile="default",
+        review_strategy="manual",
+        trigger="change",
+    )
+    assert store.claim_due_schedule(now_utc=time.time()) is None
+
+    # A normal time schedule with an elapsed fire_at IS claimed.
+    tid = store.create_scheduled_run(
+        name="timed",
+        fire_at_utc=time.time() - 60,
+        fire_at_tz="UTC",
+        db_profile="prof-a",
+        scope_json=json.dumps({"mode": "all"}),
+        llm_profile="default",
+        review_strategy="auto",
+        trigger="time",
+    )
+    assert store.claim_due_schedule(now_utc=time.time()) == tid
+
+
+# ── rearm ──────────────────────────────────────────────────────────────
+
+
+def test_rearm_change_schedule_returns_to_pending(
+    store_and_catalog: tuple[SQLiteHistoryStore, SearchCatalog],
+) -> None:
+    store, _ = store_and_catalog
+    sid = _make_change_schedule(store, profile="prof-a", watermark=time.time())
+    store.set_scheduled_run_status(sid, "running")
+    assert store.rearm_change_schedule(sid) is True
+    assert store.get_scheduled_run(sid)["status"] == "pending"
+
+
+def test_rearm_change_schedule_false_for_time_schedule(
+    store_and_catalog: tuple[SQLiteHistoryStore, SearchCatalog],
+) -> None:
+    store, _ = store_and_catalog
+    tid = store.create_scheduled_run(
+        name="timed",
+        fire_at_utc=time.time(),
+        fire_at_tz="UTC",
+        db_profile="prof-a",
+        scope_json=json.dumps({"mode": "all"}),
+        llm_profile="default",
+        review_strategy="auto",
+        trigger="time",
+    )
+    assert store.rearm_change_schedule(tid) is False
+
+
+# ── new_entities_since ──────────────────────────────────────────────────
+
+
+def test_new_entities_since_respects_watermark_and_scope(
+    store_and_catalog: tuple[SQLiteHistoryStore, SearchCatalog],
+) -> None:
+    store, cat = store_and_catalog
+    t0 = time.time()
+    _insert_entity(cat, profile="p", schema="public", table="old", column=None, kind="table", first_synced_at=t0 - 100)
+    _insert_entity(cat, profile="p", schema="public", table="new", column=None, kind="table", first_synced_at=t0 + 100)
+    _insert_entity(cat, profile="p", schema="other", table="elsewhere", column=None, kind="table", first_synced_at=t0 + 100)
+
+    rows = cat.new_entities_since("p", t0, schemas=["public"])
+    names = {r["table_name"] for r in rows}
+    assert names == {"new"}  # old is before watermark; elsewhere is out of scope
+
+
+# ── dispatcher: fire, narrow, advance, no-refire ────────────────────────
+
+
+def test_evaluate_one_fires_narrowed_run_and_advances_watermark(
+    store_and_catalog: tuple[SQLiteHistoryStore, SearchCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, cat = store_and_catalog
+    t0 = time.time()
+    # Watermark in the recent past; assets are stamped at insert time so
+    # their first_synced_at is always <= now (never in the future).
+    sid = _make_change_schedule(store, profile="p", watermark=t0 - 10)
+    # One pre-existing table (before watermark) + one that appeared after.
+    _insert_entity(cat, profile="p", schema="public", table="users", column=None, kind="table", first_synced_at=t0 - 50)
+    _insert_entity(cat, profile="p", schema="public", table="orders", column=None, kind="table", first_synced_at=t0 - 1)
+
+    captured: dict[str, Any] = {}
+
+    import amx.runtime.worker as worker
+
+    def _fake_spawn(payload: dict[str, Any], **_kw: Any) -> int:
+        captured["payload"] = payload
+        return 999
+
+    monkeypatch.setattr(worker, "spawn_scheduled_worker", _fake_spawn)
+
+    sched = store.get_scheduled_run(sid)
+    fired = _evaluate_one(store, cat, sched, databases=None)
+
+    assert fired == 1
+    scope = json.loads(captured["payload"]["scope_json"])
+    assert scope["mode"] == "tables"
+    assert scope["missing_only"] is True
+    assert [t["table"] for t in scope["tables"]] == ["orders"]  # only the new table
+
+    # Watermark advanced — a second evaluation with no further changes
+    # must not fire again.
+    captured.clear()
+    sched2 = store.get_scheduled_run(sid)
+    fired2 = _evaluate_one(store, cat, sched2, databases=None)
+    assert fired2 == 0
+    assert "payload" not in captured
+
+
+def test_evaluate_one_no_new_assets_does_not_fire(
+    store_and_catalog: tuple[SQLiteHistoryStore, SearchCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, cat = store_and_catalog
+    t0 = time.time()
+    sid = _make_change_schedule(store, profile="p", watermark=t0)
+    _insert_entity(cat, profile="p", schema="public", table="users", column=None, kind="table", first_synced_at=t0 - 50)
+
+    import amx.runtime.worker as worker
+
+    def _boom(*_a: Any, **_k: Any) -> int:
+        raise AssertionError("must not fire when nothing is new")
+
+    monkeypatch.setattr(worker, "spawn_scheduled_worker", _boom)
+    assert _evaluate_one(store, cat, store.get_scheduled_run(sid), databases=None) == 0


### PR DESCRIPTION
## Summary

PR-B of 3. A schedule with **no fire time** that runs when a new asset appears under its watched scope. Detection rides on the syncs AMX already performs — no new polling loop.

**Storage (`scheduled_runs`):** `trigger` ('time'|'change') + `last_checked_at` watermark (descriptions + ALTER migration). `claim_due_schedule` excludes `trigger='change'`. `create_scheduled_run` seeds a watcher's watermark to creation time. New helpers: `list_change_schedules` (pending-only, so a sync mid-run can't double-fire), `advance_change_watermark` (forward-only), `rearm_change_schedule` (running→pending after each fire).

**Detection + dispatch:** `SearchCatalog.new_entities_since(...)` returns assets newer than the watermark within scope. New `amx/scheduler/change_trigger.py:dispatch_after_sync` fires a `missing_only` analyze run narrowed to exactly the tables that gained something (reusing `spawn_scheduled_worker` + `production_run_executor`), then advances the watermark. Hooked at the end of `sync_profile_skeleton` (new tables) + `deep_sync_profile` (new columns). A fired run's own deep-sync passes `dispatch_changes=False`, so it can't recursively re-trigger; combined with the running-guard, a watcher never reacts to assets it created.

Backend only — no UI to create change schedules yet (PR-C); the dispatcher is inert until one exists.

## Test plan

- [x] `tests/test_change_trigger.py`: claim excludes change schedules; `new_entities_since` honours watermark + scope; dispatcher fires a narrowed run, advances watermark, no re-fire; change run re-arms to pending.
- [x] Schema-comment gates green; `ruff`/`mypy` clean; scheduler/sync/schedules regression (153) green.