### PR TITLE
fix(scheduler): scheduled-run apply writeback + column-scope no longer regenerates parents

### DIFF
--- a/amx/agents/base.py
+++ b/amx/agents/base.py
@@ -226,6 +226,14 @@ class AgentContext:
     # from user (re-run):" block so the original DB/docs/code context
     # is preserved and only this guidance is layered on top.
     user_instructions: str = ""
+    # True when the run is column-scoped (the caller asked for specific
+    # column(s), not the whole table). The ProfileAgent then omits the
+    # table-level description from its prompt, and the orchestrator skips
+    # injecting / persisting / applying a table-level suggestion —
+    # generating a table comment when only a column was requested wastes
+    # tokens and clobbers the existing table description. Set by the
+    # orchestrator in ``_build_context`` from ``column_overrides``.
+    skip_table_description: bool = False
 
 
 def _user_instructions_block(ctx: AgentContext) -> str:

--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -405,6 +405,14 @@ class Orchestrator:
         with a low-confidence fallback instead of silently dropping them.
         """
         out = list(merged)
+        # Column-scoped run: the caller asked for specific column(s), so the
+        # table-level description is out of scope. Drop any table-level
+        # suggestion the model emitted anyway and skip the fallback
+        # injection below — generating/writing a table comment here wastes
+        # tokens and clobbers the existing one.
+        column_scoped = (profile.schema, profile.name) in self.column_overrides
+        if column_scoped:
+            out = [s for s in out if s.column is not None]
         suggested_cols = {s.column for s in out if s.column is not None}
         has_table_level = any(s.column is None for s in out)
 
@@ -424,7 +432,7 @@ class Orchestrator:
         llm_cfg = getattr(getattr(self, "llm", None), "cfg", None)
         n_alts = max(1, int(getattr(llm_cfg, "n_alternatives", 1) or 1))
 
-        if not has_table_level:
+        if not has_table_level and not column_scoped:
             table_fallback_desc = (
                 f"Table {profile.name} contains business data for schema "
                 f"{profile.schema}. Auto-inference missed a reliable table "
@@ -653,6 +661,9 @@ class Orchestrator:
             asset_context=list(
                 self.asset_context_by_table.get((profile.schema.lower(), profile.name.lower()), [])
             ),
+            # Column-scoped runs (the user picked specific columns) must not
+            # spend tokens on — or overwrite — the table-level description.
+            skip_table_description=(profile.schema, profile.name) in self.column_overrides,
         )
 
     def _build_query_usage_hints(self, profile: TableProfile) -> dict[str, object]:
@@ -1055,6 +1066,23 @@ class Orchestrator:
                 with step_spinner(f"Profiling {schema}.{table}"):
                     profiles[table] = self.db.profile_table(schema, table, asset_kind=ak)
 
+        # Column scope: when the run targets specific columns, restrict each
+        # profile to those columns (chat mode does this in
+        # _filter_column_override; batch mode must too or it would describe
+        # — and bill for — every column plus the table). The table-level
+        # description is suppressed downstream via skip_table_description.
+        for table, prof in list(profiles.items()):
+            override_set = self.column_overrides.get((schema, table))
+            if override_set is None:
+                continue
+            prof.columns = [c for c in prof.columns if c.name in override_set]
+            if not prof.columns:
+                info(f"[Batch] Column scope: no matching columns on {schema}.{table}; skipping.")
+                del profiles[table]
+        tables = [t for t in tables if t in profiles]
+        if not profiles:
+            return []
+
         # Apply the missing-only filter in batch mode too. Tables fully
         # commented are dropped from the request set; tables with partial
         # coverage have their column list narrowed to the gaps before
@@ -1194,6 +1222,13 @@ class Orchestrator:
             if not merged:
                 warn(f"Merge produced no output for {schema}.{table}.")
                 continue
+            # Column-scoped: drop any table-level suggestion the model
+            # emitted despite the suppressed prompt, so it isn't persisted
+            # or applied over the existing table comment.
+            if (schema, table) in self.column_overrides:
+                merged = [s for s in merged if s.column is not None]
+                if not merged:
+                    continue
 
             result_id_map = self._save_merged_suggestions(merged, asset_kind=ak)
             reviewed = self._human_review(

--- a/amx/agents/profile_agent.py
+++ b/amx/agents/profile_agent.py
@@ -52,7 +52,7 @@ Output rules:
 - Write every description and reasoning string in **clear, business-friendly American English**.
 - Use complete sentences ending with a period.
 - Length rule (CRITICAL — honour the user's verbosity preset): {description_length_rule}
-- Keep the response labels (`COLUMN`, `DESCRIPTION_1`, `CONFIDENCE`, `REASONING`, `TABLE_DESCRIPTION_1`, etc.) verbatim.
+- Keep the response labels (`COLUMN`, `DESCRIPTION_1`, `CONFIDENCE`, `REASONING`, {table_label}etc.) verbatim.
 
 Write descriptions assertively and directly (e.g. "Telephone extension number." or "Indicates the fax number.").
 Do NOT start descriptions with "This column likely represents" or "This column likely is".
@@ -83,12 +83,7 @@ DESCRIPTION_1: <most likely description>
 {self_decl_line_1}{desc_lines}
 CONFIDENCE: <HIGH|MEDIUM|LOW>
 REASONING: <why you think so>
-
-Also include ONE table-level description block (even when processing column batches):
-TABLE_DESCRIPTION_1: <most likely table description>
-{table_desc_lines}
-TABLE_CONFIDENCE: <HIGH|MEDIUM|LOW>
-
+{table_description_block}
 Example style:
 COLUMN: account_ref
 DESCRIPTION_1: Account reference identifier.
@@ -103,6 +98,7 @@ def _build_system_prompt(
     style_profile: StyleProfile | None = None,
     emit_self_decl: bool = False,
     alternatives_mode: str = DEFAULT_ALTERNATIVES_MODE,
+    include_table_description: bool = True,
 ) -> str:
     """Build the system prompt dynamically for the requested number of alternatives.
 
@@ -149,6 +145,22 @@ def _build_system_prompt(
         )
         alternatives_length_reminder = ALTERNATIVES_LENGTH_RULE_REMINDER
     description_length_rule = length_rule(description_verbosity)
+    # Omit the table-level block entirely when the run is column-scoped —
+    # the caller only asked for specific column(s), so spending tokens on a
+    # table description (which would then overwrite the table comment) is
+    # waste. The block is the only place TABLE_DESCRIPTION is requested.
+    if include_table_description:
+        table_description_block = (
+            "\nAlso include ONE table-level description block (even when processing "
+            "column batches):\n"
+            "TABLE_DESCRIPTION_1: <most likely table description>\n"
+            f"{table_desc_lines}\n"
+            "TABLE_CONFIDENCE: <HIGH|MEDIUM|LOW>\n"
+        )
+        table_label = "`TABLE_DESCRIPTION_1`, "
+    else:
+        table_description_block = ""
+        table_label = ""
     return (
         _BASE_SYSTEM_PROMPT.format(
             description_length_rule=description_length_rule,
@@ -158,7 +170,8 @@ def _build_system_prompt(
             extra_items=extra_items,
             desc_lines=desc_lines,
             self_decl_line_1=self_decl_line_1,
-            table_desc_lines=table_desc_lines,
+            table_description_block=table_description_block,
+            table_label=table_label,
         ).strip()
         + "\n"
         + render_style_section(style_profile)
@@ -361,6 +374,7 @@ class ProfileAgent(BaseAgent):
             rag_context=ctx.rag_context,
             code_context=ctx.code_context,
             existing_metadata=ctx.existing_metadata,
+            skip_table_description=ctx.skip_table_description,
         )
 
     def collect_messages(self, ctx: AgentContext) -> list:
@@ -428,6 +442,7 @@ class ProfileAgent(BaseAgent):
             style_profile=self._style_profile,
             emit_self_decl=emit_self_decl,
             alternatives_mode=getattr(self.llm.cfg, "alternatives_mode", DEFAULT_ALTERNATIVES_MODE),
+            include_table_description=not ctx.skip_table_description,
         )
         return [
             {"role": "system", "content": system},

--- a/amx/runtime/worker.py
+++ b/amx/runtime/worker.py
@@ -294,7 +294,20 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
                     except Exception:  # noqa: BLE001
                         pass
                 try:
-                    orchestrator.process_table(schema, table, interactive_review=False)
+                    # auto_apply threads the review strategy into the
+                    # per-table dispatch: 'auto' takes the _auto_apply_branch
+                    # which accepts the top suggestion and writes it to BOTH
+                    # the live DB (COMMENT ON) and the catalog cache
+                    # (sync_review_decision) immediately. Without this the
+                    # table took the deferred branch (applied=False) and the
+                    # end-of-run apply step — which only writes already-applied
+                    # rows — silently applied nothing.
+                    orchestrator.process_table(
+                        schema,
+                        table,
+                        interactive_review=False,
+                        auto_apply=(review_strategy == "auto"),
+                    )
                 except Exception as exc:  # noqa: BLE001 - keep going on per-table errors
                     log.exception(
                         "production_run_executor: %s.%s failed under schedule #%s",
@@ -316,24 +329,13 @@ def production_run_executor(run_id: int, payload: dict[str, Any]) -> None:
             summary += f"; (+{len(per_table_errors) - 5} more)"
         raise RuntimeError(f"All {processed} table(s) in scope failed. {summary}")
 
-    # Apply policy. 'auto' writes the generated descriptions to the DB
-    # (COMMENT ON) right after generation — the unattended path that
-    # makes a scheduled run a true auto-generation. 'manual' leaves the
-    # results in pending review for a human to approve later.
-    if review_strategy == "auto":
-        try:
-            applied = orchestrator.apply_results()
-            log.info(
-                "production_run_executor: schedule #%s auto-applied %s description(s).",
-                schedule_id,
-                applied,
-            )
-        except Exception:
-            log.exception(
-                "production_run_executor: auto-apply failed for schedule #%s; "
-                "results remain in pending review.",
-                schedule_id,
-            )
+    # Apply policy. With 'auto' each table already wrote its accepted
+    # description to the live DB (COMMENT ON) and the catalog cache inside
+    # process_table's _auto_apply_branch — per-table so a mid-run crash
+    # still leaves finished tables applied. 'manual' leaves the results in
+    # pending review for a human to approve later. No end-of-run apply step
+    # is needed (the previous one filtered on the applied flag and, with
+    # the deferred branch, applied nothing).
 
 
 def _scope_column_overrides(

--- a/tests/runtime/test_auto_generation_executor.py
+++ b/tests/runtime/test_auto_generation_executor.py
@@ -27,11 +27,18 @@ class _FakeOrchestrator:
     def __init__(self, *a: Any, **k: Any) -> None:
         self.missing_only = k.get("missing_only")
         self.process_calls: list[tuple[str, str]] = []
+        # Record the auto_apply kwarg per call — the auto path must thread
+        # review_strategy='auto' into process_table so the per-table
+        # _auto_apply_branch writes to the DB + catalog cache. (The old
+        # design called apply_results() at the end, but with deferred
+        # results that filter never applied anything.)
+        self.auto_apply_calls: list[bool] = []
         self.applied = 0
         _FakeOrchestrator.last = self
 
-    def process_table(self, schema: str, table: str, **_k: Any) -> None:
+    def process_table(self, schema: str, table: str, **k: Any) -> None:
         self.process_calls.append((schema, table))
+        self.auto_apply_calls.append(bool(k.get("auto_apply")))
 
     def apply_results(self, results: Any = None) -> int:
         self.applied += 1
@@ -84,7 +91,9 @@ def test_auto_strategy_applies_results(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_common(monkeypatch)
     production_run_executor(1, _payload(missing_only=True, review_strategy="auto"))
 
-    assert _FakeOrchestrator.last.applied == 1  # apply_results called once
+    # 'auto' must thread auto_apply=True into every process_table call so
+    # the accepted description lands in the live DB AND the catalog cache.
+    assert _FakeOrchestrator.last.auto_apply_calls == [True]
 
 
 def test_manual_strategy_does_not_apply(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -93,7 +102,8 @@ def test_manual_strategy_does_not_apply(monkeypatch: pytest.MonkeyPatch) -> None
     _patch_common(monkeypatch)
     production_run_executor(1, _payload(review_strategy="manual"))
 
-    assert _FakeOrchestrator.last.applied == 0  # left in pending review
+    # 'manual' leaves results in pending review — no auto-apply.
+    assert _FakeOrchestrator.last.auto_apply_calls == [False]
 
 
 def test_deep_first_runs_deep_sync_before_generation(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_profile_agent_verbosity.py
+++ b/tests/test_profile_agent_verbosity.py
@@ -118,3 +118,22 @@ def test_profile_agent_prompt_n_alternatives_one_omits_reminder() -> None:
     prompt as small as before the fix."""
     prompt = _build_system_prompt(1, description_verbosity="brief")
     assert ALTERNATIVES_LENGTH_RULE_REMINDER not in prompt
+
+
+def test_table_description_block_present_by_default() -> None:
+    """Whole-table runs still ask the model for a table-level description."""
+    prompt = _build_system_prompt(3)
+    assert "TABLE_DESCRIPTION_1" in prompt
+    assert "table-level description block" in prompt
+
+
+def test_table_description_block_omitted_when_column_scoped() -> None:
+    """Column-scoped runs (include_table_description=False) must NOT ask
+    for a table description — generating one wastes tokens and clobbers
+    the existing table comment."""
+    prompt = _build_system_prompt(3, include_table_description=False)
+    assert "TABLE_DESCRIPTION_1" not in prompt
+    assert "table-level description block" not in prompt
+    # Column instructions are still present.
+    assert "COLUMN:" in prompt
+    assert "DESCRIPTION_1" in prompt

--- a/tests/test_table_level_fallback.py
+++ b/tests/test_table_level_fallback.py
@@ -46,6 +46,10 @@ class _StubOrchestrator:
 
     def __init__(self, n_alternatives: int = 3) -> None:
         self.llm = _StubLLM(cfg=_StubLLMCfg(n_alternatives=n_alternatives))
+        # Mirrors the real Orchestrator (initialised empty in __init__).
+        # A non-empty map marks a (schema, table) as column-scoped, which
+        # suppresses table-level coverage.
+        self.column_overrides: dict[tuple[str, str], set[str]] = {}
 
 
 def _profile(*, columns: list[str]) -> TableProfile:
@@ -146,6 +150,42 @@ class TestFallbackHonorsNAlternatives:
         table_row = next(s for s in out if s.column is None)
         assert "3" in (table_row.reasoning or "")
         assert "fallback" in (table_row.reasoning or "").lower()
+
+    def test_column_scoped_run_drops_and_skips_table_level(self) -> None:
+        """Column-scoped run: a table-level suggestion the model emitted
+        must be dropped, and no table-level fallback injected — generating
+        a table comment when only a column was requested wastes tokens and
+        clobbers the existing table description."""
+        orch = _StubOrchestrator(n_alternatives=3)
+        orch.column_overrides = {("public", "orders"): {"country"}}
+        profile = _profile(columns=["country"])
+        existing = [
+            MetadataSuggestion(
+                schema="public",
+                table="orders",
+                column=None,  # stray table-level the model emitted anyway
+                suggestions=["t1", "t2", "t3"],
+                confidence=Confidence.HIGH,
+                reasoning="seeded",
+                source="llm",
+            ),
+            MetadataSuggestion(
+                schema="public",
+                table="orders",
+                column="country",
+                suggestions=["c1", "c2", "c3"],
+                confidence=Confidence.HIGH,
+                reasoning="seeded",
+                source="llm",
+            ),
+        ]
+        out = _ensure(orch, profile, existing)
+        assert all(s.column is not None for s in out), (
+            "Column-scoped run must contain no table-level (column=None) rows."
+        )
+        assert not any(s.source == "fallback" for s in out), (
+            "Column-scoped run must not inject a table-level fallback."
+        )
 
     def test_no_fallback_when_model_succeeded(self) -> None:
         """The fallback path must NOT fire when the model returned a


### PR DESCRIPTION
Two correctness fixes for the Orchestrator-driven Run / Schedule pipeline.

## 1. `auto` review strategy now writes to the DB and cache
A scheduled (or change-triggered) run with `review_strategy='auto'` completed and surfaced results in run_results, but wrote nothing to the live DB or catalog cache. `production_run_executor` called `process_table` without `auto_apply`, so it took the deferred branch (`applied=False`); the end-of-run `apply_results()` only writes rows where `r.applied` is True, so it applied **zero**. Fix: thread `auto_apply=(review_strategy=='auto')` into `process_table` so the auto path takes `_auto_apply_branch` (per-table write to DB via `COMMENT ON` + cache via `sync_review_decision`); dropped the redundant end-of-run apply. `manual` is unchanged.

## 2. Column-scoped runs no longer regenerate the table description
A run scoped to specific column(s) still generated — and wrote — a table-level description (wasted tokens + overwritten table comment). The ProfileAgent prompt always asked for a `TABLE_DESCRIPTION` block, and `_ensure_complete_table_coverage` force-injected a table-level row (batch mode ignored column scope entirely). Fix: `AgentContext.skip_table_description` (set from `column_overrides`) makes the prompt omit the table block + label hint, the coverage helper drops/skips table-level, and batch mode now restricts to the picked columns. Whole-table / whole-schema runs unchanged.

## Test plan
- [x] Executor tests assert `auto`→`process_table(auto_apply=True)`, `manual`→False.
- [x] Prompt omits/keeps the table block per flag; coverage helper drops + skips table-level under column scope.
- [x] Runtime/scheduler + agent/orchestrator regression green. deploy.sh → Studio live.