### PR TITLE
fix(scheduler): per-table Deep sync fires watchers; missing-only leaves commented tables alone

### DIFF
--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -405,13 +405,13 @@ class Orchestrator:
         with a low-confidence fallback instead of silently dropping them.
         """
         out = list(merged)
-        # Column-scoped run: the caller asked for specific column(s), so the
-        # table-level description is out of scope. Drop any table-level
-        # suggestion the model emitted anyway and skip the fallback
-        # injection below — generating/writing a table comment here wastes
+        # Drop any table-level suggestion (and skip the fallback injection
+        # below) when this run must not touch the table description —
+        # column-scoped, or missing-only over a table that already has a
+        # comment. Otherwise generating/writing a table comment here wastes
         # tokens and clobbers the existing one.
-        column_scoped = (profile.schema, profile.name) in self.column_overrides
-        if column_scoped:
+        skip_table = self._should_skip_table_level(profile)
+        if skip_table:
             out = [s for s in out if s.column is not None]
         suggested_cols = {s.column for s in out if s.column is not None}
         has_table_level = any(s.column is None for s in out)
@@ -432,7 +432,7 @@ class Orchestrator:
         llm_cfg = getattr(getattr(self, "llm", None), "cfg", None)
         n_alts = max(1, int(getattr(llm_cfg, "n_alternatives", 1) or 1))
 
-        if not has_table_level and not column_scoped:
+        if not has_table_level and not skip_table:
             table_fallback_desc = (
                 f"Table {profile.name} contains business data for schema "
                 f"{profile.schema}. Auto-inference missed a reliable table "
@@ -611,6 +611,27 @@ class Orchestrator:
 
         return out, statuses
 
+    def _should_skip_table_level(self, profile: TableProfile) -> bool:
+        """Whether to suppress table-level description generation for this
+        table — so the agent doesn't spend tokens on, or overwrite, a
+        table comment the run didn't ask for.
+
+        True when EITHER:
+        * the run is column-scoped (``column_overrides`` names this table)
+          — only the picked columns are in scope; or
+        * ``missing_only`` is set and the table already has a real
+          (non-placeholder) comment — the table description is not
+          "missing", so a missing-only run must leave it alone and only
+          fill the column gaps.
+        """
+        if (profile.schema, profile.name) in self.column_overrides:
+            return True
+        if self.missing_only:
+            existing = (profile.existing_comment or "").strip()
+            if existing and not is_placeholder_description(existing):
+                return True
+        return False
+
     def _build_context(self, profile: TableProfile) -> AgentContext:
         db_name = self.db.cfg.database or self.db.cfg.project or self.db.cfg.catalog or "N/A"
         query_usage = self._build_query_usage_hints(profile)
@@ -661,9 +682,11 @@ class Orchestrator:
             asset_context=list(
                 self.asset_context_by_table.get((profile.schema.lower(), profile.name.lower()), [])
             ),
-            # Column-scoped runs (the user picked specific columns) must not
-            # spend tokens on — or overwrite — the table-level description.
-            skip_table_description=(profile.schema, profile.name) in self.column_overrides,
+            # Suppress table-level generation when the run didn't ask for
+            # it — column-scoped, or a missing-only run over a table that
+            # already has a description. Saves tokens and protects the
+            # existing table comment from being overwritten.
+            skip_table_description=self._should_skip_table_level(profile),
         )
 
     def _build_query_usage_hints(self, profile: TableProfile) -> dict[str, object]:
@@ -1222,10 +1245,11 @@ class Orchestrator:
             if not merged:
                 warn(f"Merge produced no output for {schema}.{table}.")
                 continue
-            # Column-scoped: drop any table-level suggestion the model
-            # emitted despite the suppressed prompt, so it isn't persisted
-            # or applied over the existing table comment.
-            if (schema, table) in self.column_overrides:
+            # Drop any table-level suggestion the model emitted despite the
+            # suppressed prompt, so it isn't persisted or applied over the
+            # existing table comment (column-scoped, or missing-only over a
+            # table that already has a description).
+            if self._should_skip_table_level(profile):
                 merged = [s for s in merged if s.column is not None]
                 if not merged:
                     continue

--- a/amx/scheduler/change_trigger.py
+++ b/amx/scheduler/change_trigger.py
@@ -120,9 +120,11 @@ def _evaluate_one(
     watermark = sched.get("last_checked_at")
     watch_scope_json = sched.get("scope_json")
     schemas = _watched_schemas(watch_scope_json)
-    # The watcher's database overlay narrows detection to one database; a
-    # sync that touched other databases shouldn't fire it.
-    sched_db = sched.get("database") or None
+    # The watcher's container overlay narrows detection to one database
+    # (or catalog, on three-level backends like Databricks where the
+    # catalog is stored in catalog_entities.database_name). A sync that
+    # touched other containers shouldn't fire it.
+    sched_db = sched.get("database") or sched.get("catalog") or None
     if sched_db and databases is not None and sched_db not in databases:
         return 0
 

--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -962,6 +962,10 @@ def _deep_sync_one_table_impl(
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
     _push_catalog_if_shared(profile)
+    # A per-table deep sync discovers new columns just like a full deep
+    # sync — let change-triggered schedules react (the "Deep sync" button
+    # on the Table page lands here). Best-effort; never breaks the sync.
+    _dispatch_change_schedules(profile, cfg, databases=[database] if database else None)
     return {
         "ok": True,
         "schema": schema,

--- a/tests/test_change_trigger.py
+++ b/tests/test_change_trigger.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -222,3 +223,90 @@ def test_evaluate_one_no_new_assets_does_not_fire(
 
     monkeypatch.setattr(worker, "spawn_scheduled_worker", _boom)
     assert _evaluate_one(store, cat, store.get_scheduled_run(sid), databases=None) == 0
+
+
+# ── catalog overlay (Databricks) + per-table deep-sync dispatch ─────────
+
+
+def test_evaluate_one_matches_catalog_overlay(
+    store_and_catalog: tuple[SQLiteHistoryStore, SearchCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On three-level backends the watcher stores its container in
+    ``catalog`` (not ``database``); the dispatcher must match on it and
+    not skip the schedule when the synced container list carries it."""
+    store, cat = store_and_catalog
+    t0 = time.time()
+    sid = store.create_scheduled_run(
+        name="watch catalog",
+        fire_at_utc=t0,
+        fire_at_tz="UTC",
+        db_profile="dbr",
+        catalog="amx_test",
+        scope_json=json.dumps({"mode": "all", "deep_first": True}),
+        llm_profile="default",
+        review_strategy="manual",
+        trigger="change",
+    )
+    with store._connect() as conn:  # noqa: SLF001
+        conn.execute(
+            "UPDATE scheduled_runs SET last_checked_at = ? WHERE id = ?", (t0 - 10, sid)
+        )
+    _insert_entity(
+        cat, profile="dbr", schema="amx_test_schema", table="adr_6",
+        column="test2", kind="column", first_synced_at=t0 - 1,
+    )
+    # The new column's database_name must be the catalog for the filter to
+    # match — mirror how deep_sync writes Databricks rows.
+    with cat._connect() as conn:  # noqa: SLF001
+        conn.execute("UPDATE catalog_entities SET database_name = 'amx_test'")
+
+    import amx.runtime.worker as worker
+
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        worker, "spawn_scheduled_worker", lambda payload, **_k: captured.update(payload=payload) or 1
+    )
+    sched = store.get_scheduled_run(sid)
+    fired = _evaluate_one(store, cat, sched, databases=["amx_test"])
+    assert fired == 1
+    scope = json.loads(captured["payload"]["scope_json"])
+    assert [t["table"] for t in scope["tables"]] == ["adr_6"]
+
+
+def test_deep_sync_one_table_dispatches_change_schedules(
+    store_and_catalog: tuple[SQLiteHistoryStore, SearchCatalog],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-table 'Deep sync' button (deep_sync_one_table) must invoke
+    the change-trigger dispatcher — without it a Watching schedule never
+    reacts to a newly-added column discovered by a single-table deep
+    sync."""
+    import amx.search.drift as drift
+    from amx.db.connector import AssetKind, ColumnProfile, TableProfile
+
+    class _StubConn:
+        def profile_table(self, schema: str, table: str, sample_size: int = 0) -> TableProfile:
+            return TableProfile(
+                schema=schema,
+                name=table,
+                asset_kind=AssetKind.TABLE,
+                columns=[ColumnProfile(name="test2", dtype="STRING", nullable=True)],
+                row_count=5,
+            )
+
+    monkeypatch.setattr(drift, "_scoped_connector", lambda *a, **k: _StubConn())
+    recorded: dict[str, Any] = {}
+    monkeypatch.setattr(
+        drift,
+        "_dispatch_change_schedules",
+        lambda profile, cfg, *, databases=None: recorded.update(
+            profile=profile, databases=databases
+        ),
+    )
+    cfg = SimpleNamespace(db_profiles={"dbr": SimpleNamespace(backend="databricks")}, db=None)
+
+    out = drift.deep_sync_one_table(cfg, "dbr", schema="amx_test_schema", table="adr_6", database="amx_test")
+    assert out["ok"] is True
+    assert recorded.get("profile") == "dbr"
+    assert recorded.get("databases") == ["amx_test"]

--- a/tests/test_table_level_fallback.py
+++ b/tests/test_table_level_fallback.py
@@ -50,13 +50,23 @@ class _StubOrchestrator:
         # A non-empty map marks a (schema, table) as column-scoped, which
         # suppresses table-level coverage.
         self.column_overrides: dict[tuple[str, str], set[str]] = {}
+        self.missing_only = False
+
+    def _should_skip_table_level(self, profile: Any) -> bool:
+        """Delegate to the real method so the suppression logic is exercised
+        exactly as in production (column-scoped OR missing-only with an
+        existing comment)."""
+        from amx.agents.orchestrator import Orchestrator
+
+        return Orchestrator._should_skip_table_level(self, profile)
 
 
-def _profile(*, columns: list[str]) -> TableProfile:
+def _profile(*, columns: list[str], existing_comment: str = "") -> TableProfile:
     return TableProfile(
         schema="public",
         name="orders",
         asset_kind=AssetKind.TABLE,
+        existing_comment=existing_comment,
         columns=[ColumnProfile(name=c, dtype="TEXT", nullable=True) for c in columns],
     )
 
@@ -185,6 +195,64 @@ class TestFallbackHonorsNAlternatives:
         )
         assert not any(s.source == "fallback" for s in out), (
             "Column-scoped run must not inject a table-level fallback."
+        )
+
+    def test_missing_only_skips_table_level_when_table_already_commented(self) -> None:
+        """missing-only run over a table that already has a real comment:
+        the table-level description must NOT be regenerated — only the
+        missing columns. (The user's bug: a Watching schedule re-described
+        an already-documented table every time a new column appeared.)"""
+        orch = _StubOrchestrator(n_alternatives=3)
+        orch.missing_only = True
+        profile = _profile(
+            columns=["test2"],
+            existing_comment="Client address master data with email contacts.",
+        )
+        existing = [
+            MetadataSuggestion(
+                schema="public",
+                table="orders",
+                column=None,  # model emitted a table-level anyway
+                suggestions=["t1", "t2", "t3"],
+                confidence=Confidence.HIGH,
+                reasoning="seeded",
+                source="llm",
+            ),
+            MetadataSuggestion(
+                schema="public",
+                table="orders",
+                column="test2",
+                suggestions=["c1", "c2", "c3"],
+                confidence=Confidence.MEDIUM,
+                reasoning="seeded",
+                source="llm",
+            ),
+        ]
+        out = _ensure(orch, profile, existing)
+        assert all(s.column is not None for s in out), (
+            "missing-only over an already-commented table must keep no table-level row."
+        )
+
+    def test_missing_only_keeps_table_level_when_comment_absent(self) -> None:
+        """missing-only run where the table has NO comment: the table-level
+        description IS still produced (it is genuinely missing)."""
+        orch = _StubOrchestrator(n_alternatives=3)
+        orch.missing_only = True
+        profile = _profile(columns=["test2"], existing_comment="")
+        existing = [
+            MetadataSuggestion(
+                schema="public",
+                table="orders",
+                column=None,
+                suggestions=["t1", "t2", "t3"],
+                confidence=Confidence.HIGH,
+                reasoning="seeded",
+                source="llm",
+            ),
+        ]
+        out = _ensure(orch, profile, existing)
+        assert any(s.column is None for s in out), (
+            "A missing table comment must still be generated under missing-only."
         )
 
     def test_no_fallback_when_model_succeeded(self) -> None:


### PR DESCRIPTION
Two follow-up fixes for change-triggered ("Watching") schedules, found via live testing on Databricks.

## 1. Per-table Deep sync now fires Watching schedules
The "Deep sync" button on the Table page calls `deep_sync_one_table`, but the change-trigger dispatcher was only hooked into `sync_profile_skeleton` / `deep_sync_profile`. So a single-table deep sync wrote the new columns but never evaluated any watcher. Also, on three-level backends (Databricks) the watcher stores its container in `catalog` (and `catalog_entities.database_name`), but `_evaluate_one` only matched on `database` — skipping catalog-scoped watchers. Fixed both. Verified live: deep sync of `adr_6` fired watcher #12 → run 173 → re-armed.

## 2. `missing_only` no longer regenerates an already-commented table
A Watching schedule re-described a table every time a new column appeared, even though it already had a comment. Generalized the suppression into `Orchestrator._should_skip_table_level`: skip the table-level (prompt block, coverage injection, persist/apply) when the run is column-scoped **or** `missing_only` is set and the table already has a non-placeholder comment. A genuinely missing table comment is still generated. Used by `_build_context`, `_ensure_complete_table_coverage`, and the batch loop. Verified live: re-firing #12 produced 0 table-level rows.

## Test plan
- [x] `deep_sync_one_table` invokes the dispatcher with the synced container; `_evaluate_one` matches a catalog-overlay watcher.
- [x] missing-only over a commented table keeps no table-level row; over an uncommented table still produces one.
- [x] 122-test agent/scheduler regression green; deploy.sh → Studio live-verified (runs 173/174).