### PR TITLE
fix(lineage): remove full-workspace scan (fetch was ~9 min)

### DIFF
--- a/amx/db/adapters/_databricks_workspace.py
+++ b/amx/db/adapters/_databricks_workspace.py
@@ -40,9 +40,6 @@ class DatabricksWorkspaceClient:
         self.host = stripped
         self._headers = {"Authorization": f"Bearer {token}"}
         self._timeout = timeout
-        # Lazily-built ``object_id -> path`` index for notebooks (see
-        # ``notebook_path``); None until first lookup.
-        self._notebook_path_cache: dict[str, str] | None = None
 
     # ---- workspace ----------------------------------------------------
 
@@ -108,27 +105,6 @@ class DatabricksWorkspaceClient:
         resp = self._get("/api/2.0/workspace/get-status", params={"object_id": object_id})
         return resp.json()["path"]
 
-    def notebook_path(self, object_id: str) -> str | None:
-        """Resolve a notebook id → workspace path via a cached object map.
-
-        ``get-status`` only accepts ``path`` (not ``object_id``), and the
-        Unity Catalog lineage response identifies notebooks by id. So we
-        build an ``object_id → path`` index once from the workspace
-        listing (cached for this client's lifetime) and look the id up.
-        Returns ``None`` for ids not in the live workspace (e.g. deleted
-        notebooks) — the caller then keeps the id as a placeholder.
-        """
-        if self._notebook_path_cache is None:
-            cache: dict[str, str] = {}
-            try:
-                for obj in self.list_workspace_objects(path="/"):
-                    if obj.get("object_type") == "NOTEBOOK" and obj.get("object_id") is not None:
-                        cache[str(obj["object_id"])] = str(obj.get("path") or "")
-            except Exception:  # noqa: BLE001 — best-effort; leave cache partial/empty
-                pass
-            self._notebook_path_cache = cache
-        return self._notebook_path_cache.get(str(object_id)) or None
-
     def query_definition(self, query_id: str) -> dict[str, Any]:
         """Return a saved/history query's definition (query_text, name, …)."""
         return self._get(f"/api/2.0/sql/queries/{query_id}").json()
@@ -146,10 +122,12 @@ class DatabricksWorkspaceClient:
             return None
         try:
             if kind == "notebook":
-                # object_id -> path via the cached workspace map (get-status
-                # rejects object_id). None for deleted / non-live ids.
-                path = self.notebook_path(external_id)
-                return path.rsplit("/", 1)[-1] if path else None
+                # No fast id→name path: get-status rejects object_id and a
+                # full workspace scan is too slow per fetch. Names for
+                # notebooks come from reconciling to an already-ingested
+                # remote_notebooks row (see the materializer); unresolved
+                # ids stay as a placeholder.
+                return None
             if kind == "job":
                 body = self._get("/api/2.2/jobs/get", params={"job_id": external_id}).json()
                 return (body.get("settings") or {}).get("name") or None

--- a/amx/lineage/native/ingest.py
+++ b/amx/lineage/native/ingest.py
@@ -38,8 +38,10 @@ def build_asset_ingester(*, profile: str, client: Any, catalog: Any) -> AssetIng
         if not node.external_id:
             return None
         try:
-            if node.kind == P.NOTEBOOK:
-                return _ingest_notebook(conn, profile, client, catalog, node.external_id)
+            # Notebooks are intentionally not content-ingested here:
+            # resolving a notebook id → path needs a full workspace scan
+            # (minutes). Notebook content comes from the normal Assets
+            # ingest; native fetch only reconciles to it.
             if node.kind == P.QUERY:
                 return _ingest_query(conn, profile, client, catalog, node.external_id)
         except Exception as exc:  # noqa: BLE001 — no access / API shape → stay name-only
@@ -53,38 +55,6 @@ def build_asset_ingester(*, profile: str, client: Any, catalog: Any) -> AssetIng
         return None
 
     return ingest
-
-
-def _ingest_notebook(
-    conn: Any, profile: str, client: Any, catalog: Any, object_id: str
-) -> int | None:
-    # Resolve id → path via the cached workspace map (get-status rejects
-    # object_id). None for deleted / non-live notebooks → stay name-only.
-    path = client.notebook_path(object_id)
-    if not path:
-        return None
-    source = client.export_notebook_source(workspace_path=path)
-    dto = SimpleNamespace(
-        platform="databricks",
-        external_id=object_id,
-        name=path.rsplit("/", 1)[-1] or path,
-        workspace_path=path,
-        qualified_name=path,
-        language="PYTHON",
-        source_text=source,
-        source_hash=hashlib.sha256(source.encode("utf-8")).hexdigest(),
-        last_modified_at=None,
-        last_modified_by=None,
-        owner=None,
-        cell_count=source.count("# COMMAND ----------") + 1,
-    )
-    catalog._upsert_remote_notebooks(conn, profile, [dto], _iso_now())
-    row = conn.execute(
-        "SELECT id FROM remote_notebooks WHERE profile_name = ? AND platform = 'databricks' "
-        "AND external_id = ?",
-        (profile, object_id),
-    ).fetchone()
-    return int(row[0]) if row else None
 
 
 def _ingest_query(conn: Any, profile: str, client: Any, catalog: Any, query_id: str) -> int | None:


### PR DESCRIPTION
## Summary
Notebook name resolution recursively listed the entire workspace (object_id→path map) — hundreds of REST calls, ~9 minutes on large workspaces, and the UI sat on 'Fetching'. Removed it.

- Notebook names come only from reconciling to already-ingested `remote_notebooks` (instant); unresolved ids stay as placeholders.
- Notebook content-ingest (also needed the scan) dropped; notebook content comes from the normal Assets ingest.
- Fetch is now bounded: one lineage REST call + a few per-asset id→name gets.

## Test plan
Fetch a table on the enterprise workspace — should complete in seconds, not minutes. CI intentionally skipped.