### PR TITLE
fix(lineage): notebook names via persisted index + working Databricks deep-links

### DIFF
--- a/amx/db/adapters/_databricks_workspace.py
+++ b/amx/db/adapters/_databricks_workspace.py
@@ -122,11 +122,13 @@ class DatabricksWorkspaceClient:
             return None
         try:
             if kind == "notebook":
-                # The lineage notebook id is the workspace object_id.
-                # Resolve it to a path and take the basename — one cheap
-                # REST get per notebook in this graph, no workspace scan.
-                path = self.path_for_object_id(external_id)
-                return path.rstrip("/").rsplit("/", 1)[-1] if path else None
+                # No id→name reverse lookup exists: ``workspace/get-status``
+                # requires a ``path`` and rejects an ``object_id`` (HTTP 400
+                # "Missing required field: path"). Notebook names come from
+                # the persisted ``workspace/list`` index (see
+                # ``amx.lineage.native.notebook_index``); an unresolved id
+                # stays a ``"notebook <id>"`` placeholder.
+                return None
             if kind == "job":
                 body = self._get("/api/2.2/jobs/get", params={"job_id": external_id}).json()
                 return (body.get("settings") or {}).get("name") or None

--- a/amx/lineage/native/notebook_index.py
+++ b/amx/lineage/native/notebook_index.py
@@ -1,0 +1,174 @@
+"""Persisted, background-built notebook name index for Databricks.
+
+Unity Catalog lineage identifies a notebook only by its workspace
+``object_id``, and Databricks exposes no ``object_id -> name`` reverse
+lookup: ``/api/2.0/workspace/get-status`` *requires* a ``path`` and
+rejects an ``object_id`` (HTTP 400 "Missing required field: path"). The
+only public mapping is the recursive ``workspace/list`` scan.
+
+This module runs that scan once, **off the fetch path**, in a daemon
+thread, and persists the resulting ``object_id -> name`` map to a JSON
+cache next to the history DB (keyed by profile + host). A fetch reads
+whatever the cache holds and never blocks on the scan: the first fetch
+on a cold cache leaves notebooks as ``"notebook <id>"`` placeholders and
+kicks off the background build; later fetches resolve instantly. The
+cache is rebuilt when older than a TTL.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from amx.lineage.native import provider as P
+from amx.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from amx.db.adapters._databricks_workspace import DatabricksWorkspaceClient
+
+log = get_logger("lineage.native.notebook_index")
+
+# How long a built index stays valid before a background rebuild.
+DEFAULT_TTL_S = 24 * 3600.0
+
+# Guards against two concurrent background builds for the same cache file.
+_BUILDING: set[str] = set()
+_LOCK = threading.Lock()
+
+
+def _basename(path: str) -> str:
+    p = (path or "").rstrip("/")
+    return p.rsplit("/", 1)[-1] if "/" in p else p
+
+
+def _slug(value: str) -> str:
+    out = "".join(ch if ch.isalnum() else "_" for ch in (value or "")).strip("_")
+    return out or "default"
+
+
+def cache_path(cache_dir: Path, profile: str, host: str) -> Path:
+    """Return the JSON cache path for one ``profile`` + ``host`` index."""
+    return Path(cache_dir) / f"notebook_index_{_slug(profile)}_{_slug(host)}.json"
+
+
+def load_names(path: Path) -> dict[str, str]:
+    """Return the cached ``object_id -> name`` map, or ``{}`` if absent/unreadable."""
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    names = data.get("names") if isinstance(data, dict) else None
+    if not isinstance(names, dict):
+        return {}
+    return {str(k): str(v) for k, v in names.items()}
+
+
+def built_at(path: Path) -> float:
+    """Epoch seconds when the cache was last written, or ``0.0`` if absent."""
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return 0.0
+    if not isinstance(data, dict):
+        return 0.0
+    try:
+        return float(data.get("built_at", 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def is_stale(path: Path, *, ttl_s: float = DEFAULT_TTL_S) -> bool:
+    """True when the cache is missing or older than ``ttl_s`` seconds."""
+    ts = built_at(path)
+    return ts <= 0.0 or (time.time() - ts) > ttl_s
+
+
+def build_index(client: DatabricksWorkspaceClient, path: Path) -> int:
+    """Scan the workspace tree into the JSON cache; return the notebook count.
+
+    Blocking and uncapped — meant to run in a background thread, never
+    inline on a fetch. Persists atomically (temp file + ``os.replace``)
+    so a concurrent reader never sees a half-written cache.
+    """
+    names: dict[str, str] = {}
+    try:
+        for obj in client.list_workspace_objects():
+            if obj.get("object_type") != "NOTEBOOK":
+                continue
+            oid = obj.get("object_id")
+            obj_path = obj.get("path")
+            if oid is not None and obj_path:
+                names[str(oid)] = _basename(str(obj_path))
+    except Exception as exc:  # noqa: BLE001 — best-effort; persist whatever we reached
+        log.info("notebook index: scan stopped (%s); resolved %d so far", exc, len(names))
+
+    payload = {"built_at": time.time(), "names": names}
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(tmp, target)
+    log.info("notebook index: built %d notebooks at %s", len(names), target)
+    return len(names)
+
+
+def ensure_background_build(
+    client: DatabricksWorkspaceClient, path: Path, *, ttl_s: float = DEFAULT_TTL_S
+) -> None:
+    """Build the index in a daemon thread if cold/stale (never blocks the caller)."""
+    if not is_stale(path, ttl_s=ttl_s):
+        return
+    key = str(path)
+    with _LOCK:
+        if key in _BUILDING:
+            return
+        _BUILDING.add(key)
+
+    def _run() -> None:
+        try:
+            build_index(client, path)
+        except Exception as exc:  # noqa: BLE001 — never let a background build crash the app
+            log.info("notebook index: background build failed: %s", exc)
+        finally:
+            with _LOCK:
+                _BUILDING.discard(key)
+
+    threading.Thread(target=_run, name="amx-notebook-index", daemon=True).start()
+
+
+def resolve_names(result: P.NativeLineageResult, path: Path) -> None:
+    """Rewrite ``notebook <id>`` placeholders in ``result`` from the cache, in place.
+
+    Best-effort: notebooks whose id is not in the cache (or a cold cache)
+    keep their placeholder, so this is purely additive and never raises.
+    """
+    names = load_names(path)
+    if not names:
+        return
+
+    def named(node: P.NativeLineageNode) -> P.NativeLineageNode:
+        if node.kind != P.NOTEBOOK or not node.external_id:
+            return node
+        nm = names.get(str(node.external_id))
+        return replace(node, name=nm) if nm else node
+
+    result.edges = [
+        replace(e, source=named(e.source), target=named(e.target)) for e in result.edges
+    ]
+
+
+__all__ = [
+    "cache_path",
+    "load_names",
+    "built_at",
+    "is_stale",
+    "build_index",
+    "ensure_background_build",
+    "resolve_names",
+    "DEFAULT_TTL_S",
+]

--- a/amx/lineage/native/service.py
+++ b/amx/lineage/native/service.py
@@ -15,6 +15,9 @@ from amx.db.adapters._databricks_workspace import DatabricksApiError, Databricks
 from amx.lineage.native import provider as P
 from amx.lineage.native.materializer import LineageMaterializer, MaterializeCounts
 from amx.search.catalog import SearchCatalog
+from amx.utils.logging import get_logger
+
+log = get_logger("lineage.native.service")
 
 
 class NativeLineageError(RuntimeError):
@@ -65,6 +68,24 @@ class LineageFetchService:
             ingester = build_asset_ingester(
                 profile=profile_name, client=client, catalog=self.catalog
             )
+
+            # Resolve notebook names from the persisted workspace index.
+            # Unity Catalog hands back only a notebook ``object_id`` and
+            # Databricks has no id→name reverse lookup, so names come from
+            # a cached ``workspace/list`` scan. Reading the cache is cheap
+            # and best-effort (cold cache → ids stay placeholders); a
+            # cold/stale cache kicks off a background rebuild that never
+            # blocks this fetch.
+            from amx.lineage.native import notebook_index
+
+            try:
+                idx_path = notebook_index.cache_path(
+                    self.catalog.db_path.parent, profile_name, getattr(client, "host", "")
+                )
+                notebook_index.resolve_names(result, idx_path)
+                notebook_index.ensure_background_build(client, idx_path)
+            except Exception as exc:  # noqa: BLE001 — naming is best-effort
+                log.debug("notebook index resolve/build skipped: %s", exc)
 
         materializer = LineageMaterializer(
             self.catalog, profile_name=profile_name, backend=backend, ingester=ingester

--- a/amx/web/routers/lineage.py
+++ b/amx/web/routers/lineage.py
@@ -668,14 +668,14 @@ def post_fetch(
     # the source of truth; a seeding hiccup must not fail the request.
     artifact_id: int | None = None
     try:
-        artifact_id = _seed_native_artifact(hs, profile=name, fqn=fqn)
+        artifact_id = _seed_native_artifact(hs, profile=name, fqn=fqn, backend=backend)
     except Exception as exc:  # noqa: BLE001
         log.info("native lineage: artifact seed failed for %s: %s", fqn, exc)
 
     return {"profile": name, "fqn": fqn, "artifact_id": artifact_id, **counts.as_dict()}
 
 
-def _seed_native_artifact(hs: Any, *, profile: str, fqn: str) -> int | None:
+def _seed_native_artifact(hs: Any, *, profile: str, fqn: str, backend: str = "") -> int | None:
     """Create/refresh a saved artifact framing the native subgraph.
 
     Persists ``lineage_artifact_nodes`` for the anchor + every entity it
@@ -774,14 +774,19 @@ def _seed_native_artifact(hs: Any, *, profile: str, fqn: str) -> int | None:
 
     _column(upstream, cx - col_gap)
     _column(downstream, cx + col_gap)
+    # Bind the backend's brand logo to every seeded node so a table node
+    # renders its logo badge — which doubles as the "open in Databricks"
+    # deep-link. Without this the loaded table node has no logo_key and
+    # the badge (and thus the link) never appears. Asset nodes ignore it.
+    logo_key = "databricks" if (backend or "").lower() == "databricks" else ""
     with hs._lock, hs._connect() as conn:
         conn.executemany(
             """
             INSERT INTO lineage_artifact_nodes
-                (artifact_id, entity_id, db_profile, x, y, width, height, z_index)
-            VALUES (?, ?, ?, ?, ?, 240, 120, 0)
+                (artifact_id, entity_id, db_profile, x, y, width, height, z_index, logo_key)
+            VALUES (?, ?, ?, ?, ?, 240, 120, 0, ?)
             """,
-            [(artifact_id, nid, profile, x, y) for (nid, x, y) in placements],
+            [(artifact_id, nid, profile, x, y, logo_key) for (nid, x, y) in placements],
         )
     return int(artifact_id)
 

--- a/frontend/src/lineage-canvas/logos/databricksDeepLink.test.ts
+++ b/frontend/src/lineage-canvas/logos/databricksDeepLink.test.ts
@@ -8,9 +8,9 @@ describe("databricksDeepLink", () => {
       "https://example.cloud.databricks.com/explore/data/cat/sch/tbl",
     );
   });
-  it("builds a notebook link from externalId", () => {
+  it("builds a notebook link from externalId (object_id hash route)", () => {
     expect(databricksDeepLink({ kind: "notebook", host, externalId: "123" })).toBe(
-      "https://example.cloud.databricks.com/editor/notebooks/123",
+      "https://example.cloud.databricks.com/#notebook/123",
     );
   });
   it("builds a job link", () => {

--- a/frontend/src/lineage-canvas/logos/databricksDeepLink.ts
+++ b/frontend/src/lineage-canvas/logos/databricksDeepLink.ts
@@ -32,7 +32,9 @@ export function databricksDeepLink(args: DeepLinkArgs): string | null {
   if (!externalId) return null;
   switch (kind) {
     case "notebook":
-      return `${base}/editor/notebooks/${externalId}`;
+      // The lineage notebook id is the workspace object_id; the
+      // ``#notebook/<object_id>`` hash route opens it by id without a path.
+      return `${base}/#notebook/${externalId}`;
     case "job":
       return `${base}/jobs/${externalId}`;
     case "pipeline":

--- a/tests/lineage/test_native_lineage.py
+++ b/tests/lineage/test_native_lineage.py
@@ -432,24 +432,23 @@ def test_service_materializes_via_registered_provider(hs, monkeypatch) -> None:
     assert counts.name_only == 1
 
 
-def test_resolve_notebook_name_uses_object_id_path(monkeypatch):
-    """notebook id resolves to the path basename via get-status?object_id."""
+def test_resolve_notebook_name_returns_none_without_rest(monkeypatch):
+    """notebook id has no cheap reverse lookup: resolve returns None, no REST call.
+
+    Databricks ``workspace/get-status`` requires a path and rejects an
+    object_id (HTTP 400), so notebook names come from the persisted
+    workspace index, not from this per-entity resolver.
+    """
     from amx.db.adapters._databricks_workspace import DatabricksWorkspaceClient
 
     client = DatabricksWorkspaceClient(host="example.cloud.databricks.com", token="t")
 
-    class _Resp:
-        def json(self):
-            return {"path": "/Users/me/Folder/My Notebook"}
+    calls = []
 
-    seen = {}
-
-    def fake_get(path, *, params=None):
-        seen["path"] = path
-        seen["params"] = params
-        return _Resp()
+    def fake_get(path, *, params=None):  # pragma: no cover - must not be reached
+        calls.append((path, params))
+        raise AssertionError("notebook resolution must not hit the REST API")
 
     monkeypatch.setattr(client, "_get", fake_get)
-    name = client.resolve_entity_name(kind="notebook", external_id="2257615622929527")
-    assert name == "My Notebook"
-    assert seen["params"] == {"object_id": "2257615622929527"}
+    assert client.resolve_entity_name(kind="notebook", external_id="2257615622929527") is None
+    assert calls == []

--- a/tests/lineage/test_notebook_index.py
+++ b/tests/lineage/test_notebook_index.py
@@ -1,0 +1,60 @@
+"""Persisted notebook index — build, lookup, staleness, name resolution."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from amx.lineage.native import notebook_index as ni
+from amx.lineage.native import provider as P
+
+
+class _FakeClient:
+    """Yields a small workspace tree like ``list_workspace_objects`` does."""
+
+    def list_workspace_objects(self):
+        yield {"object_type": "DIRECTORY", "object_id": 1, "path": "/Users/me/Folder"}
+        yield {"object_type": "NOTEBOOK", "object_id": 123, "path": "/Users/me/Folder/My NB"}
+        yield {"object_type": "NOTEBOOK", "object_id": 456, "path": "/A/B/Other"}
+        yield {"object_type": "FILE", "object_id": 2, "path": "/Users/me/data.csv"}
+
+
+def test_build_index_writes_only_notebooks(tmp_path):
+    path = ni.cache_path(tmp_path, "db", "host.example.com")
+    count = ni.build_index(_FakeClient(), path)
+    assert count == 2
+    names = ni.load_names(path)
+    assert names == {"123": "My NB", "456": "Other"}
+
+
+def test_load_names_missing_returns_empty(tmp_path):
+    assert ni.load_names(tmp_path / "nope.json") == {}
+
+
+def test_is_stale(tmp_path):
+    path = tmp_path / "idx.json"
+    assert ni.is_stale(path)  # missing → stale
+    path.write_text(json.dumps({"built_at": time.time(), "names": {}}), encoding="utf-8")
+    assert not ni.is_stale(path, ttl_s=3600)
+    path.write_text(json.dumps({"built_at": time.time() - 10_000, "names": {}}), encoding="utf-8")
+    assert ni.is_stale(path, ttl_s=3600)
+
+
+def test_resolve_names_rewrites_known_ids_only(tmp_path):
+    path = ni.cache_path(tmp_path, "db", "h")
+    path.write_text(
+        json.dumps({"built_at": time.time(), "names": {"123": "My NB"}}), encoding="utf-8"
+    )
+
+    anchor = P.NativeLineageNode(kind=P.TABLE, name="t", fqn="c.s.t")
+    known = P.NativeLineageNode(kind=P.NOTEBOOK, name="notebook 123", external_id="123")
+    unknown = P.NativeLineageNode(kind=P.NOTEBOOK, name="notebook 999", external_id="999")
+    res = P.NativeLineageResult(anchor=anchor)
+    res.edges = [
+        P.NativeLineageEdge(source=known, target=anchor, direction=P.UPSTREAM),
+        P.NativeLineageEdge(source=unknown, target=anchor, direction=P.UPSTREAM),
+    ]
+    ni.resolve_names(res, path)
+    names = {n.name for e in res.edges for n in (e.source, e.target)}
+    assert "My NB" in names  # known id resolved
+    assert "notebook 999" in names  # unknown id left as placeholder


### PR DESCRIPTION
## Summary
Follow-up fixes after live testing of native lineage.

- **Notebook names**: `workspace/get-status` requires a `path` and rejects an `object_id` (HTTP 400), so the previous per-node id→name lookup never worked. Replaced with a persisted, background-built notebook index — a cached `workspace/list` scan (`object_id → name`) that runs off the fetch path; cold/stale caches rebuild in a daemon thread. First fetch on a cold cache leaves `notebook <id>` placeholders and triggers the build; later fetches resolve instantly.
- **Removed** the always-failing `get-status?object_id` call from `resolve_entity_name`.
- **Deep-links**: notebook link now uses the canonical `#notebook/<object_id>` hash route (was `/editor/notebooks/...`); native-fetch-seeded table nodes now carry a backend `logo_key` so the table logo badge — which doubles as the "open in Databricks" link — actually renders.

## Test plan
- Backend: `pytest tests/lineage/ tests/web/test_lineage_router.py` — 201 passed; mypy + ruff clean.
- Frontend: `vitest run src/lineage-canvas/logos/databricksDeepLink.test.ts` — 5 passed; `tsc --noEmit` clean.
- Live: verified the index builds against a real workspace (scanned notebooks → real `object_id → name` map).
- Manual (test machine): after deploy + hard refresh, fetch lineage for a Databricks table; the table logo opens Catalog Explorer; notebook/job nodes show an ↗ that opens the asset in Databricks; notebook names fill in after the background scan completes (re-fetch to see them).

Note: notebook content ingest (open-in-Assets) and the path-based lineage view's deep-links remain follow-ups.