### PR TITLE
ci: add no-attribution-trailers workflow

### DIFF
--- a/.github/workflows/no-attribution-trailers.yml
+++ b/.github/workflows/no-attribution-trailers.yml
@@ -1,0 +1,42 @@
+name: No attribution trailers
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: no-attribution-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-trailers:
+    name: Reject agent-attribution trailers in commit bodies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Scan commit bodies in PR range
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Compare the PR head against the base branch. We look at the
+          # commit messages introduced by this PR only — not the whole
+          # history, not file contents.
+          git fetch origin "$BASE_REF" --depth=200 --quiet
+          range="origin/${BASE_REF}..${HEAD_SHA}"
+          if git log "$range" --pretty=%B \
+              | grep -iqE 'Co-[Aa]uthored-[Bb]y:.*[Cc]laude|noreply@anthropic\.com|🤖 Generated'; then
+            echo "::error::Commit body in this PR carries an agent-attribution trailer."
+            echo "Strip the trailer line(s) before merging."
+            echo "Range scanned: $range"
+            git log "$range" --pretty='%h %s'
+            exit 1
+          fi
+          echo "Commit bodies in range are clean."

--- a/tests/analyze/test_run_loop_lineage_blocks.py
+++ b/tests/analyze/test_run_loop_lineage_blocks.py
@@ -54,20 +54,19 @@ def test_resolves_blocks_for_scope(tmp_path: Path) -> None:
 
 def test_returns_empty_without_profile_or_store(tmp_path: Path) -> None:
     cfg_noprofile = SimpleNamespace(active_db_profile="")
-    assert resolve_run_lineage_blocks(
-        cfg=cfg_noprofile, history_store_fn=lambda: None, scope={}
-    ) == {}
+    assert (
+        resolve_run_lineage_blocks(cfg=cfg_noprofile, history_store_fn=lambda: None, scope={}) == {}
+    )
     cfg = SimpleNamespace(active_db_profile="dbr")
-    assert resolve_run_lineage_blocks(
-        cfg=cfg, history_store_fn=lambda: None, scope={}
-    ) == {}
+    assert resolve_run_lineage_blocks(cfg=cfg, history_store_fn=lambda: None, scope={}) == {}
 
 
 def test_returns_empty_when_history_store_fn_is_none() -> None:
     cfg = SimpleNamespace(active_db_profile="dbr")
-    assert resolve_run_lineage_blocks(
-        cfg=cfg, history_store_fn=None, scope={"sales": ["orders"]}
-    ) == {}
+    assert (
+        resolve_run_lineage_blocks(cfg=cfg, history_store_fn=None, scope={"sales": ["orders"]})
+        == {}
+    )
 
 
 def test_returns_empty_on_store_error() -> None:
@@ -76,6 +75,7 @@ def test_returns_empty_on_store_error() -> None:
     bad_store = MagicMock()
     bad_store._connect.side_effect = RuntimeError("corrupt db")
     cfg = SimpleNamespace(active_db_profile="dbr")
-    assert resolve_run_lineage_blocks(
-        cfg=cfg, history_store_fn=lambda: bad_store, scope={"s": ["t"]}
-    ) == {}
+    assert (
+        resolve_run_lineage_blocks(cfg=cfg, history_store_fn=lambda: bad_store, scope={"s": ["t"]})
+        == {}
+    )

--- a/tests/lineage/test_native_lineage.py
+++ b/tests/lineage/test_native_lineage.py
@@ -131,9 +131,7 @@ def test_fetch_resolves_notebook_without_workspace_scan():
     mechanism has been removed; this locks in that the fetch path does
     not list workspace objects."""
     table_resp = {
-        "upstreams": [
-            {"notebookInfos": [{"notebook_id": "2257615622929527"}]}
-        ],
+        "upstreams": [{"notebookInfos": [{"notebook_id": "2257615622929527"}]}],
         "downstreams": [],
     }
 

--- a/tests/lineage/test_neighbors.py
+++ b/tests/lineage/test_neighbors.py
@@ -44,18 +44,14 @@ def test_resolves_upstream_and_downstream_names(tmp_path: Path) -> None:
     parent = _entity(hs, schema="sales", table="customers")
     nb = _entity(hs, schema="__assets", table="nb#1", kind="notebook", search_text="ETL nb")
     _edge(hs, parent, anchor, "lineage_native_table")  # parent feeds anchor -> upstream
-    _edge(hs, anchor, nb, "lineage_native_asset")       # anchor feeds nb -> downstream
+    _edge(hs, anchor, nb, "lineage_native_asset")  # anchor feeds nb -> downstream
 
     with hs._connect() as conn:
         out = lineage_neighbors(conn, anchor_entity_ids=[anchor])
 
     nbs = out[anchor]
-    assert ("upstream", "sales.customers", "table") in {
-        (n.direction, n.name, n.kind) for n in nbs
-    }
-    assert ("downstream", "ETL nb", "notebook") in {
-        (n.direction, n.name, n.kind) for n in nbs
-    }
+    assert ("upstream", "sales.customers", "table") in {(n.direction, n.name, n.kind) for n in nbs}
+    assert ("downstream", "ETL nb", "notebook") in {(n.direction, n.name, n.kind) for n in nbs}
     assert all(isinstance(n, Neighbor) for n in nbs)
 
 

--- a/tests/search/test_retrieval_lineage_pages.py
+++ b/tests/search/test_retrieval_lineage_pages.py
@@ -330,8 +330,15 @@ def test_retrieval_includes_named_neighbours_without_canvas(tmp_path: Path) -> N
             (parent, anchor, "lineage_native_table", time.time()),
         )
 
-    rows = [{"id": anchor, "row_type": "table", "db_profile": "p1",
-             "schema_name": "s", "table_name": "customers"}]
+    rows = [
+        {
+            "id": anchor,
+            "row_type": "table",
+            "db_profile": "p1",
+            "schema_name": "s",
+            "table_name": "customers",
+        }
+    ]
     enriched = enrich_retrieval_details_with_lineage_and_pages(
         store=store,
         rows=rows,


### PR DESCRIPTION
## Summary
- Blocks any commit body containing `Co-Authored-By: …` agent-attribution lines from entering main via PR.
- Scans only the commit range introduced by the PR (`origin/<base>..<head>`), not file contents.
- Runs as a PR check; branch protection is not enabled, so this is advisory but visible.

## Test plan
- [ ] Wait for green run on this PR (this PR's own commit body has no trailer).
- [ ] After merge, verify on a deliberate trailer-bearing test branch that the gate fails.