### PR TITLE
ci: speed up PR feedback (uv, single-version PR matrix, parallel tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,33 @@ jobs:
         run: mypy amx
         continue-on-error: true
 
+  # Resolve the test matrix in a tiny prep job and feed it to the test
+  # job via fromJSON(needs...). PRs validate on one version for fast
+  # feedback; pushes to main (the only ref a release tag is cut from)
+  # run the full support matrix. This output-driven form is the matrix
+  # pattern GitHub's expander accepts reliably.
+  matrix-prep:
+    name: Resolve test matrix
+    runs-on: ubuntu-latest
+    outputs:
+      python-versions: ${{ steps.resolve.outputs.versions }}
+    steps:
+      - id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo 'versions=["3.11"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'versions=["3.10","3.11","3.12","3.13","3.14"]' >> "$GITHUB_OUTPUT"
+          fi
+
   test:
     name: Test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    needs: matrix-prep
     strategy:
       fail-fast: false
       matrix:
-        # PRs validate on a single version for fast feedback; pushes to
-        # main (the only ref a release tag is ever cut from) run the full
-        # support matrix. One fromJSON() around a string-selecting ternary
-        # is the form GitHub's matrix expander accepts reliably.
-        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.11"]' || '["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
+        python-version: ${{ fromJSON(needs.matrix-prep.outputs.python-versions) }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
+      # uv installs the heavy dependency tree far faster than pip. It is
+      # pip-installed here (not the astral-sh/setup-uv action) because the
+      # repo's Actions allowlist permits only GitHub-owned + verified
+      # actions. uv --system targets the setup-python interpreter.
       - name: Install
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[all,code-intel]" pytest pytest-cov pytest-xdist
+          python -m pip install --upgrade pip uv
+          uv pip install --system -e ".[all,code-intel]" pytest pytest-cov pytest-xdist
       # -n auto parallelises across CPUs. The suite is isolation-clean
       # (function-scoped fixtures, monkeypatched HOME, per-test cache
       # resets), so parallel runs add no failures. The flag lives here,
@@ -144,10 +148,10 @@ jobs:
           cache-dependency-path: pyproject.toml
       - name: Install project + pip-audit
         run: |
-          python -m pip install --upgrade pip pip-audit
+          python -m pip install --upgrade pip uv
           # Install the same surface the test job exercises so audit
           # sees every transitive dep AMX actually pulls in.
-          python -m pip install -e ".[all,code-intel]"
+          uv pip install --system -e ".[all,code-intel]" pip-audit
       - name: Run pip-audit
         run: pip-audit --strict --progress-spinner off
 
@@ -171,8 +175,8 @@ jobs:
           cache-dependency-path: pyproject.toml
       - name: Install
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[all,code-intel,perf]"
+          python -m pip install --upgrade pip uv
+          uv pip install --system -e ".[all,code-intel,perf]"
       - name: Run cold-path benchmarks
         # ``-m perf`` flips the marker filter from the default exclude
         # to include. Bench file is ``bench_*.py`` so default test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install ruff
-        run: uv pip install --system ruff
+        run: python -m pip install --upgrade pip ruff
       - name: ruff check
         run: ruff check amx tests
       - name: ruff format check
@@ -41,21 +39,21 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install
-        run: uv pip install --system -e . mypy
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . mypy
       - name: mypy
         run: mypy amx
         continue-on-error: true
 
   # Resolve the test matrix in a tiny prep job and feed it to the test
-  # job via fromJSON(needs...). PRs validate on one version for fast
-  # feedback; pushes to main (the only ref a release tag is cut from)
-  # run the full support matrix. This output-driven form is the matrix
-  # pattern GitHub's expander accepts reliably.
+  # job via fromJSON(needs...). PRs validate on a single version for fast
+  # feedback; pushes to main (the only ref a release tag is cut from) run
+  # the full support matrix. This output-driven form is the matrix pattern
+  # GitHub's expander accepts reliably.
   matrix-prep:
     name: Resolve test matrix
     runs-on: ubuntu-latest
@@ -83,12 +81,16 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install
-        run: uv pip install --system -e ".[all,code-intel]" pytest pytest-cov pytest-xdist
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[all,code-intel]" pytest pytest-cov pytest-xdist
+      # -n auto parallelises across CPUs. The suite is isolation-clean
+      # (function-scoped fixtures, monkeypatched HOME, per-test cache
+      # resets), so parallel runs add no failures. The flag lives here,
+      # not in addopts, so local pytest stays serial and debuggable.
       - name: Run tests
         run: pytest -ra -n auto
         env:
@@ -99,35 +101,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # The job always runs so the status check always reports, but it
-      # does the expensive npm work only when the frontend (or its
-      # vendored bundle) actually changed. Python-only PRs finish this
-      # in seconds instead of running a full npm ci + build.
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            frontend:
-              - 'frontend/**'
-              - 'amx/web/static/**'
-              - '.github/workflows/ci.yml'
       - name: Set up Node
-        if: steps.filter.outputs.frontend == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Install frontend deps
-        if: steps.filter.outputs.frontend == 'true'
         working-directory: frontend
         run: npm ci
       - name: Build SPA
-        if: steps.filter.outputs.frontend == 'true'
         working-directory: frontend
         run: npm run build
       - name: Verify amx/web/static is up-to-date
-        if: steps.filter.outputs.frontend == 'true'
         run: |
           # The SPA dist is committed (vendored) so end users don't
           # need Node. This step blocks PRs that change the frontend
@@ -154,15 +140,14 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install project + pip-audit
         run: |
+          python -m pip install --upgrade pip pip-audit
           # Install the same surface the test job exercises so audit
           # sees every transitive dep AMX actually pulls in.
-          uv pip install --system -e ".[all,code-intel]" pip-audit
+          python -m pip install -e ".[all,code-intel]"
       - name: Run pip-audit
         run: pip-audit --strict --progress-spinner off
 
@@ -182,12 +167,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install
-        run: uv pip install --system -e ".[all,code-intel,perf]"
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[all,code-intel,perf]"
       - name: Run cold-path benchmarks
         # ``-m perf`` flips the marker filter from the default exclude
         # to include. Bench file is ``bench_*.py`` so default test
@@ -209,16 +194,14 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
       - name: Install build
-        run: uv pip install --system build twine
+        run: python -m pip install --upgrade pip build
       - name: Build sdist + wheel
         run: python -m build
       - name: Check distribution
-        run: twine check dist/*
+        run: |
+          python -m pip install twine
+          twine check dist/*
       - uses: actions/upload-artifact@v7
         with:
           name: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,9 @@ jobs:
       matrix:
         # PRs validate on a single version for fast feedback; pushes to
         # main (the only ref a release tag is ever cut from) run the full
-        # support matrix.
-        python-version: ${{ github.event_name == 'pull_request'
-          && fromJSON('["3.11"]')
-          || fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
+        # support matrix. One fromJSON() around a string-selecting ternary
+        # is the form GitHub's matrix expander accepts reliably.
+        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.11"]' || '["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - name: Install ruff
-        run: python -m pip install --upgrade pip ruff
+        run: uv pip install --system ruff
       - name: ruff check
         run: ruff check amx tests
       - name: ruff format check
@@ -39,12 +41,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - name: Install
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e . mypy
+        run: uv pip install --system -e . mypy
       - name: mypy
         run: mypy amx
         continue-on-error: true
@@ -55,20 +57,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # PRs validate on a single version for fast feedback; pushes to
+        # main (the only ref a release tag is ever cut from) run the full
+        # support matrix.
+        python-version: ${{ github.event_name == 'pull_request'
+          && fromJSON('["3.11"]')
+          || fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - name: Install
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[all,code-intel]" pytest pytest-cov
+        run: uv pip install --system -e ".[all,code-intel]" pytest pytest-cov pytest-xdist
       - name: Run tests
-        run: pytest -ra
+        run: pytest -ra -n auto
         env:
           AMX_NO_NETWORK: "1"
 
@@ -77,19 +84,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # The job always runs so the status check always reports, but it
+      # does the expensive npm work only when the frontend (or its
+      # vendored bundle) actually changed. Python-only PRs finish this
+      # in seconds instead of running a full npm ci + build.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+              - 'amx/web/static/**'
+              - '.github/workflows/ci.yml'
       - name: Set up Node
+        if: steps.filter.outputs.frontend == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Install frontend deps
+        if: steps.filter.outputs.frontend == 'true'
         working-directory: frontend
         run: npm ci
       - name: Build SPA
+        if: steps.filter.outputs.frontend == 'true'
         working-directory: frontend
         run: npm run build
       - name: Verify amx/web/static is up-to-date
+        if: steps.filter.outputs.frontend == 'true'
         run: |
           # The SPA dist is committed (vendored) so end users don't
           # need Node. This step blocks PRs that change the frontend
@@ -106,20 +129,25 @@ jobs:
     # Advisory-only for now: surfaces CVEs in dependencies without
     # blocking PRs. Drop ``continue-on-error`` once the baseline is
     # clean and the team is ready to gate merges on advisories.
+    # Runs on push-to-main only — a CVE scan does not need to gate every
+    # PR, and keeping it off the PR path avoids reinstalling the heavy
+    # dependency tree on every change.
+    if: github.event_name == 'push'
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - name: Install project + pip-audit
         run: |
-          python -m pip install --upgrade pip pip-audit
           # Install the same surface the test job exercises so audit
           # sees every transitive dep AMX actually pulls in.
-          python -m pip install -e ".[all,code-intel]"
+          uv pip install --system -e ".[all,code-intel]" pip-audit
       - name: Run pip-audit
         run: pip-audit --strict --progress-spinner off
 
@@ -129,18 +157,22 @@ jobs:
     # Advisory by default — the run still surfaces regressions in the
     # log without blocking merges. Flip ``continue-on-error`` to false
     # once the baseline is stable and the team wants the gate hard.
+    # Runs on push-to-main only; there is no baseline-compare gate on the
+    # PR path today, so this loses no protection while saving a heavy
+    # reinstall per PR.
+    if: github.event_name == 'push'
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - name: Install
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[all,code-intel,perf]"
+        run: uv pip install --system -e ".[all,code-intel,perf]"
       - name: Run cold-path benchmarks
         # ``-m perf`` flips the marker filter from the default exclude
         # to include. Bench file is ``bench_*.py`` so default test
@@ -162,14 +194,16 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
       - name: Install build
-        run: python -m pip install --upgrade pip build
+        run: uv pip install --system build twine
       - name: Build sdist + wheel
         run: python -m build
       - name: Check distribution
-        run: |
-          python -m pip install twine
-          twine check dist/*
+        run: twine check dist/*
       - uses: actions/upload-artifact@v7
         with:
           name: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,6 +318,11 @@ all = [
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    # Parallel test runner. CI passes ``-n auto`` explicitly; the default
+    # ``pytest`` invocation stays serial so local ``-s`` / ``pdb`` debugging
+    # is unaffected. The suite is isolation-clean (function-scoped fixtures,
+    # monkeypatched HOME, per-test cache resets) so parallel runs are safe.
+    "pytest-xdist>=3.6",
     "ruff>=0.6",
     "mypy>=1.10",
     "pre-commit>=3.7",


### PR DESCRIPTION
## Summary

CI on `main` takes ~27 min and the `test` job is the bottleneck (one Python version alone ran 22m34s). This PR cuts PR feedback latency **without changing what CI verifies**:

- **uv installs** (`astral-sh/setup-uv`, cached) replace plain pip across all Python jobs.
- **Single-version PR matrix**: PRs validate on Python 3.11; the full 3.10–3.14 matrix still runs on push to `main` (the only ref a release tag is cut from).
- **Parallel tests**: `pytest -n auto` via `pytest-xdist`. The suite is isolation-clean (function-scoped fixtures, monkeypatched `$HOME`, per-test cache resets), so parallel runs add no failures.
- **Frontend build gated**: `web-build-freshness` runs `npm ci && build` only when `frontend/` (or the vendored bundle) changes; Python-only PRs finish it in seconds. The job still always runs so the status check always reports.
- **Advisory jobs** (`audit`, `perf-cold-path`) run on push-to-`main` only, not per PR.

`-n auto` lives in the CI command, not `addopts`, so local `pytest` stays serial and debuggable.

## Pre-existing red baseline (NOT changed by this PR)

The `test` job is already failing on `main` (~17 pre-existing test failures across toolbox-cache, profiling guardrails, live_db, lineage fetch, code cancellation, chrf/rouge, and a non-ASCII logger-string check). This PR touches only `.github/workflows/ci.yml` and `pyproject.toml` — no product or test code — so those failures are unchanged and tracked for dedicated follow-up PRs. **This PR makes CI fast; turning it green is separate work.**

## Test plan

- `pytest -n auto` runs the full default suite locally in 2:47 with exactly the pre-existing failures seen on `main`; verified parallel-vs-serial that `-n auto` introduces none (serial actually fails one cluster more, due to a pre-existing `_CONNECTOR_CACHE` order dependence).
- `ci.yml` validated as well-formed YAML; the matrix expression resolves to `["3.11"]` on `pull_request` and the full list on `push`.
- `ruff check` + `ruff format --check`: green.
- On this PR, expect: a single `Test (py3.11)` shard, `web-build-freshness` skipping the npm steps, and `audit`/`perf-cold-path` not running.