### PR TITLE
fix(studio): make the live-DB connector cache thread-safe

### DIFF
--- a/amx/web/routers/live_db.py
+++ b/amx/web/routers/live_db.py
@@ -27,6 +27,7 @@ browse requests can't race each other.
 
 from __future__ import annotations
 
+import threading
 from dataclasses import replace
 from typing import Any
 
@@ -49,6 +50,14 @@ router = APIRouter(prefix="/api/live", tags=["live-db"])
 #: is still well within file-descriptor budget.
 _CONNECTOR_CACHE: dict[tuple, DatabaseConnector] = {}
 _CONNECTOR_CACHE_MAX = 32
+
+#: Guards every read/mutation of ``_CONNECTOR_CACHE``. FastAPI runs sync route
+#: handlers in a threadpool, so concurrent requests would otherwise insert,
+#: evict, and iterate the dict at the same time — yielding duplicate
+#: connectors, a double ``close()`` on the same engine, or a "dict changed
+#: size during iteration" error. Reentrant so the insert path can call
+#: :func:`_evict_oldest` while already holding the lock.
+_CONNECTOR_CACHE_LOCK = threading.RLock()
 
 
 def _profile_key(db: DBConfig) -> tuple:
@@ -75,13 +84,14 @@ def _profile_key(db: DBConfig) -> tuple:
 
 def _evict_oldest() -> None:
     """Drop the oldest cache entry and close its connector."""
-    if not _CONNECTOR_CACHE:
-        return
-    oldest_key = next(iter(_CONNECTOR_CACHE))
-    try:
-        _CONNECTOR_CACHE.pop(oldest_key).close()
-    except Exception:  # pragma: no cover - defensive
-        pass
+    with _CONNECTOR_CACHE_LOCK:
+        if not _CONNECTOR_CACHE:
+            return
+        oldest_key = next(iter(_CONNECTOR_CACHE))
+        try:
+            _CONNECTOR_CACHE.pop(oldest_key).close()
+        except Exception:  # pragma: no cover - defensive
+            pass
 
 
 def evict_connector_cache(profile_name: str) -> int:
@@ -106,15 +116,15 @@ def evict_connector_cache(profile_name: str) -> int:
     name = (profile_name or "").strip()
     if not name:
         return 0
-    removed_keys: list[tuple] = []
-    for key in list(_CONNECTOR_CACHE.keys()):
-        if key and key[0] == name:
-            removed_keys.append(key)
-    for key in removed_keys:
-        try:
-            _CONNECTOR_CACHE.pop(key).close()
-        except Exception:  # pragma: no cover - defensive
-            pass
+    with _CONNECTOR_CACHE_LOCK:
+        removed_keys: list[tuple] = [
+            key for key in list(_CONNECTOR_CACHE.keys()) if key and key[0] == name
+        ]
+        for key in removed_keys:
+            try:
+                _CONNECTOR_CACHE.pop(key).close()
+            except Exception:  # pragma: no cover - defensive
+                pass
     return len(removed_keys)
 
 
@@ -159,14 +169,27 @@ def _connector_for_scope(
         overlay["catalog"] = catalog
     scoped: DBConfig = replace(base, **overlay) if overlay else base
     key = (profile_name,) + _profile_key(scoped)
-    cached = _CONNECTOR_CACHE.get(key)
-    if cached is not None:
-        return cached
-    if len(_CONNECTOR_CACHE) >= _CONNECTOR_CACHE_MAX:
-        _evict_oldest()
+    with _CONNECTOR_CACHE_LOCK:
+        cached = _CONNECTOR_CACHE.get(key)
+        if cached is not None:
+            return cached
+    # Build outside the lock: connector construction can touch the driver
+    # and must not serialise every other cache reader behind it.
     connector = DatabaseConnector(scoped, profile_name=profile_name)
-    _CONNECTOR_CACHE[key] = connector
-    return connector
+    with _CONNECTOR_CACHE_LOCK:
+        # A concurrent request may have created the same connector while we
+        # were building ours — keep the cached one and drop the duplicate.
+        existing = _CONNECTOR_CACHE.get(key)
+        if existing is not None:
+            try:
+                connector.close()
+            except Exception:  # pragma: no cover - defensive
+                pass
+            return existing
+        if len(_CONNECTOR_CACHE) >= _CONNECTOR_CACHE_MAX:
+            _evict_oldest()
+        _CONNECTOR_CACHE[key] = connector
+        return connector
 
 
 def _coerce_or_500(action: str, fn):

--- a/tests/web/test_live_db_connector_cache_threadsafe.py
+++ b/tests/web/test_live_db_connector_cache_threadsafe.py
@@ -1,0 +1,119 @@
+"""Thread-safety of the Studio live-DB connector cache.
+
+FastAPI runs sync route handlers in a threadpool, so ``_connector_for_scope``,
+``evict_connector_cache`` and ``_evict_oldest`` can hit the module-level
+``_CONNECTOR_CACHE`` from several threads at once. These tests exercise that
+the cache stays correct under contention: concurrent builds of the same key
+dedupe to a single connector (the losers are closed), and a mix of inserts and
+evictions never leaks past the cap or raises.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+import pytest
+
+from amx.config import AMXConfig, DBConfig
+from amx.web.routers import live_db
+
+
+@dataclass
+class _FakeConnector:
+    db_cfg: object
+    profile_name: str | None = None
+    closed: bool = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    live_db._CONNECTOR_CACHE.clear()
+    yield
+    live_db._CONNECTOR_CACHE.clear()
+
+
+def _cfg() -> AMXConfig:
+    cfg = AMXConfig()
+    cfg.upsert_db_profile("prod", DBConfig(backend="duckdb", database="main"))
+    return cfg
+
+
+def test_concurrent_same_key_dedupes_to_one_connector(monkeypatch) -> None:
+    cfg = _cfg()
+    parties = 8
+    barrier = threading.Barrier(parties)
+    created: list[_FakeConnector] = []
+    created_lock = threading.Lock()
+
+    def _factory(db_cfg, profile_name=None):
+        # Release all builders together so every thread races on one key.
+        barrier.wait()
+        conn = _FakeConnector(db_cfg, profile_name)
+        with created_lock:
+            created.append(conn)
+        return conn
+
+    monkeypatch.setattr(live_db, "DatabaseConnector", _factory)
+
+    results: list[_FakeConnector] = []
+    results_lock = threading.Lock()
+
+    def _worker():
+        conn = live_db._connector_for_scope(cfg, "prod", database="main")
+        with results_lock:
+            results.append(conn)
+
+    threads = [threading.Thread(target=_worker) for _ in range(parties)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Every caller gets the same single cached connector.
+    assert len({id(c) for c in results}) == 1
+    cached = list(live_db._CONNECTOR_CACHE.values())
+    assert len(cached) == 1
+    winner = cached[0]
+    assert not winner.closed
+    # The duplicates that lost the race were built then closed.
+    losers = [c for c in created if c is not winner]
+    assert losers, "expected the race to build more than one connector"
+    assert all(c.closed for c in losers)
+
+
+def test_concurrent_inserts_and_evictions_stay_bounded(monkeypatch) -> None:
+    cfg = _cfg()
+    monkeypatch.setattr(
+        live_db,
+        "DatabaseConnector",
+        lambda db_cfg, profile_name=None: _FakeConnector(db_cfg, profile_name),
+    )
+    errors: list[BaseException] = []
+
+    def _insert(worker: int):
+        try:
+            for j in range(40):
+                live_db._connector_for_scope(cfg, "prod", database=f"db{(worker * 40 + j) % 100}")
+        except BaseException as exc:  # noqa: BLE001 - captured for the assertion
+            errors.append(exc)
+
+    def _evict():
+        try:
+            for _ in range(40):
+                live_db.evict_connector_cache("prod")
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_insert, args=(i,)) for i in range(8)]
+    threads += [threading.Thread(target=_evict) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"cache raised under concurrency: {errors[:3]}"
+    assert len(live_db._CONNECTOR_CACHE) <= live_db._CONNECTOR_CACHE_MAX


### PR DESCRIPTION
## Summary

FastAPI serves sync route handlers from a threadpool, so concurrent Studio requests mutated the module-level `_CONNECTOR_CACHE` (`amx/web/routers/live_db.py`) with no synchronisation. Under contention that could leak duplicate connectors, double-`close()` an engine during eviction, or collide a profile-edit eviction with a read.

- All cache reads/mutations now run under a reentrant `_CONNECTOR_CACHE_LOCK`.
- The build path uses **double-checked locking**: the cache is checked under the lock, the connector is constructed *outside* it (construction can touch the driver and shouldn't serialise other readers), then re-checked — a duplicate built during the race is closed and the already-cached instance is returned.

## Test plan

- New `tests/web/test_live_db_connector_cache_threadsafe.py` (2 cases): 8 threads racing the *same* key dedupe to one cached connector with the losers closed; mixed concurrent inserts + evictions stay within the cap and never raise. Stable across repeated runs.
- Existing `tests/web/test_live_db.py` + `test_comments_invalidation.py` still pass.
- The 3 pre-existing failures in `test_live_db_columns_fallback.py` are part of the repo's red baseline — verified they fail identically on `main` with this change stashed, so they are untouched by this PR.