### PR TITLE
ci(web): run the Studio vitest suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,8 @@ jobs:
         env:
           AMX_NO_NETWORK: "1"
 
-  web-build-freshness:
-    name: Web bundle freshness
+  web:
+    name: Web build & unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -114,6 +114,11 @@ jobs:
       - name: Install frontend deps
         working-directory: frontend
         run: npm ci
+      # Run the Studio unit tests (vitest). They existed but had never been
+      # wired into CI, so component regressions could land unnoticed.
+      - name: Run unit tests
+        working-directory: frontend
+        run: npm run test:run
       - name: Build SPA
         working-directory: frontend
         run: npm run build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",


### PR DESCRIPTION
## Summary

The Studio frontend ships 18 vitest unit tests (9 files) that were **never run by CI** — the `web` job only did `npm run build`, so component regressions could merge unnoticed. This wires the existing suite into CI:

- Add a `test:run` script (`vitest run`, non-watch) to `frontend/package.json`.
- Run it in the web CI job (renamed `Web build & unit tests`) before the build, reusing the same `npm ci`.

No UI/runtime change — tooling + CI only.

## Test plan

- `npm run test:run` locally → **18 passed** in ~1.5s.
- `actionlint` clean on the workflow.

Follow-up (not in this PR): ESLint/Prettier for the frontend is a separate decision — a never-linted 193-file codebase needs a strictness call and a likely sizeable fix pass, so it warrants its own PR.