### PR TITLE
fix(run): abort on fatal LLM errors instead of churning every table

### DIFF
--- a/amx/agents/orchestrator.py
+++ b/amx/agents/orchestrator.py
@@ -49,6 +49,7 @@ from amx.codebase.analyzer import CodebaseReport
 from amx.config import DEFAULT_ALTERNATIVES_MODE
 from amx.db.connector import AssetKind, ColumnProfile, DatabaseConnector, TableProfile
 from amx.docs.rag import RAGStore
+from amx.llm._provider_errors import FatalLLMError
 from amx.llm.provider import LLMProvider
 from amx.storage.sqlite_store import history_store
 from amx.utils.console import (
@@ -578,6 +579,14 @@ class Orchestrator:
             except RunCancelled:
                 statuses[label] = "cancelled"
                 raise
+            except FatalLLMError:
+                # Non-recoverable (auth / quota / model-not-found). Re-raise
+                # so the run aborts at analyze_flow with one actionable
+                # message instead of swallowing it here and churning through
+                # every remaining table, failing identically and consuming
+                # tokens each time. Mirrors the RunCancelled re-raise above.
+                statuses[label] = "failed"
+                raise
             except Exception as exc:
                 statuses[label] = "failed"
                 warn(f"{label.upper()} agent failed: {exc}")
@@ -601,6 +610,13 @@ class Orchestrator:
                 except RunCancelled:
                     statuses[label] = "cancelled"
                     cancel_observed = True
+                except FatalLLMError:
+                    # Non-recoverable LLM error — re-raise so the run aborts
+                    # with one actionable message rather than failing the
+                    # same way on every table. The ``finally`` below still
+                    # shuts the pool down cleanly before this propagates.
+                    statuses[label] = "failed"
+                    raise
                 except Exception as exc:
                     statuses[label] = "failed"
                     warn(f"{label.upper()} agent failed: {exc}")

--- a/amx/cli_support/commands/search.py
+++ b/amx/cli_support/commands/search.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     # annotations``; runtime use sites lazy-import these names below.
     from amx.search.catalog import SearchCatalog
     from amx.search.service import SearchService
+from amx.llm._provider_errors import FatalLLMError
 from amx.storage.sqlite_store import history_store
 from amx.utils.console import (
     ask_choice,
@@ -337,6 +338,22 @@ def _run_search_ask_body(
             summary="Cancelled by user.",
             provenance=["user_cancelled"],
             details={"reason": "cancelled_by_user"},
+        )
+    except FatalLLMError as fatal:
+        # Non-recoverable LLM error (auth / quota / model-not-found). Surface
+        # the actionable message instead of letting the raw provider error
+        # crash the /ask REPL, and return a graceful low-confidence answer.
+        from amx.search.catalog import SearchAnswer
+
+        error("LLM request failed: " + fatal.user_message)
+        answer = SearchAnswer(
+            intent="error",
+            question=question_text,
+            rows=[],
+            confidence="low",
+            summary=fatal.user_message,
+            provenance=["llm_error"],
+            details={"reason": "fatal_llm_error"},
         )
     finally:
         if started_display:

--- a/amx/llm/batch.py
+++ b/amx/llm/batch.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from amx.config import LLMConfig
+from amx.llm._provider_errors import FatalLLMError, _classify_fatal_llm_error
 from amx.llm.provider import ChatResult
 from amx.utils.console import console
 from amx.utils.logging import get_logger
@@ -445,4 +446,17 @@ def run_batch(
             f"Supported: {', '.join(supported_providers())}."
         )
 
-    return provider.submit(requests)
+    try:
+        return provider.submit(requests)
+    except FatalLLMError:
+        raise
+    except Exception as exc:
+        # Auth / quota / model-not-found surfaced by the batch submit are
+        # just as non-recoverable as in chat mode. Classify them into a
+        # FatalLLMError so the analyze_flow handler aborts the run with one
+        # actionable message instead of letting a raw provider error escape
+        # past the FatalLLMError-only catch.
+        fatal = _classify_fatal_llm_error(exc)
+        if fatal is not None:
+            raise fatal from exc
+        raise

--- a/tests/test_run_batch_fatal_classification.py
+++ b/tests/test_run_batch_fatal_classification.py
@@ -1,0 +1,64 @@
+"""``run_batch`` maps fatal provider errors into ``FatalLLMError``.
+
+Auth / quota / model-not-found surfaced by a batch ``submit`` are just
+as non-recoverable as in chat mode. ``run_batch`` must classify them so
+the ``analyze_flow`` handler aborts the run with one actionable message,
+instead of leaking a raw provider error past the ``FatalLLMError``-only
+catch (where it would crash with a stack trace and no guidance).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import amx.llm.batch as batch
+from amx.llm._provider_errors import FatalLLMError
+
+
+class _FakeProvider:
+    """Batch provider whose ``submit`` always raises the given error."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def submit(self, requests: list[batch.BatchRequest]) -> dict:
+        raise self._exc
+
+
+def _requests() -> list[batch.BatchRequest]:
+    return [batch.BatchRequest(custom_id="c1", messages=[{"role": "user", "content": "hi"}])]
+
+
+def test_run_batch_maps_auth_error_to_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        batch,
+        "get_batch_provider",
+        lambda cfg: _FakeProvider(Exception("Error code: 401 - invalid api key")),
+    )
+    with pytest.raises(FatalLLMError) as excinfo:
+        batch.run_batch(_requests(), object())  # type: ignore[arg-type]
+    # The user-facing message must be actionable (point at /llm).
+    assert "/llm" in excinfo.value.user_message
+
+
+def test_run_batch_passes_through_already_classified_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = FatalLLMError("already classified")
+    monkeypatch.setattr(batch, "get_batch_provider", lambda cfg: _FakeProvider(sentinel))
+    with pytest.raises(FatalLLMError) as excinfo:
+        batch.run_batch(_requests(), object())  # type: ignore[arg-type]
+    assert excinfo.value is sentinel
+
+
+def test_run_batch_reraises_non_fatal_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Operational batch failures (job status, parse errors) are NOT fatal
+    # LLM errors and must propagate unchanged, not be relabelled.
+    err = RuntimeError("Batch job ended with status 'failed'.")
+    monkeypatch.setattr(batch, "get_batch_provider", lambda cfg: _FakeProvider(err))
+    with pytest.raises(RuntimeError) as excinfo:
+        batch.run_batch(_requests(), object())  # type: ignore[arg-type]
+    assert not isinstance(excinfo.value, FatalLLMError)
+    assert excinfo.value is err

--- a/tests/test_run_enabled_agents_statuses.py
+++ b/tests/test_run_enabled_agents_statuses.py
@@ -27,6 +27,7 @@ import pytest
 
 from amx.agents.base import AgentContext, MetadataSuggestion
 from amx.agents.orchestrator import RunCancelled
+from amx.llm._provider_errors import FatalLLMError
 
 
 class _FakeAgent:
@@ -166,6 +167,29 @@ def test_single_agent_path_propagates_run_cancelled() -> None:
     orch = _make_orch(profile=profile)
 
     with pytest.raises(RunCancelled):
+        orch._run_enabled_agents(AgentContext())
+
+
+def test_fatal_llm_error_in_one_agent_reraises_not_swallowed() -> None:
+    """A non-recoverable LLM error (auth / quota / model-not-found) raised
+    by one sub-agent in the multi-agent ThreadPool path must propagate so
+    the run aborts at analyze_flow — NOT be swallowed like a generic
+    Exception, which would let the run churn through every table."""
+    profile = _FakeAgent(suggestions=[_make_suggestion("profile")])
+    rag = _FakeAgent(raises=FatalLLMError)
+    code = _FakeAgent(suggestions=[_make_suggestion("code")])
+    orch = _make_orch(profile=profile, rag=rag, code=code)
+
+    with pytest.raises(FatalLLMError):
+        orch._run_enabled_agents(AgentContext())
+
+
+def test_single_agent_path_propagates_fatal_llm_error() -> None:
+    """Same contract on the single-agent fast path."""
+    profile = _FakeAgent(raises=FatalLLMError)
+    orch = _make_orch(profile=profile)
+
+    with pytest.raises(FatalLLMError):
         orch._run_enabled_agents(AgentContext())
 
 


### PR DESCRIPTION
## Summary

A fatal LLM error (expired key, no credit, wrong model) was swallowed by the orchestrator's per-agent `except Exception`, so a `/run` never aborted. It failed identically on every remaining table, emitting 200+ cryptic warnings and consuming tokens each time, never reaching the actionable abort message already built in `analyze_flow` ("top up credits / rotate the key / pick another model under /llm").

This restores the safety net on the default (chat-mode) run path, plus batch mode and `/ask`:

- **`orchestrator._run_enabled_agents`**: re-raise `FatalLLMError` on both the single-agent fast path and the `ThreadPoolExecutor` fan-out, mirroring the existing `RunCancelled` re-raise. The `finally` still shuts the pool down cleanly.
- **`batch.run_batch`**: classify provider `submit` errors so batch-mode auth/quota/model failures also surface as `FatalLLMError` and reach the same handler. Operational batch errors (job status, parse failures) propagate unchanged.
- **`/ask`**: handle `FatalLLMError` with the actionable message instead of crashing the REPL.

## Test plan

- `tests/test_run_enabled_agents_statuses.py`: two new cases asserting `FatalLLMError` re-raises (not swallowed) on both orchestrator paths; the 8 existing status/cancel cases still pass.
- `tests/test_run_batch_fatal_classification.py` (new): auth error → `FatalLLMError`; already-classified fatal passes through; non-fatal `RuntimeError` propagates unchanged.
- `49 passed` across the orchestrator/batch/rerun/cancel test files; `ruff check` + `ruff format --check` clean on all touched files.