### PR TITLE
fix: CLI connection, config-recovery, and review-gate safety (usability wave 1)

### DIFF
--- a/amx/cli.py
+++ b/amx/cli.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import click
+import yaml
 
 from amx import __version__
 from amx.cli_support import run_interactive_session
@@ -51,9 +52,12 @@ from amx.config import AMXConfig, ConfigSchemaTooNewError
 from amx.storage.factory import init_history_store
 from amx.storage.sqlite_store import history_store
 from amx.utils.console import (
+    ask_choice,
+    confirm,
     error,
     info,
     show_banner,
+    success,
     warn,
 )
 from amx.utils.logging import get_logger
@@ -343,6 +347,71 @@ def _raise_open_file_limit(target: int = 4096) -> None:
         return
 
 
+def _recover_corrupt_config(cfg_path: str | None, exc: Exception) -> AMXConfig | None:
+    """Offer inline recovery when ``config.yml`` can't be parsed at startup.
+
+    Without this, a corrupt config.yml hard-exits before the REPL even
+    starts — yet the documented fix, ``/restore-config``, lives *inside*
+    the REPL that just refused to start, and the error never showed where
+    the backups live. We print the absolute config/backup path and, when
+    running interactively, let the user restore a rotated backup right
+    here, then retry the load. Returns the recovered config, or ``None``
+    when recovery wasn't possible (caller exits).
+    """
+    from pathlib import Path
+
+    from amx.config import list_config_backups, restore_config_from_backup
+
+    if cfg_path:
+        config_path = Path(cfg_path).expanduser()
+    else:
+        config_path = Path(AMXConfig().CONFIG_DIR) / "config.yml"
+
+    error(f"AMX could not read its configuration file:\n  {config_path}")
+    error(f"Reason: {exc}")
+
+    backups = list_config_backups(config_path)
+    if not backups:
+        info(
+            "No rotated backups are available to restore from. Fix the YAML by "
+            "hand, or back up and remove the file to start fresh. Backups (when "
+            f"present) live alongside it in:\n  {config_path.parent}"
+        )
+        return None
+
+    info(f"Rotated backups available in {config_path.parent}:")
+    for backup in backups:
+        info(f"  {backup.name}")
+
+    interactive = sys.stdin.isatty() and sys.stdout.isatty()
+    if not interactive:
+        info(
+            "Restore one over the live file to recover, e.g. copy the newest "
+            f"backup above to {config_path.name}, or run /restore-config once "
+            "the CLI starts."
+        )
+        return None
+
+    if not confirm("Restore a backup now so AMX can start?", default=True):
+        info(f"Restore later with /restore-config, or manually from {config_path.parent}.")
+        return None
+
+    choices = [backup.name for backup in backups]
+    picked = ask_choice("Restore which backup?", choices)
+    backup = backups[choices.index(picked)]
+    try:
+        restore_config_from_backup(backup, config_path)
+    except Exception as restore_exc:  # noqa: BLE001 — surface any restore failure
+        error(f"Restore failed: {restore_exc}")
+        return None
+    success(f"Restored {backup.name}. Re-reading configuration...")
+    try:
+        return AMXConfig.load(cfg_path)
+    except Exception as reload_exc:  # noqa: BLE001 — the backup may also be bad
+        error(f"Configuration is still unreadable after restore: {reload_exc}")
+        return None
+
+
 @click.group(invoke_without_command=True)
 @click.version_option(__version__, prog_name="amx")
 @click.option("--config", "cfg_path", default=None, help="Path to config YAML file.")
@@ -379,6 +448,15 @@ def main(ctx: click.Context, cfg_path: str | None, debug: bool) -> None:
             "and delete `~/.amx/config.yml` to start fresh."
         )
         sys.exit(2)
+    except (yaml.YAMLError, OSError, UnicodeDecodeError) as exc:
+        # A corrupt / unreadable config.yml used to crash before the REPL,
+        # leaving the user pointed at /restore-config — a command only
+        # reachable inside the REPL that just refused to start. Recover
+        # inline (or at least show where the backups live) instead.
+        recovered = _recover_corrupt_config(cfg_path, exc)
+        if recovered is None:
+            sys.exit(2)
+        ctx.obj = recovered
     init_history_store(ctx.obj)
     _bootstrap_scheduler_tick()
     _install_embedding_provider(ctx.obj)

--- a/amx/cli_support/root_commands.py
+++ b/amx/cli_support/root_commands.py
@@ -95,11 +95,18 @@ def register_root_commands(
         db = DatabaseConnector(cfg.db)
         with command_display(mode="setup-db", provider=cfg.llm.provider, model=cfg.llm.model):
             with step_spinner("Testing database connection..."):
-                connected = db.test_connection()
-        if connected:
+                result = db.test_connection_result()
+        if result.ok:
             success(f"Database connection successful! (backend: {cfg.db.backend})")
         else:
-            error("Database connection failed. Check credentials and try again.")
+            # Surface the categorised cause (wrong password / SSL / timeout /
+            # missing driver / unknown database) instead of a fixed
+            # credentials-only hint — the LLM step below already shows its
+            # real error via test_result().
+            if result.message:
+                error(f"Database connection failed: {result.message}")
+            else:
+                error("Database connection failed. Check credentials and try again.")
             if not confirm("Continue anyway?", default=False):
                 sys.exit(1)
 
@@ -265,11 +272,19 @@ def register_root_commands(
         db_conn = DatabaseConnector(cfg.db)
         with command_display(mode="db-connect", provider=cfg.llm.provider, model=cfg.llm.model):
             with step_spinner("Testing database connection..."):
-                connected = db_conn.test_connection()
-        if connected:
+                result = db_conn.test_connection_result()
+        if result.ok:
             success(f"Connected to [{cfg.db.backend}] {cfg.db.display_summary}")
         else:
-            error("Connection failed.")
+            # Surface the categorised, actionable cause (wrong password /
+            # SSL / timeout / missing driver / unknown database) that
+            # test_connection_result already built. The bool
+            # test_connection() path threw it away and printed a bare
+            # "Connection failed.", so every non-Databricks backend hit a
+            # dead end while Databricks showed the cause.
+            error(
+                f"Connection failed: {result.message}" if result.message else "Connection failed."
+            )
             sys.exit(1)
 
     @db.command("tls")

--- a/amx/db/_connector_types.py
+++ b/amx/db/_connector_types.py
@@ -159,6 +159,18 @@ MAX_CONNECTION_RETRIES = 1
 CONNECTION_RETRY_BACKOFF_SEC = 1.5
 
 
+# Upper bound on how long a single connectivity probe may block before we
+# stop waiting and report an actionable host/network error. Without this,
+# an unreachable host (off-VPN, wrong host/port, firewalled SYN drop) hangs
+# for the OS TCP default (~75-130s), doubled by the retry layer above —
+# and because the native driver connect holds the GIL in C, Ctrl-C cannot
+# break it. Running the probe in a daemon thread bounded by this timeout
+# returns control to the user promptly and keeps Ctrl-C responsive. Only
+# Databricks set its own connect timeout before; this makes the bound
+# uniform across every backend.
+DB_CONNECT_TIMEOUT_SEC = 15.0
+
+
 _TRANSIENT_DB_PATTERNS: tuple[str, ...] = (
     "could not connect",
     "connection refused",

--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -5,6 +5,7 @@ Supports multiple backends via the adapter layer in ``amx.db.adapters``.
 
 from __future__ import annotations
 
+import threading
 import time
 from typing import Any
 
@@ -22,6 +23,9 @@ from amx.db._connector_types import (
 )
 from amx.db._connector_types import (  # noqa: PLC0414
     CONNECTION_RETRY_BACKOFF_SEC as CONNECTION_RETRY_BACKOFF_SEC,
+)
+from amx.db._connector_types import (
+    DB_CONNECT_TIMEOUT_SEC,
 )
 from amx.db._connector_types import (
     MAX_CONNECTION_RETRIES as MAX_CONNECTION_RETRIES,
@@ -51,6 +55,16 @@ from amx.db.adapters.base import BackendCapabilities, UnsupportedDatabaseOperati
 from amx.utils.logging import get_logger
 
 log = get_logger("db.connector")
+
+
+class _ConnectTimeout(Exception):
+    """Raised when a connectivity probe exceeds ``DB_CONNECT_TIMEOUT_SEC``.
+
+    Distinct from a transient connection error: a probe that blew the
+    timeout means the host is effectively unreachable, so retrying just
+    burns another full timeout. ``test_connection_result`` returns
+    immediately with the actionable host/network message instead.
+    """
 
 
 #: TTL stamped on comment-cache rows written by a deliberate *sync*
@@ -210,6 +224,47 @@ class DatabaseConnector:
         except Exception:
             return value
 
+    def _probe_connection_bounded(self) -> None:
+        """Run the backend connectivity check, but stop waiting after
+        :data:`DB_CONNECT_TIMEOUT_SEC`.
+
+        The native driver connect blocks inside C code holding the GIL, so
+        it cannot be cancelled and Ctrl-C cannot interrupt it. Running it in
+        a *daemon* worker thread means the main thread parks in
+        ``Event.wait(timeout=...)`` instead — which IS interruptible by
+        Ctrl-C and returns control to the user within the timeout rather
+        than the OS TCP default (~75-130s, doubled by the retry layer).
+
+        On timeout we raise :class:`_ConnectTimeout` and leave the daemon
+        thread to die on its own when the OS finally gives up; a daemon
+        thread never blocks interpreter exit, so AMX stays responsive. Any
+        real connect error is re-raised unchanged so the existing
+        transient-retry and actionable-message classification still apply.
+        """
+        outcome: dict[str, BaseException | None] = {"exc": None}
+        done = threading.Event()
+
+        def _probe() -> None:
+            try:
+                self._adapter.test_connection(self._engine)
+            except BaseException as exc:  # noqa: BLE001 — re-raised on the caller thread
+                outcome["exc"] = exc
+            finally:
+                done.set()
+
+        worker = threading.Thread(target=_probe, name="amx-db-connect", daemon=True)
+        worker.start()
+        if not done.wait(timeout=DB_CONNECT_TIMEOUT_SEC):
+            raise _ConnectTimeout(
+                f"Connection timed out after {DB_CONNECT_TIMEOUT_SEC:.0f}s. The "
+                f"[{self.backend}] host may be unreachable — check the host and "
+                "port, that you are on the right network/VPN, and that a firewall "
+                "is not silently dropping the connection. Open the profile with "
+                "/edit to review the connection details."
+            )
+        if outcome["exc"] is not None:
+            raise outcome["exc"]
+
     def test_connection_result(self) -> ConnectionTestResult:
         """Test the active connection, retrying once on transient failures.
 
@@ -223,8 +278,14 @@ class DatabaseConnector:
         last_exc: Exception | None = None
         for attempt in range(MAX_CONNECTION_RETRIES + 1):
             try:
-                self._adapter.test_connection(self._engine)
+                self._probe_connection_bounded()
                 return ConnectionTestResult(ok=True)
+            except _ConnectTimeout as exc:
+                # An unreachable host won't recover on retry — that would
+                # just burn another full timeout while the user waits.
+                # Return immediately with the actionable host/network hint.
+                log.error("Connection timed out: %s", exc)
+                return ConnectionTestResult(ok=False, message=str(exc), exception=exc)
             except Exception as exc:
                 last_exc = exc
                 if attempt < MAX_CONNECTION_RETRIES and _is_transient_db_connection_error(exc):

--- a/amx/utils/console.py
+++ b/amx/utils/console.py
@@ -340,6 +340,12 @@ def ask_password(question: str) -> str:
     return _safe_pt_prompt(f"  {question}: ", is_password=True).strip()
 
 
+#: How many times ``ask_choice`` re-prompts on unrecognised input before
+#: giving up and taking the default. Bounds a non-interactive / EOF caller
+#: that keeps yielding the same invalid value so it can't loop forever.
+_ASK_CHOICE_MAX_RETRIES = 5
+
+
 def ask_choice(
     question: str,
     choices: list[str],
@@ -362,13 +368,26 @@ def ask_choice(
         console.print(f"    {i}. [bold]{c}[/bold]{desc}[dim]{mark}[/dim]")
     # Keep the prompt minimal: users can press Enter for default without extra hint text.
     # Do not pass default= to pt_prompt — it pre-fills the whole string and forces delete-before-2.
-    answer = _safe_pt_prompt("  > ", completer=completer).strip()
-    if not answer:
-        return default if default in choices else ""
-    if answer.isdigit() and 1 <= int(answer) <= len(choices):
-        return choices[int(answer) - 1]
-    if answer in choices:
-        return answer
+    # Re-prompt on unrecognised input rather than silently falling back to
+    # the default. ask_choice also gates DB writeback in the review loop,
+    # where silently accepting the top suggestion on a typo (e.g. "q"/"w")
+    # is a data-safety footgun. Empty input still accepts the default (the
+    # documented "press Enter" convention).
+    for attempt in range(_ASK_CHOICE_MAX_RETRIES):
+        answer = _safe_pt_prompt("  > ", completer=completer).strip()
+        if not answer:
+            return default if default in choices else ""
+        if answer.isdigit() and 1 <= int(answer) <= len(choices):
+            return choices[int(answer) - 1]
+        if answer in choices:
+            return answer
+        if attempt < _ASK_CHOICE_MAX_RETRIES - 1:
+            warn(
+                f"'{answer}' is not one of the options — enter a number "
+                f"1-{len(choices)} or a listed name."
+            )
+    # Exhausted retries (non-interactive / EOF garbage): take the default
+    # rather than spin forever.
     return default if default in choices else ""
 
 

--- a/tests/test_ask_choice_reprompt.py
+++ b/tests/test_ask_choice_reprompt.py
@@ -1,0 +1,44 @@
+"""``ask_choice`` re-prompts on unrecognised input.
+
+It also gates DB writeback in the review loop, where silently accepting
+the top suggestion on a typo (e.g. "q"/"w") was a data-safety footgun.
+Empty input still accepts the default; valid input returns immediately;
+unrecognised input re-prompts up to a retry cap, then falls back.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import amx.utils.console as console
+
+
+def test_invalid_then_valid_reprompts(monkeypatch: pytest.MonkeyPatch) -> None:
+    inputs = iter(["nope", "2"])
+    monkeypatch.setattr(console, "_safe_pt_prompt", lambda *a, **k: next(inputs))
+    assert console.ask_choice("pick", ["a", "b", "c"], default="a") == "b"
+
+
+def test_empty_accepts_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(console, "_safe_pt_prompt", lambda *a, **k: "")
+    assert console.ask_choice("pick", ["a", "b"], default="b") == "b"
+
+
+def test_label_match_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(console, "_safe_pt_prompt", lambda *a, **k: "b")
+    assert console.ask_choice("pick", ["a", "b"], default="a") == "b"
+
+
+def test_exhausted_retries_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A non-interactive caller that keeps yielding the same invalid value
+    # must not loop forever — it falls back to the default after the cap.
+    calls = {"n": 0}
+
+    def _always_garbage(*a: object, **k: object) -> str:
+        calls["n"] += 1
+        return "garbage"
+
+    monkeypatch.setattr(console, "_safe_pt_prompt", _always_garbage)
+    assert console.ask_choice("pick", ["a", "b"], default="a") == "a"
+    # Bounded, not infinite.
+    assert calls["n"] == console._ASK_CHOICE_MAX_RETRIES

--- a/tests/test_connect_timeout.py
+++ b/tests/test_connect_timeout.py
@@ -1,0 +1,69 @@
+"""Connectivity probes are bounded by ``DB_CONNECT_TIMEOUT_SEC``.
+
+An unreachable host (off-VPN, wrong host/port, firewalled SYN drop) used
+to hang for the OS TCP default (~75-130s), doubled by the retry layer,
+with Ctrl-C unable to break the native driver connect. The probe now runs
+in a daemon thread bounded by the timeout, so ``test_connection_result``
+returns promptly with an actionable host/network message — uniformly
+across every backend, not just Databricks.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+import amx.db.connector as connector_mod
+from amx.config import DBConfig
+from amx.db.connector import DatabaseConnector
+
+
+def _duckdb_connector() -> DatabaseConnector:
+    # DuckDB is the only driver shipped by default, so it is always
+    # importable in CI; we monkeypatch the adapter probe to simulate the
+    # network behaviours we cannot reproduce against a real remote host.
+    return DatabaseConnector(DBConfig(backend="duckdb", database=":memory:"))
+
+
+def test_probe_times_out_and_returns_actionable_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(connector_mod, "DB_CONNECT_TIMEOUT_SEC", 0.2)
+    conn = _duckdb_connector()
+
+    def _hang(engine: object = None) -> None:
+        time.sleep(5.0)  # simulate an unreachable host
+
+    monkeypatch.setattr(conn._adapter, "test_connection", _hang)
+
+    started = time.monotonic()
+    result = conn.test_connection_result()
+    elapsed = time.monotonic() - started
+
+    assert result.ok is False
+    assert "timed out" in (result.message or "").lower()
+    # Must return at ~the timeout, NOT wait out the full 5s hang.
+    assert elapsed < 2.0
+
+
+def test_probe_success_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(connector_mod, "DB_CONNECT_TIMEOUT_SEC", 5.0)
+    conn = _duckdb_connector()
+    monkeypatch.setattr(conn._adapter, "test_connection", lambda engine=None: None)
+    assert conn.test_connection_result().ok is True
+
+
+def test_probe_reraises_real_connect_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A genuine (non-timeout) connect error still flows through the
+    # existing actionable-message classification, not the timeout branch.
+    monkeypatch.setattr(connector_mod, "DB_CONNECT_TIMEOUT_SEC", 5.0)
+    conn = _duckdb_connector()
+
+    def _boom(engine: object = None) -> None:
+        raise RuntimeError("password authentication failed")
+
+    monkeypatch.setattr(conn._adapter, "test_connection", _boom)
+    result = conn.test_connection_result()
+    assert result.ok is False
+    assert "timed out" not in (result.message or "").lower()

--- a/tests/test_corrupt_config_recovery.py
+++ b/tests/test_corrupt_config_recovery.py
@@ -1,0 +1,54 @@
+"""Startup recovery when ``config.yml`` cannot be parsed.
+
+A corrupt config.yml used to hard-exit before the REPL even started,
+pointing the user at ``/restore-config`` — a command only reachable
+inside the REPL that just refused to start, with no hint where the
+backups live. ``_recover_corrupt_config`` surfaces the backup directory
+and offers an inline restore (when interactive), then retries the load.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import amx.cli as cli
+import amx.config as config_mod
+
+
+def test_recover_no_backups_returns_none(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    monkeypatch.setattr(config_mod, "list_config_backups", lambda p=None: [])
+    out = cli._recover_corrupt_config(str(tmp_path / "config.yml"), ValueError("bad yaml"))
+    assert out is None
+
+
+def test_recover_non_interactive_returns_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    # With backups present but no TTY, we must NOT prompt — just surface
+    # the path and bail so the caller exits with the actionable message.
+    backup = tmp_path / "config.yml.bak.1"
+    monkeypatch.setattr(config_mod, "list_config_backups", lambda p=None: [backup])
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False, raising=False)
+    out = cli._recover_corrupt_config(str(tmp_path / "config.yml"), ValueError("bad yaml"))
+    assert out is None
+
+
+def test_recover_restores_and_reloads(monkeypatch: pytest.MonkeyPatch, tmp_path: object) -> None:
+    backup = tmp_path / "config.yml.bak.1"
+    monkeypatch.setattr(config_mod, "list_config_backups", lambda p=None: [backup])
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(cli, "confirm", lambda *a, **k: True)
+    monkeypatch.setattr(cli, "ask_choice", lambda *a, **k: backup.name)
+    restored: dict[str, object] = {}
+    monkeypatch.setattr(
+        config_mod,
+        "restore_config_from_backup",
+        lambda b, p=None: restored.setdefault("backup", b) or b,
+    )
+    sentinel = object()
+    monkeypatch.setattr(cli.AMXConfig, "load", classmethod(lambda cls, path=None: sentinel))
+
+    out = cli._recover_corrupt_config(str(tmp_path / "config.yml"), ValueError("bad yaml"))
+    assert out is sentinel
+    assert restored["backup"] == backup


### PR DESCRIPTION
## Summary

The CLI/recovery slice of the usability remediation. Four independent, self-contained safety fixes (no Studio surface):

1. **`/connect` + `/setup` surface the real failure cause.** The generic (non-Databricks) branch called the bool `test_connection()` and printed a fixed `Connection failed.` / `Check credentials and try again.`, discarding the categorised, actionable message (wrong password / SSL / timeout / missing driver / unknown database) that `test_connection_result()` already builds — and that the Databricks branch, `/inspect`, and the `/setup` LLM step already show. Both paths now report the real cause.

2. **Uniform connect timeout across all backends.** Only Databricks set one; every other backend hung for the OS TCP default (~75–130s, doubled by the retry layer) on an unreachable host, and the native driver connect (GIL-holding C call) ignored Ctrl-C. The probe now runs in a **daemon thread** bounded by `DB_CONNECT_TIMEOUT_SEC` (15s): the main thread parks in `Event.wait(timeout=)`, which is Ctrl-C–interruptible and returns control promptly with an actionable host/network message. Daemon → never blocks exit; real errors re-raise unchanged so existing classification still applies.

3. **Corrupt `config.yml` recovery at startup.** A YAML typo raised `yaml.YAMLError` past the only guard and crashed before the REPL — while telling the user to run `/restore-config`, a command only reachable *inside* the REPL that just refused to start, with no hint where backups live. Startup now catches `YAMLError`/`OSError`/`UnicodeDecodeError`, prints the absolute config + backup-directory path, and (when interactive) offers an inline restore before retrying the load.

4. **Review gate re-prompts on invalid input.** `ask_choice` returned the default on any unrecognised input; at the review gate (`default=options[0]`) a typo silently accepted the top LLM suggestion right before DB writeback. It now re-prompts with a hint (empty still accepts the default), capped so a non-interactive/EOF caller can't loop forever. Applies everywhere `ask_choice` is used.

## Test plan

- New: `tests/test_connect_timeout.py`, `tests/test_corrupt_config_recovery.py`, `tests/test_ask_choice_reprompt.py` (10 cases) — timeout bound + actionable message, no-backups/non-interactive/restore-and-reload recovery, and re-prompt/empty-default/retry-cap behaviour.
- 52 existing `ask_choice`-driven wizard tests pass unchanged; connector + orchestrator regression files green.
- `ruff check` + `ruff format --check` clean on all touched files.

> Remaining usability wave-1 work (separate PRs): wiring the existing `review_keynav` navigation into the review loop, and the Studio Apply confirm/preview guard (Studio-visible → deploy first).