### PR TITLE
fix(review): repair accept-path crash + add keyboard navigation to the review loop

### DIFF
--- a/amx/agents/_orchestrator/review.py
+++ b/amx/agents/_orchestrator/review.py
@@ -39,6 +39,11 @@ def human_review(
     asset_kind: str = "table",
     result_id_map: dict[str | None, int] | None = None,
 ) -> list[ReviewResult]:
+    # Deferred import — see review_single for why this can't live at
+    # module top (circular with ``orchestrator``). The accept-all /
+    # reject-all branches below construct ReviewResult at runtime.
+    from amx.agents.orchestrator import ReviewResult
+
     results: list[ReviewResult] = []
     result_id_map = result_id_map or {}
 
@@ -138,6 +143,15 @@ def review_single(
     asset_kind: str = "table",
     result_id: int | None = None,
 ) -> ReviewResult:
+    # Runtime import: ReviewResult lives in ``orchestrator`` which imports
+    # this module's functions lazily, so a module-top import would be
+    # circular — hence the TYPE_CHECKING-only import above. By call time
+    # ``orchestrator`` is fully loaded, so this deferred import is safe.
+    # Without it the accept / skip / custom branches below raised
+    # ``NameError: name 'ReviewResult' is not defined`` the moment a user
+    # picked anything in the one-by-one review.
+    from amx.agents.orchestrator import ReviewResult
+
     kind_label = asset_kind.replace("_", " ").title() if is_table else "Column"
     asset = f"{kind_label}: {s.schema}.{s.table}" if is_table else f"Column: {s.table}.{s.column}"
     console.print(f"\n  [heading]{asset}[/heading]")

--- a/amx/agents/_orchestrator/review.py
+++ b/amx/agents/_orchestrator/review.py
@@ -11,10 +11,12 @@ so any external caller that patches them stays unaffected.
 
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from amx.agents.base import Confidence, MetadataSuggestion
+from amx.cli_support.review_keynav import format_help, parse_nav_command
 from amx.utils.console import (
     ask,
     ask_choice,
@@ -22,6 +24,7 @@ from amx.utils.console import (
     heading,
     info,
     render_table,
+    warn,
 )
 from amx.utils.logging import get_logger
 
@@ -83,55 +86,52 @@ def human_review(
             default="one-by-one",
         )
 
-        for s in col_suggestions:
-            rid = result_id_map.get(s.column)
-            if (
-                review_mode == "accept-all"
-                or review_mode == "accept-all-high"
-                and s.confidence == Confidence.HIGH
-            ):
-                rr = ReviewResult(
-                    schema=s.schema,
-                    table=s.table,
-                    column=s.column,
-                    final_description=s.suggestions[0],
-                    confidence=s.confidence,
-                    source=s.source,
-                    applied=True,
-                    asset_kind=asset_kind,
-                    result_id=rid,
-                    logprob_score=s.logprob_score,
-                    citations=list(getattr(s, "citations", None) or []),
-                )
-                orch._record_evaluation(
-                    rid, chosen_description=s.suggestions[0], evaluation="accepted"
-                )
-                results.append(rr)
-            elif (
-                review_mode == "accept-all-high"
-                and s.confidence != Confidence.HIGH
-                or review_mode == "reject-all"
-            ):
-                rr = ReviewResult(
-                    schema=s.schema,
-                    table=s.table,
-                    column=s.column,
-                    final_description="",
-                    confidence=s.confidence,
-                    source=s.source,
-                    applied=False,
-                    asset_kind=asset_kind,
-                    result_id=rid,
-                    logprob_score=s.logprob_score,
-                    citations=list(getattr(s, "citations", None) or []),
-                )
-                orch._record_evaluation(rid, chosen_description="", evaluation="skipped")
-                results.append(rr)
-            else:
-                result = orch._review_single(
-                    s, is_table=False, asset_kind=asset_kind, result_id=rid
-                )
-                results.append(result)
+        if review_mode == "one-by-one":
+            # Position-aware, navigable review (back / goto / filter / help)
+            # with a [i/N] counter. Replaces the old forward-only loop.
+            results.extend(_navigable_review(orch, col_suggestions, asset_kind, result_id_map))
+        else:
+            for s in col_suggestions:
+                rid = result_id_map.get(s.column)
+                if (
+                    review_mode == "accept-all"
+                    or review_mode == "accept-all-high"
+                    and s.confidence == Confidence.HIGH
+                ):
+                    rr = ReviewResult(
+                        schema=s.schema,
+                        table=s.table,
+                        column=s.column,
+                        final_description=s.suggestions[0],
+                        confidence=s.confidence,
+                        source=s.source,
+                        applied=True,
+                        asset_kind=asset_kind,
+                        result_id=rid,
+                        logprob_score=s.logprob_score,
+                        citations=list(getattr(s, "citations", None) or []),
+                    )
+                    orch._record_evaluation(
+                        rid, chosen_description=s.suggestions[0], evaluation="accepted"
+                    )
+                    results.append(rr)
+                else:
+                    # accept-all-high + non-HIGH, or reject-all → skip.
+                    rr = ReviewResult(
+                        schema=s.schema,
+                        table=s.table,
+                        column=s.column,
+                        final_description="",
+                        confidence=s.confidence,
+                        source=s.source,
+                        applied=False,
+                        asset_kind=asset_kind,
+                        result_id=rid,
+                        logprob_score=s.logprob_score,
+                        citations=list(getattr(s, "citations", None) or []),
+                    )
+                    orch._record_evaluation(rid, chosen_description="", evaluation="skipped")
+                    results.append(rr)
 
     return results
 
@@ -143,18 +143,25 @@ def review_single(
     asset_kind: str = "table",
     result_id: int | None = None,
 ) -> ReviewResult:
-    # Runtime import: ReviewResult lives in ``orchestrator`` which imports
-    # this module's functions lazily, so a module-top import would be
-    # circular — hence the TYPE_CHECKING-only import above. By call time
-    # ``orchestrator`` is fully loaded, so this deferred import is safe.
-    # Without it the accept / skip / custom branches below raised
-    # ``NameError: name 'ReviewResult' is not defined`` the moment a user
-    # picked anything in the one-by-one review.
-    from amx.agents.orchestrator import ReviewResult
+    _render_review_header(s, is_table=is_table, asset_kind=asset_kind)
+    options = list(s.suggestions) + ["Other (type your own)", "Skip"]
+    choice = ask_choice("Select a description", options, default=options[0])
+    return _finalize_choice(orch, s, choice, asset_kind=asset_kind, result_id=result_id)
 
+
+def _render_review_header(
+    s: MetadataSuggestion,
+    *,
+    is_table: bool,
+    asset_kind: str,
+    position: tuple[int, int] | None = None,
+) -> None:
+    """Print the per-item review header. ``position`` adds a ``[i/N]``
+    counter so the user always knows where they are in the queue."""
     kind_label = asset_kind.replace("_", " ").title() if is_table else "Column"
     asset = f"{kind_label}: {s.schema}.{s.table}" if is_table else f"Column: {s.table}.{s.column}"
-    console.print(f"\n  [heading]{asset}[/heading]")
+    counter = f"[{position[0]}/{position[1]}] " if position else ""
+    console.print(f"\n  [heading]{counter}{asset}[/heading]")
     console.print(
         f"  Confidence: [{'success' if s.confidence == Confidence.HIGH else 'warning'}]{s.confidence.value}[/]"
     )
@@ -165,9 +172,24 @@ def review_single(
     console.print(f"  Reasoning: {s.reasoning}")
     console.print()
 
-    options = list(s.suggestions) + ["Other (type your own)", "Skip"]
-    choice = ask_choice("Select a description", options, default=options[0])
 
+def _finalize_choice(
+    orch: Orchestrator,
+    s: MetadataSuggestion,
+    choice: str,
+    *,
+    asset_kind: str,
+    result_id: int | None,
+) -> ReviewResult:
+    """Turn a picked option into a recorded :class:`ReviewResult`.
+
+    Shared by ``review_single`` and the navigable loop. ``ReviewResult``
+    is imported at call time — see ``review_single`` for why a module-top
+    import would be circular.
+    """
+    from amx.agents.orchestrator import ReviewResult
+
+    citations = list(getattr(s, "citations", None) or [])
     if choice == "Skip":
         orch._record_evaluation(result_id, chosen_description="", evaluation="skipped")
         return ReviewResult(
@@ -181,9 +203,9 @@ def review_single(
             asset_kind=asset_kind,
             result_id=result_id,
             logprob_score=s.logprob_score,
-            citations=list(getattr(s, "citations", None) or []),
+            citations=citations,
         )
-    elif choice == "Other (type your own)":
+    if choice == "Other (type your own)":
         custom = ask("Enter your description")
         orch._record_evaluation(result_id, chosen_description=custom, evaluation="custom")
         return ReviewResult(
@@ -197,23 +219,169 @@ def review_single(
             asset_kind=asset_kind,
             result_id=result_id,
             logprob_score=s.logprob_score,
-            citations=list(getattr(s, "citations", None) or []),
+            citations=citations,
         )
-    else:
-        orch._record_evaluation(result_id, chosen_description=choice, evaluation="accepted")
-        return ReviewResult(
-            schema=s.schema,
-            table=s.table,
-            column=s.column,
-            final_description=choice,
-            confidence=s.confidence,
-            source=s.source,
-            applied=True,
-            asset_kind=asset_kind,
-            result_id=result_id,
-            logprob_score=s.logprob_score,
-            citations=list(getattr(s, "citations", None) or []),
+    orch._record_evaluation(result_id, chosen_description=choice, evaluation="accepted")
+    return ReviewResult(
+        schema=s.schema,
+        table=s.table,
+        column=s.column,
+        final_description=choice,
+        confidence=s.confidence,
+        source=s.source,
+        applied=True,
+        asset_kind=asset_kind,
+        result_id=result_id,
+        logprob_score=s.logprob_score,
+        citations=citations,
+    )
+
+
+def _interpret_selection(raw: str, options: list[str]) -> str | None:
+    """Map raw input to a review option, or ``None`` if it isn't one.
+
+    ``s``/``skip`` and ``o``/``other`` are shortcuts; a bare number picks
+    by position; an exact label also matches. Nav keys (n/p/g/G///?) are
+    NOT options — they're handled by ``parse_nav_command`` first.
+    """
+    low = raw.strip().lower()
+    if low in ("s", "skip"):
+        return "Skip"
+    if low in ("o", "other"):
+        return "Other (type your own)"
+    if raw.strip().isdigit():
+        n = int(raw.strip())
+        return options[n - 1] if 1 <= n <= len(options) else None
+    for opt in options:
+        if raw.strip() == opt:
+            return opt
+    return None
+
+
+def _filter_review_order(items: list[MetadataSuggestion], pattern: str) -> list[int]:
+    """Indices of ``items`` whose column matches ``pattern`` (regex, case-
+    insensitive). Falls back to the full list on an empty/invalid pattern
+    or no match, with a warning, so a filter can never strand the user."""
+    if not pattern:
+        return list(range(len(items)))
+    try:
+        rx = re.compile(pattern, re.IGNORECASE)
+    except re.error:
+        warn(f"Invalid filter pattern: /{pattern} — showing all rows.")
+        return list(range(len(items)))
+    matched = [i for i, s in enumerate(items) if rx.search(s.column or "")]
+    if not matched:
+        warn(f"No columns match /{pattern} — showing all rows.")
+        return list(range(len(items)))
+    return matched
+
+
+def _advance_to_undecided(order: list[int], decided: set[int], pos: int) -> int:
+    """Next position in ``order`` (after ``pos``, wrapping) whose item is
+    still undecided. Returns ``pos`` unchanged when everything is decided
+    (the caller's ``while`` guard then exits)."""
+    n = len(order)
+    for step in range(1, n + 1):
+        cand = (pos + step) % n
+        if order[cand] not in decided:
+            return cand
+    return pos
+
+
+def _navigable_review(
+    orch: Orchestrator,
+    items: list[MetadataSuggestion],
+    asset_kind: str,
+    result_id_map: dict[str | None, int],
+) -> list[ReviewResult]:
+    """One-by-one column review with a position counter + navigation.
+
+    Replaces the forward-only loop. Every item still gets a decision —
+    the loop exits only once all items are decided, matching the old
+    semantics — but the user can now step back (``p``/``k``), jump
+    (``g N``), jump to the last (``G``), filter the remaining queue
+    (``/pattern``), or show help (``?``). ``Enter`` accepts the top
+    suggestion and advances (the established convention), which also
+    guarantees the loop terminates. A step budget bounds a
+    non-interactive / EOF caller so it can never spin forever.
+    """
+    total = len(items)
+    decisions: dict[int, ReviewResult] = {}
+    order = list(range(total))
+    pos = 0
+    info(
+        "Review one-by-one — Enter accepts the top suggestion; type a number "
+        "to pick, 's' to skip, 'o' for your own text; n/p move, g N jump, "
+        "G last, /text filter, ? help."
+    )
+    guard = 0
+    max_iter = total * 50 + 100
+    while len(decisions) < total:
+        guard += 1
+        if guard > max_iter:
+            warn("Review exceeded its step budget — skipping the remaining undecided rows.")
+            for i, s in enumerate(items):
+                if i not in decisions:
+                    decisions[i] = _finalize_choice(
+                        orch,
+                        s,
+                        "Skip",
+                        asset_kind=asset_kind,
+                        result_id=result_id_map.get(s.column),
+                    )
+            break
+        # If the current (possibly filtered) view is fully decided but the
+        # run isn't, expand back to all rows so a filter can't strand the
+        # user on the rows it hid — then land on the first undecided one.
+        if not order or all(i in decisions for i in order):
+            order = list(range(total))
+            pos = next((p for p, i in enumerate(order) if i not in decisions), 0)
+        pos = max(0, min(pos, len(order) - 1))
+        idx = order[pos]
+        s = items[idx]
+        _render_review_header(
+            s, is_table=False, asset_kind=asset_kind, position=(pos + 1, len(order))
         )
+        if idx in decisions:
+            console.print("  [dim](already decided — pick again to change, or navigate on)[/dim]")
+        options = list(s.suggestions) + ["Other (type your own)", "Skip"]
+        for i, opt in enumerate(options, 1):
+            console.print(f"    {i}. {opt}")
+        raw = ask("> ")
+        if raw == "":
+            decisions[idx] = _finalize_choice(
+                orch, s, options[0], asset_kind=asset_kind, result_id=result_id_map.get(s.column)
+            )
+            pos = _advance_to_undecided(order, set(decisions), pos)
+            continue
+        nav = parse_nav_command(raw, position=pos, queue_len=len(order))
+        if nav.action == "help":
+            console.print(format_help())
+            continue
+        if nav.action == "filter":
+            order = _filter_review_order(items, nav.payload)
+            pos = 0
+            continue
+        if nav.action == "goto" and nav.payload == "":
+            target = ask("Go to row #").strip()
+            if target.isdigit():
+                pos = max(0, min(len(order) - 1, int(target) - 1))
+            continue
+        if nav.action in ("next", "prev", "last", "goto"):
+            pos = nav.position
+            continue
+        choice = _interpret_selection(raw, options)
+        if choice is None:
+            warn(
+                f"'{raw}' isn't a row choice or nav key — type a number "
+                f"1-{len(options)}, 's', 'o', or '?' for help."
+            )
+            continue
+        decisions[idx] = _finalize_choice(
+            orch, s, choice, asset_kind=asset_kind, result_id=result_id_map.get(s.column)
+        )
+        pos = _advance_to_undecided(order, set(decisions), pos)
+    return [decisions[i] for i in range(total)]
 
 
 def review_single_result(orch: Orchestrator, r: ReviewResult) -> ReviewResult:

--- a/tests/test_navigable_review.py
+++ b/tests/test_navigable_review.py
@@ -1,0 +1,124 @@
+"""Navigable one-by-one review loop (``_navigable_review``).
+
+Adds a position counter and back/goto/filter/help navigation to the
+per-column review while preserving the old "every item gets a decision"
+termination. Enter accepts the top suggestion and advances. Because the
+loop is interactive, these tests drive it by scripting the ``ask`` reader
+(monkeypatched) — covering each navigation path, re-decide-on-revisit,
+invalid-input re-prompt, and the non-interactive step-budget backstop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import amx.agents._orchestrator.review as review
+from amx.agents.base import Confidence, MetadataSuggestion
+
+
+class _StubOrch:
+    def __init__(self) -> None:
+        self.recorded: list[tuple[int | None, str, str]] = []
+
+    def _record_evaluation(self, result_id, chosen_description, evaluation) -> None:  # noqa: ANN001
+        self.recorded.append((result_id, chosen_description, evaluation))
+
+
+def _items(*cols: str) -> list[MetadataSuggestion]:
+    out = []
+    for i, col in enumerate(cols):
+        out.append(
+            MetadataSuggestion(
+                schema="s",
+                table="t",
+                column=col,
+                suggestions=[f"{col}-first", f"{col}-second"],
+                confidence=Confidence.HIGH,
+                reasoning="",
+                source="profile",
+            )
+        )
+    return out
+
+
+def _script(monkeypatch: pytest.MonkeyPatch, inputs: list[str]) -> None:
+    it = iter(inputs)
+    monkeypatch.setattr(review, "ask", lambda *a, **k: next(it))
+
+
+def _rid_map(items: list[MetadataSuggestion]) -> dict[str | None, int]:
+    return {s.column: i + 1 for i, s in enumerate(items)}
+
+
+def test_enter_accepts_top_and_advances_through_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = _items("a", "b")
+    _script(monkeypatch, ["", ""])  # Enter, Enter
+    orch = _StubOrch()
+    out = review._navigable_review(orch, items, "table", _rid_map(items))
+    assert [r.final_description for r in out] == ["a-first", "b-first"]
+    assert all(r.applied for r in out)
+
+
+def test_number_selects_specific_suggestion(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = _items("a")
+    _script(monkeypatch, ["2"])  # pick the 2nd suggestion
+    out = review._navigable_review(_StubOrch(), items, "table", _rid_map(items))
+    assert out[0].final_description == "a-second"
+
+
+def test_skip_shortcut_marks_unapplied(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = _items("a")
+    _script(monkeypatch, ["s"])
+    out = review._navigable_review(_StubOrch(), items, "table", _rid_map(items))
+    assert out[0].applied is False
+    assert out[0].final_description == ""
+
+
+def test_prev_navigation_allows_redeciding(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = _items("a", "b")
+    # item a -> pick "2" (advance to b); at b -> "p" (back to a); at a -> "1"
+    # (overwrite to first); advance to b; Enter accepts b.
+    _script(monkeypatch, ["2", "p", "1", ""])
+    out = review._navigable_review(_StubOrch(), items, "table", _rid_map(items))
+    assert out[0].final_description == "a-first"  # overwritten on revisit
+    assert out[1].final_description == "b-first"
+
+
+def test_goto_jumps_to_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = _items("a", "b", "c")
+    # 'g 3' jumps to row 3 (c); decide it; then Enter through the rest.
+    _script(monkeypatch, ["g 3", "1", "", ""])
+    out = review._navigable_review(_StubOrch(), items, "table", _rid_map(items))
+    assert out[2].final_description == "c-first"
+    assert all(r.applied for r in out)
+
+
+def test_filter_narrows_then_restores(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = _items("alpha", "beta", "gamma")
+    # Filter to 'beta' only, decide it; cleared filter (no match path) keeps
+    # all, then Enter through remaining undecided.
+    _script(monkeypatch, ["/beta", "1", "", ""])
+    out = review._navigable_review(_StubOrch(), items, "table", _rid_map(items))
+    # beta decided via filter, the rest via Enter — all decided, order kept.
+    assert [r.column for r in out] == ["alpha", "beta", "gamma"]
+    assert out[1].final_description == "beta-first"
+
+
+def test_invalid_input_reprompts_without_deciding(monkeypatch: pytest.MonkeyPatch) -> None:
+    items = _items("a")
+    _script(monkeypatch, ["zzz", "1"])  # garbage then a valid pick
+    orch = _StubOrch()
+    out = review._navigable_review(orch, items, "table", _rid_map(items))
+    assert out[0].final_description == "a-first"
+    # Exactly one decision recorded despite two prompts.
+    assert len(orch.recorded) == 1
+
+
+def test_step_budget_terminates_on_pathological_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A caller that only ever navigates (never decides) must not loop
+    # forever — the step budget skips the remainder and returns.
+    items = _items("a", "b")
+    monkeypatch.setattr(review, "ask", lambda *a, **k: "n")  # always "next"
+    out = review._navigable_review(_StubOrch(), items, "table", _rid_map(items))
+    assert len(out) == 2
+    assert all(r.applied is False for r in out)  # forced-skipped at the budget

--- a/tests/test_review_single_construction.py
+++ b/tests/test_review_single_construction.py
@@ -1,0 +1,67 @@
+"""``review_single`` builds a ReviewResult on every branch.
+
+Regression guard: ReviewResult is defined in ``amx.agents.orchestrator``
+(circular with this module, so it's TYPE_CHECKING-only). The runtime
+construction had no deferred import, so accept / skip / custom each
+raised ``NameError: name 'ReviewResult' is not defined`` the moment a
+user picked anything in the one-by-one review — the core human-in-the-
+loop gate. These tests exercise all three branches.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import amx.agents._orchestrator.review as review
+from amx.agents.base import Confidence, MetadataSuggestion
+
+
+class _StubOrch:
+    def __init__(self) -> None:
+        self.recorded: list[tuple[int | None, str, str]] = []
+
+    def _record_evaluation(
+        self, result_id: int | None, chosen_description: str, evaluation: str
+    ) -> None:
+        self.recorded.append((result_id, chosen_description, evaluation))
+
+
+def _suggestion() -> MetadataSuggestion:
+    return MetadataSuggestion(
+        schema="s",
+        table="t",
+        column="c",
+        suggestions=["desc one", "desc two"],
+        confidence=Confidence.HIGH,
+        reasoning="",
+        source="profile",
+    )
+
+
+def test_accept_builds_applied_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(review, "ask_choice", lambda *a, **k: "desc one")
+    orch = _StubOrch()
+    rr = review.review_single(orch, _suggestion(), is_table=False, asset_kind="table", result_id=1)
+    assert rr.applied is True
+    assert rr.final_description == "desc one"
+    assert orch.recorded == [(1, "desc one", "accepted")]
+
+
+def test_skip_builds_unapplied_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(review, "ask_choice", lambda *a, **k: "Skip")
+    orch = _StubOrch()
+    rr = review.review_single(orch, _suggestion(), is_table=False, asset_kind="table", result_id=2)
+    assert rr.applied is False
+    assert rr.final_description == ""
+    assert orch.recorded == [(2, "", "skipped")]
+
+
+def test_custom_text_builds_human_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(review, "ask_choice", lambda *a, **k: "Other (type your own)")
+    monkeypatch.setattr(review, "ask", lambda *a, **k: "my own text")
+    orch = _StubOrch()
+    rr = review.review_single(orch, _suggestion(), is_table=False, asset_kind="table", result_id=3)
+    assert rr.applied is True
+    assert rr.final_description == "my own text"
+    assert rr.source == "human"
+    assert orch.recorded == [(3, "my own text", "custom")]


### PR DESCRIPTION
## Summary

The interactive one-by-one review loop, in two parts:

1. **Crash fix (latent bug).** `ReviewResult` is defined in `amx.agents.orchestrator`, which lazily imports `review.py`'s functions — so `review.py` kept `ReviewResult` under a `TYPE_CHECKING`-only import to dodge a circular import. But the accept / skip / custom branches *construct* `ReviewResult` at runtime with no deferred import, so the moment a user picked anything in the one-by-one review the gate raised `NameError: name 'ReviewResult' is not defined`. Added a call-time import in `review_single` and `human_review` (safe — `orchestrator` is fully loaded by call time). This path had **no test coverage** (the existing `test_review_pick` tests a different module, `review_picker`), which is why it slipped.

2. **Keyboard navigation.** The review was a forward-only click-through — no position counter, no way back, no jump; a mis-pick on column 3 of 200 was unrecoverable without re-running. Wired in the existing-but-never-called `review_keynav` state machine:
   - `[i/N]` position counter on every item
   - back (`p`/`k`), goto (`g N`), last (`G`), filter (`/regex`), help (`?`)
   - `Enter` accepts the top suggestion and advances (existing convention) — also guarantees termination
   - a filter can't strand the user: once its subset is decided the view auto-expands back to the undecided rows
   - a step budget bounds non-interactive / EOF callers so the loop can never spin forever

Refactored the per-item render + decision into `_render_review_header` / `_finalize_choice`, shared with `review_single` (behaviour-preserving). Accept-all / accept-all-high / reject-all paths are unchanged.

## Test plan

- New `tests/test_review_single_construction.py` (3 cases) — guards the NameError regression on accept/skip/custom.
- New `tests/test_navigable_review.py` (8 cases) — Enter-through-all, number/skip selection, back-nav re-decide, goto, filter (incl. the un-strand path), invalid-input re-prompt, and the step-budget backstop.
- All 65 existing review tests (`test_review_pick`, `test_review_keynav`, `test_review_bulk_actions`, `test_review_filter_sort_group`) pass unchanged.
- `ruff check` + `ruff format --check` clean.