### PR TITLE
fix(studio): confirm + dry-run preview before Apply writes to the live database

### DIFF
--- a/frontend/src/routes/Pending.test.tsx
+++ b/frontend/src/routes/Pending.test.tsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+
+import Pending from "./Pending";
+import { renderWithProviders } from "../test/render";
+
+const originalFetch = globalThis.fetch;
+const originalEventSource = globalThis.EventSource;
+
+interface Call {
+  url: string;
+  method: string;
+}
+let calls: Call[] = [];
+
+beforeEach(() => {
+  calls = [];
+  // jsdom has no EventSource; JobProgress opens one after apply starts.
+  class FakeEventSource {
+    close(): void {}
+    addEventListener(): void {}
+    removeEventListener(): void {}
+    onmessage: ((ev: MessageEvent) => void) | null = null;
+    onerror: ((ev: Event) => void) | null = null;
+  }
+  globalThis.EventSource = FakeEventSource as unknown as typeof EventSource;
+
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+    calls.push({ url, method });
+
+    if (url.endsWith("/api/pending") && method === "GET") {
+      return jsonResponse({
+        count: 2,
+        pending: [
+          row(0, "orders", "id"),
+          row(1, "orders", "status"),
+        ],
+      });
+    }
+    if (url.endsWith("/api/pending/preview")) {
+      return jsonResponse({
+        count: 2,
+        events: [
+          previewEvent(0, "orders", "id"),
+          previewEvent(1, "orders", "status"),
+        ],
+      });
+    }
+    if (url.endsWith("/api/pending/apply")) {
+      return jsonResponse({ job_id: "job-1" });
+    }
+    return jsonResponse({});
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.EventSource = originalEventSource;
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function row(idx: number, table: string, column: string) {
+  return {
+    idx,
+    schema: "public",
+    table,
+    column,
+    final_description: `desc for ${column}`,
+    confidence: "high",
+    source: "profile",
+    asset_kind: "column",
+    result_id: idx + 1,
+    alternatives: [],
+    logprob_score: null,
+  };
+}
+
+function previewEvent(idx: number, table: string, column: string) {
+  return {
+    idx,
+    schema: "public",
+    table,
+    column,
+    asset_kind: "column",
+    new_comment: `desc for ${column}`,
+    sql_template: `COMMENT ON COLUMN public.${table}.${column} IS 'desc for ${column}';`,
+  };
+}
+
+function applyCalls(): Call[] {
+  return calls.filter((c) => c.url.endsWith("/api/pending/apply"));
+}
+
+describe("Pending — Apply safety gate", () => {
+  it("does not write to the DB on the Apply click; it opens the dry-run preview first", async () => {
+    renderWithProviders(<Pending />, { route: "/pending" });
+
+    const applyBtn = await screen.findByRole("button", { name: /Apply \(2\)/i });
+    fireEvent.click(applyBtn);
+
+    // The preview (dry-run) is fetched and the modal appears...
+    await waitFor(() =>
+      expect(calls.some((c) => c.url.endsWith("/api/pending/preview"))).toBe(true),
+    );
+    await screen.findByText(/Apply preview/i);
+    // ...but NOTHING has been written yet.
+    expect(applyCalls()).toHaveLength(0);
+  });
+
+  it("writes only after confirming inside the preview modal", async () => {
+    renderWithProviders(<Pending />, { route: "/pending" });
+
+    fireEvent.click(await screen.findByRole("button", { name: /Apply \(2\)/i }));
+    // The modal's confirm button is labelled with the live-database write.
+    const confirmBtn = await screen.findByRole("button", {
+      name: /Apply 2 statements to the live database/i,
+    });
+    expect(applyCalls()).toHaveLength(0);
+
+    fireEvent.click(confirmBtn);
+    await waitFor(() => expect(applyCalls()).toHaveLength(1));
+    expect(applyCalls()[0].method).toBe("POST");
+  });
+});

--- a/frontend/src/routes/Pending.tsx
+++ b/frontend/src/routes/Pending.tsx
@@ -67,6 +67,9 @@ export default function Pending() {
   const [query, setQuery] = useState("");
   const [previewEvents, setPreviewEvents] = useState<PreviewEvent[] | null>(null);
   const [previewing, setPreviewing] = useState(false);
+  // When true the preview modal is acting as the Apply confirmation gate
+  // (it shows a danger "Apply" button); when false it's a read-only dry-run.
+  const [applyMode, setApplyMode] = useState(false);
 
   const pending = useQuery({
     queryKey: ["pending"],
@@ -135,13 +138,14 @@ export default function Pending() {
     }
   }
 
-  async function handlePreview() {
+  async function handlePreview(confirmApply = false) {
     setPreviewing(true);
     try {
       const res = await apiFetch<PreviewResponse>("/api/pending/preview", {
         method: "POST",
         body: JSON.stringify({}),
       });
+      setApplyMode(confirmApply);
       setPreviewEvents(res.events);
     } catch (err) {
       toast.push({
@@ -152,6 +156,19 @@ export default function Pending() {
     } finally {
       setPreviewing(false);
     }
+  }
+
+  function closePreview() {
+    setPreviewEvents(null);
+    setApplyMode(false);
+  }
+
+  // The preview modal's Apply button is the explicit confirmation: the
+  // user is looking at the exact SQL that will run against the live
+  // database. Only here do we actually write.
+  async function confirmApplyFromPreview() {
+    closePreview();
+    await handleApply();
   }
 
   const filtered = useMemo(() => {
@@ -197,7 +214,7 @@ export default function Pending() {
               size="md"
               leadingIcon={<Eye size={14} />}
               disabled={!total || previewing}
-              onClick={handlePreview}
+              onClick={() => handlePreview(false)}
             >
               {previewing ? "Previewing…" : "Preview SQL"}
             </Button>
@@ -205,8 +222,8 @@ export default function Pending() {
               variant="primary"
               size="md"
               leadingIcon={<Play size={14} />}
-              disabled={!total || applyInFlight}
-              onClick={handleApply}
+              disabled={!total || applyInFlight || previewing}
+              onClick={() => handlePreview(true)}
             >
               Apply ({total})
             </Button>
@@ -217,7 +234,9 @@ export default function Pending() {
       {previewEvents !== null && (
         <PreviewModal
           events={previewEvents}
-          onClose={() => setPreviewEvents(null)}
+          onClose={closePreview}
+          onApply={applyMode ? confirmApplyFromPreview : undefined}
+          applying={applyInFlight}
         />
       )}
 
@@ -443,9 +462,15 @@ function PendingItem({
 function PreviewModal({
   events,
   onClose,
+  onApply,
+  applying = false,
 }: {
   events: PreviewEvent[];
   onClose: () => void;
+  // When provided, the modal is the Apply confirmation gate and renders a
+  // danger "Apply" button. The exact SQL above it is what will run.
+  onApply?: () => void;
+  applying?: boolean;
 }) {
   const writeable = events.filter((e) => e.sql_template);
   const skipped = events.filter((e) => e.skipped_reason || e.error);
@@ -467,8 +492,10 @@ function PreviewModal({
             </h2>
             <p className="text-xs text-text-soft">
               {writeable.length} statement{writeable.length === 1 ? "" : "s"} would
-              run; {skipped.length} skipped. Nothing has been written to the
-              database.
+              run; {skipped.length} skipped.{" "}
+              {onApply
+                ? "Review the exact SQL below, then Apply to write it to the live database."
+                : "Nothing has been written to the database."}
             </p>
           </div>
           <button
@@ -508,6 +535,26 @@ function PreviewModal({
             </ul>
           )}
         </div>
+        {onApply && (
+          <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+            <Button variant="subtle" size="md" onClick={onClose} disabled={applying}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="md"
+              leadingIcon={<Play size={14} />}
+              disabled={applying || writeable.length === 0}
+              onClick={onApply}
+            >
+              {applying
+                ? "Applying…"
+                : `Apply ${writeable.length} statement${
+                    writeable.length === 1 ? "" : "s"
+                  } to the live database`}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Studio's **Apply** button POSTed `/api/pending/apply` immediately on click — a direct, irreversible write to the live catalog with **no confirmation** — while the far-safer **Clear all** action already had an `AlertDialog`. The documented confirmation modal didn't exist.

Apply now routes through the existing **dry-run preview**: clicking Apply opens the preview modal showing the exact `COMMENT` statements that will run, with a danger **"Apply N statements to the live database"** button as the explicit confirm. The standalone **Preview SQL** button stays read-only (no confirm button — pass no `onApply`). Nothing writes until the user confirms against SQL they can actually see.

Implementation reuses the existing `PreviewModal` as the confirm surface (an `applyMode` flag distinguishes look-only vs confirm-gate), so the change is contained to `Pending.tsx`.

## Test plan

- New `frontend/src/routes/Pending.test.tsx` (2 cases): clicking Apply does **not** POST `/api/pending/apply` (it fetches the dry-run preview and opens the modal); the write happens **only** after clicking the modal's confirm button.
- `tsc -b` clean, `eslint` clean, full frontend vitest suite green (24 tests).

## Deploy note

Studio-visible change. Per the deploy-order rule, `deploy.sh` should publish this to the live Studio — but it builds from the main checkout, so the deploy lands naturally after this merges to `main` and the main checkout is synced. (This work was done in an isolated worktree to avoid disturbing a concurrent task on the main checkout.)