### PR TITLE
fix(cli): make /rerun, /variations, /usage reachable + discoverable; fix stale model hints

### DIFF
--- a/amx/cli_support/commands/profiles.py
+++ b/amx/cli_support/commands/profiles.py
@@ -99,9 +99,9 @@ def interactive_llm_block(defaults: LLMConfig | None = None) -> LLMConfig:
     elif provider == "anthropic":
         info("Anthropic model example: claude-sonnet-4-20250514")
     elif provider == "gemini":
-        info("Gemini model example: gemini-2.0-flash")
+        info("Gemini model example: gemini-2.5-flash")
     elif provider == "deepseek":
-        info("DeepSeek model example: deepseek-chat")
+        info("DeepSeek model example: deepseek-chat-v4")
     elif provider == "ollama":
         info("Ollama model example: llama3")
     elif provider == "databricks_serving":

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -699,6 +699,11 @@ _CROSS_NAMESPACE_HEADS: frozenset[str] = frozenset(
         "studio",
         "lineage",
         "pages",
+        # Real top-level Click commands that were reachable via `amx rerun`
+        # / `amx variations` but returned None here (→ "Unknown command")
+        # when typed in the REPL, because they were missing from this set.
+        "rerun",
+        "variations",
     }
 )
 

--- a/amx/cli_support/slash_commands.py
+++ b/amx/cli_support/slash_commands.py
@@ -159,6 +159,30 @@ _ROOT_ENTRYPOINTS: tuple[SlashCommand, ...] = (
             "terminal stops the server."
         ),
     ),
+    # Real top-level operations that were invokable but invisible — absent
+    # from this registry, so they never appeared in /help or autocomplete
+    # (and /rerun + /variations were also unreachable from the REPL root
+    # until added to session._CROSS_NAMESPACE_HEADS).
+    SlashCommand(
+        "/rerun",
+        "root",
+        "Re-run a past analysis result (/rerun <result_id>)",
+        long_desc=(
+            "Re-generate descriptions for a previously analyzed asset using "
+            "the stored run context, without re-profiling from scratch. Takes "
+            "the numeric result_id shown in /history results."
+        ),
+    ),
+    SlashCommand(
+        "/variations",
+        "root",
+        "Generate alternative descriptions for a result (/variations <result_id>)",
+    ),
+    SlashCommand(
+        "/usage",
+        "root",
+        "Show LLM token/cost usage from local history (/usage [--live])",
+    ),
 )
 
 _DB_COMMANDS: tuple[SlashCommand, ...] = (

--- a/tests/test_command_registry_reachability.py
+++ b/tests/test_command_registry_reachability.py
@@ -1,0 +1,35 @@
+"""Real commands are both reachable from the REPL and discoverable.
+
+`/rerun` and `/variations` are real top-level Click commands but were
+missing from `session._CROSS_NAMESPACE_HEADS`, so typing them at the
+REPL root returned None → "Unknown command" (unreachable, not just
+invisible). `/usage` works via a builtin handler but was absent from the
+slash-command registry, so it never appeared in /help or autocomplete.
+"""
+
+from __future__ import annotations
+
+from amx.cli_support.session import session_to_click_args
+from amx.cli_support.slash_commands import find_command
+
+
+def test_rerun_dispatches_from_root() -> None:
+    assert session_to_click_args("", ["rerun"]) == ["rerun"]
+    # with an argument (a result id)
+    assert session_to_click_args("", ["rerun", "42"]) == ["rerun", "42"]
+
+
+def test_variations_dispatches_from_root() -> None:
+    assert session_to_click_args("", ["variations"]) == ["variations"]
+    assert session_to_click_args("", ["variations", "42"]) == ["variations", "42"]
+
+
+def test_existing_root_command_still_dispatches() -> None:
+    # regression guard for the cross-namespace set
+    assert session_to_click_args("", ["setup"]) == ["setup"]
+
+
+def test_invisible_commands_now_in_registry() -> None:
+    for cmd in ("rerun", "variations", "usage"):
+        assert find_command(cmd) is not None, f"/{cmd} missing from the registry"
+        assert find_command(f"/{cmd}") is not None


### PR DESCRIPTION
## Summary

The discoverability/reachability slice of the docs-drift wave (AMX-repo half).

- **`/rerun` and `/variations` were unreachable from the REPL.** They're real top-level Click commands, but absent from `session._CROSS_NAMESPACE_HEADS`, so `session_to_click_args` returned `None` at the root namespace → `Unknown command`. (You could only reach them via `amx rerun` shell-style, which the REPL forbids.) Added them to the cross-namespace set so they dispatch, and to the slash-command registry so they appear in `/help` + autocomplete.
- **`/usage` was invisible.** It works via a builtin handler (`session.py`), but was missing from the registry, so it never showed in `/help`/autocomplete. Registered it.
- **Stale in-code model hints.** The Gemini/DeepSeek "model example" hints in the setup wizard showed `gemini-2.0-flash` / `deepseek-chat` while the wizard's real defaults are `gemini-2.5-flash` / `deepseek-chat-v4`. Aligned them.

## Test plan

- New `tests/test_command_registry_reachability.py`: `/rerun` and `/variations` resolve from the REPL root (with and without args); `/setup` still dispatches (cross-namespace regression guard); `/rerun`, `/variations`, `/usage` all resolve in the registry.
- 16 existing session/registry/rollback tests pass; `ruff` clean.

> Part of usability wave 2. The user-facing docs sweep (correcting `/db inspect`→`/inspect`, `/scan`→`/index`, etc.) lands separately in the `amx-docs` repo.