### PR TITLE
fix(schedule): validate cron at creation so recurring schedules don't silently die

### DIFF
--- a/amx/cli_support/commands/schedule.py
+++ b/amx/cli_support/commands/schedule.py
@@ -240,6 +240,33 @@ def _require_store():
 # ── Registration ────────────────────────────────────────────────────
 
 
+def _validate_cli_cron(expr: str | None) -> str | None:
+    """Reject a malformed cron expression at creation time.
+
+    The tick engine treats an invalid expression as one-shot (no re-arm),
+    so a typo would silently turn a "recurring" schedule into a single
+    fire that then stops — the error only ever reached a log file the user
+    never saw. Validate up front instead, mirroring the Studio route's
+    check in ``amx/web/routers/schedules.py`` so the CLI and Studio behave
+    the same. Empty / None normalises to None (a one-shot schedule).
+    """
+    if expr is None:
+        return None
+    cleaned = expr.strip()
+    if not cleaned:
+        return None
+    try:
+        from croniter import croniter
+    except Exception as exc:  # pragma: no cover - optional runtime dep
+        raise click.BadParameter(f"croniter unavailable: {exc}") from exc
+    if not croniter.is_valid(cleaned):
+        raise click.BadParameter(
+            f"invalid cron expression: {cleaned!r}. Use a 5- or 6-field cron "
+            "(e.g. '0 */6 * * *' for every 6 hours)."
+        )
+    return cleaned
+
+
 def register_schedule_commands(
     parent: click.Group,
     *,
@@ -369,6 +396,11 @@ def register_schedule_commands(
         """
         is_cache_refresh = kind == "cache_refresh"
         hs = _require_store()
+
+        # Validate the cron up front: an invalid expression is treated as
+        # one-shot by the tick engine, so without this a typo'd "recurring"
+        # schedule would fire once and silently stop. Reject it now instead.
+        cron_expr = _validate_cli_cron(cron_expr)
 
         # Resolve each field: use the flag if given, otherwise prompt.
         if not name:

--- a/tests/test_schedule_cron_validation.py
+++ b/tests/test_schedule_cron_validation.py
@@ -1,0 +1,31 @@
+"""CLI `schedule add` validates the cron expression at creation time.
+
+The tick engine treats an invalid cron as one-shot (no re-arm), so a
+typo'd "recurring" schedule used to fire once and silently stop, with the
+error only in a log file the user never saw. The CLI now rejects it at
+creation, matching the Studio route's behaviour.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from amx.cli_support.commands.schedule import _validate_cli_cron
+
+
+def test_valid_cron_returns_cleaned() -> None:
+    assert _validate_cli_cron("0 */6 * * *") == "0 */6 * * *"
+    assert _validate_cli_cron("  0 0 * * *  ") == "0 0 * * *"
+
+
+def test_none_and_empty_normalise_to_none() -> None:
+    assert _validate_cli_cron(None) is None
+    assert _validate_cli_cron("   ") is None
+
+
+def test_invalid_cron_raises_badparameter() -> None:
+    with pytest.raises(click.BadParameter):
+        _validate_cli_cron("every 6 hours")  # natural language, not cron
+    with pytest.raises(click.BadParameter):
+        _validate_cli_cron("0 0 0")  # too few fields


### PR DESCRIPTION
## Summary

`/analyze schedule add --cron '...'` stored the expression verbatim, printed `Schedule #N created`, then — for a malformed expression — fired **once and silently stopped**. The tick engine treats an invalid cron as one-shot (no re-arm), and the `croniter` error only reached a log file the user never saw. Studio already validated cron inline; the CLI didn't.

The CLI now validates at creation time (`click.BadParameter` on an invalid expression), mirroring `amx/web/routers/schedules.py::_validate_cron_expr`. Empty/None still normalises to a one-shot schedule.

## Test plan

- New `tests/test_schedule_cron_validation.py`: valid cron returns cleaned; None/empty → None; natural-language and too-few-fields raise `click.BadParameter`.
- `ruff` clean; `croniter` is already a dependency.

Part of usability wave 3.