### PR TITLE
fix(apply): surface the classified write-failure remediation in the CLI

### DIFF
--- a/amx/cli_support/commands/run.py
+++ b/amx/cli_support/commands/run.py
@@ -135,6 +135,32 @@ def _resolve_codebase_for_run(
     )
 
 
+def _report_apply_failures(outcomes: list[Any]) -> None:
+    """Surface classified write failures with their per-backend remediation.
+
+    When apply captures ``outcomes_out``, the classifier computes an
+    actionable title + suggested action (e.g. the ``GRANT ALTER`` the role
+    is missing) for each failed row. The CLI used to discard all of that
+    and record only the raw driver exception, so a privilege/ALTER failure
+    printed an opaque stack message. Show the classified title once per row
+    and each distinct remediation hint once.
+    """
+    failed = [o for o in outcomes if getattr(o, "status", "") == "failed"]
+    if not failed:
+        return
+    warn(f"{len(failed)} comment(s) could not be written to the live database:")
+    for o in failed:
+        loc = ".".join(p for p in (o.schema, o.table, o.column) if p)
+        title = getattr(o, "error_title", "") or getattr(o, "error_kind", "") or "write failed"
+        error(f"  {loc}: {title}")
+    seen: set[str] = set()
+    for o in failed:
+        action = (getattr(o, "error_action", "") or "").strip()
+        if action and action not in seen:
+            seen.add(action)
+            info(f"  → {action}")
+
+
 def register_analyze_commands(
     main: click.Group,
     *,
@@ -320,6 +346,7 @@ def register_analyze_commands(
         except Exception:
             hostname = ""
 
+        outcomes: list[Any] = []
         try:
             applied_count = apply_review_results_to_db(
                 db,
@@ -331,10 +358,12 @@ def register_analyze_commands(
                 audit_profile=getattr(cfg.db, "name", "") or "",
                 audit_user=applied_by,
                 audit_host=hostname,
+                outcomes_out=outcomes,
             )
         finally:
             if pending:
                 _finish_progress()
+        _report_apply_failures(outcomes)
         clear_pending()
         success(f"Applied {applied_count} comment(s). Pending file cleared.")
         log_event(

--- a/tests/test_apply_failure_reporting.py
+++ b/tests/test_apply_failure_reporting.py
@@ -1,0 +1,57 @@
+"""CLI apply surfaces classified write failures + their remediation.
+
+The classifier computes an actionable title + suggested action (e.g. the
+missing `GRANT ALTER`) for each failed row when apply captures outcomes.
+The CLI used to discard all of that and record only the raw driver
+exception, so a privilege/ALTER failure printed an opaque stack message.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import amx.cli_support.commands.run as run
+
+
+def _outcome(**kw: object) -> types.SimpleNamespace:
+    base = {
+        "status": "failed",
+        "schema": "sales",
+        "table": "orders",
+        "column": "id",
+        "error_title": "",
+        "error_action": "",
+        "error_kind": "",
+    }
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+def test_reports_failed_rows_with_title_and_deduped_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    errs: list[str] = []
+    infos: list[str] = []
+    warns: list[str] = []
+    monkeypatch.setattr(run, "error", lambda m: errs.append(m))
+    monkeypatch.setattr(run, "info", lambda m: infos.append(m))
+    monkeypatch.setattr(run, "warn", lambda m: warns.append(m))
+
+    grant = "Run GRANT ALTER ON sales.orders TO your_role; as the owner."
+    outcomes = [
+        _outcome(error_title="Missing ALTER privilege", error_action=grant),
+        _outcome(column="status", error_title="Missing ALTER privilege", error_action=grant),
+    ]
+    run._report_apply_failures(outcomes)
+
+    assert warns and "2 comment(s) could not be written" in warns[0]
+    assert sum("Missing ALTER privilege" in e for e in errs) == 2  # one per row
+    assert sum(grant in i for i in infos) == 1  # distinct action shown once
+
+
+def test_no_failures_reports_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    for fn in ("error", "info", "warn"):
+        monkeypatch.setattr(run, fn, lambda m, _c=calls: _c.append(m))
+    run._report_apply_failures([_outcome(status="applied")])
+    assert calls == []


### PR DESCRIPTION
## Summary

The CLI apply path called `apply_review_results_to_db` without `outcomes_out`, so the classifier's actionable per-backend remediation (e.g. the missing `GRANT ALTER`) was never captured — `_on_failed` recorded only `str(exc)` and the user saw an opaque driver stack message. Studio shows the classified hint; the CLI didn't.

Now the CLI captures `outcomes_out`, then surfaces each failed row's classified title (once per row) plus each distinct remediation action (deduped). Apply behaviour is otherwise unchanged.

## Test plan

- New `tests/test_apply_failure_reporting.py`: failed rows report the title per row and the distinct GRANT action exactly once; an all-applied list reports nothing.
- `ruff` clean.

Part of usability wave 3.