### PR TITLE
fix(db): verify the connection after /add-db-profile (no more blind 'saved and activated')

### DIFF
--- a/amx/cli_support/commands/db.py
+++ b/amx/cli_support/commands/db.py
@@ -1378,6 +1378,31 @@ def interactive_db_block(defaults: DBConfig | None = None) -> DBConfig:
     return defaults
 
 
+def _verify_saved_db_profile(name: str, db: Any) -> bool:
+    """Test a just-saved DB profile and report the result.
+
+    /add-db-profile used to print "Profile saved and activated" without
+    ever opening a connection, so a wrong password or unreachable host
+    only surfaced much later inside /run. We test now — the profile is
+    already saved (no input lost), we just tell the user whether it works
+    and how to fix it. Returns True on success. The probe is bounded by
+    DB_CONNECT_TIMEOUT_SEC so it can't hang.
+    """
+    from amx.db.connector import DatabaseConnector
+    from amx.utils.console import step_spinner
+
+    with step_spinner(f"Testing the connection for {name}..."):
+        result = DatabaseConnector(db).test_connection_result()
+    if result.ok:
+        success(f"Connection verified for {name}.")
+        return True
+    warn(f"Profile {name!r} was saved, but its connection test failed:")
+    if result.message:
+        info(f"  {result.message}")
+    info(f"Fix it with /edit-db-profile {name} (otherwise /run will fail to connect).")
+    return False
+
+
 def cmd_add_profile(
     cfg: AMXConfig,
     rest: list[str],
@@ -1415,6 +1440,7 @@ def cmd_add_profile(
         cfg.upsert_db_profile(name, db)
         cfg.set_active_db_profile(name)
     success(f"Profile saved and activated: {name} [{db.backend}]")
+    _verify_saved_db_profile(name, db)
     if log_event is not None:
         log_event(
             event_type="db_profile_upsert",

--- a/tests/test_db_profile_verify_on_save.py
+++ b/tests/test_db_profile_verify_on_save.py
@@ -1,0 +1,48 @@
+"""/add-db-profile tests the connection after saving.
+
+It used to print "Profile saved and activated" without ever opening a
+connection, so a wrong password / unreachable host only surfaced later
+inside /run. The profile is still saved (no input lost); we now also
+report whether it actually connects and how to fix it.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import amx.cli_support.commands.db as dbmod
+import amx.db.connector as connector_mod
+
+
+def _patch_console(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[str]]:
+    msgs: dict[str, list[str]] = {"success": [], "warn": [], "info": []}
+    for level in msgs:
+        monkeypatch.setattr(dbmod, level, lambda m, _l=level: msgs[_l].append(m))
+    return msgs
+
+
+def _patch_connector(monkeypatch: pytest.MonkeyPatch, ok: bool, message: str = "") -> None:
+    result = types.SimpleNamespace(ok=ok, message=message)
+    monkeypatch.setattr(
+        connector_mod,
+        "DatabaseConnector",
+        lambda db: types.SimpleNamespace(test_connection_result=lambda: result),
+    )
+
+
+def test_verify_success_reports_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    msgs = _patch_console(monkeypatch)
+    _patch_connector(monkeypatch, ok=True)
+    assert dbmod._verify_saved_db_profile("prod", object()) is True
+    assert msgs["success"] and not msgs["warn"]
+
+
+def test_verify_failure_surfaces_actionable_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    msgs = _patch_console(monkeypatch)
+    _patch_connector(monkeypatch, ok=False, message="PostgreSQL refused the credentials.")
+    assert dbmod._verify_saved_db_profile("prod", object()) is False
+    assert msgs["warn"]
+    assert any("refused the credentials" in i for i in msgs["info"])
+    assert any("/edit-db-profile prod" in i for i in msgs["info"])


### PR DESCRIPTION
## Summary

`/add-db-profile` printed `Profile saved and activated` without ever opening a connection, so a wrong password / unreachable host only surfaced much later inside `/run`, with a less obvious link back to "the profile is misconfigured". (`/setup` already tested DB + LLM; `/add-db-profile` didn't.)

After saving (the profile is kept regardless, so no input is lost), it now runs the bounded `test_connection_result()` and reports either success or the categorised actionable cause + a pointer to `/edit-db-profile`. The probe is bounded by the wave-1 connect timeout so it can't hang.

## Test plan

- New `tests/test_db_profile_verify_on_save.py`: success path reports OK; failure surfaces the actionable message + the `/edit-db-profile` hint and returns False.
- Existing `test_edit_db_profile` passes; `ruff` clean.

Part of usability wave 3.