### PR TITLE
fix(admin): wire the /admin namespace (was an advertised-but-dead tab)

### DIFF
--- a/amx/cli.py
+++ b/amx/cli.py
@@ -10,6 +10,7 @@ import yaml
 
 from amx import __version__
 from amx.cli_support import run_interactive_session
+from amx.cli_support.commands.admin import register_admin_commands
 from amx.cli_support.commands.analyze_flow import (
     register_analyze_review_command,
     register_analyze_run_command,
@@ -508,6 +509,12 @@ register_analyze_run_command(
 register_analyze_review_command(analyze, log_event=_log_app_event)
 register_rerun_command(main, pass_config=pass_config, log_event=_log_app_event)
 register_variations_command(main, pass_config=pass_config, log_event=_log_app_event)
+# /admin is a real role-gated shared-workspace feature (members, roles,
+# audit, sessions) that was implemented + tested but never wired in, so
+# the tab showed everywhere yet /admin returned "Unknown command". Wire it;
+# the commands self-gate on the admin role, so they degrade gracefully
+# outside a shared workspace rather than crashing.
+register_admin_commands(main, pass_config=pass_config, log_event=_log_app_event)
 register_schedule_commands(analyze, pass_config=pass_config, log_event=_log_app_event)
 register_docs_commands(
     main,

--- a/amx/cli_support/session.py
+++ b/amx/cli_support/session.py
@@ -699,6 +699,10 @@ _CROSS_NAMESPACE_HEADS: frozenset[str] = frozenset(
         "studio",
         "lineage",
         "pages",
+        # /admin is now wired (register_admin_commands is called in cli.py);
+        # without this it stayed a dead tab — advertised everywhere but
+        # "Unknown command" when entered.
+        "admin",
         # Real top-level Click commands that were reachable via `amx rerun`
         # / `amx variations` but returned None here (→ "Unknown command")
         # when typed in the REPL, because they were missing from this set.

--- a/tests/test_admin_wired.py
+++ b/tests/test_admin_wired.py
@@ -1,0 +1,24 @@
+"""The /admin namespace is wired into the CLI.
+
+`register_admin_commands` is implemented + tested but was never called,
+and session dispatch omitted "admin", so the ADMIN tab showed everywhere
+yet `/admin` returned "Unknown command" and its subcommands raised
+"No such command" — a 100% dead tab. Guard the wiring so it can't regress.
+"""
+
+from __future__ import annotations
+
+from amx.cli_support.session import session_to_click_args
+
+
+def test_admin_group_registered_on_main() -> None:
+    import amx.cli as cli
+
+    assert "admin" in cli.main.commands, "/admin group not registered on the CLI"
+    admin = cli.main.commands["admin"]
+    assert "members" in admin.commands  # type: ignore[attr-defined]
+
+
+def test_admin_enters_namespace_and_subcommands_route() -> None:
+    assert session_to_click_args("", ["admin"]) == ["admin"]
+    assert session_to_click_args("admin", ["members"]) == ["admin", "members"]


### PR DESCRIPTION
## Summary

`register_admin_commands` — a real role-gated shared-workspace feature (members / promote / demote / revoke / unrevoke / audit / sessions), implemented and covered by `test_admin_cli.py` — was **never called**, and session dispatch omitted `admin`. So the ADMIN tab showed in the tab bar, autocomplete, `/help`, and the docs, yet `/admin` returned `Unknown command` and its subcommands raised `No such command`: a 100% dead, advertised tab.

Fix: call `register_admin_commands(main, ...)` in `cli.py` alongside the other namespaces, and add `admin` to `session._CROSS_NAMESPACE_HEADS` so `/admin` enters its namespace and the subcommands route. The commands already self-gate on the admin role (and a configured shared store), so outside a shared workspace they print an actionable "admin role required" message rather than crashing.

## Test plan

- New `tests/test_admin_wired.py`: the `admin` group is registered on the CLI with its subcommands; `/admin` enters the namespace and `/admin members` routes.
- Existing `test_admin_cli.py` (5 tests) passes; `ruff` clean.

Part of usability wave 3.