### PR TITLE
feat(run): confirm before a large, token-consuming run

### DIFF
--- a/amx/cli_support/commands/analyze_flow.py
+++ b/amx/cli_support/commands/analyze_flow.py
@@ -57,6 +57,41 @@ from amx.utils.token_tracker import tracker as token_tracker
 log = get_logger("cli.analyze_flow")
 
 
+#: A /run touching at least this many assets is "large" enough to warrant a
+#: heads-up: a Database / wide scope can fan dozens-to-hundreds of assets
+#: through the LLM with no upfront "proceed?", so the user couldn't bail
+#: before spending. Below this we don't nag.
+_LARGE_RUN_ASSET_THRESHOLD = 50
+
+
+def _should_confirm_large_run(total_assets: int, *, interactive: bool) -> bool:
+    """Whether to gate a run behind a confirmation prompt.
+
+    Only large, interactive runs are gated — small runs and
+    non-interactive callers (scheduler, Studio worker, piped input) run
+    straight through so we never block automation.
+    """
+    return interactive and total_assets >= _LARGE_RUN_ASSET_THRESHOLD
+
+
+def _confirm_large_run(total_assets: int, total_schemas: int, cfg: AMXConfig) -> bool:
+    """Show the run size + that it consumes tokens, and ask to proceed.
+
+    Returns True to proceed. A precise per-run dollar figure isn't
+    available before profiling (prompt sizes aren't known yet), so we
+    surface the asset count and the token-consuming nature on the active
+    model rather than a misleading fake estimate. Default is No, so a
+    stray Enter on a 300-table run doesn't start spending.
+    """
+    where = f"across {total_schemas} schema(s)" if total_schemas > 1 else "in one schema"
+    warn(
+        f"About to analyze {total_assets} assets {where}. This makes one or "
+        f"more LLM calls per asset on {cfg.llm.provider}/{cfg.llm.model} and "
+        "consumes tokens on that model."
+    )
+    return confirm(f"Proceed with analyzing {total_assets} assets?", default=False)
+
+
 def _review_sort_keys() -> tuple[str, ...]:
     """Return the canonical bulk-review sort keys.
 
@@ -1000,6 +1035,16 @@ def execute_analyze_run(
                 scope = ScopeResult(restricted, column_overrides=columns_overrides)
 
             total_assets = sum(len(v) for v in scope.values())
+
+            # Pre-run cost gate: confirm before a large, token-consuming run
+            # so a Database / wide scope can't start spending on hundreds of
+            # assets without an upfront "proceed?". Fires only for large
+            # interactive runs (never blocks the scheduler / Studio worker),
+            # and before create_run so a declined run leaves no orphan row.
+            if _should_confirm_large_run(total_assets, interactive=sys.stdin.isatty()):
+                if not _confirm_large_run(total_assets, len(scope), cfg):
+                    info("Run cancelled — nothing was analyzed.")
+                    return
 
             # ── Comment-coverage filter ──────────────────────────────────
             # When the user picks Database / Schema / Asset scope on a DB

--- a/tests/test_run_cost_gate.py
+++ b/tests/test_run_cost_gate.py
@@ -1,0 +1,44 @@
+"""A large /run is gated behind a confirmation before it spends tokens.
+
+A Database / wide-scope run could fan dozens-to-hundreds of assets
+through the LLM with no upfront "proceed?". Large *interactive* runs now
+confirm first; small runs and non-interactive callers (scheduler, Studio
+worker, piped input) run straight through.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import amx.cli_support.commands.analyze_flow as af
+
+
+def test_gate_fires_only_for_large_interactive_runs() -> None:
+    big = af._LARGE_RUN_ASSET_THRESHOLD
+    assert af._should_confirm_large_run(big, interactive=True) is True
+    assert af._should_confirm_large_run(big + 100, interactive=True) is True
+    # small run → no nag
+    assert af._should_confirm_large_run(big - 1, interactive=True) is False
+    # non-interactive (scheduler / Studio / pipe) → never blocked
+    assert af._should_confirm_large_run(big + 100, interactive=False) is False
+
+
+def _fake_cfg() -> types.SimpleNamespace:
+    return types.SimpleNamespace(llm=types.SimpleNamespace(provider="openai", model="gpt-5.4-mini"))
+
+
+def test_confirm_proceeds_on_yes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(af, "warn", lambda _m: None)
+    monkeypatch.setattr(af, "confirm", lambda *_a, **_k: True)
+    assert af._confirm_large_run(300, 4, _fake_cfg()) is True
+
+
+def test_confirm_aborts_on_no(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(af, "warn", lambda m: seen.setdefault("warn", m))
+    monkeypatch.setattr(af, "confirm", lambda *_a, **k: k.get("default", False))
+    assert af._confirm_large_run(300, 4, _fake_cfg()) is False
+    # default must be No (a stray Enter doesn't start a 300-asset run)
+    assert "300 assets" in str(seen.get("warn", ""))


### PR DESCRIPTION
## Summary

A Database / wide-scope `/run` could fan dozens-to-hundreds of assets through the LLM with **no upfront "proceed?"** — a cost-conscious user couldn't bail before spending. Large *interactive* runs (≥ 50 assets) now confirm first, surfacing the asset count and that the run consumes tokens on the active provider/model. Default is **No** (a stray Enter on a 300-table run doesn't start spending). The gate fires **before** `create_run`, so a declined run leaves no orphan history row.

Non-interactive callers (scheduler, Studio worker, piped input) and small runs are never gated.

A precise pre-run dollar figure isn't shown: prompt sizes aren't known until profiling, so a fake-precise estimate would mislead. We surface the count + token-consuming nature instead. (A Studio-side gate + a profiled estimate are noted as follow-ons.)

## Test plan

- New `tests/test_run_cost_gate.py`: the gate fires only for large interactive runs (≥ threshold), never for small or non-interactive ones; confirm proceeds on yes; default is No and the warning names the asset count.
- `ruff` clean.

Completes the CLI half of usability wave 3.