### PR TITLE
fix(secrets): keyring the MotherDuck token + warn on plaintext fallback

### DIFF
--- a/amx/config.py
+++ b/amx/config.py
@@ -295,7 +295,16 @@ def has_legacy_database_default(db: DBConfig) -> bool:
 
 # Secret-bearing fields per scope. These are externalised to the OS keyring
 # on save and resolved back to plaintext on load via amx.storage.secrets.
-_DB_SECRET_FIELDS = ("password", "access_token", "jwt_token", "workspace_token")
+_DB_SECRET_FIELDS = (
+    "password",
+    "access_token",
+    "jwt_token",
+    "workspace_token",
+    # MotherDuck token is collected with a masked prompt but was absent
+    # here, so it was the one credential written in plaintext to config.yml
+    # (and its rotated .bak copies). Externalise it to the keyring too.
+    "motherduck_token",
+)
 _LLM_SECRET_FIELDS = ("api_key",)
 _EMBEDDING_SECRET_FIELDS = ("api_key",)
 

--- a/amx/storage/secrets.py
+++ b/amx/storage/secrets.py
@@ -24,6 +24,10 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from amx.utils.logging import get_logger
+
+log = get_logger("storage.secrets")
+
 KEYRING_PREFIX = "keyring:"
 SERVICE_NAME = "amx"
 
@@ -148,6 +152,34 @@ def parse_reference(ref: str) -> str:
 
 
 _default_store: SecretStore | None = None
+_keyring_warning_emitted = False
+
+
+def _warn_keyring_unavailable() -> None:
+    """Warn once when no keyring backend is reachable.
+
+    Without this the fall back to plaintext storage in config.yml was
+    silent — security.md and the masked prompts promise the OS keyring,
+    so a headless-Linux / CI / Keychain-denied user was downgraded with
+    no signal except a /doctor check they had no reason to run.
+    """
+    global _keyring_warning_emitted
+    if _keyring_warning_emitted:
+        return
+    _keyring_warning_emitted = True
+    msg = (
+        "No OS keyring backend is available — database/LLM credentials will "
+        "be stored as PLAINTEXT in config.yml (and its rotated backups). "
+        "On headless Linux / CI install a keyring backend (e.g. SecretService "
+        "or keyrings.alt); run /doctor for details."
+    )
+    log.warning(msg)
+    try:
+        from amx.utils.console import warn as _console_warn
+
+        _console_warn(msg)
+    except Exception:  # pragma: no cover - console is best-effort here
+        pass
 
 
 def get_default_store() -> SecretStore:
@@ -155,6 +187,7 @@ def get_default_store() -> SecretStore:
     if _default_store is None:
         store: SecretStore = KeyringSecretStore()
         if not store.is_available():
+            _warn_keyring_unavailable()
             store = NullSecretStore()
         _default_store = store
     return _default_store

--- a/tests/test_secret_store_warning.py
+++ b/tests/test_secret_store_warning.py
@@ -1,0 +1,45 @@
+"""Secrets aren't silently downgraded to plaintext.
+
+(1) The MotherDuck token is now in the DB secret fields, so it goes to
+the keyring like every other credential instead of plaintext config.yml.
+(2) When no keyring backend is reachable, AMX warns once instead of
+silently storing plaintext (security.md promises the keyring).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import amx.config as config_mod
+import amx.storage.secrets as secrets
+import amx.utils.console as console
+
+
+def test_motherduck_token_is_a_secret_field() -> None:
+    assert "motherduck_token" in config_mod._DB_SECRET_FIELDS
+
+
+def test_keyring_unavailable_warns_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    log_calls: list[str] = []
+    monkeypatch.setattr(secrets.log, "warning", lambda m: log_calls.append(m))
+    monkeypatch.setattr(console, "warn", lambda _m: None)
+    monkeypatch.setattr(secrets, "_keyring_warning_emitted", False)
+
+    secrets._warn_keyring_unavailable()
+    secrets._warn_keyring_unavailable()  # second call is a no-op
+
+    assert len(log_calls) == 1
+    assert "PLAINTEXT" in log_calls[0]
+
+
+def test_get_default_store_falls_back_with_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(secrets.KeyringSecretStore, "is_available", lambda self: False)
+    warned: list[bool] = []
+    monkeypatch.setattr(secrets, "_warn_keyring_unavailable", lambda: warned.append(True))
+    secrets.set_default_store(None)
+    try:
+        store = secrets.get_default_store()
+        assert isinstance(store, secrets.NullSecretStore)
+        assert warned == [True]
+    finally:
+        secrets.set_default_store(None)


### PR DESCRIPTION
## Summary

Two silent plaintext-downgrade paths, both contradicting `security.md` and the masked credential prompts:

1. **MotherDuck token** was collected with a masked prompt but was **absent from `_DB_SECRET_FIELDS`**, so it was the one credential always written in plaintext to `config.yml` (and its up-to-5 rotated `.bak` copies). Added it, so it externalises to the OS keyring like every other secret.
2. **Keyring-unavailable fallback was silent.** When no keyring backend is reachable (headless Linux, CI/Docker, Keychain ACL denial), the store fell back to `NullSecretStore` with no warning — the docstring promised a one-time warning that never fired. Now `get_default_store` warns once (logger + console) that credentials will be stored plaintext, and points at `/doctor`.

## Test plan

- New `tests/test_secret_store_warning.py`: `motherduck_token` is in the secret fields; the keyring warning fires exactly once; `get_default_store` falls back to `NullSecretStore` and triggers the warning.
- Existing secret tests pass; `ruff` clean.

Part of usability wave 4.