### PR TITLE
fix(repl): report dropped tokens in ask_multi_choice (no more silent partial selection)

### DIFF
--- a/amx/utils/console.py
+++ b/amx/utils/console.py
@@ -391,11 +391,32 @@ def ask_choice(
     return default if default in choices else ""
 
 
+def _match_choice_token(token: str, choices: list[str]) -> str | None:
+    """Resolve one ``ask_multi_choice`` token to a choice, or None when it
+    doesn't match exactly one option (by number, exact name,
+    case-insensitive name, unique prefix, or unique substring)."""
+    if token.isdigit() and 1 <= int(token) <= len(choices):
+        return choices[int(token) - 1]
+    if token in choices:
+        return token
+    lower = [c for c in choices if c.lower() == token.lower()]
+    if len(lower) == 1:
+        return lower[0]
+    pref = [c for c in choices if c.lower().startswith(token.lower())]
+    if len(pref) == 1:
+        return pref[0]
+    sub = [c for c in choices if token.lower() in c.lower()]
+    if len(sub) == 1:
+        return sub[0]
+    return None
+
+
 def ask_multi_choice(question: str, choices: list[str]) -> list[str]:
     console.print(f"  [info]{question}[/info]")
     console.print(
         "  (comma-separated numbers or names; `all` = everything; "
-        "Enter alone cancels — no accidental 'run on every table'; Esc aborts the wizard)"
+        "Enter alone cancels — no accidental 'run on every table'; Esc aborts the wizard; "
+        "unrecognised tokens are reported, not silently dropped)"
     )
     for i, c in enumerate(choices, 1):
         console.print(f"    {i}. {c}")
@@ -405,30 +426,25 @@ def ask_multi_choice(question: str, choices: list[str]) -> list[str]:
     if raw.lower() == "all":
         return choices
     selected: list[str] = []
+    unmatched: list[str] = []
     for token in raw.split(","):
         token = token.strip()
         if not token:
             continue
-        if token.isdigit() and 1 <= int(token) <= len(choices):
-            selected.append(choices[int(token) - 1])
-            continue
-        if token in choices:
-            selected.append(token)
-            continue
-        lower_matches = [c for c in choices if c.lower() == token.lower()]
-        if len(lower_matches) == 1:
-            selected.append(lower_matches[0])
-            continue
-        pref = [c for c in choices if c.lower().startswith(token.lower())]
-        if len(pref) == 1:
-            selected.append(pref[0])
-            continue
-        sub = [c for c in choices if token.lower() in c.lower()]
-        if len(sub) == 1:
-            selected.append(sub[0])
-            continue
-    if not selected:
-        warn(f"No option matched {raw!r}. Use numbers from the list, exact names, or `all`.")
+        match = _match_choice_token(token, choices)
+        if match is not None:
+            selected.append(match)
+        else:
+            unmatched.append(token)
+    if unmatched:
+        # Previously typo'd / ambiguous tokens were dropped silently, so
+        # "1,3,tabl" quietly ran on 1 and 3 only. Surface the ignored
+        # inputs so a partial selection is never a surprise.
+        warn(
+            "Ignored unrecognised input: "
+            + ", ".join(repr(t) for t in unmatched)
+            + " — use numbers from the list, exact names, or `all`."
+        )
     return selected
 
 

--- a/tests/test_multi_choice_unmatched.py
+++ b/tests/test_multi_choice_unmatched.py
@@ -1,0 +1,40 @@
+"""ask_multi_choice reports unrecognised tokens instead of dropping them.
+
+"1,3,tabl" used to quietly run on 1 and 3 only — typo'd / ambiguous
+tokens were silently dropped, so a partial selection looked like a full
+one. Now the ignored tokens are surfaced.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import amx.utils.console as console
+
+
+def test_match_token_resolves_and_rejects() -> None:
+    ch = ["alpha", "beta", "gamma"]
+    assert console._match_choice_token("1", ch) == "alpha"
+    assert console._match_choice_token("beta", ch) == "beta"
+    assert console._match_choice_token("gam", ch) == "gamma"  # unique prefix
+    assert console._match_choice_token("zzz", ch) is None
+
+
+def test_unmatched_tokens_are_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    ch = ["alpha", "beta", "gamma"]
+    monkeypatch.setattr(console, "_safe_pt_prompt", lambda *a, **k: "1,3,tabl")
+    warns: list[str] = []
+    monkeypatch.setattr(console, "warn", lambda m: warns.append(m))
+    out = console.ask_multi_choice("pick", ch)
+    assert out == ["alpha", "gamma"]
+    assert warns and "tabl" in warns[0]
+
+
+def test_all_matched_no_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    ch = ["alpha", "beta"]
+    monkeypatch.setattr(console, "_safe_pt_prompt", lambda *a, **k: "1,2")
+    warns: list[str] = []
+    monkeypatch.setattr(console, "warn", lambda m: warns.append(m))
+    out = console.ask_multi_choice("pick", ch)
+    assert out == ["alpha", "beta"]
+    assert warns == []


### PR DESCRIPTION
## Summary

`ask_multi_choice` silently dropped typo'd / ambiguous tokens — it only warned when **nothing** matched. So `1,3,tabl` quietly ran on 1 and 3 only, and the user believed all three were selected. The matching logic is now an extracted `_match_choice_token` helper, and any **unmatched** tokens are reported (`Ignored unrecognised input: 'tabl' — …`) so a partial selection is never a silent surprise.

## Test plan

- New `tests/test_multi_choice_unmatched.py`: the matcher resolves number/name/prefix and rejects unknowns; `1,3,tabl` selects 1+3 and warns about `tabl`; a fully-matched input warns nothing.
- `ask_choice` + runtime-picker tests pass; `ruff` clean.

Part of usability wave 4.