### PR TITLE
feat(feedback): progress on long downloads + /pages LLM composition

### DIFF
--- a/amx/cli_support/commands/pages.py
+++ b/amx/cli_support/commands/pages.py
@@ -659,7 +659,12 @@ def register_pages_commands(
             return
 
         try:
-            svc.generate(page_id, now=_utcnow())
+            # LLM composition can take many seconds; without a spinner the
+            # REPL looked frozen and users assumed the page generation hung.
+            from amx.utils.console import step_spinner
+
+            with step_spinner("Composing the page with the LLM..."):
+                svc.generate(page_id, now=_utcnow())
         except Exception as exc:  # noqa: BLE001
             error(f"Generation failed: {exc}. Draft was saved; re-run with /pages edit.")
             return

--- a/amx/docs/scanner.py
+++ b/amx/docs/scanner.py
@@ -238,16 +238,35 @@ def _parse_google_drive_folder_id(url: str) -> str | None:
 
 
 def _download_to_file(url: str, dest: Path, *, timeout: int = 300) -> int:
-    """Stream-download a URL to a local file; return byte count."""
+    """Stream-download a URL to a local file; return byte count.
+
+    Emits a throttled progress line every ~5 MB so a large download isn't
+    indistinguishable from a hung one (it streamed silently for up to the
+    300s timeout before, tempting a Ctrl-C). Plain ``info()`` prints are
+    used rather than a Rich progress bar so this is safe to call from
+    anywhere — including inside another live display — without risking a
+    nested-Live crash, and they short-circuit under the Studio quiet flag.
+    """
+    from amx.utils.console import info as _info
+
     r = requests.get(url, timeout=timeout, stream=True, allow_redirects=True)
     if r.status_code >= 400:
         raise RuntimeError(f"Download failed {r.status_code}: {r.text[:300]}")
+    total = int(r.headers.get("Content-Length") or 0)
+    report_every = 5 * 1024 * 1024
+    next_report = report_every
     n = 0
     with dest.open("wb") as f:
         for chunk in r.iter_content(chunk_size=1024 * 256):
             if chunk:
                 f.write(chunk)
                 n += len(chunk)
+                if n >= next_report:
+                    if total:
+                        _info(f"Downloading {dest.name}: {n / 1e6:.1f} / {total / 1e6:.1f} MB")
+                    else:
+                        _info(f"Downloading {dest.name}: {n / 1e6:.1f} MB")
+                    next_report += report_every
     return n
 
 

--- a/tests/test_download_progress.py
+++ b/tests/test_download_progress.py
@@ -1,0 +1,58 @@
+"""Large downloads emit progress so they aren't mistaken for a hang.
+
+Document downloads streamed silently in 256KB chunks for up to the 300s
+timeout — a stalled and a progressing transfer looked identical, tempting
+a Ctrl-C. ``_download_to_file`` now prints a throttled byte-progress line.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import amx.docs.scanner as scanner
+import amx.utils.console as console
+
+
+class _FakeResp:
+    def __init__(self, chunks: list[bytes], total: int) -> None:
+        self.status_code = 200
+        self.headers = {"Content-Length": str(total)} if total else {}
+        self._chunks = chunks
+
+    def iter_content(self, chunk_size: int) -> object:
+        return iter(self._chunks)
+
+
+def test_download_emits_throttled_progress(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    chunk = b"x" * (256 * 1024)
+    n_chunks = 48  # 48 * 256KB = 12 MB → crosses the 5 MB report threshold twice
+    total = n_chunks * len(chunk)
+    monkeypatch.setattr(
+        scanner.requests, "get", lambda *a, **k: _FakeResp([chunk] * n_chunks, total)
+    )
+    infos: list[str] = []
+    monkeypatch.setattr(console, "info", lambda m: infos.append(m))
+
+    dest = tmp_path / "f.bin"
+    written = scanner._download_to_file("http://example/f.bin", dest)
+
+    assert written == total
+    assert dest.stat().st_size == total
+    progress_lines = [i for i in infos if "Downloading" in i]
+    assert len(progress_lines) >= 2  # 12 MB / 5 MB threshold
+    assert any("/" in i and "MB" in i for i in progress_lines)  # shows total when known
+
+
+def test_download_without_content_length_still_reports(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> None:
+    chunk = b"y" * (256 * 1024)
+    n_chunks = 24  # 6 MB, no Content-Length header
+    monkeypatch.setattr(scanner.requests, "get", lambda *a, **k: _FakeResp([chunk] * n_chunks, 0))
+    infos: list[str] = []
+    monkeypatch.setattr(console, "info", lambda m: infos.append(m))
+
+    scanner._download_to_file("http://example/f.bin", tmp_path / "g.bin")
+    assert any("Downloading" in i and "MB" in i for i in infos)


### PR DESCRIPTION
## Summary

Two "looks frozen" surfaces:

1. **Document downloads** streamed silently in 256KB chunks for up to the 300s timeout — a stalled and a progressing transfer were indistinguishable, tempting a Ctrl-C. `_download_to_file` now prints a throttled byte-progress line every ~5 MB (`Downloading f.bin: 12.0 / 52.4 MB`). Uses plain `info()` rather than a Rich bar so it's safe to call from inside another live display (no nested-Live crash) and short-circuits under the Studio quiet flag.
2. **`/pages new`** ran the LLM composition (`svc.generate`) with no indicator. Wrapped in a `step_spinner` so the REPL no longer looks hung during a multi-second compose.

## Test plan

- New `tests/test_download_progress.py`: a 12 MB download emits ≥2 progress lines showing `current / total MB`; a download with no `Content-Length` still reports bytes.
- `ruff` clean. (The `/pages new` spinner is an interactive surface; verified by import + the existing pages tests.)

Part of usability wave 4.