### PR TITLE
fix(studio): don't auto-open the browser onto a not-ready port

### DIFF
--- a/amx/web/launcher.py
+++ b/amx/web/launcher.py
@@ -194,27 +194,42 @@ def launch_studio(
     )
 
     started = _wait_for_http(chosen_port, STARTUP_TIMEOUT_SEC)
-    if not started:
-        log.warning(
-            "AMX Studio did not respond on :%d within %.1fs; opening the browser anyway.",
-            chosen_port,
-            STARTUP_TIMEOUT_SEC,
-        )
 
-    print(  # user-facing — keep print, not log
-        f"AMX Studio running → {url}\nPress Ctrl-C in this terminal to stop AMX Studio."
-    )
     # Log path also goes to the rotating file logger so a user who
     # needs to debug can find it via ``amx doctor`` or by tailing
     # the logs directory directly. Not printed to the interactive
     # terminal because it adds visual noise for the 99% of users
     # who never need it.
     log.debug("AMX Studio logs at %s", log_path)
-    if open_browser:
-        try:
-            webbrowser.open_new_tab(url)
-        except Exception as exc:  # pragma: no cover - browser launch is best-effort
-            log.debug("Could not auto-open browser: %s", exc)
+
+    if not started:
+        # The server hasn't answered the health check yet. Do NOT fling
+        # the browser at a not-ready port — that lands a first-time user
+        # on the browser's native "connection refused" page and looks
+        # broken. Tell them what's happening and let them open it once
+        # it's up, instead of auto-opening into an error.
+        log.warning(
+            "AMX Studio did not respond on :%d within %.1fs.",
+            chosen_port,
+            STARTUP_TIMEOUT_SEC,
+        )
+        print(  # user-facing — keep print, not log
+            f"AMX Studio is still starting and didn't respond on :{chosen_port} "
+            f"within {STARTUP_TIMEOUT_SEC:.0f}s.\n"
+            f"  Open {url} in your browser once it's ready (not auto-opening to "
+            "avoid a connection-error page).\n"
+            f"  If it never comes up, check the logs at {log_path}.\n"
+            "Press Ctrl-C in this terminal to stop AMX Studio."
+        )
+    else:
+        print(  # user-facing — keep print, not log
+            f"AMX Studio running → {url}\nPress Ctrl-C in this terminal to stop AMX Studio."
+        )
+        if open_browser:
+            try:
+                webbrowser.open_new_tab(url)
+            except Exception as exc:  # pragma: no cover - browser launch is best-effort
+                log.debug("Could not auto-open browser: %s", exc)
 
     if not block:
         # Caller (tests) owns the lifecycle; leave the log file open


### PR DESCRIPTION
## Summary

`/studio` polled the port with `_wait_for_http`, but then opened the browser **regardless of the result** (it only logged a buried "opening anyway" warning). So on a slow or failed cold start a first-time user landed on the browser's native "connection refused" page and assumed Studio was broken.

Now the browser auto-opens **only when the health check succeeds**. If it doesn't come up in time, we print where to open it once ready and where the logs are — and never fling the browser at an error page. Both paths still block on the process so Ctrl-C stops Studio as before.

## Test plan

- Import + `ruff` clean; existing `test_studio_bundle_assertions` + `test_studio_cold_start_no_pip` (15 tests) pass. (`launch_studio` spawns a uvicorn subprocess, so the small control-flow change is verified by import/lint + the existing studio suite rather than a brittle full subprocess mock.)

## Follow-on (not in this PR)

The session-token re-auth UI (a stale/bookmarked tab 401s with no token-entry recovery) is a larger frontend auth-flow change and is noted for a separate PR.

Studio-visible → ships with the next `deploy.sh`.