### PR TITLE
fix(catalog): keep synced schemas_cache durable so freshness doesn't false-fail

### DIFF
--- a/amx/db/connector.py
+++ b/amx/db/connector.py
@@ -441,14 +441,30 @@ class DatabaseConnector:
         # path so non-synced profiles behave exactly as before.
         if live is None and self._is_cache_warm():
             cached = self._list_schemas_from_cache(catalog)
-            log.info(
-                "list_schemas: cache-only mode for profile=%r catalog=%r - "
-                "served %d cached rows, no live DB query",
+            if cached:
+                log.info(
+                    "list_schemas: cache-only mode for profile=%r catalog=%r - "
+                    "served %d cached rows, no live DB query",
+                    self.profile_name,
+                    catalog,
+                    len(cached),
+                )
+                return self._apply_pinned_schema_filter([name for name, _ in cached])
+            # Warm-but-empty: the profile is marked fully synced yet the
+            # schemas_cache holds no rows for this catalog. A successful
+            # sync provably produced >=1 schema, so an empty cache here is
+            # never legitimate — it means the rows were swept (e.g. the
+            # startup ``gc_schemas_cache`` purge of expired rows) while the
+            # never-expiring ``is_profile_fully_synced`` markers stayed
+            # set. Fall through to the live path below to self-heal and
+            # repopulate the cache rather than serving an empty list that
+            # would flip the freshness pill to a false "no schemas" failure.
+            log.warning(
+                "list_schemas: profile=%r catalog=%r is marked fully synced but "
+                "schemas_cache is empty - falling through to live DB to self-heal",
                 self.profile_name,
                 catalog,
-                len(cached),
             )
-            return self._apply_pinned_schema_filter([name for name, _ in cached])
         if live is None and self._populate_catalogs_cache(catalog):
             cached = self._list_schemas_from_cache(catalog)
             if cached:
@@ -1160,7 +1176,19 @@ class DatabaseConnector:
         entries: dict[str, str | None],
         *,
         bulk_filled: bool = False,
+        ttl_seconds: float | None = None,
     ) -> None:
+        """Persist schema-level entries for ``catalog`` to the cache.
+
+        ``ttl_seconds`` overrides the store's default browse TTL. The
+        skeleton-sync warm pass passes
+        :data:`DURABLE_COMMENT_CACHE_TTL_SECONDS` so sync-imported schema
+        rows persist instead of evaporating an hour later — otherwise the
+        startup ``gc_schemas_cache`` sweep empties the table while the
+        ``is_profile_fully_synced`` markers stay set, and the cache-only
+        read gate in :meth:`list_schemas` then serves an empty schema list
+        with no live fallback. ``None`` keeps the store default.
+        """
         if not entries:
             return
         try:
@@ -1170,24 +1198,33 @@ class DatabaseConnector:
         store = history_store()
         if store is None:
             return
+        kwargs: dict[str, Any] = {
+            "db_profile": self._cache_profile_key,
+            "database": self._cache_database_key(),
+            "catalog": catalog,
+            "entries": entries,
+            "bulk_filled": bulk_filled,
+        }
+        if ttl_seconds is not None:
+            kwargs["ttl_seconds"] = ttl_seconds
         try:
-            store.save_schemas_cache(
-                db_profile=self._cache_profile_key,
-                database=self._cache_database_key(),
-                catalog=catalog,
-                entries=entries,
-                bulk_filled=bulk_filled,
-            )
+            store.save_schemas_cache(**kwargs)
         except Exception as exc:
             log.debug("schemas cache save failed: %s", exc)
 
-    def _populate_catalogs_cache(self, catalog: str) -> bool:
+    def _populate_catalogs_cache(self, catalog: str, *, ttl_seconds: float | None = None) -> bool:
         """Run the adapter's ``bulk_catalog_metadata`` and cache it.
 
         Returns ``True`` when the adapter delivered a non-empty dict
         (every reachable schema in the catalog) and ``False`` when the
         backend has no bulk source — the caller then falls back to
         per-schema enumeration + per-schema comment lookups.
+
+        ``ttl_seconds`` is forwarded to :meth:`_save_schemas_cache`; the
+        skeleton-sync warm pass passes
+        :data:`DURABLE_COMMENT_CACHE_TTL_SECONDS` so the freshly cached
+        schema rows survive the next startup cache sweep. ``None`` keeps
+        the store's 1-hour browse default for read-path callers.
         """
         try:
             payload = self._adapter.bulk_catalog_metadata(self.engine, catalog)
@@ -1201,7 +1238,7 @@ class DatabaseConnector:
             return False
         if not payload:
             return False
-        self._save_schemas_cache(catalog, payload, bulk_filled=True)
+        self._save_schemas_cache(catalog, payload, bulk_filled=True, ttl_seconds=ttl_seconds)
         return True
 
     def _populate_schema_metadata_cache(

--- a/amx/search/drift.py
+++ b/amx/search/drift.py
@@ -648,8 +648,10 @@ def sync_profile_skeleton(
     # hit live DB to fetch table + column comments. We walk per
     # (container, schema) and let the connector's bulk helper fill
     # the cache one round-trip at a time.
-    schemas_warmed_ok = reached_any
+    schemas_warmed_ok: bool = reached_any
     columns_warmed_ok = True
+    from amx.db.connector import DURABLE_COMMENT_CACHE_TTL_SECONDS
+
     for container, schema_assets in per_container_plan:
         if cancel_event.is_set():
             break
@@ -664,6 +666,29 @@ def sync_profile_skeleton(
             )
             columns_warmed_ok = False
             continue
+        # Re-stamp schemas_cache durably for this container. Pass 1
+        # populated it as a side effect of ``list_schemas`` with the
+        # 1-hour browse TTL; without this the startup
+        # ``gc_schemas_cache`` sweep empties the table within the hour
+        # while the never-expiring ``is_profile_fully_synced`` markers
+        # stay set, which drives ``list_schemas``'s cache-only gate to
+        # serve an empty schema list and flips the freshness pill to a
+        # false "no schemas were visible" failure on the next open. The
+        # 30-day durable TTL keeps the rows past the sweep — mirrors the
+        # column_comments durable warm below.
+        try:
+            cat = getattr(getattr(connector, "cfg", None), "catalog", "") or ""
+            connector._populate_catalogs_cache(  # noqa: SLF001
+                cat, ttl_seconds=DURABLE_COMMENT_CACHE_TTL_SECONDS
+            )
+        except Exception as exc:
+            log.debug(
+                "Durable schemas re-stamp raised for %s/%s: %s",
+                profile,
+                container or "<default>",
+                exc,
+            )
+            schemas_warmed_ok = False
         for schema, _assets in schema_assets:
             if cancel_event.is_set():
                 break
@@ -676,8 +701,6 @@ def sync_profile_skeleton(
                 # gate (get_column_comments / get_table_comment) starts
                 # returning empty an hour after every sync and Studio
                 # silently loses every comment this pass just imported.
-                from amx.db.connector import DURABLE_COMMENT_CACHE_TTL_SECONDS
-
                 connector._populate_schema_metadata_cache(  # noqa: SLF001
                     schema, ttl_seconds=DURABLE_COMMENT_CACHE_TTL_SECONDS
                 )

--- a/tests/test_catalog_skeleton_sync.py
+++ b/tests/test_catalog_skeleton_sync.py
@@ -54,6 +54,18 @@ class _StubConnector:
         self.last_warm_ttl = ttl_seconds
         return True
 
+    def _populate_catalogs_cache(
+        self, catalog: str = "", *, ttl_seconds: float | None = None
+    ) -> bool:
+        """No-op stand-in for the durable ``schemas_cache`` re-stamp the
+        warm pass now issues per container. The real connector re-runs
+        ``bulk_catalog_metadata`` and writes the rows with the durable
+        TTL; the stub just records ``ttl_seconds`` so the durable-schemas
+        regression test can assert the sync stamps schemas durably (the
+        fix for the "Catalog freshness failed on every open" bug)."""
+        self.last_schemas_ttl = ttl_seconds
+        return True
+
 
 class _StubCfg:
     """Stand-in for ``AMXConfig`` carrying just the fields the
@@ -532,6 +544,78 @@ def test_skeleton_sync_warms_comments_with_durable_ttl(
     sync_profile_skeleton(_StubCfg(), "prof-a", fresh_catalog)
 
     assert getattr(connector, "last_warm_ttl", None) == DURABLE_COMMENT_CACHE_TTL_SECONDS
+
+
+def test_skeleton_sync_restamps_schemas_with_durable_ttl(
+    fresh_catalog: SearchCatalog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The warm pass re-stamps ``schemas_cache`` with the durable TTL,
+    not the 1-hour browse TTL ``list_schemas`` writes during enumeration.
+
+    Regression guard for the reported bug: schemas_cache rows carried
+    only a 1h TTL, so the startup ``gc_schemas_cache`` sweep emptied the
+    table within the hour while the never-expiring
+    ``is_profile_fully_synced`` markers stayed set — driving
+    ``list_schemas``'s cache-only gate to serve an empty schema list and
+    flip the freshness pill to a false "no schemas were visible" failure
+    on every open."""
+    from amx.db.connector import DURABLE_COMMENT_CACHE_TTL_SECONDS
+
+    connector = _StubConnector(schemas=["public"], assets={"public": [("users", "table")]})
+    _stub_build_connector(monkeypatch, connector)
+
+    sync_profile_skeleton(_StubCfg(), "prof-a", fresh_catalog)
+
+    assert getattr(connector, "last_schemas_ttl", None) == DURABLE_COMMENT_CACHE_TTL_SECONDS
+
+
+def test_durable_schemas_cache_survives_startup_gc_sweep(
+    fresh_catalog: SearchCatalog,
+) -> None:
+    """A schemas_cache row stamped with the durable sync TTL survives the
+    startup ``gc_schemas_cache`` sweep, while a row left on the 1-hour
+    browse TTL (here pre-expired) is purged.
+
+    This pins the other half of the fix: the durable TTL chosen by the
+    warm pass actually defeats the gc sweep that caused the bug, so a
+    fully-synced profile's schemas stay cached until the next sync."""
+    from amx.db.connector import DURABLE_COMMENT_CACHE_TTL_SECONDS
+
+    store = ss._store  # noqa: SLF001 — the fixture-bound singleton
+
+    # Durable row (what the warm pass now writes) and a browse-TTL row
+    # that has already expired (what the pre-fix sync left behind).
+    store.save_schemas_cache(
+        db_profile="prof-durable",
+        database="appdb",
+        catalog="",
+        entries={"public": None, "analytics": None},
+        bulk_filled=True,
+        ttl_seconds=DURABLE_COMMENT_CACHE_TTL_SECONDS,
+    )
+    store.save_schemas_cache(
+        db_profile="prof-expired",
+        database="appdb",
+        catalog="",
+        entries={"stale": None},
+        bulk_filled=True,
+        ttl_seconds=-1.0,  # already expired — mimics a 1h row past its window
+    )
+
+    swept = store.gc_schemas_cache()
+    assert swept == 1  # only the expired row
+
+    with fresh_catalog._connect() as conn:  # noqa: SLF001
+        durable = conn.execute(
+            "SELECT schema_name FROM schemas_cache WHERE db_profile = ? ORDER BY schema_name",
+            ("prof-durable",),
+        ).fetchall()
+        expired = conn.execute(
+            "SELECT schema_name FROM schemas_cache WHERE db_profile = ?",
+            ("prof-expired",),
+        ).fetchall()
+    assert [r["schema_name"] for r in durable] == ["analytics", "public"]
+    assert expired == []
 
 
 def _first_synced(cat: SearchCatalog, profile: str, table: str) -> float | None:

--- a/tests/test_connector_cache_only_mode.py
+++ b/tests/test_connector_cache_only_mode.py
@@ -102,10 +102,12 @@ class _RaisingConnector(DatabaseConnector):
     must short-circuit BEFORE any fallback runs — if the gate is
     broken, the test sees the raising side."""
 
-    def _populate_catalogs_cache(self, catalog: str) -> bool:
+    def _populate_catalogs_cache(self, catalog: str, *, ttl_seconds: float | None = None) -> bool:
         raise AssertionError("live DB fallback was reached")
 
-    def _populate_schema_metadata_cache(self, schema: str) -> bool:
+    def _populate_schema_metadata_cache(
+        self, schema: str, *, ttl_seconds: float | None = None
+    ) -> bool:
         raise AssertionError("live DB fallback was reached")
 
     @property
@@ -113,14 +115,49 @@ class _RaisingConnector(DatabaseConnector):
         raise AssertionError("live DB engine was opened")
 
 
-def test_list_schemas_cache_only_when_warm(store: SQLiteHistoryStore) -> None:
-    """Empty schemas_cache + warm profile = return [], no live DB."""
+def test_list_schemas_cache_only_when_warm_and_populated(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Warm profile + NON-EMPTY schemas_cache = serve cached rows, no
+    live DB. The cache-only gate is honored when there is something to
+    serve."""
+    _mark_profile_fully_synced(store, "warm")
+    # Populate the schemas_cache for the connector's exact keys:
+    # profile='warm', database=':memory:', catalog='' (duckdb).
+    store.save_schemas_cache(
+        db_profile="warm",
+        database=":memory:",
+        catalog="",
+        entries={"public": None, "analytics": "the analytics schema"},
+        bulk_filled=True,
+    )
+    conn = _RaisingConnector(
+        DBConfig(backend="duckdb", database=":memory:"),
+        profile_name="warm",
+    )
+    # No live fallback runs (would raise); cached schemas come back.
+    assert sorted(conn.list_schemas()) == ["analytics", "public"]
+
+
+def test_list_schemas_warm_but_empty_falls_through_to_live(
+    store: SQLiteHistoryStore,
+) -> None:
+    """Warm profile + EMPTY schemas_cache = self-heal by falling through
+    to the live path, NOT returning []. A successful sync provably
+    produced >=1 schema, so an empty cache here means the rows were
+    gc-swept while the never-expiring sync markers stayed set; serving
+    [] would flip the freshness pill to a false "no schemas" failure.
+
+    Regression guard for the "Catalog freshness failed on every open"
+    bug. With the old gate this returned ``[]``; now it must attempt the
+    live path (which the raising connector surfaces)."""
     _mark_profile_fully_synced(store, "warm")
     conn = _RaisingConnector(
         DBConfig(backend="duckdb", database=":memory:"),
         profile_name="warm",
     )
-    assert conn.list_schemas() == []
+    with pytest.raises(AssertionError, match="live DB"):
+        conn.list_schemas()
 
 
 def test_get_column_comments_cache_only_when_warm(


### PR DESCRIPTION
## Summary

The Catalog freshness pill reported every DB profile as `failed` with "Connected but no schemas were visible" on every launch, even though the catalog held thousands of entities.

Root cause is a TTL asymmetry. A successful sync stamps the never-expiring `is_profile_fully_synced` markers, but `schemas_cache` rows were written with only the 1-hour browse TTL and never re-stamped durably (unlike `column_comments_cache`). The startup `gc_schemas_cache` sweep then emptied the table within the hour while the warm markers stayed set, so `list_schemas`' cache-only gate served an empty schema list with no live fallback and the skeleton sync flipped the profile to `failed`.

Two complementary fixes:

- **Self-heal (`connector.list_schemas`):** when a profile is marked fully synced but `schemas_cache` is empty — a state that is never legitimate, since a successful sync provably produced at least one schema — fall through to the live path and repopulate instead of returning an empty list. Recovers already-affected installs without a manual re-sync.
- **Durable TTL (`drift` warm pass):** re-stamp `schemas_cache` with the durable TTL per container, mirroring the existing `column_comments_cache` warm, so the rows survive the startup sweep. Granular per-database refresh routes through the same function and is covered automatically.

No schema change (TTL values + read-path control flow only).

## Test plan

- `pytest tests/test_connector_cache_only_mode.py tests/test_catalog_skeleton_sync.py` — green, including new regression tests:
  - `test_list_schemas_warm_but_empty_falls_through_to_live`
  - `test_list_schemas_cache_only_when_warm_and_populated`
  - `test_skeleton_sync_restamps_schemas_with_durable_ttl`
  - `test_durable_schemas_cache_survives_startup_gc_sweep`
- Adjacent suites green: `test_db_cache_ops`, `test_column_comments_cache`, `storage/test_history_caches_purge`, `test_listing_memo_and_drift_gate`, `test_bulk_schema_metadata_duckdb`, `test_remove_db_profile_purges_cache`.
- `ruff check` / `ruff format --check` clean; no new mypy errors in the changed files.