### PR TITLE
feat(studio): reuse a running Studio and default to embedded host mode

### DIFF
--- a/amx/cli_support/root_commands.py
+++ b/amx/cli_support/root_commands.py
@@ -205,7 +205,8 @@ def register_root_commands(
         # passing it (older versions reject unknown options).
         help=(
             "Relax framing headers so an IDE host can render Studio "
-            "inside a webview iframe. Set by IDE integrations, not users."
+            "inside a webview iframe. Now the default; kept for "
+            "compatibility with IDE integrations that pass it."
         ),
     )
     @click.pass_obj
@@ -220,7 +221,13 @@ def register_root_commands(
                 f"Underlying import error: {exc}"
             )
             return
-        launch_studio(cfg, port=port, open_browser=not no_open, embedded=embedded)
+        # Embedded host mode is always on so the single shared server
+        # (discovery-file reuse) is frameable by IDE webviews no matter
+        # who started it first. The flag above is accepted but no
+        # longer steers behavior; see security_headers.py for why the
+        # relaxed framing headers are safe on a loopback token server.
+        del embedded
+        launch_studio(cfg, port=port, open_browser=not no_open, embedded=True)
 
     @main.group()
     def db() -> None:

--- a/amx/web/launcher.py
+++ b/amx/web/launcher.py
@@ -3,6 +3,10 @@
 Architecture (triple-layer defense after PRs #353/#354/#355 each
 fixed a layer but left a sibling open):
 
+0. Check the discovery file first — if a healthy Studio is already
+   running (started by another REPL or an IDE integration), reuse
+   it: print its URL, open the browser, and return without
+   spawning a duplicate.
 1. Pick a port (preferred 47821, otherwise an ephemeral one).
 2. Generate a one-shot URL-safe Bearer token.
 3. Spawn a **subprocess** running :mod:`amx.web._studio_subprocess`
@@ -41,12 +45,16 @@ import socket
 import subprocess
 import sys
 import time
+import urllib.request
 import webbrowser
 from contextlib import suppress
 from pathlib import Path as _Path
-from typing import IO
+from typing import IO, TYPE_CHECKING
 
 from amx.config import AMXConfig
+
+if TYPE_CHECKING:
+    from amx.web.discovery import StudioDiscovery
 
 log = logging.getLogger("amx.web.launcher")
 
@@ -73,6 +81,45 @@ SHUTDOWN_TIMEOUT_SEC = 1.5
 #: drain wait — this should always succeed quickly.
 TERMINATE_TIMEOUT_SEC = 1.0
 KILL_TIMEOUT_SEC = 1.0
+
+#: Health-check deadline when probing a discovery-file record for an
+#: already-running Studio. Localhost answers in single-digit
+#: milliseconds; 1.5 s tolerates a server momentarily busy with an
+#: LLM-bound request without making a cold ``/studio`` feel slow.
+REUSE_PROBE_TIMEOUT_SEC = 1.5
+
+
+def _probe_running_studio() -> StudioDiscovery | None:
+    """Return the discovery record for a live Studio, or ``None``.
+
+    Reads ``<config-dir>/studio.json`` and health-checks the recorded
+    endpoint (``GET /api/health`` with the recorded bearer token). A
+    missing, malformed, or stale record — including one whose server
+    no longer answers — yields ``None``; the caller then spawns a
+    fresh server, whose child atomically overwrites the discovery
+    file. The stale file is deliberately NOT deleted here: deletion
+    is the owning process's job (pid-guarded in
+    :func:`amx.web.discovery.clear_discovery`), and racing it from a
+    reader could drop the record of a healthy server mid-restart.
+    """
+    from amx.web.discovery import read_discovery
+
+    record = read_discovery()
+    if record is None:
+        return None
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{record.port}/api/health",
+        headers={"Authorization": f"Bearer {record.token}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=REUSE_PROBE_TIMEOUT_SEC) as response:
+            if response.status == 200:
+                return record
+    except (OSError, ValueError):
+        # URLError subclasses OSError; ValueError covers a corrupt
+        # port landing in the URL. All mean "not reusable".
+        return None
+    return None
 
 
 def _pick_port(preferred: int) -> int:
@@ -120,7 +167,7 @@ def launch_studio(
     port: int | None = None,
     open_browser: bool = True,
     block: bool = True,
-    embedded: bool = False,
+    embedded: bool = True,
 ) -> bool:
     """Start AMX Studio for one ``/studio`` invocation.
 
@@ -149,10 +196,32 @@ def launch_studio(
         responsible for closing the log file).
     embedded
         Pass-through for the server's embedded host mode (relaxed
-        framing headers so IDE webviews can iframe the SPA). Set by
-        IDE integrations that drive ``amx studio --embedded``; the
-        browser-facing default stays strict.
+        framing headers so IDE webviews can iframe the SPA). Defaults
+        to ``True`` so the one server every surface shares — browser
+        tabs, REPL, IDE webviews — is always frameable; the server
+        still binds 127.0.0.1 and requires the bearer token, so the
+        relaxed ``frame-ancestors`` grants nothing by itself (see
+        the rationale in :mod:`amx.web.security_headers`). Pass
+        ``False`` to get the strict browser-only headers.
     """
+    if port is None:
+        running = _probe_running_studio()
+        if running is not None:
+            reused_url = f"http://127.0.0.1:{running.port}/?t={running.token}"
+            owner = running.owner or "unknown"
+            print(  # user-facing — keep print, not log
+                f"AMX Studio already running → {reused_url}\n"
+                f"  Reusing the existing server (started by {owner}, pid {running.pid}); "
+                "this terminal does not control it.\n"
+                "  Stop it from wherever it was started."
+            )
+            if open_browser:
+                try:
+                    webbrowser.open_new_tab(reused_url)
+                except Exception as exc:  # pragma: no cover - browser launch is best-effort
+                    log.debug("Could not auto-open browser: %s", exc)
+            return True
+
     chosen_port = port if port is not None else _pick_port(PREFERRED_PORT)
 
     # Generate the bearer token in the PARENT so we can immediately

--- a/tests/web/test_launcher_reuse.py
+++ b/tests/web/test_launcher_reuse.py
@@ -1,0 +1,171 @@
+"""Discovery-file reuse in ``launch_studio`` (single shared Studio).
+
+A second ``/studio`` — from another REPL or alongside an IDE-owned
+server — must reuse the already-running instance instead of spawning
+a duplicate: probe the discovery record, health-check it with its
+bearer token, and on success just print/open the recorded URL. Every
+non-usable record state (missing, malformed, dead server, wrong
+token semantics) must fall through to a normal spawn, and an
+explicit ``--port`` override must bypass the reuse probe entirely.
+"""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from amx.config import AMXConfig
+from amx.web import discovery, launcher
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_dir(tmp_path, monkeypatch):
+    """Point AMX_CONFIG_DIR at a temp dir so tests never touch ~/.amx."""
+    monkeypatch.setenv("AMX_CONFIG_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def cfg(tmp_path):
+    config = AMXConfig()
+    object.__setattr__(config, "_config_path", str(tmp_path / "config.yml"))
+    object.__setattr__(config, "CONFIG_DIR", str(tmp_path))
+    return config
+
+
+class _HealthHandler(BaseHTTPRequestHandler):
+    """Minimal stand-in for a live Studio: 200 on a token-authed
+    ``/api/health``, 401 otherwise — mirroring TokenAuthMiddleware."""
+
+    expected_token = ""
+
+    def do_GET(self) -> None:  # noqa: N802 - http.server API
+        authed = self.headers.get("Authorization") == f"Bearer {self.expected_token}"
+        if self.path == "/api/health" and authed:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status": "ok"}')
+        else:
+            self.send_response(401)
+            self.end_headers()
+
+    def log_message(self, *args) -> None:  # silence test output
+        del args
+
+
+@pytest.fixture
+def fake_studio():
+    """A live loopback HTTP server registered in the discovery file."""
+    server = HTTPServer(("127.0.0.1", 0), _HealthHandler)
+    port = server.server_address[1]
+    _HealthHandler.expected_token = "tok-live"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    discovery.write_discovery(port, "tok-live", owner="cli")
+    try:
+        yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_reuses_healthy_running_studio_without_spawning(cfg, fake_studio) -> None:
+    with patch.object(launcher.subprocess, "Popen") as fake_popen:
+        with patch.object(launcher, "webbrowser") as fake_browser:
+            ok = launcher.launch_studio(cfg, open_browser=True)
+    assert ok is True
+    fake_popen.assert_not_called()
+    opened_url = fake_browser.open_new_tab.call_args.args[0]
+    assert opened_url == f"http://127.0.0.1:{fake_studio}/?t=tok-live"
+
+
+def test_reuse_respects_open_browser_false(cfg, fake_studio) -> None:
+    with patch.object(launcher.subprocess, "Popen") as fake_popen:
+        with patch.object(launcher, "webbrowser") as fake_browser:
+            ok = launcher.launch_studio(cfg, open_browser=False)
+    assert ok is True
+    fake_popen.assert_not_called()
+    fake_browser.open_new_tab.assert_not_called()
+
+
+def test_dead_record_falls_through_to_spawn(cfg) -> None:
+    """A record pointing at a closed port must not block the launch."""
+    closed_port = launcher._pick_port(0)  # allocated then released → closed
+    discovery.write_discovery(closed_port, "tok-dead", owner="cli")
+
+    fake_proc = MagicMock()
+    fake_proc.wait.return_value = 0
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc) as fake_popen:
+        with (
+            patch.object(launcher, "_wait_for_http", return_value=True),
+            patch.object(launcher, "webbrowser"),
+        ):
+            ok = launcher.launch_studio(cfg, open_browser=False)
+    assert ok is True
+    fake_popen.assert_called_once()
+
+
+def test_missing_record_spawns_normally(cfg) -> None:
+    fake_proc = MagicMock()
+    fake_proc.wait.return_value = 0
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc) as fake_popen:
+        with (
+            patch.object(launcher, "_wait_for_http", return_value=True),
+            patch.object(launcher, "webbrowser"),
+        ):
+            ok = launcher.launch_studio(cfg, open_browser=False)
+    assert ok is True
+    fake_popen.assert_called_once()
+
+
+def test_malformed_record_spawns_normally(cfg) -> None:
+    discovery.discovery_path().parent.mkdir(parents=True, exist_ok=True)
+    discovery.discovery_path().write_text("{not json", encoding="utf-8")
+
+    fake_proc = MagicMock()
+    fake_proc.wait.return_value = 0
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc) as fake_popen:
+        with (
+            patch.object(launcher, "_wait_for_http", return_value=True),
+            patch.object(launcher, "webbrowser"),
+        ):
+            ok = launcher.launch_studio(cfg, open_browser=False)
+    assert ok is True
+    fake_popen.assert_called_once()
+
+
+def test_explicit_port_bypasses_reuse_probe(cfg, fake_studio) -> None:
+    """Tests and power users pin a port deliberately — a running
+    server elsewhere must not hijack that request."""
+    fake_proc = MagicMock()
+    fake_proc.wait.return_value = 0
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc) as fake_popen:
+        with (
+            patch.object(launcher, "_wait_for_http", return_value=True),
+            patch.object(launcher, "webbrowser"),
+        ):
+            ok = launcher.launch_studio(cfg, port=fake_studio + 1, open_browser=False)
+    assert ok is True
+    fake_popen.assert_called_once()
+
+
+def test_probe_rejects_record_with_stale_token(cfg, fake_studio) -> None:
+    """A record whose token the server no longer accepts (401) is not
+    reusable — fall through to spawn."""
+    discovery.write_discovery(fake_studio, "tok-stale", owner="cli")
+
+    fake_proc = MagicMock()
+    fake_proc.wait.return_value = 0
+    with patch.object(launcher.subprocess, "Popen", return_value=fake_proc) as fake_popen:
+        with (
+            patch.object(launcher, "_wait_for_http", return_value=True),
+            patch.object(launcher, "webbrowser"),
+        ):
+            ok = launcher.launch_studio(cfg, open_browser=False)
+    assert ok is True
+    fake_popen.assert_called_once()

--- a/tests/web/test_launcher_subprocess.py
+++ b/tests/web/test_launcher_subprocess.py
@@ -49,13 +49,14 @@ def test_launch_studio_spawns_subprocess_with_python_module(tmp_path, monkeypatc
     assert "47821" in cmd
     assert "--token" in cmd
     assert "--config-path" in cmd
-    # Browser launches stay strict — embedded mode is opt-in.
-    assert "--embedded" not in cmd
+    # Embedded host mode is the default: the one server every surface
+    # shares (browser, REPL, IDE webview) must always be frameable.
+    assert "--embedded" in cmd
 
 
-def test_launch_studio_embedded_passthrough(tmp_path):
-    """``launch_studio(embedded=True)`` forwards ``--embedded`` to the
-    server subprocess so IDE hosts get frameable headers."""
+def test_launch_studio_strict_mode_opt_out(tmp_path):
+    """``launch_studio(embedded=False)`` omits ``--embedded`` so the
+    strict browser-only header path stays reachable."""
     from amx.config import AMXConfig
     from amx.web import launcher
 
@@ -70,10 +71,10 @@ def test_launch_studio_embedded_passthrough(tmp_path):
             patch.object(launcher, "_wait_for_http", return_value=True),
             patch.object(launcher, "webbrowser"),
         ):
-            ok = launcher.launch_studio(cfg, port=47822, open_browser=False, embedded=True)
+            ok = launcher.launch_studio(cfg, port=47822, open_browser=False, embedded=False)
     assert ok is True
     cmd = fake_popen.call_args.args[0]
-    assert "--embedded" in cmd
+    assert "--embedded" not in cmd
 
 
 def test_popen_kwargs_isolate_child_from_parent_terminal(tmp_path):


### PR DESCRIPTION
## Summary
- `/studio` now checks the discovery file (`studio.json`) before spawning: if a recorded server passes a token-authenticated `GET /api/health`, the existing instance is reused (URL printed, browser opened) instead of starting a duplicate. Explicit `--port` overrides bypass the probe.
- Embedded host mode (relaxed `frame-ancestors` headers) is now the default for every launch, so the single shared server is frameable by IDE webviews regardless of which surface started it first. The server still binds 127.0.0.1 and requires the bearer token, so the relaxed framing grants nothing by itself (rationale in `security_headers.py`).
- The strict header path stays reachable via `launch_studio(embedded=False)` and remains covered by the existing app-level header tests. `--embedded` stays visible in `--help` for IDE integrations that probe it; it no longer steers behavior.

This removes the root cause of the IDE-extension gap where a REPL-launched Studio could be adopted but not iframed, forcing users to Ctrl-C it.

## Test plan
- New `tests/web/test_launcher_reuse.py`: healthy record → no spawn, browser opens recorded URL; dead/missing/malformed/stale-token records → normal spawn; explicit port bypasses the probe.
- Updated `tests/web/test_launcher_subprocess.py`: default launch passes `--embedded`; `embedded=False` omits it.
- `pytest tests/web/test_launcher*.py tests/web/test_discovery.py tests/web/test_embedded_mode.py tests/web/test_security_headers.py` — 42 passed.
- Manual: `/studio` twice (second reuses); `/studio` then open an extension panel (iframe renders).