### PR TITLE
feat(vscode): auto-recover when an adopted Studio server goes away

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -586,6 +586,11 @@
           "default": true,
           "description": "Reuse a Studio server already running on this machine (e.g. launched from the REPL) instead of starting a second one."
         },
+        "amx.server.autoRecover": {
+          "type": "boolean",
+          "default": true,
+          "description": "When an adopted Studio server goes away (e.g. Ctrl-C in the terminal that launched it), automatically adopt its replacement or start a new one."
+        },
         "amx.catalog.cacheTtlSeconds": {
           "type": "number",
           "default": 300,

--- a/vscode-extension/src/server/healthMonitor.ts
+++ b/vscode-extension/src/server/healthMonitor.ts
@@ -1,0 +1,134 @@
+// Liveness watcher for an adopted (REPL-owned) Studio server. The
+// extension has no process handle for servers it merely attached to,
+// so death is detected out-of-band: a periodic health probe plus a
+// watch on the discovery file the server rewrites/clears. Kept free
+// of vscode imports so plain vitest can exercise the timing logic.
+import { watch, type FSWatcher } from "node:fs";
+
+export interface HealthMonitorOptions {
+  /** Health probe for the monitored server; true means alive. */
+  readonly probe: () => Promise<boolean>;
+  /** Directory containing the discovery file. Watching the directory
+   *  (not the file) survives the atomic temp-file + rename writes the
+   *  Python side uses, on every platform. */
+  readonly watchDir: string;
+  /** Discovery file name inside watchDir. */
+  readonly watchFileName?: string;
+  /** Delay between successful probes. */
+  readonly intervalMs?: number;
+  /** Consecutive probe failures before the server counts as lost. */
+  readonly failureThreshold?: number;
+  /** Fired once when the server is declared lost; the monitor stops
+   *  itself first so the callback can safely restart/replace it. */
+  readonly onServerLost: () => void;
+  /** Fired (debounced) when the discovery file changes — a new server
+   *  may have replaced the one being monitored. */
+  readonly onDiscoveryChanged?: () => void;
+}
+
+const DEFAULT_INTERVAL_MS = 5_000;
+const DEFAULT_FAILURE_THRESHOLD = 2;
+const DISCOVERY_DEBOUNCE_MS = 300;
+
+export class HealthMonitor {
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private watcher: FSWatcher | undefined;
+  private failures = 0;
+  private running = false;
+  private probing = false;
+
+  constructor(private readonly options: HealthMonitorOptions) {}
+
+  /** True while the poll loop is active. */
+  get active(): boolean {
+    return this.running;
+  }
+
+  /** Milliseconds timestamp of the last successful probe, if any. */
+  lastHealthyAt: number | undefined;
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.failures = 0;
+    this.scheduleProbe();
+    try {
+      // fs.watch on a directory is supported on macOS, Windows, and
+      // Linux; per-file watches break on the atomic os.replace() the
+      // server uses, because the watched inode is swapped out.
+      this.watcher = watch(this.options.watchDir, (_event, filename) => {
+        const expected = this.options.watchFileName ?? "studio.json";
+        // Some platforms omit the filename; treat those events as
+        // potentially relevant rather than dropping them.
+        if (filename && filename !== expected) return;
+        this.debounceDiscoveryChanged();
+      });
+    } catch {
+      // Watching is an accelerator on top of the poll loop, never a
+      // requirement — a missing directory just means slower detection.
+    }
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = undefined;
+    this.watcher?.close();
+    this.watcher = undefined;
+  }
+
+  dispose(): void {
+    this.stop();
+  }
+
+  private scheduleProbe(): void {
+    if (!this.running) return;
+    this.timer = setTimeout(() => {
+      void this.probeOnce();
+    }, this.options.intervalMs ?? DEFAULT_INTERVAL_MS);
+  }
+
+  private async probeOnce(): Promise<void> {
+    if (!this.running || this.probing) {
+      this.scheduleProbe();
+      return;
+    }
+    this.probing = true;
+    let ok = false;
+    try {
+      ok = await this.options.probe();
+    } catch {
+      ok = false;
+    } finally {
+      this.probing = false;
+    }
+    if (!this.running) return;
+    if (ok) {
+      this.failures = 0;
+      this.lastHealthyAt = Date.now();
+      this.scheduleProbe();
+      return;
+    }
+    this.failures += 1;
+    if (this.failures >= (this.options.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD)) {
+      // Stop before notifying so the handler can tear down / replace
+      // this monitor without racing another probe.
+      this.stop();
+      this.options.onServerLost();
+      return;
+    }
+    this.scheduleProbe();
+  }
+
+  private debounceDiscoveryChanged(): void {
+    if (!this.options.onDiscoveryChanged) return;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      if (this.running) this.options.onDiscoveryChanged?.();
+    }, DISCOVERY_DEBOUNCE_MS);
+  }
+}

--- a/vscode-extension/src/server/serverManager.ts
+++ b/vscode-extension/src/server/serverManager.ts
@@ -10,11 +10,14 @@ import * as vscode from "vscode";
 import type { RuntimeManager } from "../runtime/runtimeManager";
 import { backoffDelayMs, singleFlight, sleep } from "../util/async";
 import { getServerChannel, log } from "../util/log";
-import { readDiscovery } from "./discoveryFile";
+import { amxConfigDir, readDiscovery } from "./discoveryFile";
+import { HealthMonitor } from "./healthMonitor";
 import { pickPort } from "./ports";
 import {
   buildCliSpawnSpec,
   buildServerSpawnSpec,
+  isPidAlive,
+  killPid,
   killServer,
   probeEmbeddedSupport,
   spawnServer,
@@ -46,17 +49,32 @@ const HEALTH_TIMEOUT_MS = 1500;
 const STARTUP_TIMEOUT_MS = 15_000;
 const MAX_RESTARTS = 3;
 const RESTART_WINDOW_MS = 60_000;
+/** Cached "running" state older than this is revalidated in ensure().
+ *  The attached-server monitor refreshes the timestamp every probe,
+ *  so the revalidation only fires when the monitor itself is wedged
+ *  or was never able to start. */
+const HEALTH_STALENESS_MS = 15_000;
+/** globalState key holding the pid of the owned server subprocess,
+ *  written on spawn and cleared on clean shutdown. A surviving value
+ *  on activation means the previous extension host could not finish
+ *  its kill — see reconcileOrphans(). */
+const OWNED_PID_KEY = "amx.server.ownedPid";
 
 export class ServerManager implements vscode.Disposable {
   private current: ServerState = { status: "stopped" };
   private proc: ChildProcess | undefined;
   private disposing = false;
   private restartTimestamps: number[] = [];
+  private monitor: HealthMonitor | undefined;
+  private lastHealthyAt = 0;
   private readonly didChange = new vscode.EventEmitter<ServerState>();
   readonly onDidChangeState = this.didChange.event;
   private readonly ensureOnce = singleFlight(() => this.startOrAttach());
 
-  constructor(private readonly runtime: RuntimeManager) {}
+  constructor(
+    private readonly runtime: RuntimeManager,
+    private readonly memento?: vscode.Memento,
+  ) {}
 
   get state(): ServerState {
     return this.current;
@@ -64,8 +82,50 @@ export class ServerManager implements vscode.Disposable {
 
   /** Start-or-attach, idempotent and single-flight. */
   async ensure(): Promise<RunningServer> {
-    if (this.current.status === "running") return this.current;
+    const current = this.current;
+    if (current.status === "running") {
+      // An attached server can die without any signal to us (REPL
+      // Ctrl-C). The monitor usually notices first; this staleness
+      // guard catches the window before it does, so callers never
+      // get handed a dead server.
+      if (current.mode === "attached" && Date.now() - this.lastHealthyAt > HEALTH_STALENESS_MS) {
+        const health = await this.healthCheck(current.port, current.token);
+        if (!health.ok) {
+          log(`cached attached server on :${current.port} failed revalidation`);
+          this.setState({ status: "stopped" });
+          return this.ensureOnce();
+        }
+        this.lastHealthyAt = Date.now();
+      }
+      return current;
+    }
     return this.ensureOnce();
+  }
+
+  /**
+   * Reap an owned server left over from a previous extension host.
+   * deactivate() cannot await the kill, so a recorded pid that is
+   * still alive but no longer healthy is cleaned up here, on the
+   * next activation, before it can squat on the preferred port.
+   * A leftover that IS healthy is left alone — tryAdopt() will
+   * reuse it through the discovery file.
+   */
+  async reconcileOrphans(): Promise<void> {
+    const pid = this.memento?.get<number>(OWNED_PID_KEY);
+    if (pid === undefined) return;
+    if (!isPidAlive(pid)) {
+      await this.memento?.update(OWNED_PID_KEY, undefined);
+      return;
+    }
+    const record = await readDiscovery();
+    const isOurs = record !== undefined && record.pid === pid && record.owner === "vscode";
+    if (isOurs && (await this.healthCheck(record.port, record.token)).ok) {
+      log(`previous owned server (pid ${pid}) is still healthy — leaving it for adoption`);
+      return;
+    }
+    log(`reaping orphaned Studio server from a previous session (pid ${pid})`);
+    await killPid(pid);
+    await this.memento?.update(OWNED_PID_KEY, undefined);
   }
 
   async stop(): Promise<void> {
@@ -73,6 +133,7 @@ export class ServerManager implements vscode.Disposable {
       const proc = this.proc;
       this.proc = undefined;
       await killServer(proc);
+      await this.memento?.update(OWNED_PID_KEY, undefined);
     }
     this.setState({ status: "stopped" });
   }
@@ -84,8 +145,12 @@ export class ServerManager implements vscode.Disposable {
 
   dispose(): void {
     this.disposing = true;
+    this.monitor?.dispose();
+    this.monitor = undefined;
     if (this.proc) {
       // Fire and forget — deactivate cannot await long shutdowns.
+      // reconcileOrphans() on the next activation handles the case
+      // where this kill never finishes; the recorded pid is its input.
       void killServer(this.proc);
       this.proc = undefined;
     }
@@ -94,7 +159,67 @@ export class ServerManager implements vscode.Disposable {
 
   private setState(state: ServerState): void {
     this.current = state;
+    this.syncMonitor(state);
     this.didChange.fire(state);
+  }
+
+  /** Keep the out-of-band liveness monitor running exactly while an
+   *  attached server is the current state. Owned servers already
+   *  report death through the ChildProcess exit event. */
+  private syncMonitor(state: ServerState): void {
+    this.monitor?.dispose();
+    this.monitor = undefined;
+    if (state.status !== "running" || state.mode !== "attached" || this.disposing) return;
+    const { port, token } = state;
+    this.lastHealthyAt = Date.now();
+    const monitor = new HealthMonitor({
+      probe: async () => {
+        const ok = (await this.healthCheck(port, token)).ok;
+        // Feed the staleness guard in ensure() so it only revalidates
+        // when this loop has genuinely stopped producing heartbeats.
+        if (ok) this.lastHealthyAt = Date.now();
+        return ok;
+      },
+      watchDir: amxConfigDir(),
+      onServerLost: () => this.handleAttachedLoss(port),
+      onDiscoveryChanged: () => void this.handleDiscoveryChanged(port, token),
+    });
+    this.monitor = monitor;
+    monitor.start();
+  }
+
+  /** The attached server stopped answering — drop the state and, when
+   *  enabled, re-run the adopt-or-spawn flow through the same backoff
+   *  budget owned-server crashes use. */
+  private handleAttachedLoss(port: number): void {
+    if (this.disposing) return;
+    const current = this.current;
+    if (current.status !== "running" || current.mode !== "attached" || current.port !== port) {
+      return; // superseded — a newer state already replaced this server
+    }
+    log(`attached Studio server on :${port} stopped responding`);
+    this.setState({ status: "stopped" });
+    const autoRecover = vscode.workspace
+      .getConfiguration("amx")
+      .get<boolean>("server.autoRecover", true);
+    if (autoRecover) void this.maybeRestart();
+  }
+
+  /** The discovery file changed while attached — a new server may have
+   *  replaced the monitored one (REPL restart on a new port). Verify
+   *  the monitored server; if it is gone, fail over immediately
+   *  instead of waiting for the probe loop's failure threshold. */
+  private async handleDiscoveryChanged(port: number, token: string): Promise<void> {
+    if (this.disposing) return;
+    const current = this.current;
+    if (current.status !== "running" || current.mode !== "attached" || current.port !== port) {
+      return;
+    }
+    if ((await this.healthCheck(port, token)).ok) {
+      this.lastHealthyAt = Date.now();
+      return; // still alive — the file change was about someone else
+    }
+    this.handleAttachedLoss(port);
   }
 
   private async startOrAttach(): Promise<RunningServer> {
@@ -198,12 +323,16 @@ export class ServerManager implements vscode.Disposable {
 
   private attachProcess(proc: ChildProcess): void {
     this.proc = proc;
+    // Persist the pid so the NEXT extension host can reap this server
+    // if deactivate's fire-and-forget kill never lands.
+    if (proc.pid !== undefined) void this.memento?.update(OWNED_PID_KEY, proc.pid);
     const channel = getServerChannel();
     proc.stdout?.on("data", (chunk: Buffer) => channel.append(chunk.toString()));
     proc.stderr?.on("data", (chunk: Buffer) => channel.append(chunk.toString()));
     proc.on("exit", (code, signal) => {
       if (this.proc !== proc) return; // superseded or stopped on purpose
       this.proc = undefined;
+      void this.memento?.update(OWNED_PID_KEY, undefined);
       log(`Studio server exited (code=${code} signal=${signal})`);
       if (this.disposing) return;
       this.setState({ status: "stopped" });

--- a/vscode-extension/src/server/spawn.ts
+++ b/vscode-extension/src/server/spawn.ts
@@ -111,6 +111,55 @@ export function spawnServer(spec: SpawnSpec): ChildProcess {
  * detached-stdin child, so go through taskkill with /T to take the
  * process tree down.
  */
+/** Whether a process with this pid currently exists (signal 0 probe). */
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stop a server by raw pid — used to reap an owned server left over
+ * from a previous extension host (deactivate cannot await the kill,
+ * so reconciliation happens on the next activation). Unlike
+ * killServer there is no ChildProcess to await, so liveness is
+ * polled between escalation steps.
+ */
+export async function killPid(pid: number, graceMs = 2000): Promise<void> {
+  if (!isPidAlive(pid)) return;
+  if (process.platform === "win32") {
+    try {
+      await execFileAsync("taskkill", ["/pid", String(pid), "/T", "/F"]);
+    } catch {
+      /* best effort — the process may have exited already */
+    }
+    return;
+  }
+  const signalAndWait = async (signal: NodeJS.Signals): Promise<boolean> => {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      return true; // already gone
+    }
+    const deadline = Date.now() + graceMs;
+    while (Date.now() < deadline) {
+      if (!isPidAlive(pid)) return true;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    return !isPidAlive(pid);
+  };
+  if (await signalAndWait("SIGINT")) return;
+  if (await signalAndWait("SIGTERM")) return;
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    /* already gone */
+  }
+}
+
 export async function killServer(proc: ChildProcess, graceMs = 2000): Promise<void> {
   if (proc.exitCode !== null || proc.signalCode !== null) return;
   const exited = new Promise<void>((resolve) => {

--- a/vscode-extension/src/services.ts
+++ b/vscode-extension/src/services.ts
@@ -17,7 +17,12 @@ export interface ExtensionServices {
 
 export function createServices(context: vscode.ExtensionContext): ExtensionServices {
   const runtime = new RuntimeManager(context.globalStorageUri.fsPath);
-  const server = new ServerManager(runtime);
+  const server = new ServerManager(runtime, context.globalState);
+  // Reap any owned server a previous extension host failed to kill
+  // (deactivate cannot await) before it can squat on the preferred
+  // port and wedge the next spawn. Healthy leftovers are kept and
+  // re-adopted through the discovery file.
+  void server.reconcileOrphans();
   const client = new AmxClient(server);
   const ttlSeconds = vscode.workspace
     .getConfiguration("amx")

--- a/vscode-extension/src/webviews/html.ts
+++ b/vscode-extension/src/webviews/html.ts
@@ -90,6 +90,10 @@ export function buildFrameHtml(options: FrameHtmlOptions): string {
         if (ready) return;
         document.getElementById("loading").classList.add("hidden");
         document.getElementById("stalled").classList.remove("hidden");
+        // Tell the extension host too: it re-checks the server and
+        // rebuilds the panel once it is healthy again, so a stall
+        // caused by a server restart heals without a manual Retry.
+        vscode.postMessage({ type: "amx:stalled" });
       }, 12000);
       window.addEventListener("message", (event) => {
         const data = event.data;

--- a/vscode-extension/src/webviews/studioPanel.ts
+++ b/vscode-extension/src/webviews/studioPanel.ts
@@ -63,13 +63,38 @@ export class StudioPanel implements vscode.Disposable {
     this.subscriptions.push(
       panel.webview.onDidReceiveMessage((message: unknown) => this.handleMessage(message)),
       this.services.server.onDidChangeState((state) => {
+        if (state.status === "running") {
+          if (this.rendered === undefined) {
+            // Panel is showing error/guidance HTML from an earlier
+            // failure — the server is back, recover without making
+            // the user click Retry (or reload the window).
+            log(`Studio server is back — rebuilding ${this.definition.viewType}`);
+            void this.rebuild();
+          } else if (
+            state.port !== this.rendered.port ||
+            state.token !== this.rendered.token
+          ) {
+            log(`Studio server moved to :${state.port} — rebuilding ${this.definition.viewType}`);
+            void this.rebuild();
+          }
+          return;
+        }
         if (
-          state.status === "running" &&
-          this.rendered !== undefined &&
-          (state.port !== this.rendered.port || state.token !== this.rendered.token)
+          (state.status === "stopped" || state.status === "error") &&
+          this.rendered !== undefined
         ) {
-          log(`Studio server moved to :${state.port} — rebuilding ${this.definition.viewType}`);
-          void this.rebuild();
+          // The rendered iframe points at a dead server — swap to the
+          // error shell instead of leaving a silently dead page. The
+          // running-state branch above rebuilds when it recovers.
+          this.rendered = undefined;
+          this.panel.webview.html = buildErrorHtml({
+            title: this.definition.buildTitle(this.args),
+            message:
+              state.status === "error"
+                ? state.message
+                : "The Studio server stopped. It restarts automatically; retry if this persists.",
+            state: this.persistedState(),
+          });
         }
       }),
     );
@@ -179,6 +204,22 @@ export class StudioPanel implements vscode.Disposable {
     }
     if (type === "amx:retry") {
       void this.rebuild();
+      return;
+    }
+    if (type === "amx:stalled") {
+      // The SPA never reported in. If the server identity has moved
+      // (or the server is down and will be re-ensured), rebuild —
+      // ensure() inside rebuild() revalidates a stale attached
+      // server. When the server is verifiably the one we rendered
+      // and healthy, leave the overlay's manual buttons in charge so
+      // a genuinely broken SPA doesn't trigger a rebuild loop.
+      const state = this.services.server.state;
+      const sameServer =
+        state.status === "running" &&
+        this.rendered !== undefined &&
+        state.port === this.rendered.port &&
+        state.token === this.rendered.token;
+      if (!sameServer) void this.rebuild();
       return;
     }
     if (type === "amx:openBrowser") {

--- a/vscode-extension/test/unit/healthMonitor.test.ts
+++ b/vscode-extension/test/unit/healthMonitor.test.ts
@@ -1,0 +1,159 @@
+// HealthMonitor: probe-loop failure threshold, recovery reset, and
+// discovery-file change detection across atomic replaces.
+import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HealthMonitor } from "../../src/server/healthMonitor";
+
+let dir: string;
+let monitor: HealthMonitor | undefined;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "amx-monitor-"));
+});
+
+afterEach(async () => {
+  monitor?.dispose();
+  monitor = undefined;
+  await rm(dir, { recursive: true, force: true });
+});
+
+const flushTimers = async (ms: number, steps = 10): Promise<void> => {
+  // advance in slices so chained setTimeout callbacks (probe →
+  // reschedule) all get a chance to run their async bodies.
+  for (let i = 0; i < steps; i += 1) {
+    await vi.advanceTimersByTimeAsync(ms / steps);
+  }
+};
+
+describe("HealthMonitor probe loop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("declares the server lost after consecutive failures", async () => {
+    const onServerLost = vi.fn();
+    const probe = vi.fn().mockResolvedValue(false);
+    monitor = new HealthMonitor({
+      probe,
+      watchDir: dir,
+      intervalMs: 100,
+      failureThreshold: 2,
+      onServerLost,
+    });
+    monitor.start();
+
+    await flushTimers(150);
+    expect(onServerLost).not.toHaveBeenCalled(); // one failure tolerated
+
+    await flushTimers(150);
+    expect(onServerLost).toHaveBeenCalledTimes(1);
+    expect(monitor.active).toBe(false); // stops itself before notifying
+  });
+
+  it("resets the failure count after a successful probe", async () => {
+    const onServerLost = vi.fn();
+    const probe = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+    monitor = new HealthMonitor({
+      probe,
+      watchDir: dir,
+      intervalMs: 100,
+      failureThreshold: 2,
+      onServerLost,
+    });
+    monitor.start();
+
+    await flushTimers(600);
+    expect(onServerLost).not.toHaveBeenCalled();
+    expect(monitor.lastHealthyAt).toBeDefined();
+  });
+
+  it("treats a throwing probe as a failure", async () => {
+    const onServerLost = vi.fn();
+    const probe = vi.fn().mockRejectedValue(new Error("connection refused"));
+    monitor = new HealthMonitor({
+      probe,
+      watchDir: dir,
+      intervalMs: 100,
+      failureThreshold: 2,
+      onServerLost,
+    });
+    monitor.start();
+
+    await flushTimers(400);
+    expect(onServerLost).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not probe after stop()", async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    monitor = new HealthMonitor({
+      probe,
+      watchDir: dir,
+      intervalMs: 100,
+      onServerLost: vi.fn(),
+    });
+    monitor.start();
+    await flushTimers(150);
+    const calls = probe.mock.calls.length;
+    monitor.stop();
+    await flushTimers(500);
+    expect(probe.mock.calls.length).toBe(calls);
+  });
+});
+
+describe("HealthMonitor discovery watch", () => {
+  // Real timers: fs.watch events arrive on the real event loop.
+  it("fires onDiscoveryChanged for an atomic temp-file replace", async () => {
+    const changed = new Promise<void>((resolve) => {
+      monitor = new HealthMonitor({
+        probe: () => Promise.resolve(true),
+        watchDir: dir,
+        intervalMs: 60_000, // keep the probe loop out of the way
+        onServerLost: () => {},
+        onDiscoveryChanged: () => resolve(),
+      });
+    });
+    monitor?.start();
+
+    // Mirror the Python writer: temp file in the same dir + rename.
+    const tmp = join(dir, ".studio.json.tmp");
+    await writeFile(tmp, JSON.stringify({ port: 1 }), "utf-8");
+    await rename(tmp, join(dir, "studio.json"));
+
+    await expect(
+      Promise.race([
+        changed,
+        new Promise((_resolve, reject) =>
+          setTimeout(() => reject(new Error("no discovery event within 5s")), 5_000),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores changes to unrelated files", async () => {
+    const onDiscoveryChanged = vi.fn();
+    monitor = new HealthMonitor({
+      probe: () => Promise.resolve(true),
+      watchDir: dir,
+      intervalMs: 60_000,
+      onServerLost: () => {},
+      onDiscoveryChanged,
+    });
+    monitor.start();
+
+    await writeFile(join(dir, "config.yml"), "x: 1", "utf-8");
+    await new Promise((resolve) => setTimeout(resolve, 700)); // > debounce
+    expect(onDiscoveryChanged).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/server/healthMonitor.ts`: while attached to a REPL-owned Studio, polls `/api/health` (~5 s, 2-failure tolerance) and watches the config **directory** for `studio.json` changes (directory watch survives the Python side's atomic temp-file + rename writes). vscode-free so vitest covers the timing logic.
- `ServerManager`: on attached-server loss → state drops to stopped and the adopt-or-spawn flow re-runs through the existing crash-backoff budget (new `amx.server.autoRecover` setting, default on). A discovery-file change triggers an immediate verify-and-failover instead of waiting out the probe loop. `ensure()` revalidates a stale cached attached state before handing it to callers.
- Orphan reaping: the owned server's pid is persisted in `globalState` on spawn and cleared on clean shutdown; the next activation kills a leftover that is alive but unhealthy (`deactivate()` cannot await its kill). A healthy leftover is kept and re-adopted via the discovery file. New cross-platform `killPid`/`isPidAlive` helpers in `spawn.ts` (taskkill on Windows, SIGINT→SIGTERM→SIGKILL elsewhere).
- Panels: rebuild automatically when the server comes back while showing error HTML, swap to the error shell when the rendered server drops, and the stalled overlay now posts `amx:stalled` so the extension can heal a stall caused by a server move without a manual Retry.

Together with #655 this fixes the reported flow: REPL `/studio` → open an extension panel → Ctrl-C the REPL → the panel recovers on its own, no Reload Window.

## Test plan
- New `test/unit/healthMonitor.test.ts`: failure threshold, reset-on-success, throwing probe, stop semantics, atomic-replace detection, unrelated-file filtering — 83 unit tests green.
- `npm run typecheck` and `node esbuild.mjs` pass.
- Manual: adopt a REPL Studio, Ctrl-C it, watch the panel rebuild against the auto-spawned replacement within ~10 s.