### PR TITLE
feat(vscode): bulk-generate missing descriptions from the catalog tree

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -228,6 +228,11 @@
         "category": "AMX"
       },
       {
+        "command": "amx.catalog.generateMissing",
+        "title": "Generate Missing Descriptions…",
+        "category": "AMX"
+      },
+      {
         "command": "amx.catalog.copyName",
         "title": "Copy Qualified Name",
         "category": "AMX"
@@ -368,6 +373,10 @@
         },
         {
           "command": "amx.catalog.generateDescription",
+          "when": "false"
+        },
+        {
+          "command": "amx.catalog.generateMissing",
           "when": "false"
         },
         {
@@ -515,6 +524,11 @@
           "command": "amx.catalog.generateDescription",
           "when": "view == amx.catalog && viewItem =~ /amx\\.catalog(Table|Column)/",
           "group": "2_modify@2"
+        },
+        {
+          "command": "amx.catalog.generateMissing",
+          "when": "view == amx.catalog && viewItem =~ /amx\\.catalog(Schema|Table)/",
+          "group": "2_modify@3"
         },
         {
           "command": "amx.catalog.copyName",

--- a/vscode-extension/src/management/bulkGenerate.ts
+++ b/vscode-extension/src/management/bulkGenerate.ts
@@ -1,0 +1,245 @@
+// amx.catalog.generateMissing: bulk-generate descriptions for the
+// undocumented tables (and optionally columns) under a schema or table
+// node in the catalog tree. Generation runs client-side over the
+// existing per-asset endpoints with a small concurrency pool, a
+// cancellable progress notification, and a final review step before
+// anything is written. Generation consumes tokens on the active LLM
+// profile, so the wizard always shows the asset count up front and
+// never writes without an explicit Apply choice. The pure logic
+// (enumerate / generate / apply) lives in bulkGenerateCore.ts.
+import * as vscode from "vscode";
+
+import type { ExtensionServices } from "../services";
+import { mapPool } from "../util/async";
+import { refreshViews } from "../views";
+import {
+  applyOne,
+  describeError,
+  enumerateMissing,
+  generateOne,
+  type GenProposal,
+  type GenTarget,
+} from "./bulkGenerateCore";
+import { catalogArgFromNode } from "./catalogNodeArg";
+
+const COLUMN_SCOPE = "Tables and columns";
+const TABLE_SCOPE = "Tables only";
+const POOL_WIDTH = 3;
+
+export function registerBulkGenerate(services: ExtensionServices): vscode.Disposable {
+  return vscode.commands.registerCommand("amx.catalog.generateMissing", (element?: unknown) =>
+    runBulkGenerate(services, catalogArgFromNode(element)),
+  );
+}
+
+async function runBulkGenerate(
+  services: ExtensionServices,
+  node: ReturnType<typeof catalogArgFromNode>,
+): Promise<void> {
+  if (!node?.schema) {
+    void vscode.window.showWarningMessage("AMX: select a catalog schema or table first.");
+    return;
+  }
+  const scopeLabel = node.table ? `${node.schema}.${node.table}` : node.schema;
+
+  const includeColumns = await pickScope(scopeLabel);
+  if (includeColumns === undefined) return;
+
+  const targets = await vscode.window.withProgress(
+    { location: vscode.ProgressLocation.Window, title: "AMX: finding undocumented assets…" },
+    () => enumerateMissing(services, node, includeColumns),
+  );
+  if (targets.length === 0) {
+    void vscode.window.showInformationMessage(
+      `AMX: every ${includeColumns ? "table and column" : "table"} under ${scopeLabel} already has a description.`,
+    );
+    return;
+  }
+
+  const selected = await pickTargets(targets);
+  if (!selected || selected.length === 0) return;
+
+  const proposals = await generateWithProgress(services, selected);
+  const generated = proposals.filter((p) => p.description !== undefined);
+  const failed = proposals.filter((p) => p.error !== undefined);
+  if (generated.length === 0) {
+    void vscode.window.showErrorMessage(
+      `AMX: no descriptions were generated (${failed.length} failed). First error: ${failed[0]?.error ?? "unknown"}`,
+    );
+    return;
+  }
+
+  const approved = await reviewProposals(generated, failed);
+  if (!approved || approved.length === 0) return;
+
+  const toDatabase = await pickDestination();
+  if (toDatabase === undefined) return;
+
+  await applyWithProgress(services, approved, toDatabase, node.profile);
+}
+
+async function pickScope(scopeLabel: string): Promise<boolean | undefined> {
+  const pick = await vscode.window.showQuickPick(
+    [
+      {
+        label: TABLE_SCOPE,
+        description: "Generate descriptions for undocumented tables only",
+        columns: false,
+      },
+      {
+        label: COLUMN_SCOPE,
+        description: "Also generate for undocumented columns (more token usage)",
+        columns: true,
+      },
+    ],
+    { title: `AMX: generate missing descriptions under ${scopeLabel}`, ignoreFocusOut: true },
+  );
+  return pick?.columns;
+}
+
+interface TargetItem extends vscode.QuickPickItem {
+  target: GenTarget;
+}
+
+async function pickTargets(targets: GenTarget[]): Promise<GenTarget[] | undefined> {
+  const tableCount = targets.filter((t) => t.kind === "table").length;
+  const columnCount = targets.length - tableCount;
+  const items: TargetItem[] = targets.map((target) => ({
+    label: target.label,
+    description: target.kind,
+    picked: true,
+    target,
+  }));
+  const picked = await vscode.window.showQuickPick(items, {
+    title: `AMX: ${tableCount} tables, ${columnCount} columns — generation consumes tokens on the active LLM`,
+    placeHolder: "Select the assets to generate descriptions for",
+    canPickMany: true,
+    ignoreFocusOut: true,
+  });
+  return picked?.map((item) => item.target);
+}
+
+async function generateWithProgress(
+  services: ExtensionServices,
+  targets: GenTarget[],
+): Promise<GenProposal[]> {
+  return vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: "AMX: generating descriptions",
+      cancellable: true,
+    },
+    async (progress, token) => {
+      let done = 0;
+      const step = 100 / targets.length;
+      const results = await mapPool(
+        targets,
+        POOL_WIDTH,
+        async (target) => {
+          const proposal = await generateOne(services, target);
+          done += 1;
+          progress.report({
+            increment: step,
+            message: `${done}/${targets.length} — ${target.label}`,
+          });
+          return proposal;
+        },
+        () => token.isCancellationRequested,
+      );
+      // Cancelled slots stay undefined; keep whatever was generated so
+      // the user can still review and apply the completed work.
+      return results.filter((r): r is GenProposal => r !== undefined);
+    },
+  );
+}
+
+interface ProposalItem extends vscode.QuickPickItem {
+  proposal: GenProposal;
+}
+
+async function reviewProposals(
+  generated: GenProposal[],
+  failed: GenProposal[],
+): Promise<GenProposal[] | undefined> {
+  const items: ProposalItem[] = [
+    ...generated.map((proposal) => ({
+      label: proposal.target.label,
+      detail: proposal.description ?? "",
+      picked: true,
+      proposal,
+    })),
+    // Surface failures unchecked so the user sees what was skipped and
+    // why, without being able to apply an empty description.
+    ...failed.map((proposal) => ({
+      label: `$(error) ${proposal.target.label}`,
+      detail: `failed: ${proposal.error}`,
+      picked: false,
+      proposal,
+    })),
+  ];
+  const picked = await vscode.window.showQuickPick(items, {
+    title: `AMX: review ${generated.length} generated descriptions`,
+    placeHolder: "Uncheck any you don't want, then confirm to choose where to save",
+    canPickMany: true,
+    ignoreFocusOut: true,
+  });
+  // Drop any failed rows the user may have left checked — nothing to apply.
+  return picked?.map((item) => item.proposal).filter((p) => p.description !== undefined);
+}
+
+async function pickDestination(): Promise<boolean | undefined> {
+  const where = await vscode.window.showQuickPick(
+    [
+      {
+        label: "Apply to catalog",
+        description: "Local override — never writes to the source database",
+        toDatabase: false,
+      },
+      {
+        label: "Apply to database",
+        description: "COMMENT ON … against the source database",
+        toDatabase: true,
+      },
+    ],
+    { title: "AMX: where should the descriptions go?", ignoreFocusOut: true },
+  );
+  return where?.toDatabase;
+}
+
+async function applyWithProgress(
+  services: ExtensionServices,
+  approved: GenProposal[],
+  toDatabase: boolean,
+  invalidateProfile: string | undefined,
+): Promise<void> {
+  let applied = 0;
+  const failures: string[] = [];
+  await vscode.window.withProgress(
+    { location: vscode.ProgressLocation.Notification, title: "AMX: saving descriptions" },
+    async (progress) => {
+      const step = 100 / approved.length;
+      for (const proposal of approved) {
+        try {
+          await applyOne(services, proposal, toDatabase);
+          applied += 1;
+        } catch (error) {
+          failures.push(`${proposal.target.label}: ${describeError(error)}`);
+        }
+        progress.report({ increment: step, message: proposal.target.label });
+      }
+    },
+  );
+  services.catalog.invalidate(invalidateProfile ? { profile: invalidateProfile } : undefined);
+  refreshViews("catalog");
+
+  const where = toDatabase ? "database" : "catalog";
+  if (failures.length === 0) {
+    void vscode.window.showInformationMessage(
+      `AMX: saved ${applied} descriptions to the ${where}.`,
+    );
+  } else {
+    void vscode.window.showWarningMessage(
+      `AMX: saved ${applied} descriptions to the ${where}; ${failures.length} failed. First: ${failures[0]}`,
+    );
+  }
+}

--- a/vscode-extension/src/management/bulkGenerateCore.ts
+++ b/vscode-extension/src/management/bulkGenerateCore.ts
@@ -1,0 +1,153 @@
+// Pure enumeration + generate/apply logic for bulk description
+// generation. No vscode imports, so the decision-making (what counts
+// as undocumented, how a target maps to an endpoint, how failures are
+// captured) is unit-tested directly. The vscode UI orchestration lives
+// in bulkGenerate.ts.
+import { AmxApiError } from "../api/errors";
+import type { ExtensionServices } from "../services";
+import type { CatalogNodeArg } from "./catalogNodeArg";
+
+/** A single undocumented asset queued for generation. */
+export interface GenTarget {
+  kind: "table" | "column";
+  profile: string;
+  schema: string;
+  table: string;
+  column?: string;
+  /** schema.table or schema.table.column — display + dedupe key. */
+  label: string;
+}
+
+/** A target paired with the outcome of its generate call. */
+export interface GenProposal {
+  target: GenTarget;
+  description?: string;
+  error?: string;
+}
+
+/** The slices of ExtensionServices this logic needs — narrowed so the
+ *  functions are testable with light fakes. */
+export interface BulkGenerateDeps {
+  catalog: Pick<ExtensionServices["catalog"], "getTables" | "getColumns" | "invalidate">;
+  client: {
+    generate: ExtensionServices["client"]["generate"];
+    comments: ExtensionServices["client"]["comments"];
+  };
+}
+
+/**
+ * Find the undocumented assets under a schema or table node. Tables
+ * come from the (already-fetched) catalog inventory; columns are
+ * pulled per table only when requested. A table without a resolvable
+ * profile is skipped — the generate endpoints require one.
+ */
+export async function enumerateMissing(
+  deps: BulkGenerateDeps,
+  node: CatalogNodeArg,
+  includeColumns: boolean,
+): Promise<GenTarget[]> {
+  if (!node.schema) return [];
+  const scope: { profile?: string; database?: string } = {};
+  if (node.profile !== undefined) scope.profile = node.profile;
+  if (node.database !== undefined) scope.database = node.database;
+
+  const allTables = await deps.catalog.getTables(scope);
+  const inScope = allTables.filter(
+    (t) =>
+      t.schema.toLowerCase() === node.schema!.toLowerCase() &&
+      // A table node narrows to a single table; a schema node takes all.
+      (node.table === undefined || t.name.toLowerCase() === node.table.toLowerCase()),
+  );
+
+  const targets: GenTarget[] = [];
+  for (const table of inScope) {
+    const profile = table.profile ?? node.profile;
+    if (!profile) continue; // can't generate without a profile
+    if (!table.description?.trim()) {
+      targets.push({
+        kind: "table",
+        profile,
+        schema: table.schema,
+        table: table.name,
+        label: `${table.schema}.${table.name}`,
+      });
+    }
+    if (!includeColumns) continue;
+    const columns = await deps.catalog.getColumns(table.schema, table.name, profile);
+    for (const column of columns) {
+      if (column.description?.trim()) continue;
+      targets.push({
+        kind: "column",
+        profile,
+        schema: table.schema,
+        table: table.name,
+        column: column.name,
+        label: `${table.schema}.${table.name}.${column.name}`,
+      });
+    }
+  }
+  return targets;
+}
+
+/**
+ * Generate a description for one target. Never throws — failures are
+ * captured on the returned proposal so a single bad asset doesn't abort
+ * the batch.
+ */
+export async function generateOne(
+  deps: BulkGenerateDeps,
+  target: GenTarget,
+): Promise<GenProposal> {
+  try {
+    const result =
+      target.kind === "column"
+        ? await deps.client.generate.column(
+            target.schema,
+            target.table,
+            target.column!,
+            target.profile,
+          )
+        : await deps.client.generate.table(target.schema, target.table, target.profile);
+    return { target, description: result.description };
+  } catch (error) {
+    return { target, error: describeError(error) };
+  }
+}
+
+/** Write one approved proposal to the catalog or the source database. */
+export async function applyOne(
+  deps: BulkGenerateDeps,
+  proposal: GenProposal,
+  toDatabase: boolean,
+): Promise<void> {
+  const { target, description } = proposal;
+  if (!description) return;
+  if (toDatabase) {
+    if (target.column) {
+      await deps.client.comments.setColumn(
+        target.schema,
+        target.table,
+        target.column,
+        description,
+        target.profile,
+      );
+    } else {
+      await deps.client.comments.setTable(target.schema, target.table, description, target.profile);
+    }
+    return;
+  }
+  await deps.client.comments.setLocal({
+    profile: target.profile,
+    schema: target.schema,
+    table: target.table,
+    ...(target.column ? { column: target.column } : {}),
+    description,
+  });
+}
+
+export function describeError(error: unknown): string {
+  if (error instanceof AmxApiError) {
+    return error.hint ? `${error.detail} — ${error.hint}` : error.detail;
+  }
+  return error instanceof Error ? error.message : String(error);
+}

--- a/vscode-extension/src/management/index.ts
+++ b/vscode-extension/src/management/index.ts
@@ -6,6 +6,7 @@
 import * as vscode from "vscode";
 
 import type { ExtensionServices } from "../services";
+import { registerBulkGenerate } from "./bulkGenerate";
 import { registerCatalogOps } from "./catalogOps";
 import { registerProfileManagement } from "./profiles";
 import { vscodePromptPort } from "./promptPort";
@@ -48,6 +49,7 @@ function scriptedPromptPort(queue: (string | string[] | undefined)[]): PromptPor
 export function registerManagement(services: ExtensionServices): void {
   registerProfileManagement(services);
   registerCatalogOps(services);
+  services.context.subscriptions.push(registerBulkGenerate(services));
   registerRunManagement(services);
   registerScheduleManagement(services);
   services.context.subscriptions.push(

--- a/vscode-extension/src/util/async.ts
+++ b/vscode-extension/src/util/async.ts
@@ -28,6 +28,37 @@ export function backoffDelayMs(attempt: number, baseMs = 1000, capMs = 30_000): 
   return Math.min(baseMs * 2 ** attempt, capMs);
 }
 
+/**
+ * Run `worker` over `items` with at most `concurrency` in flight.
+ * Results are returned index-aligned with `items`. Before each item is
+ * dispatched the pool consults `shouldStop`; once it returns true no
+ * further items start and their slots stay `undefined` (already
+ * in-flight workers finish). The worker is expected to handle its own
+ * failures and resolve to a result value — a thrown worker rejects the
+ * whole pool, which callers generally don't want for best-effort bulk
+ * work.
+ */
+export async function mapPool<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+  shouldStop?: () => boolean,
+): Promise<(R | undefined)[]> {
+  const results: (R | undefined)[] = new Array(items.length).fill(undefined);
+  const width = Math.max(1, Math.min(concurrency, items.length));
+  let cursor = 0;
+  const runLane = async (): Promise<void> => {
+    for (;;) {
+      if (shouldStop?.()) return;
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index]!, index);
+    }
+  };
+  await Promise.all(Array.from({ length: width }, () => runLane()));
+  return results;
+}
+
 /** Reject after `ms` when the wrapped promise hasn't settled. */
 export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {

--- a/vscode-extension/test/unit/async.test.ts
+++ b/vscode-extension/test/unit/async.test.ts
@@ -1,0 +1,44 @@
+// mapPool: bounded-concurrency map with cooperative cancellation,
+// the engine behind bulk description generation.
+import { describe, expect, it, vi } from "vitest";
+
+import { mapPool } from "../../src/util/async";
+
+describe("mapPool", () => {
+  it("returns results index-aligned with the input", async () => {
+    const out = await mapPool([1, 2, 3, 4], 2, async (n) => n * 10);
+    expect(out).toEqual([10, 20, 30, 40]);
+  });
+
+  it("never exceeds the concurrency width", async () => {
+    let active = 0;
+    let peak = 0;
+    await mapPool(Array.from({ length: 10 }, (_v, i) => i), 3, async (n) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return n;
+    });
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it("stops dispatching once shouldStop flips, leaving slots undefined", async () => {
+    let processed = 0;
+    let stop = false;
+    const worker = vi.fn(async (n: number) => {
+      processed += 1;
+      if (processed >= 2) stop = true; // cancel after the second item
+      return n;
+    });
+    const out = await mapPool([1, 2, 3, 4, 5], 1, worker, () => stop);
+    // Width 1 → strictly sequential; items 1 and 2 run, then stop.
+    expect(out.slice(0, 2)).toEqual([1, 2]);
+    expect(out.slice(2)).toEqual([undefined, undefined, undefined]);
+    expect(worker).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles an empty input", async () => {
+    expect(await mapPool([], 4, async (n) => n)).toEqual([]);
+  });
+});

--- a/vscode-extension/test/unit/bulkGenerate.test.ts
+++ b/vscode-extension/test/unit/bulkGenerate.test.ts
@@ -1,0 +1,221 @@
+// Bulk-generate enumeration + generate/apply logic. The vscode UI
+// orchestration is exercised manually; these tests cover the pure
+// pieces that decide what gets generated and how failures are handled.
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyOne,
+  enumerateMissing,
+  generateOne,
+  type BulkGenerateDeps,
+  type GenTarget,
+} from "../../src/management/bulkGenerateCore";
+
+type TableMeta = {
+  schema: string;
+  name: string;
+  profile?: string;
+  description?: string;
+};
+type ColumnMeta = { name: string; description?: string };
+
+const makeDeps = (options: {
+  tables: TableMeta[];
+  columns?: Record<string, ColumnMeta[]>;
+  generate?: Partial<BulkGenerateDeps["client"]["generate"]>;
+  comments?: Partial<BulkGenerateDeps["client"]["comments"]>;
+}): BulkGenerateDeps => ({
+  catalog: {
+    getTables: vi.fn().mockResolvedValue(options.tables),
+    getColumns: vi.fn(async (schema: string, table: string) => {
+      return options.columns?.[`${schema}.${table}`] ?? [];
+    }),
+    invalidate: vi.fn(),
+  } as unknown as BulkGenerateDeps["catalog"],
+  client: {
+    generate: {
+      table: vi.fn(),
+      column: vi.fn(),
+      ...options.generate,
+    } as unknown as BulkGenerateDeps["client"]["generate"],
+    comments: {
+      setLocal: vi.fn(),
+      setTable: vi.fn(),
+      setColumn: vi.fn(),
+      ...options.comments,
+    } as unknown as BulkGenerateDeps["client"]["comments"],
+  },
+});
+
+describe("enumerateMissing", () => {
+  it("returns only undocumented tables when columns are excluded", async () => {
+    const deps = makeDeps({
+      tables: [
+        { schema: "sales", name: "orders", profile: "pg", description: "" },
+        { schema: "sales", name: "customers", profile: "pg", description: "has one" },
+        { schema: "other", name: "ignored", profile: "pg" },
+      ],
+    });
+    const targets = await enumerateMissing(deps, { schema: "sales", profile: "pg" }, false);
+    expect(targets).toEqual([
+      {
+        kind: "table",
+        profile: "pg",
+        schema: "sales",
+        table: "orders",
+        label: "sales.orders",
+      },
+    ]);
+  });
+
+  it("includes undocumented columns when requested", async () => {
+    const deps = makeDeps({
+      tables: [{ schema: "sales", name: "orders", profile: "pg", description: "documented" }],
+      columns: {
+        "sales.orders": [
+          { name: "id", description: "pk" },
+          { name: "total", description: "" },
+        ],
+      },
+    });
+    const targets = await enumerateMissing(deps, { schema: "sales", profile: "pg" }, true);
+    expect(targets).toEqual([
+      {
+        kind: "column",
+        profile: "pg",
+        schema: "sales",
+        table: "orders",
+        column: "total",
+        label: "sales.orders.total",
+      },
+    ]);
+  });
+
+  it("narrows to a single table when the node is a table", async () => {
+    const deps = makeDeps({
+      tables: [
+        { schema: "sales", name: "orders", profile: "pg" },
+        { schema: "sales", name: "refunds", profile: "pg" },
+      ],
+    });
+    const targets = await enumerateMissing(
+      deps,
+      { schema: "sales", table: "orders", profile: "pg" },
+      false,
+    );
+    expect(targets.map((t) => t.label)).toEqual(["sales.orders"]);
+  });
+
+  it("skips tables without a resolvable profile", async () => {
+    const deps = makeDeps({ tables: [{ schema: "sales", name: "orders" }] });
+    const targets = await enumerateMissing(deps, { schema: "sales" }, false);
+    expect(targets).toEqual([]);
+  });
+
+  it("falls back to the node profile when the table omits one", async () => {
+    const deps = makeDeps({ tables: [{ schema: "sales", name: "orders" }] });
+    const targets = await enumerateMissing(deps, { schema: "sales", profile: "node-pg" }, false);
+    expect(targets[0]?.profile).toBe("node-pg");
+  });
+});
+
+describe("generateOne", () => {
+  const tableTarget: GenTarget = {
+    kind: "table",
+    profile: "pg",
+    schema: "sales",
+    table: "orders",
+    label: "sales.orders",
+  };
+
+  it("returns the generated description on success", async () => {
+    const deps = makeDeps({
+      tables: [],
+      generate: { table: vi.fn().mockResolvedValue({ description: "All orders" }) },
+    });
+    const proposal = await generateOne(deps, tableTarget);
+    expect(proposal).toEqual({ target: tableTarget, description: "All orders" });
+  });
+
+  it("captures the error instead of throwing", async () => {
+    const deps = makeDeps({
+      tables: [],
+      generate: { table: vi.fn().mockRejectedValue(new Error("rate limited")) },
+    });
+    const proposal = await generateOne(deps, tableTarget);
+    expect(proposal.description).toBeUndefined();
+    expect(proposal.error).toBe("rate limited");
+  });
+
+  it("routes column targets to the column endpoint", async () => {
+    const column = vi.fn().mockResolvedValue({ description: "the total" });
+    const deps = makeDeps({ tables: [], generate: { column } });
+    await generateOne(deps, {
+      kind: "column",
+      profile: "pg",
+      schema: "sales",
+      table: "orders",
+      column: "total",
+      label: "sales.orders.total",
+    });
+    expect(column).toHaveBeenCalledWith("sales", "orders", "total", "pg");
+  });
+});
+
+describe("applyOne", () => {
+  it("writes a table description to the local catalog", async () => {
+    const setLocal = vi.fn();
+    const deps = makeDeps({ tables: [], comments: { setLocal } });
+    await applyOne(
+      deps,
+      {
+        target: { kind: "table", profile: "pg", schema: "sales", table: "orders", label: "x" },
+        description: "All orders",
+      },
+      false,
+    );
+    expect(setLocal).toHaveBeenCalledWith({
+      profile: "pg",
+      schema: "sales",
+      table: "orders",
+      description: "All orders",
+    });
+  });
+
+  it("writes a column description to the database", async () => {
+    const setColumn = vi.fn();
+    const deps = makeDeps({ tables: [], comments: { setColumn } });
+    await applyOne(
+      deps,
+      {
+        target: {
+          kind: "column",
+          profile: "pg",
+          schema: "sales",
+          table: "orders",
+          column: "total",
+          label: "x",
+        },
+        description: "the total",
+      },
+      true,
+    );
+    expect(setColumn).toHaveBeenCalledWith("sales", "orders", "total", "the total", "pg");
+  });
+
+  it("is a no-op for a proposal without a description", async () => {
+    const setLocal = vi.fn();
+    const setTable = vi.fn();
+    const deps = makeDeps({ tables: [], comments: { setLocal, setTable } });
+    await applyOne(
+      deps,
+      {
+        target: { kind: "table", profile: "pg", schema: "sales", table: "orders", label: "x" },
+        error: "failed",
+      },
+      false,
+    );
+    expect(setLocal).not.toHaveBeenCalled();
+    expect(setTable).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Adds a **Generate Missing Descriptions…** action to the catalog tree's schema and table context menus, so undocumented assets can be filled in bulk instead of one dialog at a time.

Flow (wizard-first, AMX convention):
1. Scope pick — tables only, or tables + columns.
2. Enumerate undocumented assets from the catalog cache and show the count ("N tables, M columns — generation consumes tokens on the active LLM") **before** any LLM call.
3. Multi-select QuickPick (all pre-checked) to trim the batch.
4. Cancellable progress notification runs the existing `POST /api/generate/table|column` endpoints through a 3-wide concurrency pool; per-asset failures are collected, not fatal; cancelling keeps what was already generated.
5. Review QuickPick — generated rows pre-checked, failed rows shown unchecked with the error.
6. Apply to catalog (local override) or database (`COMMENT ON`) via the existing `comments.*` client methods, then invalidate the cache and refresh the tree.

Client-side orchestration over the existing endpoints — no new server endpoint, no Studio-bundle change.

## Modularity
Pure logic (`enumerateMissing` / `generateOne` / `applyOne`) lives in `bulkGenerateCore.ts` with no vscode import; the vscode UI orchestration is in `bulkGenerate.ts`. A reusable bounded-concurrency `mapPool` helper lands in `util/async.ts`.

## Test plan
- New `test/unit/bulkGenerate.test.ts` (enumerate filtering, profile fallback, column inclusion, generate success/failure capture, apply routing) and `test/unit/async.test.ts` (`mapPool` concurrency width, cancellation, index alignment). 92 unit tests green.
- `npm run typecheck` and `node esbuild.mjs` pass.
- Manual: schema with mixed documented/undocumented tables → generate → uncheck one → apply to catalog → tree tooltips refresh.