### PR TITLE
feat(vscode): surface Studio panels in a sidebar AMX Studio view

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -35,6 +35,10 @@
     "views": {
       "amx": [
         {
+          "id": "amx.studio",
+          "name": "AMX Studio"
+        },
+        {
           "id": "amx.profiles",
           "name": "Profiles"
         },
@@ -56,27 +60,32 @@
       {
         "command": "amx.openAsk",
         "title": "Open Ask Chat",
-        "category": "AMX"
+        "category": "AMX",
+        "icon": "$(comment-discussion)"
       },
       {
         "command": "amx.newRun",
         "title": "Start New Run",
-        "category": "AMX"
+        "category": "AMX",
+        "icon": "$(play)"
       },
       {
         "command": "amx.openLineage",
         "title": "Open Lineage",
-        "category": "AMX"
+        "category": "AMX",
+        "icon": "$(type-hierarchy)"
       },
       {
         "command": "amx.openPages",
         "title": "Open Pages",
-        "category": "AMX"
+        "category": "AMX",
+        "icon": "$(book)"
       },
       {
         "command": "amx.openSettings",
         "title": "Open Studio Settings",
-        "category": "AMX"
+        "category": "AMX",
+        "icon": "$(settings-gear)"
       },
       {
         "command": "amx.openRepl",
@@ -303,14 +312,34 @@
     "menus": {
       "view/title": [
         {
+          "command": "amx.openAsk",
+          "when": "view == amx.studio",
+          "group": "navigation@1"
+        },
+        {
+          "command": "amx.newRun",
+          "when": "view == amx.studio",
+          "group": "navigation@2"
+        },
+        {
+          "command": "amx.openLineage",
+          "when": "view == amx.studio",
+          "group": "navigation@3"
+        },
+        {
           "command": "amx.profiles.refresh",
           "when": "view == amx.profiles",
           "group": "navigation"
         },
         {
+          "command": "amx.openAsk",
+          "when": "view == amx.catalog",
+          "group": "navigation@0"
+        },
+        {
           "command": "amx.catalog.refresh",
           "when": "view == amx.catalog",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "amx.history.refresh",

--- a/vscode-extension/src/views/index.ts
+++ b/vscode-extension/src/views/index.ts
@@ -10,8 +10,10 @@ import { HistoryTreeProvider } from "./historyTree";
 import { ProfilesTreeProvider } from "./profilesTree";
 import { SchedulesTreeProvider } from "./schedulesTree";
 import { AmxStatusBar } from "./statusBar";
+import { StudioActionsProvider } from "./studioActionsTree";
 
 export interface ViewRegistry {
+  readonly studio: StudioActionsProvider;
   readonly profiles: ProfilesTreeProvider;
   readonly catalog: CatalogTreeProvider;
   readonly history: HistoryTreeProvider;
@@ -58,6 +60,7 @@ export function refreshViews(...targets: RefreshTarget[]): void {
 
 export function registerViews(services: ExtensionServices): void {
   const views: ViewRegistry = {
+    studio: new StudioActionsProvider(),
     profiles: new ProfilesTreeProvider(services),
     catalog: new CatalogTreeProvider(services),
     history: new HistoryTreeProvider(services),
@@ -67,6 +70,7 @@ export function registerViews(services: ExtensionServices): void {
   registry = views;
 
   services.context.subscriptions.push(
+    vscode.window.registerTreeDataProvider("amx.studio", views.studio),
     vscode.window.registerTreeDataProvider("amx.profiles", views.profiles),
     vscode.window.registerTreeDataProvider("amx.catalog", views.catalog),
     vscode.window.registerTreeDataProvider("amx.history", views.history),

--- a/vscode-extension/src/views/studioActionsTree.ts
+++ b/vscode-extension/src/views/studioActionsTree.ts
@@ -1,0 +1,37 @@
+// "AMX Studio" view: a fixed list of one-click entry points to the
+// Studio panels (Ask, New Run, Lineage, Pages, Settings). It exists so
+// the panels are discoverable from the sidebar instead of only through
+// the Command Palette. Each row just runs the matching open-panel
+// command; there is no server/state coupling, so the list is static.
+import * as vscode from "vscode";
+
+interface StudioAction {
+  label: string;
+  command: string;
+  icon: string;
+  tooltip: string;
+}
+
+const ACTIONS: readonly StudioAction[] = [
+  { label: "Ask", command: "amx.openAsk", icon: "comment-discussion", tooltip: "Open the Ask chat" },
+  { label: "New Run", command: "amx.newRun", icon: "play", tooltip: "Start a new run" },
+  { label: "Lineage", command: "amx.openLineage", icon: "type-hierarchy", tooltip: "Open the lineage canvas" },
+  { label: "Pages", command: "amx.openPages", icon: "book", tooltip: "Open documentation pages" },
+  { label: "Settings", command: "amx.openSettings", icon: "settings-gear", tooltip: "Open Studio settings" },
+];
+
+export class StudioActionsProvider implements vscode.TreeDataProvider<StudioAction> {
+  getTreeItem(action: StudioAction): vscode.TreeItem {
+    const item = new vscode.TreeItem(action.label, vscode.TreeItemCollapsibleState.None);
+    item.iconPath = new vscode.ThemeIcon(action.icon);
+    item.tooltip = action.tooltip;
+    item.contextValue = "amx.studioAction";
+    item.command = { command: action.command, title: action.tooltip };
+    return item;
+  }
+
+  getChildren(element?: StudioAction): StudioAction[] {
+    // Flat list — only the root level has items.
+    return element ? [] : [...ACTIONS];
+  }
+}


### PR DESCRIPTION
## Summary
The Ask / New Run / Lineage / Pages / Settings panels were only reachable through the Command Palette — weak for a sidebar extension. This adds first-class UI entry points:

- New **AMX Studio** tree at the top of the activity bar with one-click rows: Ask, New Run, Lineage, Pages, Settings (each runs the matching open-panel command).
- Icons on the open-panel commands so they render in the tree and toolbars.
- 💬 **Ask** button on the Catalog view title; Ask/Run/Lineage toolbar on the new view's title.

Extension-only, no Studio bundle change. Ask stays the (now-fixed) iframe panel.

## Test plan
- `npm run typecheck`, `node esbuild.mjs`, `npm test` (77 unit tests) all pass.
- Manual: AMX activity bar shows 'AMX Studio' on top; clicking Ask opens the chat panel; title icons work.